### PR TITLE
go-vcr POC approach-2 to pass httpclient using provider's Meta

### DIFF
--- a/internal/acceptance/testcase.go
+++ b/internal/acceptance/testcase.go
@@ -9,9 +9,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -20,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/testclient"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/types"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/vcr"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
@@ -215,37 +211,9 @@ func (td TestData) runAcceptanceTest(t *testing.T, testCase resource.TestCase) {
 // runAcceptanceTestWithVCR runs acceptance test with a VCR-wrapped HTTP client for recording/playback.
 func (td TestData) runAcceptanceTestWithVCR(t *testing.T, testCase resource.TestCase) {
 	testCase.ExternalProviders = td.externalProviders()
-
-	// Create provider factories with VCR HTTP client injection
-	testCase.ProtoV5ProviderFactories = make(map[string]func() (tfprotov5.ProviderServer, error))
-	for _, name := range []string{"azurerm", "azurerm-alt"} {
-		testCase.ProtoV5ProviderFactories[name] = func() (tfprotov5.ProviderServer, error) {
-			providerServerFactory, v2Provider, err := framework.ProtoV5ProviderServerFactory(context.Background())
-			if err != nil {
-				return nil, err
-			}
-
-			// Wrap the original ConfigureContextFunc to inject HTTPClient into Meta
-			configureContextFunc := v2Provider.ConfigureContextFunc
-			v2Provider.ConfigureContextFunc = func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
-				// Get VCR HTTP client
-				httpClient := vcr.GetHTTPClient(t)
-				var meta *clients.Client
-				if v, ok := v2Provider.Meta().(*clients.Client); ok && v != nil {
-					meta = v
-				} else {
-					meta = new(clients.Client)
-				}
-				meta.HTTPClient = httpClient
-				v2Provider.SetMeta(meta)
-
-				// Call the underline ConfigureContextFunc
-				return configureContextFunc(ctx, d)
-			}
-
-			return providerServerFactory(), nil
-		}
-	}
+	// Get VCR HTTP client and create provider factories with it
+	httpClient := vcr.GetHTTPClient(t)
+	testCase.ProtoV5ProviderFactories = framework.ProtoV5ProviderFactoriesInitWithHTTPClient(context.Background(), httpClient, "azurerm", "azurerm-alt")
 
 	resource.ParallelTest(t, testCase)
 }

--- a/internal/acceptance/testcase.go
+++ b/internal/acceptance/testcase.go
@@ -9,6 +9,10 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+>>>>>>> 5dbe4f4bb6 (go-vcr dummy chnages with Meta)
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -16,6 +20,8 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/helpers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/testclient"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/types"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/vcr"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
@@ -100,6 +106,48 @@ func (td TestData) ResourceTest(t *testing.T, testResource types.TestResource, s
 		Steps: steps,
 	}
 	td.runAcceptanceTest(t, testCase)
+}
+
+// ResourceTestWithVCR is an opt-in test method that uses VCR for HTTP recording/playback.
+// Tests using this method will use a VCR-wrapped HTTP client for all Azure API calls.
+// This enables faster test execution by replaying recorded HTTP interactions.
+func (td TestData) ResourceTestWithVCR(t *testing.T, testResource types.TestResource, steps []TestStep) {
+	refreshStep := TestStep{
+		RefreshState: true,
+	}
+
+	newSteps := make([]TestStep, 0)
+	for _, step := range steps {
+		if (step.Config != "" || step.ConfigDirectory != nil || step.ConfigFile != nil) && !step.PlanOnly {
+			step.ConfigPlanChecks = resource.ConfigPlanChecks{
+				PreApply: []plancheck.PlanCheck{
+					helpers.IsNotResourceAction(td.ResourceName, plancheck.ResourceActionReplace),
+				},
+			}
+		}
+
+		if !step.ImportState {
+			newSteps = append(newSteps, step)
+		} else {
+			newSteps = append(newSteps, refreshStep)
+			newSteps = append(newSteps, step)
+		}
+	}
+	steps = newSteps
+
+	testCase := resource.TestCase{
+		PreCheck: func() { PreCheck(t) },
+		CheckDestroy: func(s *terraform.State) error {
+			client, err := testclient.Build()
+			if err != nil {
+				return fmt.Errorf("building client: %+v", err)
+			}
+			return helpers.CheckDestroyedFunc(client, testResource, td.ResourceType, td.ResourceName)(s)
+		},
+		Steps: steps,
+	}
+
+	td.runAcceptanceTestWithVCR(t, testCase)
 }
 
 // ResourceTestIgnoreRecreate should be used when checking that a resource should be recreated during a test.
@@ -188,6 +236,44 @@ func RunTestsInSequence(t *testing.T, tests map[string]map[string]func(t *testin
 func (td TestData) runAcceptanceTest(t *testing.T, testCase resource.TestCase) {
 	testCase.ExternalProviders = td.externalProviders()
 	testCase.ProtoV5ProviderFactories = framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm", "azurerm-alt")
+
+	resource.ParallelTest(t, testCase)
+}
+
+// runAcceptanceTestWithVCR runs acceptance test with a VCR-wrapped HTTP client for recording/playback.
+func (td TestData) runAcceptanceTestWithVCR(t *testing.T, testCase resource.TestCase) {
+	testCase.ExternalProviders = td.externalProviders()
+
+	// Create provider factories with VCR HTTP client injection
+	testCase.ProtoV5ProviderFactories = make(map[string]func() (tfprotov5.ProviderServer, error))
+	for _, name := range []string{"azurerm", "azurerm-alt"} {
+		testCase.ProtoV5ProviderFactories[name] = func() (tfprotov5.ProviderServer, error) {
+			providerServerFactory, v2Provider, err := framework.ProtoV5ProviderServerFactory(context.Background())
+			if err != nil {
+				return nil, err
+			}
+
+			// Wrap the original ConfigureContextFunc to inject HTTPClient into Meta
+			configureContextFunc := v2Provider.ConfigureContextFunc
+			v2Provider.ConfigureContextFunc = func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
+				// Get VCR HTTP client
+				httpClient := vcr.GetHTTPClient(t)
+				var meta *clients.Client
+				if v, ok := v2Provider.Meta().(*clients.Client); ok && v != nil {
+					meta = v
+				} else {
+					meta = new(clients.Client)
+				}
+				meta.HTTPClient = httpClient
+				v2Provider.SetMeta(meta)
+
+				// Call the underline ConfigureContextFunc
+				return configureContextFunc(ctx, d)
+			}
+
+			return providerServerFactory(), nil
+		}
+	}
 
 	resource.ParallelTest(t, testCase)
 }

--- a/internal/acceptance/vcr/vcr.go
+++ b/internal/acceptance/vcr/vcr.go
@@ -1,0 +1,19 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+// Package vcr provides HTTP recording/playback for acceptance tests.
+// This is a minimal POC implementation - currently a pass-through that makes real HTTP requests.
+package vcr
+
+import (
+	"net/http"
+	"testing"
+)
+
+// GetHTTPClient returns an HTTP client for acceptance tests.
+// Currently returns a simple pass-through client for POC purposes.
+// Future: Will support VCR recording/playback based on VCR_MODE environment variable.
+func GetHTTPClient(t *testing.T) *http.Client {
+	client := &http.Client{}
+	return client
+}

--- a/internal/clients/builder.go
+++ b/internal/clients/builder.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
@@ -33,6 +34,7 @@ type ClientBuilder struct {
 	StorageUseAzureAD           bool
 	SubscriptionID              string
 	TerraformVersion            string
+	HttpClient                  *http.Client
 }
 
 const azureStackEnvironmentError = `
@@ -150,6 +152,7 @@ func Build(ctx context.Context, builder ClientBuilder) (*Client, error) {
 		StorageUseAzureAD:           builder.StorageUseAzureAD,
 
 		ResourceManagerEndpoint: *resourceManagerEndpoint,
+		HTTPClient:              builder.HttpClient,
 	}
 
 	if err := client.Build(ctx, o); err != nil {

--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -6,6 +6,7 @@ package clients
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/validation"
@@ -156,6 +157,9 @@ type Client struct {
 
 	// StopContext is used for propagating control from Terraform Core (e.g. Ctrl/Cmd+C)
 	StopContext context.Context
+
+	// HTTPClient is used for VCR testing to inject a custom HTTP client
+	HTTPClient *http.Client
 
 	Account  *ResourceManagerAccount
 	Features features.UserFeatures

--- a/internal/common/client_options.go
+++ b/internal/common/client_options.go
@@ -5,6 +5,7 @@ package common
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 
@@ -59,6 +60,8 @@ type ClientOptions struct {
 
 	// TODO: Remove when all go-autorest clients are gone
 	SkipProviderReg bool
+
+	HTTPClient *http.Client
 }
 
 // Configure set up a resourcemanager.Client using an auth.Authorizer from hashicorp/go-azure-sdk
@@ -76,6 +79,10 @@ func (o ClientOptions) Configure(c client.BaseClient, authorizer auth.Authorizer
 
 	c.AppendRequestMiddleware(requestLoggerMiddleware("AzureRM"))
 	c.AppendResponseMiddleware(responseLoggerMiddleware("AzureRM"))
+
+	// This is needed for VCR testing support
+	c.SetHTTPClient(o.HTTPClient)
+
 }
 
 // ConfigureClient sets up an autorest.Client using an autorest.Authorizer

--- a/internal/provider/framework/factory_builder.go
+++ b/internal/provider/framework/factory_builder.go
@@ -5,13 +5,16 @@ package framework
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-mux/tf5muxserver"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/echoprovider"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/provider"
 )
 
@@ -36,6 +39,43 @@ func ProtoV5ProviderFactoriesInit(ctx context.Context, providerNames ...string) 
 			providerServerFactory, _, err := ProtoV5ProviderServerFactory(ctx)
 			if err != nil {
 				return nil, err
+			}
+
+			return providerServerFactory(), nil
+		}
+	}
+
+	return factories
+}
+
+// ProtoV5ProviderFactoriesInitWithHTTPClient creates provider factories with a custom HTTP client.
+// The HTTP client is injected into provider.Meta() before ConfigureContextFunc runs,
+// allowing it to be used by the Azure SDK during client initialization.
+func ProtoV5ProviderFactoriesInitWithHTTPClient(ctx context.Context, httpClient *http.Client, providerNames ...string) map[string]func() (tfprotov5.ProviderServer, error) {
+	factories := make(map[string]func() (tfprotov5.ProviderServer, error), len(providerNames))
+
+	for _, name := range providerNames {
+		factories[name] = func() (tfprotov5.ProviderServer, error) {
+			providerServerFactory, v2Provider, err := ProtoV5ProviderServerFactory(ctx)
+			if err != nil {
+				return nil, err
+			}
+
+			// Wrap the original ConfigureContextFunc to inject HTTPClient into Meta
+			configureContextFunc := v2Provider.ConfigureContextFunc
+			v2Provider.ConfigureContextFunc = func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
+				// Set HTTPClient in Meta before ConfigureContextFunc runs
+				var meta *clients.Client
+				if v, ok := v2Provider.Meta().(*clients.Client); ok && v != nil {
+					meta = v
+				} else {
+					meta = new(clients.Client)
+				}
+				meta.HTTPClient = httpClient
+				v2Provider.SetMeta(meta)
+
+				// Call the original ConfigureContextFunc
+				return configureContextFunc(ctx, d)
 			}
 
 			return providerServerFactory(), nil

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -6,6 +6,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -522,6 +523,12 @@ func buildClient(ctx context.Context, p *schema.Provider, d *schema.ResourceData
 	}
 	requiredResourceProviders.Merge(additionalProvidersToRegister)
 
+	// Check if HTTPClient was pre-set via Meta (for VCR testing)
+	var httpClient *http.Client
+	if meta, ok := p.Meta().(*clients.Client); ok && meta != nil {
+		httpClient = meta.HTTPClient
+	}
+
 	clientBuilder := clients.ClientBuilder{
 		AuthConfig:                  authConfig,
 		DisableCorrelationRequestID: d.Get("disable_correlation_request_id").(bool),
@@ -533,6 +540,7 @@ func buildClient(ctx context.Context, p *schema.Provider, d *schema.ResourceData
 		StorageUseAzureAD:           d.Get("storage_use_azuread").(bool),
 		SubscriptionID:              d.Get("subscription_id").(string),
 		TerraformVersion:            p.TerraformVersion,
+		HttpClient:                  httpClient,
 
 		// this field is intentionally not exposed in the provider block, since it's only used for
 		// platform level tracing

--- a/internal/services/apimanagement/api_management_logger_resource_test.go
+++ b/internal/services/apimanagement/api_management_logger_resource_test.go
@@ -22,7 +22,7 @@ func TestAccApiManagementLogger_basicEventHub(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_logger", "test")
 	r := ApiManagementLoggerResource{}
 
-	data.ResourceTest(t, r, []acceptance.TestStep{
+	data.ResourceTestWithVCR(t, r, []acceptance.TestStep{
 		{
 			Config: r.basicEventHub(data),
 			Check: acceptance.ComposeTestCheckFunc(

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/client/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/client/client.go
@@ -318,6 +318,8 @@ type Client struct {
 
 	// ResponseMiddlewares is a slice of functions that are called in order before a response is parsed and returned
 	ResponseMiddlewares *[]ResponseMiddleware
+
+	HttpClient *http.Client
 }
 
 // NewClient returns a new Client configured with sensible defaults
@@ -345,6 +347,14 @@ func (c *Client) SetUserAgent(userAgent string) {
 // GetUserAgent retrieves the configured user agent for the client
 func (c *Client) GetUserAgent() string {
 	return c.UserAgent
+}
+
+func (c *Client) SetHTTPClient(httpClient *http.Client) {
+	c.HttpClient = httpClient
+}
+
+func (c *Client) GetHTTPClient() *http.Client {
+	return c.HttpClient
 }
 
 // AppendRequestMiddleware appends a request middleware function for the client
@@ -742,7 +752,10 @@ func (c *Client) retryableClient(ctx context.Context, checkRetry retryablehttp.C
 			MaxIdleConnsPerHost:   runtime.GOMAXPROCS(0) + 1,
 		},
 	}
-
+	// overrides httpClient with provided one
+	if c.HttpClient != nil{
+		r.HTTPClient = c.HttpClient
+	}
 	return
 }
 

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/client/interface.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/client/interface.go
@@ -41,6 +41,10 @@ type BaseClient interface {
 
 	// ClearResponseMiddlewares removes all response middleware functions for the client
 	ClearResponseMiddlewares()
+
+	SetHTTPClient(*http.Client)
+
+	GetHTTPClient() *http.Client
 }
 
 // RequestRetryFunc is a function that determines whether an HTTP request has failed due to eventual consistency and should be retried


### PR DESCRIPTION
Changes to passing VCR httpClient to underline go-azure-sdk using provider's Meta attribute. ( inspired from aws provider)
As It's just a POC hence made changes to vendor files instead of raising a separate azure-sdk PR.

