### PR TITLE
[Contributor Docs]: Clarify schema validation guidance

### DIFF
--- a/contributing/topics/best-practices.md
+++ b/contributing/topics/best-practices.md
@@ -78,7 +78,7 @@ Data Sources and Resources built using the Typed SDK have a number of benefits o
     2. Default values can be implied for fields, rather than requiring an explicit `d.Set` in the Read function for every field - this allows us to ensure that an empty value/list is set for a field, rather than being `null` and thus not able to be referenced in user configs.
 * Using the Typed SDK allows Data Sources and Resources to (in the future) be migrated across to using `hashicorp/terraform-plugin-framework` rather than `hashicorp/terraform-plugin-sdk` without rewriting the resource - which will unlock a number of benefits to end-users, but does involve some configuration changes (and as such will need to be done in a major release).
 * Using the Typed SDK means that these Data Sources/Resources can be more easily swapped out for generated versions down the line (since the code changes will be far smaller).
-  
+
 To facilitate the migration across to Typed Resources, we ask that any new Data Source or Resource which is added to the Provider is added as a Typed Data Source/Resource. Enhancements to existing Data Sources/Resources which are Untyped Resources can remain as Untyped Resources, however these will need to be migrated across in the future.
 
 Here is an example of an Untyped Resource:
@@ -178,7 +178,7 @@ func (r SomeResource) Create() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Timeout: 30 * time.Minute,
 		Func:    func(ctx context.Context, metadata sdk.ResourceMetaData) error {
-			// create logic is defined here 
+			// create logic is defined here
 		},
 	}
 }
@@ -261,7 +261,7 @@ When adding or updating the licensing header at the top of a Go source file, alw
 
 - `pointer.From` returns the dereferenced value or the *zero* value if the pointer is `nil`. Use `pointer.From` instead of manual `nil` checks.
 
-:white_check_mark: **DO**
+**DO**
 
 ```go
 output.Name = pointer.From(input.Name)
@@ -269,7 +269,7 @@ output.Name = pointer.From(input.Name)
 
 - Use `pointer.To` to take the address of a value without declaring temporary variables.
 
-:white_check_mark: **DO**
+**DO**
 
 ```go
 if _, err := client.Delete(ctx, newId, apirelease.DeleteOperationOptions{IfMatch: pointer.To("*")}); err != nil {
@@ -279,11 +279,10 @@ if _, err := client.Delete(ctx, newId, apirelease.DeleteOperationOptions{IfMatch
 
 - Use `pointer.ToEnum` to convert Enum type instead of explicitly type conversion.
 
-:white_check_mark: **DO**
+**DO**
 
 ```go
 return &managedclusters.ManagedClusterBootstrapProfile{
     ArtifactSource: pointer.ToEnum[managedclusters.ArtifactSource](config["artifact_source"].(string)),
 }
 ```
-

--- a/contributing/topics/guide-new-resource.md
+++ b/contributing/topics/guide-new-resource.md
@@ -604,7 +604,7 @@ Things worth noting here:
 
 For example, in this case:
 
-:white_check_mark: **DO**
+**DO**
 
 ```
 var _ sdk.ResourceWithUpdate = ResourceGroupExampleResource{}
@@ -616,7 +616,7 @@ var _ sdk.ResourceWithUpdate = ResourceGroupExampleResource{}
 
 For example, in this case:
 
-:white_check_mark: **DO**
+**DO**
 
 ```
 "name": {
@@ -634,7 +634,7 @@ For example, in this case:
 
 For example, in this case:
 
-:white_check_mark: **DO**
+**DO**
 
 ```
 func (r ResourceGroupExampleResource) Update() sdk.ResourceFunc {
@@ -650,7 +650,7 @@ func (r ResourceGroupExampleResource) Update() sdk.ResourceFunc {
             if existing.Model.Properties == nil {
                return fmt.Errorf("retrieving %s: `properties` was nil", id)
             }
-            
+
             ...
             return nil
         },
@@ -660,7 +660,7 @@ func (r ResourceGroupExampleResource) Update() sdk.ResourceFunc {
 
 - Avoid returning errors in `Update` or `CustomizeDiff` for valid configurations that cannot be updated in-place. Instead, use `ForceNew` in `CustomizeDiff` to trigger resource recreation.
 
-:white_check_mark: **DO**
+**DO**
 
 ```go
 func (r ExampleResource) CustomizeDiff() sdk.ResourceFunc {

--- a/contributing/topics/schema-design-considerations.md
+++ b/contributing/topics/schema-design-considerations.md
@@ -374,16 +374,7 @@ For numeric fields, prefer validators that match the API contract as closely as 
     Type:         pluginsdk.TypeInt,
     Optional:     true,
     // NOTE: validation is intentionally minimal because the API only defines the lower bound value (no upper bound constraints found).
-    ValidateFunc: validation.IntAtLeast(1),
-},
-```
-
-```go
-"cpu": {
-    Type:         pluginsdk.TypeFloat,
-    Required:     true,
-    // NOTE: validation is intentionally minimal because the API only defines the lower bound value (no upper bound constraints found).
-    ValidateFunc: validation.FloatAtLeast(0.1),
+    ValidateFunc: validation.IntAtLeast(0),
 },
 ```
 
@@ -497,21 +488,4 @@ Use regex or other format validators when the API contract defines a pattern rat
     Optional:     true,
     ValidateFunc: validation.IntBetween(32, 16384),
 },
-```
-
-**DO NOT** use minimal validation when stronger constraints exist
-
-```go
-// BAD: API defines allowed values / pattern / bounds, but this accepts nearly anything.
-ValidateFunc: validation.StringIsNotEmpty,
-```
-
-```go
-// BAD: API bounds exist, but this only enforces non-negative integers.
-ValidateFunc: validation.IntAtLeast(0),
-```
-
-```go
-// BAD: API bounds exist, but this only enforces non-negative decimal values.
-ValidateFunc: validation.FloatAtLeast(0),
 ```

--- a/contributing/topics/schema-design-considerations.md
+++ b/contributing/topics/schema-design-considerations.md
@@ -272,7 +272,7 @@ When designing schemas, consider flattening properties with `MaxItems: 1` that c
     Optional: true,
     Elem:     &pluginsdk.Schema{
         Type:         pluginsdk.TypeString,
-        // NOTE: validation is intentionally minimal since there is no stable RP contract for the certificate contents beyond a non-empty string.
+        // NOTE: validation is intentionally minimal since there is no stable API contract for the certificate contents beyond a non-empty string.
         ValidateFunc: validation.StringIsNotEmpty,
     },
 }
@@ -327,34 +327,86 @@ When a `pluginsdk.TypeList` block has no required nested fields, conditional val
 }
 ```
 
-## Validation
+## Validation functions
 
-String arguments must be validated against the Resource Provider (RP) / API contract wherever possible.
+### String arguments must be validated against the API contract wherever possible.
 
-As a rule of thumb, ensure common shapes have appropriate, specific validators:
+In practice, common shapes should use appropriate, specific validators:
 - Validate `name`-like fields for length and allowed characters (use regex/patterns from the spec where available)
 - Use `commonids` or service-specific ID validators for resource IDs
 - Validate common formats like dates, IPs, ports, emails, and URIs
 
-This means using constraints from the swagger/spec, SDK types/constants, or RP documentation:
+This means using constraints from the swagger/spec, SDK types/constants, or API documentation:
 - Allowed values (enums)
 - Patterns/regex
 - Length bounds
 - Formats (dates, IPs, ports, emails, URIs)
 - Resource ID shapes (prefer `commonids` or service-specific validators)
 
-`validation.StringIsNotEmpty` is a LAST RESORT ONLY.
-It is only acceptable when you have confirmed the RP truly accepts arbitrary free-form text and there are no stable rules to validate.
-If you use `validation.StringIsNotEmpty`, you MUST add an inline comment explaining why stronger validation cannot be applied and what you checked.
+> **Note:** `validation.StringIsNotEmpty` is a **LAST RESORT ONLY**. It is only acceptable when you have confirmed the API truly accepts arbitrary free-form text and there are no stable rules to validate. If you use `validation.StringIsNotEmpty`, you **MUST** add an inline comment explaining why stronger validation cannot be applied and what you checked.
 
-Numeric arguments must specify a valid range wherever possible.
-`validation.IntAtLeast(0)` is a LAST RESORT ONLY and must be justified the same way as above.
+**Example:**
+
+```go
+"description": {
+    Type:     pluginsdk.TypeString,
+    Optional: true,
+    // NOTE: validation is intentionally minimal because the API accepts arbitrary free-form text for this field (no enum/pattern/length constraints found).
+    ValidateFunc: validation.StringIsNotEmpty,
+},
+```
+
+### Numeric arguments must be validated against the API contract wherever possible.
+
+For numeric fields, prefer validators that match the API contract as closely as possible:
+- Validate numeric ranges using the documented minimum and maximum values
+- Use exact allowed values when the API only accepts a fixed set of numeric values
+- Validate percentages, capacities, counts, sizes, priorities, and similar fields against the bounds defined by the API
+- Use integer validators for integer fields and float validators for decimal fields
+- Prefer `IntBetween` / `FloatBetween` when both bounds are known, and only use `IntAtLeast` / `FloatAtLeast` when the API contract truly defines a lower bound without an upper bound
+
+> **Note:** `validation.IntAtLeast` and `validation.FloatAtLeast` are **LAST RESORT ONLY**. They are only acceptable when you have confirmed that the API defines a lower bound, but does not define a stable upper bound or fixed set of allowed values to validate against.
+
+**Example:**
+
+```go
+"parallelism": {
+    Type:         pluginsdk.TypeInt,
+    Optional:     true,
+    // NOTE: validation is intentionally minimal because the API only defines the lower bound value (no upper bound constraints found).
+    ValidateFunc: validation.IntAtLeast(1),
+},
+```
+
+```go
+"cpu": {
+    Type:         pluginsdk.TypeFloat,
+    Required:     true,
+    // NOTE: validation is intentionally minimal because the API only defines the lower bound value (no upper bound constraints found).
+    ValidateFunc: validation.FloatAtLeast(0.1),
+},
+```
+
+### Before writing a new validator, check whether one already exists.
+
+Common places to look are:
+
+* `commonids` for common Azure Resource Manager ID shapes such as `subnets`, `virtual machines`, `managed disks`, `user-assigned identities`, and `resource groups`.
+
+* `internal/tf/validation` for generic string, number, and format validators such as `StringInSlice`, `StringLenBetween`, `IsEmailAddress`, `IsURLWithHTTPS`, `IntBetween`, and `Any`.
+
+* `internal/services/<service>/validate` for service-specific validators, for example name rules, resource-specific IDs, or service-specific value constraints.
+
+> **Note:** The easiest way to discover existing validators is to first look at a similar resource in the same service and then search for `ValidateFunc:` usages in that package.
 
 ### Avoid overly-generic ValidateFunc (no "lazy validation")
 
-When adding or modifying schema fields, do not default to minimal validators if the RP provides stronger constraints.
+When adding or modifying schema fields, do not default to minimal validators if the API provides stronger constraints.
 
-**DO** validate using the RP contract
+**DO** validate using the API contract
+
+When the provider intentionally exposes only a subset of the API values, define that subset explicitly in the schema:
+
 ```go
 "allocation_strategy": {
     Type:     pluginsdk.TypeString,
@@ -364,18 +416,33 @@ When adding or modifying schema fields, do not default to minimal validators if 
         string(compute.AllocationStrategyPrioritized),
     }, false),
 },
+```
 
+When the SDK already exposes the exact set of values that the schema should accept, use the SDK helper directly:
+
+```go
+"network_api_version": {
+    Type:         pluginsdk.TypeString,
+    Optional:     true,
+    ValidateFunc: validation.StringInSlice(virtualmachinescalesets.PossibleValuesForNetworkApiVersion(), false),
+},
+```
+
+Use regex or other format validators when the API contract defines a pattern rather than a fixed list of values:
+
+```go
 "name": {
     Type:     pluginsdk.TypeString,
     Required: true,
     ValidateFunc: validation.StringMatch(
         regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9.\-_]{0,79}$`),
-        "...",
+        "`name` must be between 1 and 80 characters and must start with an alphanumeric character and can contain alphanumeric characters, dots (.), hyphens (-), and underscores (_)",
     ),
 },
 ```
 
-**DO** use ID/format validators for well-known shapes
+**DO** use existing ID/format/range validators for well-known shapes
+
 ```go
 "subnet_id": {
     Type:         pluginsdk.TypeString,
@@ -384,83 +451,67 @@ When adding or modifying schema fields, do not default to minimal validators if 
 },
 ```
 
-**DO NOT** use minimal validation when stronger constraints exist
 ```go
-// BAD: RP defines allowed values / pattern / bounds, but this accepts nearly anything.
-ValidateFunc: validation.StringIsNotEmpty,
+"user_assigned_identity_id": {
+    Type:         pluginsdk.TypeString,
+    Optional:     true,
+    ValidateFunc: commonids.ValidateUserAssignedIdentityID,
+},
+```
 
-// BAD: RP bounds exist, but this only enforces non-negative.
+```go
+"output_blob_uri": {
+    Type:         pluginsdk.TypeString,
+    Optional:     true,
+    ValidateFunc: validation.IsURLWithHTTPS,
+},
+```
+
+```go
+"extensions_time_budget": {
+    Type:         pluginsdk.TypeString,
+    Optional:     true,
+    ValidateFunc: validate.ISO8601DurationBetween("PT15M", "PT2H"),
+},
+```
+
+```go
+"ip_address": {
+    Type:         pluginsdk.TypeString,
+    Optional:     true,
+    ValidateFunc: azValidate.IPv4Address,
+},
+```
+
+```go
+"sim_policy_id": {
+    Type:         pluginsdk.TypeString,
+    Optional:     true,
+    ValidateFunc: simpolicy.ValidateSimPolicyID,
+},
+```
+
+```go
+"storage_size_in_gb": {
+    Type:         pluginsdk.TypeInt,
+    Optional:     true,
+    ValidateFunc: validation.IntBetween(32, 16384),
+},
+```
+
+**DO NOT** use minimal validation when stronger constraints exist
+
+```go
+// BAD: API defines allowed values / pattern / bounds, but this accepts nearly anything.
+ValidateFunc: validation.StringIsNotEmpty,
+```
+
+```go
+// BAD: API bounds exist, but this only enforces non-negative integers.
 ValidateFunc: validation.IntAtLeast(0),
 ```
 
-**LAST RESORT** (only when RP truly has no constraints)
 ```go
-"description": {
-    Type:     pluginsdk.TypeString,
-    Optional: true,
-    // NOTE: validation is intentionally minimal because the RP accepts arbitrary free-form text for this field (no enum/pattern/length constraints found).
-    ValidateFunc: validation.StringIsNotEmpty,
-},
-```
-
-```go
-"name": {
-	Type:     pluginsdk.TypeString,
-	Required: true,
-	ForceNew: true,
-	ValidateFunc: validation.StringMatch(
-		regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9.\-_]{0,79}$`),
-		"`name` must be between 1 and 80 characters. It must start with an alphanumeric character and can contain alphanumeric characters, dots (.), hyphens (-), and underscores (_).",
-	),
-},
-
-"subnet_id": {
-	Type:         pluginsdk.TypeString,
-	Required:     true,
-	ValidateFunc: commonids.ValidateSubnetID,
-},
-
-"description": {
-	Type:         pluginsdk.TypeString,
-	Optional:     true,
-	// NOTE: validation is intentionally minimal because the RP accepts arbitrary free-form text for this field (no enum/pattern/length constraints found).
-	ValidateFunc: validation.StringIsNotEmpty,
-},
-
-"extensions_time_budget": {
-	Type:         pluginsdk.TypeString,
-	Optional:     true,
-	Default:      "PT1H30M",
-	ValidateFunc: validate.ISO8601DurationBetween("PT15M", "PT2H"),
-},
-
-"filter_value_percentage": {
-	Type:         pluginsdk.TypeFloat,
-	Optional:     true,
-	ValidateFunc: validation.FloatBetween(0, 100),
-},
-
-"ip_address": {
-	Type:         pluginsdk.TypeString,
-	Optional:     true,
-	ValidateFunc: azValidate.IPv4Address,
-},
-
-"output_blob_uri": {
-	Type:         pluginsdk.TypeString,
-	Optional:     true,
-	ValidateFunc: validation.IsURLWithHTTPS,
-},
-
-"sim_policy_id": {
-	Type:         pluginsdk.TypeString,
-	Optional:     true,
-	ValidateFunc: simpolicy.ValidateSimPolicyID,
-},
-
-"storage_size_in_gb": {
-	Type:         pluginsdk.TypeInt,
-	Optional:     true,
-	ValidateFunc: validation.IntBetween(32, 16384),
-},
+// BAD: API bounds exist, but this only enforces non-negative decimal values.
+ValidateFunc: validation.FloatAtLeast(0),
 ```

--- a/contributing/topics/schema-design-considerations.md
+++ b/contributing/topics/schema-design-considerations.md
@@ -283,14 +283,14 @@ When designing schemas, consider flattening properties with `MaxItems: 1` that c
 If a field is an array, proper `MinItems` and `MaxItems` should be set based on the API constraints to provide clear validation feedback to users.
 
 ```go
-"email_addresses": {
+"webhook_uris": {
     Type:     pluginsdk.TypeList,
     Required: true,
     MinItems: 1,
     MaxItems: 20,
     Elem: &pluginsdk.Schema{
         Type:         pluginsdk.TypeString,
-        ValidateFunc: validation.IsEmailAddress,
+        ValidateFunc: validation.IsURLWithHTTPS,
     },
 },
 ```
@@ -374,7 +374,7 @@ For numeric fields, prefer validators that match the API contract as closely as 
     Type:         pluginsdk.TypeInt,
     Optional:     true,
     // NOTE: validation is intentionally minimal because the API only defines the lower bound value (no upper bound constraints found).
-    ValidateFunc: validation.IntAtLeast(0),
+    ValidateFunc: validation.IntAtLeast(1),
 },
 ```
 
@@ -384,7 +384,7 @@ Common places to look are:
 
 * `commonids` for common Azure Resource Manager ID shapes such as `subnets`, `virtual machines`, `managed disks`, `user-assigned identities`, and `resource groups`.
 
-* `internal/tf/validation` for generic string, number, and format validators such as `StringInSlice`, `StringLenBetween`, `IsEmailAddress`, `IsURLWithHTTPS`, `IntBetween`, and `Any`.
+* `internal/tf/validation` for generic string, number, and format validators such as `StringInSlice`, `StringLenBetween`, `IsURLWithHTTPS`, `IsPortNumber`, `IntBetween`, and `Any`.
 
 * `internal/services/<service>/validate` for service-specific validators, for example name rules, resource-specific IDs, or service-specific value constraints.
 
@@ -470,7 +470,7 @@ Use regex or other format validators when the API contract defines a pattern rat
 "ip_address": {
     Type:         pluginsdk.TypeString,
     Optional:     true,
-    ValidateFunc: azValidate.IPv4Address,
+    ValidateFunc: validation.IsIPv4Address,
 },
 ```
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Updates contributor documentation to clarify schema validation expectations and improve consistency of formatting.
Emphasizes validating fields against the Resource Provider (RP) / API contract (enums, patterns, bounds, formats) and treating generic validators like validation.StringIsNotEmpty / validation.IntAtLeast(0) as last-resort options requiring justification.
Replaces an email list example validator with validation.IsEmailAddress to demonstrate “common shape” validation.
Removes :white_check_mark: (and other emoji shortcode) prefixes from DO guidance blocks in contributor docs to keep formatting consistent and avoid relying on GitHub emoji shortcodes.
Files changed

[schema-design-considerations.md](vscode-file://vscode-app/c:/Users/jcline/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html): expands/rewrites the Validation section with concrete guidance + examples; minor formatting cleanup; removes emoji shortcode markers within this doc.
[best-practices.md](vscode-file://vscode-app/c:/Users/jcline/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html): removes :white_check_mark: prefixes, keeping **DO** headings.
[guide-new-resource.md](vscode-file://vscode-app/c:/Users/jcline/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html): removes :white_check_mark: prefixes, keeping **DO** headings.
Notes

Docs-only change; no provider behavior changes.
git diff --check clean; no trailing whitespace; code fences balanced.Updates contributor documentation to clarify schema validation expectations and improve consistency of formatting.
Emphasizes validating fields against the Resource Provider (RP) / API contract (enums, patterns, bounds, formats) and treating generic validators like validation.StringIsNotEmpty / validation.IntAtLeast(0) as last-resort options requiring justification.
Replaces an email list example validator with validation.IsEmailAddress to demonstrate “common shape” validation.
Removes :white_check_mark: (and other emoji shortcode) prefixes from DO guidance blocks in contributor docs to keep formatting consistent and avoid relying on GitHub emoji shortcodes.
Files changed

[schema-design-considerations.md](vscode-file://vscode-app/c:/Users/jcline/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html): expands/rewrites the Validation section with concrete guidance + examples; minor formatting cleanup; removes emoji shortcode markers within this doc.
[best-practices.md](vscode-file://vscode-app/c:/Users/jcline/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html): removes :white_check_mark: prefixes, keeping **DO** headings.
[guide-new-resource.md](vscode-file://vscode-app/c:/Users/jcline/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html): removes :white_check_mark: prefixes, keeping **DO** headings.
Notes

Docs-only change; no provider behavior changes.
git diff --check clean; no trailing whitespace; code fences balanced.


## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [X] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [X] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [X] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [X] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [X] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [X] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [X] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

N/A

## Change Log

N/A

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [X] Enhancement
- [ ] Breaking Change


## Related Issue(s)

N/A

## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [X] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
