### PR TITLE
azurerm_mssql_database - treat null min_capacity/auto_pause as unset for non-serverless

### DIFF
--- a/internal/services/mssql/mssql_database_resource_test.go
+++ b/internal/services/mssql/mssql_database_resource_test.go
@@ -733,6 +733,43 @@ func TestAccMsSqlDatabase_minCapacity0(t *testing.T) {
 	})
 }
 
+func TestAccMsSqlDatabase_nonServerlessNullMinCapacity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mssql_database", "test")
+	r := MsSqlDatabaseResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.nonServerlessNullMinCapacity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccMsSqlDatabase_serverlessToProvisionedNullMinCapacity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mssql_database", "test")
+	r := MsSqlDatabaseResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.gpServerless(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.nonServerlessNullMinCapacity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccMsSqlDatabase_withLongTermRetentionPolicy(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_database", "test")
 	r := MsSqlDatabaseResource{}
@@ -2124,6 +2161,22 @@ resource "azurerm_mssql_database" "test" {
   server_id = azurerm_mssql_server.test.id
 
   min_capacity = 0
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r MsSqlDatabaseResource) nonServerlessNullMinCapacity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_mssql_database" "test" {
+  name      = "acctest-db-%[2]d"
+  server_id = azurerm_mssql_server.test.id
+  sku_name  = "S1"
+  max_size_gb = 250
+
+  min_capacity                = null
+  auto_pause_delay_in_minutes = null
 }
 `, r.template(data), data.RandomInteger)
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
This PR fixes azurerm_mssql_database handling of min_capacity / auto_pause_delay_in_minutes when configured as null on non‑serverless SKUs. Previously, null still triggered validation and API payloads, causing errors like “min_capacity should only be specified when using a serverless database.”  
The fix treats null as unset in diff validation and omits these fields from Create/Update payloads unless explicitly set on serverless SKUs.

## PR Checklist
- [x] I have followed the guidelines in our Contributing Documentation.
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate closing keywords below.
- [ ] I have updated/added Documentation as required.
- [x] I have used a meaningful PR title.

## Changes to existing Resource / Data Source
- [x] I have added an explanation of what my changes do and why I'd like you to include them.
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally.
- [ ] (For changes that include a state migration only). I have manually tested the migration path.

## Testing
- [x] My submission includes Test coverage as described in the Contribution Guide and the tests pass.

TestAccMsSqlDatabase_nonServerlessNullMinCapacity  
TestAccMsSqlDatabase_serverlessToProvisionedNullMinCapacity  
TestAccMsSqlDatabase_gpServerless

## Change Log
* azurerm_mssql_database - treat null min_capacity and auto_pause_delay_in_minutes as unset for non-serverless SKUs [GH-31684]

This is a:
- [x] Bug Fix
- [ ] New Feature
- [ ] Enhancement
- [ ] Breaking Change

## Related Issue(s)
Fixes #31684

## AI Assistance Disclosure
- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs  
Extent: code changes and tests with human review/execution.

## Changes to Security Controls
No.
