### PR TITLE
fixed TestAccApiManagementProduct_approvalRequiredError

### DIFF
--- a/internal/services/apimanagement/api_management_product_resource_test.go
+++ b/internal/services/apimanagement/api_management_product_resource_test.go
@@ -161,8 +161,12 @@ func TestAccApiManagementProduct_approvalRequiredError(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config:      r.approvalRequiredError(data),
-			ExpectError: regexp.MustCompile("`subscription_required` must be true and `subscriptions_limit` must be greater than 0 to use `approval_required`"),
+			Config:      r.approvalRequiredError(data, "false"),
+			ExpectError: regexp.MustCompile("`subscription_required` must be true to use `approval_required`"),
+		},
+		{
+			Config:      r.approvalRequiredError(data, "true"),
+			ExpectError: regexp.MustCompile("`subscriptions_limit` must be greater than 0 to use `approval_required`"),
 		},
 	})
 }
@@ -390,19 +394,19 @@ resource "azurerm_api_management_product" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
-func (ApiManagementProductResource) approvalRequiredError(data acceptance.TestData) string {
+func (ApiManagementProductResource) approvalRequiredError(data acceptance.TestData, subscriptionRequired string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_api_management" "test" {
-  name                = "acctestAM-%d"
+  name                = "acctestAM-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   publisher_name      = "pub1"
@@ -416,12 +420,12 @@ resource "azurerm_api_management_product" "test" {
   resource_group_name   = azurerm_resource_group.test.name
   display_name          = "Test Product"
   approval_required     = true
-  subscription_required = false
+  subscription_required = %[3]s
   published             = true
   description           = "This is an example description"
   terms                 = "These are some example terms and conditions"
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, subscriptionRequired)
 }
 
 func (ApiManagementProductResource) subscriptionRequiredDefault(data acceptance.TestData) string {


### PR DESCRIPTION
…ror and added one more step when subscriptions_limit not set

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->
- Corrected error message check in  TestAccApiManagementProduct_approvalRequiredError
- Added one more testStep into TestAccApiManagementProduct_approvalRequiredError to check error if subscriptions_limit is not set ( when subscription_required and approval_required both are true)

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->




## Testing 
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/apimanagement	370.521s

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)







<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
