### PR TITLE
`azurerm_postgresql_flexible_server` - add Confidential Compute SKU names to `sku_name` validation

### DIFF
--- a/internal/services/postgres/validate/flexible_server_sku_name.go
+++ b/internal/services/postgres/validate/flexible_server_sku_name.go
@@ -15,7 +15,7 @@ func FlexibleServerSkuName(i interface{}, k string) (warnings []string, errors [
 		return
 	}
 
-	if !regexp.MustCompile(`^((B_Standard_B((1|2|4|8|12|16|20)ms|2s))|(GP_Standard_D(((2|4|8|16|32|48|64)s_v3)|((2|4|8|16|32|48|64)ds_v4)|((2|4|8|16|32|48|64|96)ds_v5)|((2|4|8|16|32|48|64|96)ads_v5)))|(MO_Standard_E((((2|4|8|16|20|32|48|64)s)_v3)|((2|4|6|8|16|20|32|48|64)ds_v4)|((2|4|8|16|20|32|48|64|96)ds_v5)|((2|4|8|16|32|48|64|96)ads_v5))))$`).MatchString(v) {
+	if !regexp.MustCompile(`^((B_Standard_B((1|2|4|8|12|16|20)ms|2s))|(GP_Standard_D(((2|4|8|16|32|48|64)s_v3)|((2|4|8|16|32|48|64)ds_v4)|((2|4|8|16|32|48|64|96)ds_v5)|((2|4|8|16|32|48|64|96)ads_v5)))|(GP_Standard_DC((2|4|8|16|32|48|64|96)(eds|ads)_v5))|(MO_Standard_E((((2|4|8|16|20|32|48|64)s)_v3)|((2|4|6|8|16|20|32|48|64)ds_v4)|((2|4|8|16|20|32|48|64|96)ds_v5)|((2|4|8|16|32|48|64|96)ads_v5)))|(MO_Standard_EC(((2|4|8|16|32|48|64|128)eds_v5)|((2|4|8|16|20|32|48|64|96)ads_v5)|(96as_v5))))$`).MatchString(v) {
 		errors = append(errors, fmt.Errorf("%q is not a valid sku name, got %v", k, v))
 		return
 	}

--- a/internal/services/postgres/validate/flexible_server_sku_name_test.go
+++ b/internal/services/postgres/validate/flexible_server_sku_name_test.go
@@ -111,6 +111,51 @@ func TestFlexibleServerSkuName(t *testing.T) {
 			input: "MO_Standard_E96ds_v5",
 			valid: true,
 		},
+		{
+			name:  "GP_Standard_DC2eds_v5",
+			input: "GP_Standard_DC2eds_v5",
+			valid: true,
+		},
+		{
+			name:  "GP_Standard_DC96ads_v5",
+			input: "GP_Standard_DC96ads_v5",
+			valid: true,
+		},
+		{
+			name:  "MO_Standard_EC2eds_v5",
+			input: "MO_Standard_EC2eds_v5",
+			valid: true,
+		},
+		{
+			name:  "MO_Standard_EC128eds_v5",
+			input: "MO_Standard_EC128eds_v5",
+			valid: true,
+		},
+		{
+			name:  "MO_Standard_EC20ads_v5",
+			input: "MO_Standard_EC20ads_v5",
+			valid: true,
+		},
+		{
+			name:  "MO_Standard_EC96as_v5",
+			input: "MO_Standard_EC96as_v5",
+			valid: true,
+		},
+		{
+			name:  "B_Standard_DC2eds_v5",
+			input: "B_Standard_DC2eds_v5",
+			valid: false,
+		},
+		{
+			name:  "GP_Standard_EC2eds_v5",
+			input: "GP_Standard_EC2eds_v5",
+			valid: false,
+		},
+		{
+			name:  "MO_Standard_DC2eds_v5",
+			input: "MO_Standard_DC2eds_v5",
+			valid: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Adds Confidential Compute (DC-series and EC-series) SKU names to the `sku_name` validation regex for `azurerm_postgresql_flexible_server`
- GP tier: `GP_Standard_DC{2,4,8,16,32,48,64,96}{eds,ads}_v5`
- MO tier: `MO_Standard_EC{2,4,8,16,32,48,64,128}eds_v5`, `MO_Standard_EC{2,4,8,16,20,32,48,64,96}ads_v5`, `MO_Standard_EC96as_v5`
- Adds 9 unit test cases (6 valid + 3 invalid) for the new SKU patterns

## Test plan
- [x] Unit tests pass: `go test -v ./internal/services/postgres/validate/... -run=TestFlexibleServerSkuName`
- [x] Formatting checks pass: `gofmt -l` on modified files
- [ ] Acceptance tests with Confidential Compute SKU (requires Azure credentials and CC-enabled region)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [X] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [X] Enhancement
- [ ] Breaking Change