### PR TITLE
Contributing Guides: update `guide-list-resource.md`

### DIFF
--- a/internal/services/appservice/service_plan_resource.go
+++ b/internal/services/appservice/service_plan_resource.go
@@ -249,7 +249,7 @@ func (r ServicePlanResource) Read() sdk.ResourceFunc {
 				return fmt.Errorf("retrieving %s: %+v", id, err)
 			}
 
-			return resourceServicePlanFlatten(metadata, id, servicePlan.Model)
+			return r.flatten(metadata, id, servicePlan.Model)
 		},
 	}
 }
@@ -390,7 +390,7 @@ func (r ServicePlanResource) CustomizeDiff() sdk.ResourceFunc {
 	}
 }
 
-func resourceServicePlanFlatten(metadata sdk.ResourceMetaData, id *commonids.AppServicePlanId, model *appserviceplans.AppServicePlan) error {
+func (ServicePlanResource) flatten(metadata sdk.ResourceMetaData, id *commonids.AppServicePlanId, model *appserviceplans.AppServicePlan) error {
 	state := ServicePlanModel{
 		Name:          id.ServerFarmName,
 		ResourceGroup: id.ResourceGroupName,


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Updates the guide with additional guidance on the implementation of list for typed resources, given there are some different steps needed to leverage the `(ResourceMetaData).Encode` function

I've updated an existing list implementation for a typed resource to follow some new "standards" documented here

## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

```
--- PASS: TestAccServicePlan_list_basic (122.32s)
--- PASS: TestAccServicePlan_maxElasticWorkerCountForAllSupportedSku (0.00s)
    --- PASS: TestAccServicePlan_maxElasticWorkerCountForAllSupportedSku/WS1 (155.07s)
    --- PASS: TestAccServicePlan_maxElasticWorkerCountForAllSupportedSku/EP1 (157.26s)
--- PASS: TestAccServicePlan_requiresImport (94.00s)
--- PASS: TestAccServicePlan_memoryOptimized (110.91s)
--- PASS: TestAccServicePlan_linuxFlexConsumption (114.20s)
--- PASS: TestAccServicePlan_linuxConsumption (119.50s)
--- PASS: TestAccServicePlan_basic (121.92s)
--- PASS: TestAccServicePlan_resourceIdentity (122.60s)
--- PASS: TestAccServicePlan_complete (123.30s)
--- PASS: TestAccServicePlan_linuxPremiumAutoScaleFeature (124.29s)
--- PASS: TestAccServicePlan_maxElasticWorkerCount (167.56s)
--- PASS: TestAccServicePlan_completeUpdate (217.39s)
--- PASS: TestAccServicePlan_linuxPremiumAutoScaleFeatureUpdate (243.75s)
PASS
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change



## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
