### PR TITLE
chore: go generate separator issue on windows

### DIFF
--- a/internal/tools/generator-tests/generators/resource_identity.go
+++ b/internal/tools/generator-tests/generators/resource_identity.go
@@ -210,7 +210,7 @@ func (d *resourceIdentityData) exec() error {
 	tpl := template.Must(template.New("identity_test.gotpl").Funcs(templatehelpers.TplFuncMap).ParseFS(Templatedir, "templates/identity_test.gotpl"))
 
 	outputPath := cwd + fmt.Sprintf(riOutputFileFmt, d.ResourceName)
-	cwdParts := strings.Split(cwd, "internal/services/")
+	cwdParts := strings.Split(cwd, "internal"+string(os.PathSeparator)+"services"+string(os.PathSeparator))
 
 	// Allow service package name override if needed (unlikely)
 	if d.ServicePackageName == "" {


### PR DESCRIPTION

## Description

on windows I met some issue with the build I notive that go generator program use / to split instead os seprator path

## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [X] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [X] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 



Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
