### PR TITLE
azurerm_container_app_environment - support for Flex workload profile type

### DIFF
--- a/internal/services/containerapps/helpers/container_app_environment.go
+++ b/internal/services/containerapps/helpers/container_app_environment.go
@@ -28,6 +28,7 @@ const (
 	WorkloadProfileSkuNc24A100               WorkloadProfileSku = "NC24-A100"
 	WorkloadProfileSkuNc48A100               WorkloadProfileSku = "NC48-A100"
 	WorkloadProfileSkuNc96A100               WorkloadProfileSku = "NC96-A100"
+	WorkloadProfileSkuFlex                   WorkloadProfileSku = "Flex"
 )
 
 func PossibleValuesForWorkloadProfileSku() []string {
@@ -46,6 +47,7 @@ func PossibleValuesForWorkloadProfileSku() []string {
 		string(WorkloadProfileSkuNc24A100),
 		string(WorkloadProfileSkuNc48A100),
 		string(WorkloadProfileSkuNc96A100),
+		string(WorkloadProfileSkuFlex),
 	}
 }
 

--- a/website/docs/r/container_app_environment.html.markdown
+++ b/website/docs/r/container_app_environment.html.markdown
@@ -89,7 +89,9 @@ A `workload_profile` block supports the following:
 
 * `name` - (Required) The name of the workload profile.
 
-* `workload_profile_type` - (Required) Workload profile type for the workloads to run on. Possible values include `Consumption`, `Consumption-GPU-NC24-A100`, `Consumption-GPU-NC8as-T4`, `D4`, `D8`, `D16`, `D32`, `E4`, `E8`, `E16`, `E32`, `NC24-A100`, `NC48-A100` and `NC96-A100`.
+* `workload_profile_type` - (Required) Workload profile type for the workloads to run on. Possible values include `Consumption`, `Consumption-GPU-NC24-A100`, `Consumption-GPU-NC8as-T4`, `D4`, `D8`, `D16`, `D32`, `E4`, `E8`, `E16`, `E32`, `Flex`, `NC24-A100`, `NC48-A100` and `NC96-A100`.
+
+~> **Note:** The `Flex` profile type is currently in preview and requires a subnet of at least `/25`. It is only available in select regions.
 
 ~> **Note:** A `Consumption` type must have a name of `Consumption` and an environment may only have one `Consumption` Workload Profile.
 


### PR DESCRIPTION
Add the Flex workload profile type to the list of valid workload profile SKUs for Container App Environments. The Flex profile is currently in preview and provides a blend of Consumption billing simplicity with Dedicated profile performance characteristics.

Changes:
- Add WorkloadProfileSkuFlex constant ("Flex")
- Add "Flex" to PossibleValuesForWorkloadProfileSku()
- Update documentation with Flex profile type and availability note
- Add acceptance test for Flex workload profile

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This introduces the "Flex" (Flexible) workload profile to the Azure Container Apps part of azurerm. Full details can be found here: https://learn.microsoft.com/en-us/azure/container-apps/workload-profiles-overview


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

```
   1. Go build -- PASS

   $ go build ./internal/services/containerapps/...
   (exit code 0)

  2. Test binary compilation -- PASS

   $ go test -c ./internal/services/containerapps/ -o containerapps_test.exe
   (exit code 0)

  3. Test registration -- PASS

   $ containerapps_test.exe -test.list ".*[Ff]lex.*"
   TestAccContainerAppEnvironment_flexWorkloadProfile

  4. Live Azure deployment (Consumption only) -- PASS

   $ terraform apply -var="location=swedencentral" -var="resource_group_name=rg-flex-cac-test4"
   azurerm_resource_group.main: Creation complete after 24s
   azurerm_virtual_network.main: Creation complete after 7s
   azurerm_subnet.container_apps: Creation complete after 7s
   azurerm_log_analytics_workspace.main: Creation complete after 47s
   azapi_resource.container_app_environment: Creation complete after 3m14s
   Apply complete! Resources: 5 added, 0 changed, 0 destroyed.

  5. Live Azure Flex profile addition (in-place update) -- PASS

   $ terraform apply (add Flex workload profile)
   azapi_resource.container_app_environment: Modifications complete after 6m6s
   Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

   Outputs:
     default_domain = "proudmushroom-c278f263.swedencentral.azurecontainerapps.io"
     static_ip      = "9.223.224.245"
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the Azure Container Apps Flex Workload Profile


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ x] Enhancement
- [ ] Breaking Change


## AI Assistance Disclosure

- [X] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs: Github Copilot CLI + Opus 4.6