### PR TITLE
Fix typos

### DIFF
--- a/contributing/topics/guide-opening-a-pr.md
+++ b/contributing/topics/guide-opening-a-pr.md
@@ -8,7 +8,7 @@ If you are ever unsure please just reach out, we are more than happy to guide yo
 
 ## Considerations
 
-As a general rule, the smaller the PR the quicker it's merged - as such when upgrading an SDK and introducing new properties we'd ask that you split that into multiple smaller PR's, for example if you were planning on updating an SDK to add a new resource and update an existing one we would prefer `3` separate PRs:
+As a general rule, the smaller the PR the quicker it's merged - as such when upgrading an SDK and introducing new properties we'd ask that you split that into multiple smaller PRs, for example if you were planning on updating an SDK to add a new resource and update an existing one we would prefer `3` separate PRs:
 
 1. Update the Cosmos DB SDK to use API Version `2022-02-02` from `2020-01-01`.
 2. Add the new property `new_feature` to the `azurerm_cosmosdb_*` resources.

--- a/contributing/topics/reference-errors.md
+++ b/contributing/topics/reference-errors.md
@@ -83,7 +83,7 @@ instead of:
 
 This type of error wrapping should be applied to **all** error handling including any nested function that contains two or more error checks (e.g., a function that calls an update API and waits for the update to finish or builds an SDK struct) so practitioners and code maintainers have a clear idea which generated the error.
 
-> **Note:** Wrapped error messages should generally not start with `failed`, `error`, or an uppercase letter as there will a function higher up the stack that will prefix this.
+> **Note:** Wrapped error messages should generally not start with `failed`, `error`, or an uppercase letter as there will be a function higher up the stack that will prefix this.
 
 When returning errors in those situations, it is important to consider the calling context and to exclude any information the calling function is likely to include, while including any additional context then calling function may not have.
 


### PR DESCRIPTION
Fix minor documentation issues across several files:
  - DEVELOPER.md: fix spelling (scrips → scripts)                                                                                                                                  
  - contributing/topics/guide-opening-a-pr.md: fix incorrect apostrophe in plural