### PR TITLE
`azurerm_container_app` / `_app_job` - support `volume.secrets`

### DIFF
--- a/internal/services/containerapps/container_app_resource_test.go
+++ b/internal/services/containerapps/container_app_resource_test.go
@@ -305,6 +305,23 @@ func TestAccContainerAppResource_volumeSecretWithSecrets(t *testing.T) {
 	})
 }
 
+func TestAccContainerAppResource_volumeSecretAllSecrets(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app", "test")
+	r := ContainerAppResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.volumeSecretAllSecrets(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("template.0.volume.0.storage_type").HasValue("Secret"),
+				check.That(data.ResourceName).Key("template.0.volume.0.secrets.#").HasValue("0"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccContainerAppResource_completeWithNoDaprAppPort(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_container_app", "test")
 	r := ContainerAppResource{}
@@ -3163,6 +3180,43 @@ resource "azurerm_container_app" "test" {
         secret_name = "my-secret"
         path        = "my-secret.txt"
       }
+    }
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r ContainerAppResource) volumeSecretAllSecrets(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_container_app" "test" {
+  name                         = "acctest-capp-%[2]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  container_app_environment_id = azurerm_container_app_environment.test.id
+  revision_mode                = "Single"
+
+  secret {
+    name  = "my-secret"
+    value = "c2VjcmV0dmFsdWU="
+  }
+
+  template {
+    container {
+      name   = "acctest-cont-%[2]d"
+      image  = "jackofallops/azure-containerapps-python-acctest:v0.0.1"
+      cpu    = 0.25
+      memory = "0.5Gi"
+
+      volume_mounts {
+        name = "secret-vol"
+        path = "/mnt/secrets"
+      }
+    }
+
+    volume {
+      name         = "secret-vol"
+      storage_type = "Secret"
     }
   }
 }

--- a/internal/services/containerapps/container_app_resource_test.go
+++ b/internal/services/containerapps/container_app_resource_test.go
@@ -287,6 +287,24 @@ func TestAccContainerAppResource_completeVolumeEmptyDir(t *testing.T) {
 	})
 }
 
+func TestAccContainerAppResource_volumeSecretWithSecrets(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app", "test")
+	r := ContainerAppResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.volumeSecretWithSecrets(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("template.0.volume.0.storage_type").HasValue("Secret"),
+				check.That(data.ResourceName).Key("template.0.volume.0.secrets.0.secret_name").HasValue("my-secret"),
+				check.That(data.ResourceName).Key("template.0.volume.0.secrets.0.path").HasValue("my-secret.txt"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccContainerAppResource_completeWithNoDaprAppPort(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_container_app", "test")
 	r := ContainerAppResource{}
@@ -3103,6 +3121,48 @@ resource "azurerm_container_app" "test" {
       image  = "jackofallops/azure-containerapps-python-acctest:v0.0.1"
       cpu    = 0.25
       memory = "0.5Gi"
+    }
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r ContainerAppResource) volumeSecretWithSecrets(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_container_app" "test" {
+  name                         = "acctest-capp-%[2]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  container_app_environment_id = azurerm_container_app_environment.test.id
+  revision_mode                = "Single"
+
+  secret {
+    name  = "my-secret"
+    value = "c2VjcmV0dmFsdWU="
+  }
+
+  template {
+    container {
+      name   = "acctest-cont-%[2]d"
+      image  = "jackofallops/azure-containerapps-python-acctest:v0.0.1"
+      cpu    = 0.25
+      memory = "0.5Gi"
+
+      volume_mounts {
+        name = "secret-vol"
+        path = "/mnt/secrets"
+      }
+    }
+
+    volume {
+      name         = "secret-vol"
+      storage_type = "Secret"
+
+      secrets {
+        secret_name = "my-secret"
+        path        = "my-secret.txt"
+      }
     }
   }
 }

--- a/internal/services/containerapps/helpers/container_app_job.go
+++ b/internal/services/containerapps/helpers/container_app_job.go
@@ -507,6 +507,7 @@ func expandContainerAppJobVolumes(input []ContainerVolume) *[]jobs.Volume {
 		if v.MountOptions != "" {
 			volume.MountOptions = pointer.To(v.MountOptions)
 		}
+		volume.Secrets = expandContainerAppJobSecretVolumeItems(v.Secrets)
 		volumes = append(volumes, volume)
 	}
 
@@ -545,6 +546,38 @@ func expandContainerJobVolumeMounts(input []ContainerVolumeMount) *[]jobs.Volume
 	}
 
 	return &volumeMounts
+}
+
+func expandContainerAppJobSecretVolumeItems(input []SecretVolumeItem) *[]jobs.SecretVolumeItem {
+	if len(input) == 0 {
+		return nil
+	}
+
+	items := make([]jobs.SecretVolumeItem, 0)
+	for _, v := range input {
+		items = append(items, jobs.SecretVolumeItem{
+			SecretRef: pointer.To(v.SecretName),
+			Path:      pointer.To(v.Path),
+		})
+	}
+
+	return &items
+}
+
+func flattenContainerAppJobSecretVolumeItems(input *[]jobs.SecretVolumeItem) []SecretVolumeItem {
+	if input == nil || len(*input) == 0 {
+		return []SecretVolumeItem{}
+	}
+
+	items := make([]SecretVolumeItem, 0)
+	for _, v := range *input {
+		items = append(items, SecretVolumeItem{
+			SecretName: pointer.From(v.SecretRef),
+			Path:       pointer.From(v.Path),
+		})
+	}
+
+	return items
 }
 
 func expandContainerAppJobLivenessProbe(input ContainerAppLivenessProbe) jobs.ContainerAppProbe {
@@ -856,6 +889,7 @@ func flattenContainerAppJobVolumes(input *[]jobs.Volume) []ContainerVolume {
 		if v.MountOptions != nil {
 			containerVolume.MountOptions = pointer.From(v.MountOptions)
 		}
+		containerVolume.Secrets = flattenContainerAppJobSecretVolumeItems(v.Secrets)
 
 		result = append(result, containerVolume)
 	}

--- a/internal/services/containerapps/helpers/container_apps.go
+++ b/internal/services/containerapps/helpers/container_apps.go
@@ -1611,11 +1611,17 @@ func flattenContainerAppContainers(input *[]containerapps.Container) []Container
 	return result
 }
 
+type SecretVolumeItem struct {
+	SecretName string `tfschema:"secret_name"`
+	Path       string `tfschema:"path"`
+}
+
 type ContainerVolume struct {
-	Name         string `tfschema:"name"`
-	StorageName  string `tfschema:"storage_name"`
-	StorageType  string `tfschema:"storage_type"`
-	MountOptions string `tfschema:"mount_options"`
+	Name         string             `tfschema:"name"`
+	StorageName  string             `tfschema:"storage_name"`
+	StorageType  string             `tfschema:"storage_type"`
+	MountOptions string             `tfschema:"mount_options"`
+	Secrets      []SecretVolumeItem `tfschema:"secrets"`
 }
 
 func ContainerVolumeSchema() *pluginsdk.Schema {
@@ -1640,7 +1646,7 @@ func ContainerVolumeSchema() *pluginsdk.Schema {
 						containerapps.PossibleValuesForStorageType(),
 						false,
 					),
-					Description: "The type of storage volume. Possible values include `AzureFile` and `EmptyDir`. Defaults to `EmptyDir`.",
+					Description: "The type of storage volume. Possible values are `AzureFile`, `EmptyDir`, `NfsAzureFile` and `Secret`. Defaults to `EmptyDir`.",
 				},
 
 				"storage_name": {
@@ -1655,6 +1661,29 @@ func ContainerVolumeSchema() *pluginsdk.Schema {
 					Optional:     true,
 					ValidateFunc: validation.StringIsNotEmpty,
 					Description:  "Mount options used while mounting the AzureFile. Must be a comma-separated string.",
+				},
+
+				"secrets": {
+					Type:     pluginsdk.TypeList,
+					Optional: true,
+					Elem: &pluginsdk.Resource{
+						Schema: map[string]*pluginsdk.Schema{
+							"secret_name": {
+								Type:         pluginsdk.TypeString,
+								Required:     true,
+								ValidateFunc: validation.StringIsNotEmpty,
+								Description:  "The name of the secret to include in the volume. This must match the name of a secret defined at the app level.",
+							},
+
+							"path": {
+								Type:         pluginsdk.TypeString,
+								Required:     true,
+								ValidateFunc: validation.StringIsNotEmpty,
+								Description:  "The path at which to mount the secret within the volume.",
+							},
+						},
+					},
+					Description: "A list of secrets to expose in the volume. If not specified when `storage_type` is `Secret`, all secrets will be mounted. Each `secrets` block must contain `secret_name` and `path`.",
 				},
 			},
 		},
@@ -1686,6 +1715,24 @@ func ContainerVolumeSchemaComputed() *pluginsdk.Schema {
 					Type:     pluginsdk.TypeString,
 					Computed: true,
 				},
+
+				"secrets": {
+					Type:     pluginsdk.TypeList,
+					Computed: true,
+					Elem: &pluginsdk.Resource{
+						Schema: map[string]*pluginsdk.Schema{
+							"secret_name": {
+								Type:     pluginsdk.TypeString,
+								Computed: true,
+							},
+
+							"path": {
+								Type:     pluginsdk.TypeString,
+								Computed: true,
+							},
+						},
+					},
+				},
 			},
 		},
 	}
@@ -1712,6 +1759,7 @@ func expandContainerAppVolumes(input []ContainerVolume) *[]containerapps.Volume 
 		if v.MountOptions != "" {
 			volume.MountOptions = pointer.To(v.MountOptions)
 		}
+		volume.Secrets = expandContainerAppSecretVolumeItems(v.Secrets)
 		volumes = append(volumes, volume)
 	}
 
@@ -1735,11 +1783,44 @@ func flattenContainerAppVolumes(input *[]containerapps.Volume) []ContainerVolume
 		if v.MountOptions != nil {
 			containerVolume.MountOptions = pointer.From(v.MountOptions)
 		}
+		containerVolume.Secrets = flattenContainerAppSecretVolumeItems(v.Secrets)
 
 		result = append(result, containerVolume)
 	}
 
 	return result
+}
+
+func expandContainerAppSecretVolumeItems(input []SecretVolumeItem) *[]containerapps.SecretVolumeItem {
+	if len(input) == 0 {
+		return nil
+	}
+
+	items := make([]containerapps.SecretVolumeItem, 0)
+	for _, v := range input {
+		items = append(items, containerapps.SecretVolumeItem{
+			SecretRef: pointer.To(v.SecretName),
+			Path:      pointer.To(v.Path),
+		})
+	}
+
+	return &items
+}
+
+func flattenContainerAppSecretVolumeItems(input *[]containerapps.SecretVolumeItem) []SecretVolumeItem {
+	if input == nil || len(*input) == 0 {
+		return []SecretVolumeItem{}
+	}
+
+	items := make([]SecretVolumeItem, 0)
+	for _, v := range *input {
+		items = append(items, SecretVolumeItem{
+			SecretName: pointer.From(v.SecretRef),
+			Path:       pointer.From(v.Path),
+		})
+	}
+
+	return items
 }
 
 type ContainerVolumeMount struct {

--- a/website/docs/r/container_app.html.markdown
+++ b/website/docs/r/container_app.html.markdown
@@ -198,6 +198,16 @@ A `volume` block supports the following:
 
 * `mount_options` - (Optional) Mount options used while mounting the AzureFile. Must be a comma-separated string e.g. `dir_mode=0751,file_mode=0751`.
 
+* `secrets` - (Optional) A `secrets` block as detailed below. Used to selectively mount specific secrets in a `Secret` volume. If not specified when `storage_type` is `Secret`, all secrets will be mounted.
+
+---
+
+A `secrets` block supports the following:
+
+* `secret_name` - (Required) The name of the secret to include in the volume. This must match the name of a secret defined at the app level.
+
+* `path` - (Required) The path at which to mount the secret within the volume.
+
 ---
 
 An `init_container` block supports:

--- a/website/docs/r/container_app_job.html.markdown
+++ b/website/docs/r/container_app_job.html.markdown
@@ -314,6 +314,16 @@ A `volume` block supports the following:
 
 * `mount_options` - (Optional) Mount options used while mounting the AzureFile. Must be a comma-separated string e.g. `dir_mode=0751,file_mode=0751`.
 
+* `secrets` - (Optional) A `secrets` block as detailed below. Used to selectively mount specific secrets in a `Secret` volume. If not specified when `storage_type` is `Secret`, all secrets will be mounted.
+
+---
+
+A `secrets` block (within `volume`) supports the following:
+
+* `secret_name` - (Required) The name of the secret to include in the volume. This must match the name of a secret defined at the job level.
+
+* `path` - (Required) The path at which to mount the secret within the volume.
+
 ---
 
 A `secret` block supports the following:


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description



<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

For `azurerm_container_app` and `azurerm_container_app_job`, this PR adds support for setting `secrets` blocks in a container app's volumes, which allows selecting which secrets should be mounted as volumes. Currently, the provider sends API requests omitting the `secrets` field from the [Volume](https://learn.microsoft.com/en-us/rest/api/resource-manager/containerapps/container-apps/create-or-update?view=rest-resource-manager-containerapps-2025-07-01&tabs=HTTP#volume) object, which means that all secrets are mounted.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.

## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

```
  === RUN   TestAccContainerAppResource_volumeSecretWithSecrets
  === PAUSE TestAccContainerAppResource_volumeSecretWithSecrets
  === RUN   TestAccContainerAppResource_volumeSecretAllSecrets
  === PAUSE TestAccContainerAppResource_volumeSecretAllSecrets
  === CONT  TestAccContainerAppResource_volumeSecretWithSecrets
  === CONT  TestAccContainerAppResource_volumeSecretAllSecrets
  --- PASS: TestAccContainerAppResource_volumeSecretAllSecrets (1003.50s)
  --- PASS: TestAccContainerAppResource_volumeSecretWithSecrets (1028.52s)
  PASS
  ok
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_container_app` / `azurerm_container_app_job` - support `template.volume.secrets` [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/25431

## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

AI was used to generate the code and documentation.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.
