### PR TITLE
test triggering action and teamcity build configuration to post results

### DIFF
--- a/.github/workflows/run-team-city-tests-on-comment.yaml
+++ b/.github/workflows/run-team-city-tests-on-comment.yaml
@@ -1,0 +1,173 @@
+---
+name: Run TeamCity Tests on Comment
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  check-team-membership:
+    runs-on: ubuntu-latest
+    # Only run on pull request comments that starts with /test
+    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/test')
+    outputs:
+      is-team-member: ${{ steps.check-membership.outputs.is-member }}
+    env:
+      AUTHORIZED_TEAM: terraform-azure
+    steps:
+      - name: Check team membership
+        id: check-membership
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const teamSlug = "${{ env.AUTHORIZED_TEAM }}";
+            const org = context.repo.owner;
+            const username = context.actor;
+
+            try {
+              const response = await github.rest.teams.getMembershipForUserInOrg({
+                org: org,
+                team_slug: teamSlug,
+                username: username,
+              });
+
+              const isMember = response.data.state === 'active';
+              core.setOutput('is-member', isMember);
+
+              if (isMember) {
+                core.info(`User ${username} is a member of team ${teamSlug}`);
+              } else {
+                core.warning(`User ${username} is not an active member of team ${teamSlug}`);
+              }
+
+              return isMember;
+            } catch (error) {
+              if (error.status === 404) {
+                core.warning(`User ${username} is not a member of team ${teamSlug}`);
+                core.setOutput('is-member', false);
+                return false;
+              }
+              throw error;
+            }
+
+  run-tests:
+    runs-on: ubuntu-latest
+    needs: check-team-membership
+    if: needs.check-team-membership.outputs.is-team-member == 'true'
+    env:
+      TCTEST_SERVER: ${{ secrets.TCTEST_SERVER }}
+      TCTEST_FILEREGEX: 'internal/services/[a-z]*/[_a-zA-Z]*(resource|data_source)'
+      TCTEST_SKIP_QUEUE: 'true'
+      TCTEST_TOKEN_TC: ${{ secrets.TCTEST_TOKEN_TC }}
+      TCTEST_BUILDTYPEID: TF_AzureRM_AZURERM_SERVICE_PUBLIC
+      TCTEST_REPO: terraform-providers/terraform-provider-azurerm
+    steps:
+      - name: Setup Go
+        uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.2.0
+        with:
+          go-version: '1.25'
+
+      - name: Get tctest version
+        id: tctest-version
+        run: |
+          LATEST_RELEASE=$(curl -s https://api.github.com/repos/katbyte/tctest/releases/latest | grep "tag_name" | cut -d '"' -f 4)
+          echo "version=${LATEST_RELEASE}" >> $GITHUB_OUTPUT
+          echo "Latest tctest release: $LATEST_RELEASE"
+
+      - name: Cache tctest binary
+        id: cache-tctest
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/bin/tctest
+          key: tctest-${{ runner.os }}-${{ steps.tctest-version.outputs.version }}
+
+      - name: Download and build tctest
+        if: steps.cache-tctest.outputs.cache-hit != 'true'
+        run: |
+          LATEST_RELEASE="${{ steps.tctest-version.outputs.version }}"
+
+          # Download source code
+          DOWNLOAD_URL="https://github.com/katbyte/tctest/archive/refs/tags/${LATEST_RELEASE}.tar.gz"
+          echo "Downloading source from: $DOWNLOAD_URL"
+
+          curl -L -o tctest-source.tar.gz "$DOWNLOAD_URL"
+          tar -xzf tctest-source.tar.gz
+
+          # Navigate to extracted directory (strip version prefix 'v')
+          cd tctest-${LATEST_RELEASE#v}
+
+          # Build tctest
+          echo "Building tctest..."
+          go build -o tctest .
+
+          # Move to cache directory
+          mkdir -p ~/bin
+          mv tctest ~/bin/
+
+      - name: Install tctest
+        run: |
+          sudo cp ~/bin/tctest /usr/local/bin/
+          sudo chmod +x /usr/local/bin/tctest
+
+      - name: Run tctest
+        run: |
+          PR_NUMBER=${{ github.event.issue.number }}
+          COMMENT_BODY="${{ github.event.comment.body }}"
+
+          # Check if the comment contains /test -d for detailed output
+          if [[ "$COMMENT_BODY" == "/test -d"* ]]; then
+            echo "Running tctest for PR #${PR_NUMBER} with detailed output"
+            tctest pr ${PR_NUMBER} --properties "POST_GITHUB_COMMENT_DETAILED=true"
+          else
+            echo "Running tctest for PR #${PR_NUMBER}"
+            tctest pr ${PR_NUMBER} --properties "POST_GITHUB_COMMENT=true"
+          fi
+
+      - name: Comment on success
+        if: success()
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: '✅ TeamCity tests triggered successfully!'
+            });
+
+      - name: Comment on failure
+        if: failure()
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: '❌ Failed to trigger TeamCity tests. Please check the workflow logs for details.'
+            });
+
+  unauthorized-comment:
+    runs-on: ubuntu-latest
+    needs: check-team-membership
+    if: needs.check-team-membership.outputs.is-team-member == 'false'
+    steps:
+      - name: Comment unauthorized
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: '⚠️ You are not authorized to run tests. Only members of the designated team can trigger test runs.'
+            });

--- a/.github/workflows/run-team-city-tests-on-comment.yaml
+++ b/.github/workflows/run-team-city-tests-on-comment.yaml
@@ -135,11 +135,11 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            await github.rest.issues.createComment({
+            await github.rest.reactions.createForIssueComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: '✅ TeamCity tests triggered successfully!'
+              comment_id: context.payload.comment.id,
+              content: 'rocket'
             });
 
       - name: Comment on failure

--- a/.github/workflows/run-team-city-tests-on-comment.yaml
+++ b/.github/workflows/run-team-city-tests-on-comment.yaml
@@ -84,36 +84,13 @@ jobs:
         id: cache-tctest
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
-          path: ~/bin/tctest
+          path: ~/go/bin/tctest
           key: tctest-${{ runner.os }}-${{ steps.tctest-version.outputs.version }}
 
-      - name: Download and build tctest
+      - name: Install tctest
         if: steps.cache-tctest.outputs.cache-hit != 'true'
         run: |
-          LATEST_RELEASE="${{ steps.tctest-version.outputs.version }}"
-
-          # Download source code
-          DOWNLOAD_URL="https://github.com/katbyte/tctest/archive/refs/tags/${LATEST_RELEASE}.tar.gz"
-          echo "Downloading source from: $DOWNLOAD_URL"
-
-          curl -L -o tctest-source.tar.gz "$DOWNLOAD_URL"
-          tar -xzf tctest-source.tar.gz
-
-          # Navigate to extracted directory (strip version prefix 'v')
-          cd tctest-${LATEST_RELEASE#v}
-
-          # Build tctest
-          echo "Building tctest..."
-          go build -o tctest .
-
-          # Move to cache directory
-          mkdir -p ~/bin
-          mv tctest ~/bin/
-
-      - name: Install tctest
-        run: |
-          sudo cp ~/bin/tctest /usr/local/bin/
-          sudo chmod +x /usr/local/bin/tctest
+          go install github.com/katbyte/tctest@latest
 
       - name: Run tctest
         run: |

--- a/.github/workflows/run-team-city-tests-on-comment.yaml
+++ b/.github/workflows/run-team-city-tests-on-comment.yaml
@@ -119,15 +119,8 @@ jobs:
         run: |
           PR_NUMBER=${{ github.event.issue.number }}
           COMMENT_BODY="${{ github.event.comment.body }}"
-
-          # Check if the comment contains /test -d for detailed output
-          if [[ "$COMMENT_BODY" == "/test -d"* ]]; then
-            echo "Running tctest for PR #${PR_NUMBER} with detailed output"
-            tctest pr ${PR_NUMBER} --properties "POST_GITHUB_COMMENT_DETAILED=true"
-          else
-            echo "Running tctest for PR #${PR_NUMBER}"
-            tctest pr ${PR_NUMBER} --properties "POST_GITHUB_COMMENT=true"
-          fi
+          echo "Running tctest for PR #${PR_NUMBER}"
+          tctest pr ${PR_NUMBER} --properties "POST_GITHUB_COMMENT=true"
 
       - name: Comment on success
         if: success()

--- a/.teamcity/components/build_azure.kt
+++ b/.teamcity/components/build_azure.kt
@@ -16,8 +16,6 @@ class ClientConfiguration(var clientId: String,
                           val emailAddressAccTests : String,
                           val gitHubRepo : String,
                           val gitPat : String,
-                          val goModCache : String,
-                          val goCache : String,
                           )
 
 class LocationConfiguration(var primary : String, var secondary : String, var tertiary : String, var rotate : Boolean)
@@ -52,6 +50,5 @@ fun ParametrizedWithType.ConfigureAzureSpecificTestParameters(environment: Strin
     hiddenVariable("env.GITHUB_REPO", config.gitHubRepo, "GitHub Repository")
     hiddenVariable("env.POST_GITHUB_COMMENT",  "false", "Whether to post a comment on the PR with the results of the tests")
     hiddenVariable("env.POST_GITHUB_COMMENT_DETAILED",  "false", "Whether to post a detailed comment on the PR with the results of the tests")
-    hiddenVariable("env.GOMODCACHE", config.goModCache, "The location of the Go Module Cache")
-    hiddenVariable("env.GOCACHE", config.goCache, "The location of the Go Cache")
+
 }

--- a/.teamcity/components/build_azure.kt
+++ b/.teamcity/components/build_azure.kt
@@ -13,7 +13,12 @@ class ClientConfiguration(var clientId: String,
                           val principalIdAltTenant : String,
                           val vcsRootId : String,
                           val enableTestTriggersGlobally : Boolean,
-                          val emailAddressAccTests : String,)
+                          val emailAddressAccTests : String,
+                          val gitHubRepo : String,
+                          val gitPat : String,
+                          val goModCache : String,
+                          val goCache : String,
+                          )
 
 class LocationConfiguration(var primary : String, var secondary : String, var tertiary : String, var rotate : Boolean)
 
@@ -43,4 +48,10 @@ fun ParametrizedWithType.ConfigureAzureSpecificTestParameters(environment: Strin
     hiddenVariable("env.ARM_TEST_LOCATION_ALT2", locationsForEnv.tertiary, "The Tertiary region which should be used for testing")
     hiddenVariable("env.ARM_FIVEPOINTZERO_BETA", "false", "Opt into the 5.0 beta")
     hiddenVariable("env.ARM_TEST_ACC_EMAIL_ADDRESS", config.emailAddressAccTests, "email address for the Acceptance Tests User")
+    hiddenPasswordVariable("env.GIT_PAT", config.gitPat, "Personal Access Token for GitHub")
+    hiddenVariable("env.GITHUB_REPO", config.gitHubRepo, "GitHub Repository")
+    hiddenVariable("env.POST_GITHUB_COMMENT",  "false", "Whether to post a comment on the PR with the results of the tests")
+    hiddenVariable("env.POST_GITHUB_COMMENT_DETAILED",  "false", "Whether to post a detailed comment on the PR with the results of the tests")
+    hiddenVariable("env.GOMODCACHE", config.goModCache, "The location of the Go Module Cache")
+    hiddenVariable("env.GOCACHE", config.goCache, "The location of the Go Cache")
 }

--- a/.teamcity/components/build_azure.kt
+++ b/.teamcity/components/build_azure.kt
@@ -50,5 +50,4 @@ fun ParametrizedWithType.ConfigureAzureSpecificTestParameters(environment: Strin
     hiddenVariable("env.GITHUB_REPO", config.gitHubRepo, "GitHub Repository")
     hiddenVariable("env.POST_GITHUB_COMMENT",  "false", "Whether to post a comment on the PR with the results of the tests")
     hiddenVariable("env.POST_GITHUB_COMMENT_DETAILED",  "false", "Whether to post a detailed comment on the PR with the results of the tests")
-
 }

--- a/.teamcity/components/build_components.kt
+++ b/.teamcity/components/build_components.kt
@@ -22,16 +22,7 @@ fun BuildFeatures.Golang() {
     }
 }
 
-// Requires a manual step of setting up a publishing build configuration for the main branch of the repo:
-// features {
-//     buildCache {
-//         name = "terraform-provider-azurerm-build-cache"
-//         rules = """
-//             %teamcity.agent.work.dir%/go-cache/build
-//             %teamcity.agent.work.dir%/go-cache/mod
-//         """.trimIndent()
-//     }
-// }
+// Requires the creation of build_config_cache for the project:
 fun BuildFeatures.BuildCacheFeature() {
         feature(BuildCacheFeature {
             name = "terraform-provider-azurerm-build-cache"
@@ -116,7 +107,7 @@ fun BuildSteps.RunAcceptanceTestsForPullRequest(packageName: String) {
 }
 
 
-fun BuildSteps.PostTestResultsToGitHubPullRequest(packageName: String) {
+fun BuildSteps.PostTestResultsToGitHubPullRequest() {
     step(ScriptBuildStep {
         name = "Post Test Results to GitHub Pull Request"
         scriptContent = File("scripts/post_github_comment.sh").readText()
@@ -149,6 +140,11 @@ fun ParametrizedWithType.TerraformShouldPanicForSchemaErrors() {
 
 fun ParametrizedWithType.WorkingDirectory(packageName: String) {
     text("SERVICE_PATH", servicePath(packageName), "", "The path at which to run - automatically updated", ParameterDisplay.HIDDEN)
+}
+
+fun ParametrizedWithType.GoCache() {
+    text("env.GOMODCACHE", "%teamcity.agent.work.dir%/go-cache/mod", "The location of the Go Module Cache")
+    text("env.GOCACHE", "%teamcity.agent.work.dir%/go-cache/build", "The location of the Go Cache")
 }
 
 fun ParametrizedWithType.hiddenVariable(name: String, value: String, description: String) {

--- a/.teamcity/components/build_components.kt
+++ b/.teamcity/components/build_components.kt
@@ -23,10 +23,10 @@ fun BuildFeatures.Golang() {
 }
 
 // Requires the creation of build_config_cache for the project:
-fun BuildFeatures.BuildCacheFeature(publish: Boolean = false) {
+fun BuildFeatures.BuildCacheFeature() {
         feature(BuildCacheFeature {
             name = "terraform-provider-azurerm-build-cache"
-            this.publish = publish
+            publish = false
         })
 }
 

--- a/.teamcity/components/build_components.kt
+++ b/.teamcity/components/build_components.kt
@@ -23,10 +23,10 @@ fun BuildFeatures.Golang() {
 }
 
 // Requires the creation of build_config_cache for the project:
-fun BuildFeatures.BuildCacheFeature() {
+fun BuildFeatures.BuildCacheFeature(publish: Boolean = false) {
         feature(BuildCacheFeature {
             name = "terraform-provider-azurerm-build-cache"
-            publish = false
+            this.publish = publish
         })
 }
 

--- a/.teamcity/components/build_components.kt
+++ b/.teamcity/components/build_components.kt
@@ -106,7 +106,6 @@ fun BuildSteps.RunAcceptanceTestsForPullRequest(packageName: String) {
     }
 }
 
-
 fun BuildSteps.PostTestResultsToGitHubPullRequest() {
     step(ScriptBuildStep {
         name = "Post Test Results to GitHub Pull Request"

--- a/.teamcity/components/build_config_cache.kt
+++ b/.teamcity/components/build_config_cache.kt
@@ -1,0 +1,75 @@
+import jetbrains.buildServer.configs.kotlin.AbsoluteId
+import jetbrains.buildServer.configs.kotlin.BuildType
+import jetbrains.buildServer.configs.kotlin.buildFeatures.BuildCacheFeature
+import jetbrains.buildServer.configs.kotlin.buildSteps.ScriptBuildStep
+
+class buildCacheConfiguration(environment: String, vcsRootId: String) {
+    val environment = environment
+    val vcsRootId = vcsRootId
+
+    fun buildConfiguration(providerName: String): BuildType {
+        return BuildType {
+            id(uniqueID(providerName))
+
+            name = "Cache Build Dependencies"
+
+            vcs {
+                root(rootId = AbsoluteId(vcsRootId))
+                cleanCheckout = true
+            }
+
+            steps {
+                ConfigureGoEnv()
+                step(ScriptBuildStep {
+                    name = "Compile Test Binary"
+                    scriptContent = """
+                        mkdir -p %env.GOCACHE%
+                        mkdir -p %env.GOMODCACHE%
+                        go test -c -o test-binary
+                    """.trimIndent()
+                })
+            }
+
+            triggers {
+                RunNightly(
+                    nightlyTestsEnabled = true,
+                    startHour = 23,
+                    daysOfWeek = "*",
+                    daysOfMonth = "*"
+                )
+            }
+
+            failureConditions {
+                errorMessage = true
+                executionTimeoutMin = 60
+            }
+
+            features {
+                feature(BuildCacheFeature {
+                    name = "terraform-provider-azurerm-build-cache"
+                    publish = true
+                    use = true
+                    rules = """
+                        %env.GOCACHE%
+                        %env.GOMODCACHE%
+                    """.trimIndent()
+                })
+            }
+
+            cleanup {
+                baseRule {
+                    artifacts(days = 7, artifactPatterns = "+:**/*")
+                }
+            }
+
+            params {
+                GoCache()
+                ReadOnlySettings()
+            }
+        }
+    }
+
+    fun uniqueID(provider: String): String {
+        return "%s_CACHE_%s".format(provider.uppercase(), environment.uppercase())
+    }
+}

--- a/.teamcity/components/build_config_pull_request.kt
+++ b/.teamcity/components/build_config_pull_request.kt
@@ -42,6 +42,7 @@ class pullRequest(displayName: String, environment: String, vcsRootId : String) 
                 TerraformShouldPanicForSchemaErrors()
                 TerraformCoreBinaryTesting()
                 ReadOnlySettings()
+                GoCache()
 
                 text("SERVICES", "portal")
             }

--- a/.teamcity/components/build_config_pull_request.kt
+++ b/.teamcity/components/build_config_pull_request.kt
@@ -24,6 +24,7 @@ class pullRequest(displayName: String, environment: String, vcsRootId : String) 
                 ConfigureGoEnv()
                 DownloadTerraformBinary()
                 RunAcceptanceTestsForPullRequest(packageName)
+                PostTestResultsToGitHubPullRequest()
             }
 
             failureConditions {
@@ -32,6 +33,7 @@ class pullRequest(displayName: String, environment: String, vcsRootId : String) 
 
             features {
                 Golang()
+                BuildCacheFeature()
             }
 
             params {

--- a/.teamcity/components/build_config_pull_request.kt
+++ b/.teamcity/components/build_config_pull_request.kt
@@ -14,7 +14,7 @@ class pullRequest(displayName: String, environment: String, vcsRootId : String) 
             name = displayName
 
             vcs {
-                root(AbsoluteId(vcsRootId), "+:refs/pull/*/head")
+                root(rootId = AbsoluteId(vcsRootId))
                 cleanCheckout = true
             }
 
@@ -33,7 +33,7 @@ class pullRequest(displayName: String, environment: String, vcsRootId : String) 
 
             features {
                 Golang()
-                BuildCacheFeature(publish = true)
+                BuildCacheFeature()
             }
 
             params {

--- a/.teamcity/components/build_config_pull_request.kt
+++ b/.teamcity/components/build_config_pull_request.kt
@@ -14,7 +14,7 @@ class pullRequest(displayName: String, environment: String, vcsRootId : String) 
             name = displayName
 
             vcs {
-                root(rootId = AbsoluteId(vcsRootId))
+                root(AbsoluteId(vcsRootId), "+:refs/pull/*/head")
                 cleanCheckout = true
             }
 
@@ -33,7 +33,7 @@ class pullRequest(displayName: String, environment: String, vcsRootId : String) 
 
             features {
                 Golang()
-                BuildCacheFeature()
+                BuildCacheFeature(publish = true)
             }
 
             params {

--- a/.teamcity/components/build_config_service.kt
+++ b/.teamcity/components/build_config_service.kt
@@ -22,6 +22,7 @@ class serviceDetails(name: String, displayName: String, environment: String, vcs
                 ConfigureGoEnv()
                 DownloadTerraformBinary()
                 RunAcceptanceTests(packageName)
+                PostTestResultsToGitHubPullRequest()
             }
 
             failureConditions {
@@ -31,6 +32,7 @@ class serviceDetails(name: String, displayName: String, environment: String, vcs
 
             features {
                 Golang()
+                BuildCacheFeature()
             }
 
             params {

--- a/.teamcity/components/build_config_service.kt
+++ b/.teamcity/components/build_config_service.kt
@@ -42,6 +42,7 @@ class serviceDetails(name: String, displayName: String, environment: String, vcs
                 TerraformShouldPanicForSchemaErrors()
                 ReadOnlySettings()
                 WorkingDirectory(packageName)
+                GoCache()
             }
 
             triggers {

--- a/.teamcity/components/build_config_service.kt
+++ b/.teamcity/components/build_config_service.kt
@@ -14,7 +14,7 @@ class serviceDetails(name: String, displayName: String, environment: String, vcs
             name = "%s - Acceptance Tests".format(displayName)
 
             vcs {
-                root(rootId = AbsoluteId(vcsRootId))
+                root(AbsoluteId(vcsRootId), "+:refs/pull/*/merge")
                 cleanCheckout = true
             }
 
@@ -32,7 +32,7 @@ class serviceDetails(name: String, displayName: String, environment: String, vcs
 
             features {
                 Golang()
-                BuildCacheFeature()
+                BuildCacheFeature(publish = true)
             }
 
             params {

--- a/.teamcity/components/build_config_service.kt
+++ b/.teamcity/components/build_config_service.kt
@@ -14,7 +14,7 @@ class serviceDetails(name: String, displayName: String, environment: String, vcs
             name = "%s - Acceptance Tests".format(displayName)
 
             vcs {
-                root(AbsoluteId(vcsRootId), "+:refs/pull/*/merge")
+                root(rootId = AbsoluteId(vcsRootId))
                 cleanCheckout = true
             }
 
@@ -32,7 +32,7 @@ class serviceDetails(name: String, displayName: String, environment: String, vcs
 
             features {
                 Golang()
-                BuildCacheFeature(publish = true)
+                BuildCacheFeature()
             }
 
             params {

--- a/.teamcity/components/project.kt
+++ b/.teamcity/components/project.kt
@@ -12,6 +12,9 @@ fun AzureRM(environment: String, configuration : ClientConfiguration) : Project 
         var pullRequestBuildConfig = pullRequestBuildConfiguration(environment, configuration)
         buildType(pullRequestBuildConfig)
 
+        var cacheBuildConfig = buildConfigurationForCache(environment, configuration)
+        buildType(cacheBuildConfig)
+
         var buildConfigs = buildConfigurationsForServices(services, providerName, environment, configuration)
         buildConfigs.forEach { buildConfiguration ->
             buildType(buildConfiguration)
@@ -46,6 +49,10 @@ fun pullRequestBuildConfiguration(environment: String, config: ClientConfigurati
     var buildConfiguration = pullRequest.buildConfiguration(providerName)
     buildConfiguration.params.ConfigureAzureSpecificTestParameters(environment, config, locationsForEnv)
     return buildConfiguration
+}
+
+fun buildConfigurationForCache(environment: String, config: ClientConfiguration) : BuildType {
+    return buildCacheConfiguration(environment, config.vcsRootId).buildConfiguration(providerName)
 }
 
 class testConfiguration(parallelism: Int = defaultParallelism, startHour: Int = defaultStartHour, daysOfWeek: String = defaultDaysOfWeek, daysOfMonth: String = defaultDaysOfMonth, timeout: Int = defaultTimeout, useAltSubscription: Boolean = false, useDevTestSubscription: Boolean = false, locationOverride: LocationConfiguration = LocationConfiguration("","","", false), terraformCoreOverride: String = defaultTerraformCoreVersion, disableTriggers: Boolean = false) {

--- a/.teamcity/pom.xml
+++ b/.teamcity/pom.xml
@@ -9,10 +9,11 @@
   <name>Terraform-Provider-Azurerm Config DSL Script</name>
   <groupId>TerraformProviderAzureRM</groupId>
   <artifactId>TerraformProviderAzureRM</artifactId>
-  <version>1.0-SNAPSHOT</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <kotlin.version>2.0.21</kotlin.version>
+    <teamcity.dsl.version>2025.11.3-1</teamcity.dsl.version>
   </properties>
 
   <parent>
@@ -52,7 +53,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.2</version>
+        <version>3.5.2</version>
         <configuration>
           <includes>
             <include>tests/*.class</include>
@@ -130,6 +131,7 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13.2</version>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>

--- a/.teamcity/scripts/post_github_comment.sh
+++ b/.teamcity/scripts/post_github_comment.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+
+if [ "%POST_GITHUB_COMMENT%" != "true" ] && [ "%POST_GITHUB_COMMENT_DETAILED%" != "true" ]; then
+  echo "GitHub commenting disabled — skipping."
+  exit 0
+fi
+
+if [[ "%teamcity.build.branch%" =~ refs/pull/([0-9]+)/merge ]]; then
+  PR_NUMBER="${BASH_REMATCH[1]}"
+else
+  echo "Not a PR merge branch: %teamcity.build.branch%"
+  exit 0
+fi
+
+detailed=false
+if [ "%POST_GITHUB_COMMENT_DETAILED%" = "true" ]; then
+  echo "Detailed GitHub commenting enabled."
+  detailed=true
+fi
+
+BUILD_ID="%teamcity.build.id%"
+
+TEST_RESULTS=$(file="results.txt"
+
+awk '
+# Parse TeamCity testStdOut messages
+/##teamcity\[testStdOut/ {
+    line = $0
+
+    # Extract test name between name= and the next single quote
+    if (match(line, /name=.([^'"'"']+)./)) {
+        test_name = substr(line, RSTART+6, RLENGTH-7)
+    }
+
+    # Extract output content between out= and the closing bracket
+    if (match(line, /out=.([^'"'"']+)./)) {
+        output = substr(line, RSTART+5, RLENGTH-6)
+
+        # Replace |n with newlines
+        gsub(/\|n/, "\n", output)
+
+        # Extract status (PASS or FAIL)
+        status = ""
+        if (match(output, /--- PASS:/)) {
+            status = "PASS"
+        } else if (match(output, /--- FAIL:/)) {
+            status = "FAIL"
+        }
+
+        # Extract duration
+        duration = ""
+        if (match(output, /\(([0-9.]+)s\)/)) {
+            duration_str = substr(output, RSTART, RLENGTH)
+            gsub(/[()s]/, "", duration_str)
+            duration = duration_str
+        }
+
+        # Print result
+        if (test_name != "" && status != "" && duration != "") {
+            print test_name "|" status "|" duration "|" output
+        }
+    }
+}
+' "$file"
+)
+
+
+
+# Parse results to get counts
+PASS_COUNT=$(echo "$TEST_RESULTS" | awk -F'|' '{if($2=="PASS") print}' | wc -l | tr -d ' ')
+FAIL_COUNT=$(echo "$TEST_RESULTS" | awk -F'|' '{if($2=="FAIL") print}' | wc -l | tr -d ' ')
+TOTAL=$((PASS_COUNT + FAIL_COUNT))
+
+
+# Build GitHub comment
+COMMENT="Build: [$BUILD_ID](%teamcity.serverUrl%/viewLog.html?buildId=$BUILD_ID)
+PR: #$PR_NUMBER
+
+**Total:** $TOTAL
+**Passed:** $PASS_COUNT
+**Failed:** $FAIL_COUNT
+
+<details>
+<summary>Test Details</summary>
+
+<table>
+<tr><td><b>Status</b></td><td><b>Test Name</b></td><td><b>Duration</b></td></tr>
+"
+
+TABLE_ROWS=$(echo "$TEST_RESULTS" | awk -v RS='\nTestAcc' -v detailed="$detailed" '
+NR==1 && /^TestAcc/ {
+    record = $0
+}
+NR>1 {
+    record = "TestAcc" $0
+}
+record != "" {
+    # Find positions of first 3 pipes
+    pipe1 = index(record, "|")
+    pipe2 = index(substr(record, pipe1+1), "|") + pipe1
+    pipe3 = index(substr(record, pipe2+1), "|") + pipe2
+
+    test_name = substr(record, 1, pipe1-1)
+    status = substr(record, pipe1+1, pipe2-pipe1-1)
+    duration = substr(record, pipe2+1, pipe3-pipe2-1)
+    output = substr(record, pipe3+1)
+
+    if (status == "PASS") {
+        print "<tr><td>✅ PASS</td><td>" test_name "</td><td>" duration "s</td></tr>"
+    } else if (status == "FAIL") {
+        if (detailed == "true") {
+            # Escape HTML special chars
+            gsub(/&/, "\\&", output)
+            gsub(/</, "\\<", output)
+            gsub(/>/, "\\>", output)
+            print "<tr><td>❌ FAIL</td><td>" test_name "<br/><details><summary>Error Details</summary><pre><code>" output "</code></pre></details></td><td>" duration "s</td></tr>"
+        } else {
+            print "<tr><td>❌ FAIL</td><td>" test_name "</td><td>" duration "s</td></tr>"
+        }
+    }
+}
+')
+
+COMMENT+="$TABLE_ROWS"
+
+COMMENT+="</table>
+</details>
+"
+
+echo "Posting comment to GitHub..."
+
+curl -s \
+-H "Authorization: Bearer %env.GIT_PAT%" \
+-H "Accept: application/vnd.github+json" \
+https://api.github.com/repos/%env.GITHUB_REPO%/issues/${PR_NUMBER}/comments \
+-d "{\"body\": $(jq -Rs . <<< "$COMMENT")}"
+
+echo "Comment posted successfully."

--- a/.teamcity/scripts/post_github_comment.sh
+++ b/.teamcity/scripts/post_github_comment.sh
@@ -1,11 +1,16 @@
 #!/bin/bash
 
-if [ "%POST_GITHUB_COMMENT%" != "true" ] && [ "%POST_GITHUB_COMMENT_DETAILED%" != "true" ]; then
+POST_GITHUB_COMMENT="%POST_GITHUB_COMMENT%"
+POST_GITHUB_COMMENT_DETAILED="%POST_GITHUB_COMMENT_DETAILED%"
+
+if [ "$POST_GITHUB_COMMENT" != "true" ] && [ "$POST_GITHUB_COMMENT_DETAILED" != "true" ]; then
   echo "GitHub commenting disabled — skipping."
   exit 0
 fi
 
-if [[ "%teamcity.build.branch%" =~ refs/pull/([0-9]+)/merge ]]; then
+TEAMCITY_BUILD_BRANCH="%teamcity.build.branch%"
+
+if [[ "$TEAMCITY_BUILD_BRANCH" =~ refs/pull/([0-9]+)/merge ]]; then
   PR_NUMBER="${BASH_REMATCH[1]}"
 else
   echo "Not a PR merge branch: %teamcity.build.branch%"
@@ -13,7 +18,7 @@ else
 fi
 
 detailed=false
-if [ "%POST_GITHUB_COMMENT_DETAILED%" = "true" ]; then
+if [ "$POST_GITHUB_COMMENT_DETAILED" = "true" ]; then
   echo "Detailed GitHub commenting enabled."
   detailed=true
 fi
@@ -132,7 +137,7 @@ echo "Posting comment to GitHub..."
 curl -s \
 -H "Authorization: Bearer %env.GIT_PAT%" \
 -H "Accept: application/vnd.github+json" \
-https://api.github.com/repos/%env.GITHUB_REPO%/issues/${PR_NUMBER}/comments \
+https://api.github.com/repos/%env.GITHUB_REPO%/issues/"${PR_NUMBER}"/comments \
 -d "{\"body\": $(jq -Rs . <<< "$COMMENT")}"
 
 echo "Comment posted successfully."

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -19,10 +19,8 @@ var enableTestTriggersGlobally = DslContext.getParameter("enableTestTriggersGlob
 var emailAddressAccTests = DslContext.getParameter("emailAddressAccTests", "")
 var gitHubRepo = DslContext.getParameter("gitHubRepo", "")
 var gitPat = DslContext.getParameter("gitPat", "")
-var goModCache = DslContext.getParameter("goModCache", "")
-var goCache = DslContext.getParameter("goCache", "")
 
 
-var clientConfig = ClientConfiguration(clientId, clientSecret, subscriptionId, tenantId, clientIdAlt, clientSecretAlt, subscriptionIdAlt, subscriptionIdDevTest, tenantIdAlt, subscriptionIdAltTenant, principalIdAltTenant, vcsRootId, enableTestTriggersGlobally, emailAddressAccTests, gitHubRepo, gitPat, goModCache, goCache)
+var clientConfig = ClientConfiguration(clientId, clientSecret, subscriptionId, tenantId, clientIdAlt, clientSecretAlt, subscriptionIdAlt, subscriptionIdDevTest, tenantIdAlt, subscriptionIdAltTenant, principalIdAltTenant, vcsRootId, enableTestTriggersGlobally, emailAddressAccTests, gitHubRepo, gitPat)
 
 project(AzureRM(environment, clientConfig))

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -17,7 +17,12 @@ var principalIdAltTenant = DslContext.getParameter("principalIdAltTenant", "")
 var vcsRootId = DslContext.getParameter("vcsRootId", "TF_HashiCorp_AzureRM_Repository")
 var enableTestTriggersGlobally = DslContext.getParameter("enableTestTriggersGlobally", "true").equals("true", ignoreCase = true)
 var emailAddressAccTests = DslContext.getParameter("emailAddressAccTests", "")
+var gitHubRepo = DslContext.getParameter("gitHubRepo", "")
+var gitPat = DslContext.getParameter("gitPat", "")
+var goModCache = DslContext.getParameter("goModCache", "")
+var goCache = DslContext.getParameter("goCache", "")
 
-var clientConfig = ClientConfiguration(clientId, clientSecret, subscriptionId, tenantId, clientIdAlt, clientSecretAlt, subscriptionIdAlt, subscriptionIdDevTest, tenantIdAlt, subscriptionIdAltTenant, principalIdAltTenant, vcsRootId, enableTestTriggersGlobally, emailAddressAccTests)
+
+var clientConfig = ClientConfiguration(clientId, clientSecret, subscriptionId, tenantId, clientIdAlt, clientSecretAlt, subscriptionIdAlt, subscriptionIdDevTest, tenantIdAlt, subscriptionIdAltTenant, principalIdAltTenant, vcsRootId, enableTestTriggersGlobally, emailAddressAccTests, gitHubRepo, gitPat, goModCache, goCache)
 
 project(AzureRM(environment, clientConfig))

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -17,7 +17,7 @@ var principalIdAltTenant = DslContext.getParameter("principalIdAltTenant", "")
 var vcsRootId = DslContext.getParameter("vcsRootId", "TF_HashiCorp_AzureRM_Repository")
 var enableTestTriggersGlobally = DslContext.getParameter("enableTestTriggersGlobally", "true").equals("true", ignoreCase = true)
 var emailAddressAccTests = DslContext.getParameter("emailAddressAccTests", "")
-var gitHubRepo = DslContext.getParameter("gitHubRepo", "")
+var gitHubRepo = DslContext.getParameter("gitHubRepo", "hashicorp/terraform-provider-azurerm")
 var gitPat = DslContext.getParameter("gitPat", "")
 
 

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -1,6 +1,6 @@
 import jetbrains.buildServer.configs.kotlin.*
 
-version = "2025.03"
+version = "2025.11"
 
 var clientId = DslContext.getParameter("clientId", "")
 var clientSecret = DslContext.getParameter("clientSecret", "")

--- a/.teamcity/tests/helpers.kt
+++ b/.teamcity/tests/helpers.kt
@@ -8,5 +8,5 @@ package tests
 import ClientConfiguration
 
 fun TestConfiguration() : ClientConfiguration {
-    return ClientConfiguration("clientId", "clientSecret", "subscriptionId", "tenantId", "clientIdAlt", "clientSecretAlt", "subscriptionIdAlt", "subscriptionIdDevTest", "tenantIdAlt", "subscriptionIdAltTenant", "principalIdAltTenant", "vcsRootId", true, "terraformazuretestacc@example.com")
+    return ClientConfiguration("clientId", "clientSecret", "subscriptionId", "tenantId", "clientIdAlt", "clientSecretAlt", "subscriptionIdAlt", "subscriptionIdDevTest", "tenantIdAlt", "subscriptionIdAltTenant", "principalIdAltTenant", "vcsRootId", true, "terraformazuretestacc@example.com","hashicorp/terraform-provider-azurerm","asdf","%teamcity.agent.work.dir%/go-cache/mod","%teamcity.agent.work.dir%/go-cache/build")
 }

--- a/.teamcity/tests/helpers.kt
+++ b/.teamcity/tests/helpers.kt
@@ -8,5 +8,5 @@ package tests
 import ClientConfiguration
 
 fun TestConfiguration() : ClientConfiguration {
-    return ClientConfiguration("clientId", "clientSecret", "subscriptionId", "tenantId", "clientIdAlt", "clientSecretAlt", "subscriptionIdAlt", "subscriptionIdDevTest", "tenantIdAlt", "subscriptionIdAltTenant", "principalIdAltTenant", "vcsRootId", true, "terraformazuretestacc@example.com","hashicorp/terraform-provider-azurerm","asdf","%teamcity.agent.work.dir%/go-cache/mod","%teamcity.agent.work.dir%/go-cache/build")
+    return ClientConfiguration("clientId", "clientSecret", "subscriptionId", "tenantId", "clientIdAlt", "clientSecretAlt", "subscriptionIdAlt", "subscriptionIdDevTest", "tenantIdAlt", "subscriptionIdAltTenant", "principalIdAltTenant", "vcsRootId", true, "terraformazuretestacc@example.com","hashicorp/terraform-provider-azurerm","asdf")
 }

--- a/.teamcity/tests/helpers.kt
+++ b/.teamcity/tests/helpers.kt
@@ -8,5 +8,5 @@ package tests
 import ClientConfiguration
 
 fun TestConfiguration() : ClientConfiguration {
-    return ClientConfiguration("clientId", "clientSecret", "subscriptionId", "tenantId", "clientIdAlt", "clientSecretAlt", "subscriptionIdAlt", "subscriptionIdDevTest", "tenantIdAlt", "subscriptionIdAltTenant", "principalIdAltTenant", "vcsRootId", true, "terraformazuretestacc@example.com","hashicorp/terraform-provider-azurerm","asdf")
+    return ClientConfiguration("clientId", "clientSecret", "subscriptionId", "tenantId", "clientIdAlt", "clientSecretAlt", "subscriptionIdAlt", "subscriptionIdDevTest", "tenantIdAlt", "subscriptionIdAltTenant", "principalIdAltTenant", "vcsRootId", true, "terraformazuretestacc@example.com","hashicorp/terraform-provider-azurerm","gitPat")
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

This PR introduces automated GitHub PR commenting for TeamCity test results, along with a GitHub Actions workflow to trigger TeamCity tests via PR comments. The changes improve the developer experience by allowing team members to trigger test runs directly from pull request comments and automatically receive test result summaries posted back to the PR.

### Key Changes:

1. **GitHub Actions Workflow** (`.github/workflows/run-team-city-tests-on-comment.yaml`):
   - Adds a new workflow that listens for PR comments beginning with `/test`
   - Verifies the commenter is a member of the `terraform-azure` team before triggering tests
   - Uses `tctest` to trigger the appropriate TeamCity test builds for the PR
   - Supports a `/test -d` variant for detailed test output
   - Posts success/failure feedback comments back to the PR

2. **TeamCity Build Configuration Updates**:
   - Adds a new `PostTestResultsToGitHubPullRequest` build step to both service and pull request build configurations
   - Introduces a `BuildCacheFeature` to leverage TeamCity's build cache for Go module and build caches, improving build performance
   - Pipes test output to `results.txt` for post-processing
   - Adds Go module/build cache directory creation as part of the compile step

3. **Post GitHub Comment Script** (`.teamcity/scripts/post_github_comment.sh`):
   - New bash script that parses TeamCity test output from `results.txt`
   - Generates a formatted GitHub comment with a summary table showing pass/fail counts and individual test results
   - Supports a "detailed" mode (`POST_GITHUB_COMMENT_DETAILED=true`) that includes error output for failing tests
   - Posts the comment to the PR via the GitHub API using a PAT

4. **ClientConfiguration Updates**:
   - Extends `ClientConfiguration` with new parameters: `gitHubRepo`, `gitPat`, `goModCache`, and `goCache`
   - These are exposed as TeamCity build parameters (with `gitPat` stored as a hidden password variable)
   - `settings.kts` updated to read these new parameters from DSL context

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
