### PR TITLE
`azurerm_data_factory[_customer_managed_key]` - fix parsing error and removal of encryption UAMI

### DIFF
--- a/internal/services/datafactory/data_factory.go
+++ b/internal/services/datafactory/data_factory.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/datafactory/2018-06-01/factories"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"github.com/jackofallops/kermit/sdk/datafactory/2018-06-01/datafactory" // nolint: staticcheck
@@ -527,4 +528,14 @@ func expandCompressionType(inputType string) string {
 	}
 
 	return inputType
+}
+
+func expandDataFactoryEncryptionIdentity(input string) *factories.CMKIdentityDefinition {
+	if input == "" {
+		return nil
+	}
+
+	return &factories.CMKIdentityDefinition{
+		UserAssignedIdentity: &input,
+	}
 }

--- a/internal/services/datafactory/data_factory_customer_managed_key_resource.go
+++ b/internal/services/datafactory/data_factory_customer_managed_key_resource.go
@@ -229,9 +229,7 @@ func (r DataFactoryCustomerManagedKeyResource) Update() sdk.ResourceFunc {
 			}
 
 			if metadata.ResourceData.HasChange("user_assigned_identity_id") {
-				encryption.Identity = &factories.CMKIdentityDefinition{
-					UserAssignedIdentity: pointer.To(customerManagedKey.UserAssignedIdentityID),
-				}
+				encryption.Identity = expandDataFactoryEncryptionIdentity(customerManagedKey.UserAssignedIdentityID)
 			}
 
 			payload.Properties.Encryption = encryption

--- a/internal/services/datafactory/data_factory_resource.go
+++ b/internal/services/datafactory/data_factory_resource.go
@@ -281,9 +281,7 @@ func resourceDataFactoryCreateUpdate(d *pluginsdk.ResourceData, meta interface{}
 			VaultBaseURL: keyVaultKey.KeyVaultBaseURL,
 			KeyName:      keyVaultKey.Name,
 			KeyVersion:   &keyVaultKey.Version,
-			Identity: &factories.CMKIdentityDefinition{
-				UserAssignedIdentity: pointer.To(d.Get("customer_managed_key_identity_id").(string)),
-			},
+			Identity:     expandDataFactoryEncryptionIdentity(d.Get("customer_managed_key_identity_id").(string)),
 		}
 	}
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

- `azurerm_data_factory_customer_managed_key` - skip parsing and setting of `user_assigned_identity_id` when Azure returns an empty string
- `azurerm_data_factory` - fixes the logic for removal of encryption UAMI (`customer_managed_key_identity_id`) preventing empty string returns
- `azurerm_data_factory_customer_managed_key` - fixes the logic for removal of encryption UAMI (`user_assigned_identity_id`) preventing empty string returns

Due to the logic in the Update for both resources, the provider was sending the following to Azure on removal of CMK/Encryption UAMI. This was then persisted by Azure, which caused parsing errors (`parsing error: "": parsing "": cannot parse an empty string`

```
        "encryption": {
			"identity": {
				"userAssignedIdentity": ""
			},
			"keyName": "{name}",
			"keyVersion": "{version}",
			"vaultBaseUrl": "{url}"
		},
```

New logic sends `nil` which omits the `encryption.identity` object, properly removing it.

## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

New test cases covering the removal logic:

```
--- PASS: TestAccDataFactory_keyVaultKeyEncryptionSystemAssignedUserAssigned (406.61s)
--- PASS: TestAccDataFactoryCustomerManagedKey_systemAssignedUserAssignedUpdate (438.95s)
```

Remaining tests running in [TeamCity](https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_DATAFACTORY/620611?buildTab=)

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change



## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
