### PR TITLE
New resource: `azurerm_image_builder_template`

### DIFF
--- a/.github/labeler-issue-triage.yml
+++ b/.github/labeler-issue-triage.yml
@@ -72,7 +72,7 @@ service/cognitive-services:
   - '### (|New or )Affected Resource\(s\)\/Data Source\(s\)((.|\n)*)azurerm_(ai_services|cognitive_)((.|\n)*)###'
 
 service/communication:
-  - '### (|New or )Affected Resource\(s\)\/Data Source\(s\)((.|\n)*)azurerm_(communication_service|email_communication_service|gallery_application|managed_disks|orchestrated_virtual_machine_scale_set\W+|restore_point_collection|virtual_machine_gallery_application_assignment\W+|virtual_machine_implicit_data_disk_from_source\W+|virtual_machine_restore_point\W+|virtual_machine_restore_point_collection\W+|virtual_machine_run_command\W+|virtual_machine_scale_set_standby_pool\W+)((.|\n)*)###'
+  - '### (|New or )Affected Resource\(s\)\/Data Source\(s\)((.|\n)*)azurerm_(communication_service|email_communication_service|gallery_application|image_builder_template|managed_disks|orchestrated_virtual_machine_scale_set\W+|restore_point_collection|virtual_machine_gallery_application_assignment\W+|virtual_machine_implicit_data_disk_from_source\W+|virtual_machine_restore_point\W+|virtual_machine_restore_point_collection\W+|virtual_machine_run_command\W+|virtual_machine_scale_set_standby_pool\W+)((.|\n)*)###'
 
 service/connections:
   - '### (|New or )Affected Resource\(s\)\/Data Source\(s\)((.|\n)*)azurerm_(api_connection|managed_api)((.|\n)*)###'

--- a/internal/services/compute/client/client.go
+++ b/internal/services/compute/client/client.go
@@ -39,6 +39,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetrollingupgrades"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachinescalesetvms"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-11-01/virtualmachinescalesets"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/marketplaceordering/2015-06-01/agreements"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/standbypool/2025-03-01/standbyvirtualmachinepools"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
@@ -78,6 +79,7 @@ type Client struct {
 	VirtualMachineScaleSetRollingUpgradesClient *virtualmachinescalesetrollingupgrades.VirtualMachineScaleSetRollingUpgradesClient
 	VirtualMachineScaleSetVMsClient             *virtualmachinescalesetvms.VirtualMachineScaleSetVMsClient
 	VirtualMachineImagesClient                  *virtualmachineimages.VirtualMachineImagesClient
+	VirtualMachineImageTemplateClient           *virtualmachineimagetemplate.VirtualMachineImageTemplateClient
 }
 
 func NewClient(o *common.ClientOptions) (*Client, error) {
@@ -267,6 +269,12 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 	}
 	o.Configure(vmImageClient.Client, o.Authorizers.ResourceManager)
 
+	vmImageTemplateClient, err := virtualmachineimagetemplate.NewVirtualMachineImageTemplateClientWithBaseURI(o.Environment.ResourceManager)
+	if err != nil {
+		return nil, fmt.Errorf("building VirtualMachineImages client: %+v", err)
+	}
+	o.Configure(vmImageTemplateClient.Client, o.Authorizers.ResourceManager)
+
 	return &Client{
 		AvailabilitySetsClient:                      availabilitySetsClient,
 		CapacityReservationsClient:                  capacityReservationsClient,
@@ -299,6 +307,7 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 		VirtualMachineScaleSetRollingUpgradesClient: virtualMachineScaleSetRollingUpgradesClient,
 		VirtualMachineScaleSetVMsClient:             virtualMachineScaleSetVMsClient,
 		VirtualMachineImagesClient:                  vmImageClient,
+		VirtualMachineImageTemplateClient:           vmImageTemplateClient,
 	}, nil
 }
 

--- a/internal/services/compute/image_builder_template_resource.go
+++ b/internal/services/compute/image_builder_template_resource.go
@@ -1,0 +1,1575 @@
+package compute
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-01/images"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/validate"
+	networkValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+// This is to serve input validation for the customizer block.
+var (
+	fieldsOfFileCustomizer           = []string{"file_source_uri", "file_sha256_checksum", "file_destination_path"}
+	fieldsOfPowerShellCustomizer     = []string{"powershell_commands", "powershell_run_as_system", "powershell_run_elevated", "powershell_script_uri", "powershell_sha256_checksum", "powershell_valid_exit_codes"}
+	fieldsOfShellCustomizer          = []string{"shell_commands", "shell_script_uri", "shell_sha256_checksum"}
+	fieldsOfWindowsRestartCustomizer = []string{"windows_restart_check_command", "windows_restart_command", "windows_restart_timeout"}
+	fieldsOfWindowsUpdateCustomizer  = []string{"windows_update_filters", "windows_update_search_criteria", "windows_update_limit"}
+)
+
+func resourceImageBuilderTemplate() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmImageBuilderTemplateCreate,
+		Read:   resourceArmImageBuilderTemplateRead,
+		Update: resourceArmImageBuilderTemplateUpdate,
+		Delete: resourceArmImageBuilderTemplateDelete,
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := virtualmachineimagetemplate.ParseImageTemplateID(id)
+			return err
+		}),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringMatch(
+					regexp.MustCompile("^[-_.a-zA-Z0-9]{1,64}$"),
+					"Image template name can only include alphanumeric characters, periods, underscores, hyphens, has a maximum length of 64 characters.",
+				),
+			},
+
+			"resource_group_name": commonschema.ResourceGroupName(),
+
+			"location": commonschema.Location(),
+
+			// Though the 'None' type identity is declared in swagger, passing it to service triggers error: "Removing identity is not supported when creating or updating an image template.". So not expose it to users.
+			"identity": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								string(identity.TypeUserAssigned),
+							}, false),
+						},
+						"identity_ids": {
+							Type:     schema.TypeSet,
+							Required: true,
+							Elem: &schema.Schema{
+								Type:         schema.TypeString,
+								ValidateFunc: commonids.ValidateUserAssignedIdentityID,
+							},
+						},
+					},
+				},
+			},
+
+			"build_timeout_minutes": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      240,
+				ValidateFunc: validation.IntBetween(0, 960),
+			},
+
+			// Fields in this block should not be assigned default values. Because fields mapped to Customizer Type A should not be specified when Customizer Type B is specified as the current customizer block type.
+			"customizer": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"File",
+								"PowerShell",
+								"Shell",
+								"WindowsRestart",
+								"WindowsUpdate",
+							}, false),
+						},
+
+						"file_destination_path": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+
+						// If not specify this property but only "file_source_uri" to the service, the service will calculate the sha256 of the file and return it.
+						// So set this property as Computed for possible future usage. So forth to other similar properties in the `customizer` block.
+						"file_sha256_checksum": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+
+						"file_source_uri": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+
+						"name": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+
+						"powershell_commands": {
+							Type:     schema.TypeList,
+							Optional: true,
+							ForceNew: true,
+							Elem: &schema.Schema{
+								Type:         schema.TypeString,
+								ValidateFunc: validation.StringIsNotEmpty,
+							},
+						},
+
+						"powershell_run_as_system": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							ForceNew: true,
+						},
+
+						"powershell_run_elevated": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							ForceNew: true,
+						},
+
+						"powershell_script_uri": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+
+						"powershell_sha256_checksum": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+
+						"powershell_valid_exit_codes": {
+							Type:     schema.TypeList,
+							Optional: true,
+							ForceNew: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeInt,
+							},
+						},
+
+						"shell_commands": {
+							Type:     schema.TypeList,
+							Optional: true,
+							ForceNew: true,
+							Elem: &schema.Schema{
+								Type:         schema.TypeString,
+								ValidateFunc: validation.StringIsNotEmpty,
+							},
+						},
+
+						"shell_script_uri": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+
+						"shell_sha256_checksum": {
+							Type:         schema.TypeString,
+							Computed:     true,
+							Optional:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+
+						"windows_restart_check_command": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+
+						"windows_restart_command": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+
+						"windows_restart_timeout": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+
+						"windows_update_filters": {
+							Type:     schema.TypeList,
+							Optional: true,
+							ForceNew: true,
+							Elem: &schema.Schema{
+								Type:         schema.TypeString,
+								ValidateFunc: validation.StringIsNotEmpty,
+							},
+						},
+
+						"windows_update_search_criteria": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+
+						"windows_update_limit": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							ForceNew: true,
+						},
+					},
+				},
+			},
+
+			"disk_size_gb": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.DiskSizeGB,
+			},
+
+			"distributions": {
+				Type:     schema.TypeList,
+				Required: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						// The array of this block is order insensitive. But there is a bug preventing using TypeSet for this block having a sub field `location` using StateFunc:
+						// https://github.com/hashicorp/terraform-plugin-sdk/issues/160.
+						// In detail, the symptom is specifying user friendly region say "West US 2" in the sub field `location` generated two blocks even if only specifying one block in .tf.
+						// Using normalized region say "westus2" does not have the symptom.
+						// Given this bug would break the core logic, use TypeList as a workaround.
+						// This justification also applies to the "distribution_shared_image" block below.
+						"managed_image": {
+							Type:     schema.TypeList,
+							Optional: true,
+							ForceNew: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ForceNew:     true,
+										ValidateFunc: validation.StringIsNotEmpty,
+									},
+
+									"resource_group_name": commonschema.ResourceGroupName(),
+
+									"location": commonschema.Location(),
+
+									"run_output_name": distributionRunOutputNameSchema(),
+
+									"tags": commonschema.TagsForceNew(),
+								},
+							},
+						},
+
+						"shared_image": {
+							Type:     schema.TypeList,
+							Optional: true,
+							ForceNew: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ForceNew:     true,
+										ValidateFunc: azure.ValidateResourceID,
+									},
+
+									// The latest swagger (ver: 2020-02-14) defines this type as []string. However, in native SIG Image Version, not only region name but replica count and storage type are supported for each region.
+									// So leave the type of this field as array of object here to serve future possible extensibility without bringing in breaking changes in user facing schema.
+									"replica_regions": {
+										Type:     schema.TypeList,
+										Required: true,
+										MinItems: 1,
+										ForceNew: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"name": {
+													Type:             schema.TypeString,
+													Required:         true,
+													ForceNew:         true,
+													ValidateFunc:     location.EnhancedValidate,
+													StateFunc:        location.StateFunc,
+													DiffSuppressFunc: location.DiffSuppressFunc,
+												},
+											},
+										},
+									},
+
+									"run_output_name": distributionRunOutputNameSchema(),
+
+									"exclude_from_latest": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										ForceNew: true,
+										Default:  false,
+									},
+
+									"storage_account_type": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ForceNew:     true,
+										ValidateFunc: validation.StringInSlice(virtualmachineimagetemplate.PossibleValuesForSharedImageStorageAccountType(), false),
+									},
+
+									"tags": commonschema.TagsForceNew(),
+
+									"versioning": {
+										Type:     schema.TypeList,
+										Required: true,
+										ForceNew: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"scheme": {
+													Type:     schema.TypeString,
+													Required: true,
+													ForceNew: true,
+													ValidateFunc: validation.StringInSlice([]string{
+														"Source",
+														"Latest",
+													}, false),
+												},
+												"major": {
+													Type:     schema.TypeInt,
+													Optional: true,
+													ForceNew: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+
+						"vhd": {
+							Type:     schema.TypeList,
+							Optional: true,
+							ForceNew: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"run_output_name": distributionRunOutputNameSchema(),
+
+									"tags": commonschema.TagsForceNew(),
+								},
+							},
+						},
+					},
+				},
+			},
+
+			"size": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      "Standard_D1_v2",
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"source_managed_image_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: images.ValidateImageID,
+				ExactlyOneOf: []string{"source_managed_image_id", "source_platform_image", "source_shared_image_version_id"},
+			},
+
+			"source_platform_image": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"publisher": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+
+						"offer": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+
+						"sku": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+
+						// If specify "Latest", the returned value is "latest ([a specific version])". I.e. in this situation the value returned by the service does not honor case sensitivity and adds more values.
+						// A rest api bug filed: https://github.com/Azure/azure-rest-api-specs/issues/11313
+						"version": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+							DiffSuppressFunc: func(_, old, new string, d *schema.ResourceData) bool {
+								return strings.Contains(strings.ToLower(old), "latest (") && strings.EqualFold(new, "latest")
+							},
+						},
+
+						"plan": {
+							Type:     schema.TypeList,
+							Optional: true,
+							ForceNew: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ForceNew:     true,
+										ValidateFunc: validation.StringIsNotEmpty,
+									},
+
+									"product": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ForceNew:     true,
+										ValidateFunc: validation.StringIsNotEmpty,
+									},
+
+									"publisher": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ForceNew:     true,
+										ValidateFunc: validation.StringIsNotEmpty,
+									},
+								},
+							},
+						},
+					},
+				},
+				ExactlyOneOf: []string{"source_managed_image_id", "source_platform_image", "source_shared_image_version_id"},
+			},
+
+			"source_shared_image_version_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.SharedImageVersionID,
+				ExactlyOneOf: []string{"source_managed_image_id", "source_platform_image", "source_shared_image_version_id"},
+			},
+
+			"subnet_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: networkValidate.SubnetID,
+			},
+
+			"tags": commonschema.Tags(),
+		},
+	}
+}
+
+func resourceArmImageBuilderTemplateCreate(d *schema.ResourceData, meta interface{}) error {
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	client := meta.(*clients.Client).Compute.VirtualMachineImageTemplateClient
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	name := d.Get("name").(string)
+	resourceGroup := d.Get("resource_group_name").(string)
+	id := virtualmachineimagetemplate.NewImageTemplateID(subscriptionId, resourceGroup, name)
+	resp, err := client.Get(ctx, id)
+	if err != nil {
+		if !response.WasNotFound(resp.HttpResponse) {
+			return fmt.Errorf("checking for the presence of existing Image Builder Template %q (Resource Group %q): %s", name, resourceGroup, err)
+		}
+	}
+
+	if !response.WasNotFound(resp.HttpResponse) {
+		return tf.ImportAsExistsError("azurerm_image_builder_template", id.ID())
+	}
+
+	location := d.Get("location").(string)
+
+	distribution, err := expandBasicImageTemplateDistributor(d.Get("distributions").([]interface{}), subscriptionId)
+	if err != nil {
+		return err
+	}
+
+	customizer, err := expandBasicImageTemplateCustomizer(d)
+	if err != nil {
+		return err
+	}
+	t := d.Get("tags").(map[string]interface{})
+
+	identityExpanded, err := identity.ExpandUserAssignedMap(d.Get("identity").([]interface{}))
+	if err != nil {
+		return fmt.Errorf("expanding `identity`: %+v", err)
+	}
+
+	parameters := virtualmachineimagetemplate.ImageTemplate{
+		Location: location,
+		Identity: *identityExpanded,
+		Properties: &virtualmachineimagetemplate.ImageTemplateProperties{
+			VMProfile: &virtualmachineimagetemplate.ImageTemplateVMProfile{
+				VMSize:       pointer.To(d.Get("size").(string)),
+				OsDiskSizeGB: pointer.To(int64(d.Get("disk_size_gb").(int))),
+			},
+
+			Source:                expandBasicImageTemplateSource(d.Get("source_managed_image_id").(string), d.Get("source_platform_image").([]interface{}), d.Get("source_shared_image_version_id").(string)),
+			Distribute:            *distribution,
+			Customize:             customizer,
+			BuildTimeoutInMinutes: pointer.To(int64(d.Get("build_timeout_minutes").(int))),
+		},
+
+		Tags: tags.Expand(t),
+	}
+
+	if v, ok := d.GetOk("subnet_id"); ok {
+		parameters.Properties.VMProfile.VnetConfig = &virtualmachineimagetemplate.VirtualNetworkConfig{
+			SubnetId: pointer.To(v.(string)),
+		}
+	}
+
+	err = client.CreateOrUpdateThenPoll(ctx, id, parameters)
+	if err != nil {
+		return fmt.Errorf("creating image builder template %q (Resource Group %q): %+v", name, resourceGroup, err)
+	}
+
+	d.SetId(id.ID())
+
+	return resourceArmImageBuilderTemplateRead(d, meta)
+}
+
+func resourceArmImageBuilderTemplateRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Compute.VirtualMachineImageTemplateClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := virtualmachineimagetemplate.ParseImageTemplateID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, *id)
+	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("retrieving image builder template %q (Resource Group %q): %+v", id.ImageTemplateName, id.ResourceGroupName, err)
+	}
+
+	d.Set("name", id.ImageTemplateName)
+	d.Set("resource_group_name", id.ResourceGroupName)
+
+	if model := resp.Model; model != nil {
+		d.Set("location", location.Normalize(model.Location))
+
+		identityFlattened, err := identity.FlattenUserAssignedMap(&model.Identity)
+		if err != nil {
+			return fmt.Errorf("flattening `identity`: %+v", err)
+		}
+		if err := d.Set("identity", identityFlattened); err != nil {
+			return fmt.Errorf("setting `identity`: %+v", err)
+		}
+
+		if imageTemplateProperties := resp.Model.Properties; imageTemplateProperties != nil {
+			managedImageId, platformImage, sharedImageVersionId := flattenBasicImageTemplateSource(imageTemplateProperties.Source)
+
+			// only one among managedImageId / platformImage / sharedImageVersionId would be returned.
+			if managedImageId != "" {
+				if err := d.Set("source_managed_image_id", managedImageId); err != nil {
+					return fmt.Errorf("setting image template managed image source: %+v", err)
+				}
+			}
+
+			if len(platformImage) > 0 {
+				if err := d.Set("source_platform_image", platformImage); err != nil {
+					return fmt.Errorf("setting image template platform image source: %+v", err)
+				}
+			}
+
+			if sharedImageVersionId != "" {
+				if err := d.Set("source_shared_image_version_id", sharedImageVersionId); err != nil {
+					return fmt.Errorf("setting image template shared image version source: %+v", err)
+				}
+			}
+
+			flattenedDistributions, err := flattenBasicImageTemplateDistributor(&imageTemplateProperties.Distribute)
+			if err != nil {
+				return err
+			}
+
+			if err := d.Set("distributions", flattenedDistributions); err != nil {
+				return fmt.Errorf("setting image template distribution: %+v", err)
+			}
+
+			if err := d.Set("customizer", flattenBasicImageTemplateCustomizer(imageTemplateProperties.Customize)); err != nil {
+				return fmt.Errorf("setting `customizer`: %+v", err)
+			}
+
+			if err := d.Set("build_timeout_minutes", imageTemplateProperties.BuildTimeoutInMinutes); err != nil {
+				return fmt.Errorf("setting `build timeout minutes`: %+v", err)
+			}
+
+			if vmProfile := resp.Model.Properties.VMProfile; vmProfile != nil {
+				d.Set("size", vmProfile.VMSize)
+
+				d.Set("disk_size_gb", vmProfile.OsDiskSizeGB)
+
+				if vnetConfig := vmProfile.VnetConfig; vnetConfig != nil {
+					d.Set("subnet_id", vnetConfig.SubnetId)
+				}
+			}
+		}
+		if err := tags.FlattenAndSet(d, model.Tags); err != nil {
+			return err
+		}
+
+	}
+
+	return nil
+}
+
+func resourceArmImageBuilderTemplateUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Compute.VirtualMachineImageTemplateClient
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := virtualmachineimagetemplate.ParseImageTemplateID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	parameters := virtualmachineimagetemplate.ImageTemplateUpdateParameters{}
+
+	if d.HasChange("identity") {
+		identityExpanded, err := identity.ExpandUserAssignedMap(d.Get("identity").([]interface{}))
+		if err != nil {
+			return fmt.Errorf("expanding `identity`: %+v", err)
+		}
+
+		parameters.Identity = identityExpanded
+	}
+
+	if d.HasChange("tags") {
+		parameters.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
+	}
+
+	err = client.UpdateThenPoll(ctx, *id, parameters)
+	if err != nil {
+		return fmt.Errorf("updating image builder template %q (Resource Group %q): %+v", id.ImageTemplateName, id.ResourceGroupName, err)
+	}
+
+	return resourceArmImageBuilderTemplateRead(d, meta)
+}
+
+func resourceArmImageBuilderTemplateDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Compute.VirtualMachineImageTemplateClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := virtualmachineimagetemplate.ParseImageTemplateID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	err = client.DeleteThenPoll(ctx, *id)
+	if err != nil {
+		return fmt.Errorf("deleting image builder template %q (Resource Group %q): %+v", id.ImageTemplateName, id.ResourceGroupName, err)
+	}
+
+	return nil
+}
+
+func expandBasicImageTemplateSource(managedImageId string, platformImage []interface{}, sharedImageId string) virtualmachineimagetemplate.ImageTemplateSource {
+	if len(managedImageId) != 0 {
+		return &virtualmachineimagetemplate.ImageTemplateManagedImageSource{
+			ImageId: managedImageId,
+		}
+	}
+
+	if len(platformImage) != 0 && platformImage[0] != nil {
+		v := platformImage[0].(map[string]interface{})
+		result := &virtualmachineimagetemplate.ImageTemplatePlatformImageSource{
+			Publisher: pointer.To(v["publisher"].(string)),
+			Offer:     pointer.To(v["offer"].(string)),
+			Sku:       pointer.To(v["sku"].(string)),
+			Version:   pointer.To(v["version"].(string)),
+		}
+
+		planRaw := v["plan"].([]interface{})
+		if len(planRaw) > 0 {
+			planTemp := planRaw[0].(map[string]interface{})
+			result.PlanInfo = &virtualmachineimagetemplate.PlatformImagePurchasePlan{
+				PlanName:      planTemp["name"].(string),
+				PlanProduct:   planTemp["product"].(string),
+				PlanPublisher: planTemp["publisher"].(string),
+			}
+		}
+
+		return result
+	}
+
+	if len(sharedImageId) != 0 {
+		return &virtualmachineimagetemplate.ImageTemplateSharedImageVersionSource{
+			ImageVersionId: sharedImageId,
+		}
+	}
+
+	// since there is ExactlyOneOf on the source schema, below nil won't be reached
+	return nil
+}
+
+func flattenBasicImageTemplateSource(input virtualmachineimagetemplate.ImageTemplateSource) (string, []interface{}, string) {
+	if input != nil {
+		switch source := input.(type) {
+		case virtualmachineimagetemplate.ImageTemplateManagedImageSource:
+			return flattenSourceManagedImage(&source), nil, ""
+		case virtualmachineimagetemplate.ImageTemplatePlatformImageSource:
+			return "", flattenSourcePlatformImage(&source), ""
+		case virtualmachineimagetemplate.ImageTemplateSharedImageVersionSource:
+			return "", nil, flattenSourceSharedImageVersion(&source)
+		}
+	}
+
+	return "", nil, ""
+}
+
+func flattenSourceManagedImage(input *virtualmachineimagetemplate.ImageTemplateManagedImageSource) string {
+	if input != nil && input.ImageId != "" {
+		return input.ImageId
+	}
+
+	return ""
+}
+
+func flattenSourcePlatformImage(input *virtualmachineimagetemplate.ImageTemplatePlatformImageSource) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	publisher := ""
+	if input.Publisher != nil {
+		publisher = *input.Publisher
+	}
+
+	offer := ""
+	if input.Offer != nil {
+		offer = *input.Offer
+	}
+
+	sku := ""
+	if input.Sku != nil {
+		sku = *input.Sku
+	}
+
+	version := ""
+	if input.Version != nil {
+		version = *input.Version
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"publisher": publisher,
+			"offer":     offer,
+			"sku":       sku,
+			"version":   version,
+			"plan":      flattenImageBuilderTemplateSourcePlatformImagePlan(input.PlanInfo),
+		},
+	}
+}
+
+func flattenImageBuilderTemplateSourcePlatformImagePlan(input *virtualmachineimagetemplate.PlatformImagePurchasePlan) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	name := ""
+	if input.PlanName != "" {
+		name = input.PlanName
+	}
+
+	product := ""
+	if input.PlanProduct != "" {
+		product = input.PlanProduct
+	}
+
+	publisher := ""
+	if input.PlanPublisher != "" {
+		publisher = input.PlanPublisher
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"name":      name,
+			"product":   product,
+			"publisher": publisher,
+		},
+	}
+}
+
+func flattenSourceSharedImageVersion(input *virtualmachineimagetemplate.ImageTemplateSharedImageVersionSource) string {
+	if input != nil && input.ImageVersionId != "" {
+		return input.ImageVersionId
+	}
+
+	return ""
+}
+
+func expandBasicImageTemplateDistributor(distributions []interface{}, subscriptionId string) (*[]virtualmachineimagetemplate.ImageTemplateDistributor, error) {
+	results := make([]virtualmachineimagetemplate.ImageTemplateDistributor, 0)
+	runOutputNameSet := make(map[string]bool)
+
+	if len(distributions) > 0 {
+		for _, v := range distributions {
+			if v != nil {
+				distributionItems := v.(map[string]interface{})
+				managedImages := distributionItems["managed_image"].([]interface{})
+				sharedImages := distributionItems["shared_image"].([]interface{})
+				vhds := distributionItems["vhd"].([]interface{})
+
+				if len(managedImages) > 0 {
+					for _, managedImageRaw := range managedImages {
+						if managedImageRaw != nil {
+							managedImage := managedImageRaw.(map[string]interface{})
+							resourceGroupName := managedImage["resource_group_name"].(string)
+							runOutputName := managedImage["run_output_name"].(string)
+
+							_, existing := runOutputNameSet[runOutputName]
+							if existing {
+								return &results, fmt.Errorf("`run_output_name` must be unique among all distribution destinations. %q already exists", runOutputName)
+							} else {
+								runOutputNameSet[runOutputName] = true
+
+								results = append(results, virtualmachineimagetemplate.ImageTemplateManagedImageDistributor{
+									ImageId:       "/subscriptions/" + subscriptionId + "/resourceGroups/" + resourceGroupName + "/providers/Microsoft.Compute/images/" + managedImage["name"].(string),
+									Location:      managedImage["location"].(string),
+									RunOutputName: runOutputName,
+									ArtifactTags:  tags.Expand(managedImage["tags"].(map[string]interface{})),
+								})
+							}
+						}
+					}
+				}
+
+				if len(sharedImages) > 0 {
+					for _, sharedImageRaw := range sharedImages {
+						if sharedImageRaw != nil {
+							sharedImage := sharedImageRaw.(map[string]interface{})
+							runOutputName := sharedImage["run_output_name"].(string)
+
+							_, existing := runOutputNameSet[runOutputName]
+							if existing {
+								return &results, fmt.Errorf("`run_output_name` must be unique among all distribution destinations. %q already exists", runOutputName)
+							} else {
+								runOutputNameSet[runOutputName] = true
+								results = append(results, virtualmachineimagetemplate.ImageTemplateSharedImageDistributor{
+									GalleryImageId:     sharedImage["id"].(string),
+									ReplicationRegions: expandImageTemplateSharedImageDistributorReplicaRegions(sharedImage["replica_regions"].([]interface{})),
+									RunOutputName:      sharedImage["run_output_name"].(string),
+									ExcludeFromLatest:  pointer.To(sharedImage["exclude_from_latest"].(bool)),
+									StorageAccountType: pointer.To(virtualmachineimagetemplate.SharedImageStorageAccountType(sharedImage["storage_account_type"].(string))),
+									ArtifactTags:       tags.Expand(sharedImage["tags"].(map[string]interface{})),
+									Versioning:         expandImageTemplateSharedImageDistributorVersioning(sharedImage["versioning"].([]interface{})),
+								})
+							}
+						}
+					}
+				}
+
+				if len(vhds) > 0 {
+					for _, vhdRaw := range vhds {
+						if vhdRaw != nil {
+							vhd := vhdRaw.(map[string]interface{})
+							runOutputName := vhd["run_output_name"].(string)
+
+							_, existing := runOutputNameSet[runOutputName]
+							if existing {
+								return &results, fmt.Errorf("`run_output_name` must be unique among all distribution destinations. %q already exists", runOutputName)
+							} else {
+								runOutputNameSet[runOutputName] = true
+								results = append(results, virtualmachineimagetemplate.ImageTemplateVhdDistributor{
+									RunOutputName: vhd["run_output_name"].(string),
+									ArtifactTags:  tags.Expand(vhd["tags"].(map[string]interface{})),
+								})
+							}
+						}
+					}
+				}
+			} else {
+				return &results, fmt.Errorf("at least one of `managed_image`, `shared_image` and `vhd` is required to specify in `distributions`")
+			}
+		}
+	}
+
+	return &results, nil
+}
+
+func flattenBasicImageTemplateDistributor(input *[]virtualmachineimagetemplate.ImageTemplateDistributor) ([]interface{}, error) {
+	results := make([]interface{}, 0)
+
+	distributionManagedImages := make([]interface{}, 0)
+	distributionSharedImages := make([]interface{}, 0)
+	distributionVhds := make([]interface{}, 0)
+
+	if input != nil {
+		for _, v := range *input {
+			switch distribute := v.(type) {
+			case virtualmachineimagetemplate.ImageTemplateManagedImageDistributor:
+				flattenedManagedImg, err := flattenDistributionManagedImage(&distribute)
+				if err != nil {
+					return nil, fmt.Errorf("setting image template managed image source: %+v", err)
+				}
+
+				distributionManagedImages = append(distributionManagedImages, flattenedManagedImg)
+			case virtualmachineimagetemplate.ImageTemplateSharedImageDistributor:
+				distributionSharedImages = append(distributionSharedImages, flattenDistributionSharedImage(&distribute))
+			case virtualmachineimagetemplate.ImageTemplateVhdDistributor:
+				distributionVhds = append(distributionVhds, flattenDistributionVhd(&distribute))
+			}
+		}
+	}
+
+	output := map[string]interface{}{
+		"managed_image": distributionManagedImages,
+		"shared_image":  distributionSharedImages,
+		"vhd":           distributionVhds,
+	}
+
+	results = append(results, output)
+	return results, nil
+}
+
+func expandImageTemplateSharedImageDistributorReplicaRegions(input []interface{}) *[]string {
+	if input == nil {
+		return nil
+	}
+
+	result := make([]string, 0)
+	for _, v := range input {
+		result = append(result, v.(map[string]interface{})["name"].(string))
+	}
+
+	return &result
+}
+
+func expandImageTemplateSharedImageDistributorVersioning(input []interface{}) virtualmachineimagetemplate.DistributeVersioner {
+	var result virtualmachineimagetemplate.DistributeVersioner
+	if len(input) > 0 {
+		config := input[0].(map[string]interface{})
+
+		if v := config["scheme"].(string); v == "Latest" {
+			result = virtualmachineimagetemplate.DistributeVersionerLatest{
+				Scheme: config["scheme"].(string),
+				Major:  pointer.To(config["major"].(int64)),
+			}
+		}
+
+		if v := config["scheme"].(string); v == "Source" {
+			result = virtualmachineimagetemplate.DistributeVersionerSource{
+				Scheme: config["scheme"].(string),
+			}
+		}
+	}
+	return result
+}
+
+func flattenImageTemplateSharedImageDistributorVersioning(input virtualmachineimagetemplate.DistributeVersioner) []interface{} {
+	results := make([]interface{}, 0)
+	output := make(map[string]interface{})
+
+	switch versioner := input.(type) {
+	case virtualmachineimagetemplate.DistributeVersionerLatest:
+		output["scheme"] = versioner.Scheme
+		output["major"] = versioner.Major
+
+	case virtualmachineimagetemplate.DistributeVersionerSource:
+		output["scheme"] = versioner.Scheme
+	}
+
+	results = append(results, output)
+
+	return results
+}
+
+func flattenImageTemplateSharedImageDistributorReplicaRegions(input *[]string) []interface{} {
+	results := make([]interface{}, 0)
+
+	if input != nil {
+		for _, v := range *input {
+			output := make(map[string]interface{})
+			output["name"] = v
+			results = append(results, output)
+		}
+	}
+
+	return results
+}
+
+func flattenDistributionManagedImage(input *virtualmachineimagetemplate.ImageTemplateManagedImageDistributor) (map[string]interface{}, error) {
+	result := make(map[string]interface{})
+	if input == nil {
+		return result, nil
+	}
+
+	imageName := ""
+	resourceGroupName := ""
+	if input.ImageId != "" {
+		imageNameReturned, resourceGroupNameReturned, err := imageBuilderTemplateManagedImageNameAndResourceGroupName(input.ImageId)
+		if err != nil {
+			return result, err
+		}
+
+		imageName = imageNameReturned
+		resourceGroupName = resourceGroupNameReturned
+	}
+
+	result["name"] = imageName
+	result["resource_group_name"] = resourceGroupName
+
+	if input.Location != "" {
+		result["location"] = input.Location
+	}
+
+	if input.RunOutputName != "" {
+		result["run_output_name"] = input.RunOutputName
+	}
+
+	if input.ArtifactTags != nil {
+		result["tags"] = tags.Flatten(input.ArtifactTags)
+	}
+
+	return result, nil
+}
+
+func flattenDistributionSharedImage(input *virtualmachineimagetemplate.ImageTemplateSharedImageDistributor) map[string]interface{} {
+	results := make(map[string]interface{})
+	if input == nil {
+		return results
+	}
+
+	if input.GalleryImageId != "" {
+		results["id"] = input.GalleryImageId
+	}
+
+	if input.ReplicationRegions != nil {
+		results["replica_regions"] = flattenImageTemplateSharedImageDistributorReplicaRegions(input.ReplicationRegions)
+	}
+
+	if input.RunOutputName != "" {
+		results["run_output_name"] = input.RunOutputName
+	}
+
+	if input.ExcludeFromLatest != nil {
+		results["exclude_from_latest"] = *input.ExcludeFromLatest
+	}
+
+	if input.StorageAccountType != nil {
+		results["storage_account_type"] = string(*input.StorageAccountType)
+	}
+
+	if input.ArtifactTags != nil {
+		results["tags"] = tags.Flatten(input.ArtifactTags)
+	}
+
+	results["versioning"] = flattenImageTemplateSharedImageDistributorVersioning(input.Versioning)
+	return results
+}
+
+func flattenDistributionVhd(input *virtualmachineimagetemplate.ImageTemplateVhdDistributor) map[string]interface{} {
+	results := make(map[string]interface{})
+	if input == nil {
+		return results
+	}
+
+	if input.RunOutputName != "" {
+		results["run_output_name"] = input.RunOutputName
+	}
+
+	if input.ArtifactTags != nil {
+		results["tags"] = tags.Flatten(input.ArtifactTags)
+	}
+
+	return results
+}
+
+// Passing d as input rather its business subset because this function needs d.GetOK() to verify users' input to the `customizer` block is valid.
+func expandBasicImageTemplateCustomizer(d *schema.ResourceData) (*[]virtualmachineimagetemplate.ImageTemplateCustomizer, error) {
+	input := d.Get("customizer").([]interface{})
+
+	if len(input) == 0 {
+		return nil, nil
+	}
+
+	results := make([]virtualmachineimagetemplate.ImageTemplateCustomizer, 0)
+
+	// This index serves identifying the invalid input customizer block from the customizer block list.
+	i := 0
+
+	for _, customizerRaw := range input {
+		customizer := customizerRaw.(map[string]interface{})
+		t := customizer["type"].(string)
+
+		switch t {
+		case "File":
+			if err := validateImageTemplateCustomizerInputForFileType(d, customizer, i); err != nil {
+				return nil, err
+			}
+
+			results = append(results, virtualmachineimagetemplate.ImageTemplateFileCustomizer{
+				Name:           pointer.To(customizer["name"].(string)),
+				SourceUri:      pointer.To(customizer["file_source_uri"].(string)),
+				Sha256Checksum: pointer.To(customizer["file_sha256_checksum"].(string)),
+				Destination:    pointer.To(customizer["file_destination_path"].(string)),
+			})
+
+			i++
+		case "PowerShell":
+			if err := validateImageTemplateCustomizerInputForPowerShellType(d, customizer, i); err != nil {
+				return nil, err
+			}
+
+			results = append(results, virtualmachineimagetemplate.ImageTemplatePowerShellCustomizer{
+				Name:           pointer.To(customizer["name"].(string)),
+				ScriptUri:      pointer.To(customizer["powershell_script_uri"].(string)),
+				Sha256Checksum: pointer.To(customizer["powershell_sha256_checksum"].(string)),
+				Inline:         utils.ExpandStringSlice(customizer["powershell_commands"].([]interface{})),
+				RunAsSystem:    pointer.To(customizer["powershell_run_as_system"].(bool)),
+				RunElevated:    pointer.To(customizer["powershell_run_elevated"].(bool)),
+				ValidExitCodes: utils.ExpandInt64Slice(customizer["powershell_valid_exit_codes"].([]interface{})),
+			})
+
+			i++
+		case "Shell":
+			if err := validateImageTemplateCustomizerInputForShellType(d, customizer, i); err != nil {
+				return nil, err
+			}
+
+			results = append(results, virtualmachineimagetemplate.ImageTemplateShellCustomizer{
+				Name:           pointer.To(customizer["name"].(string)),
+				ScriptUri:      pointer.To(customizer["shell_script_uri"].(string)),
+				Sha256Checksum: pointer.To(customizer["shell_sha256_checksum"].(string)),
+				Inline:         utils.ExpandStringSlice(customizer["shell_commands"].([]interface{})),
+			})
+
+			i++
+		case "WindowsRestart":
+			if err := validateImageTemplateCustomizerInputForWindowsRestartType(d, i); err != nil {
+				return nil, err
+			}
+
+			results = append(results, virtualmachineimagetemplate.ImageTemplateRestartCustomizer{
+				Name:                pointer.To(customizer["name"].(string)),
+				RestartCommand:      pointer.To(customizer["windows_restart_command"].(string)),
+				RestartCheckCommand: pointer.To(customizer["windows_restart_check_command"].(string)),
+				RestartTimeout:      pointer.To(customizer["windows_restart_timeout"].(string)),
+			})
+
+			i++
+		case "WindowsUpdate":
+			if err := validateImageTemplateCustomizerInputForWindowsUpdateType(d, i); err != nil {
+				return nil, err
+			}
+
+			results = append(results, virtualmachineimagetemplate.ImageTemplateWindowsUpdateCustomizer{
+				Name:           pointer.To(customizer["name"].(string)),
+				SearchCriteria: pointer.To(customizer["windows_update_search_criteria"].(string)),
+				Filters:        utils.ExpandStringSlice(customizer["windows_update_filters"].([]interface{})),
+				UpdateLimit:    pointer.To(int64(customizer["windows_update_limit"].(int))),
+			})
+
+			i++
+		}
+	}
+
+	return &results, nil
+}
+
+func flattenBasicImageTemplateCustomizer(input *[]virtualmachineimagetemplate.ImageTemplateCustomizer) []interface{} {
+	customizerList := make([]interface{}, 0)
+
+	if input != nil {
+		for _, v := range *input {
+			switch customizer := v.(type) {
+			case virtualmachineimagetemplate.ImageTemplateFileCustomizer:
+				customizerList = append(customizerList, flattenCustomizerFile(&customizer))
+			case virtualmachineimagetemplate.ImageTemplatePowerShellCustomizer:
+				customizerList = append(customizerList, flattenCustomizerPowerShell(&customizer))
+			case virtualmachineimagetemplate.ImageTemplateShellCustomizer:
+				customizerList = append(customizerList, flattenCustomizerShell(&customizer))
+			case virtualmachineimagetemplate.ImageTemplateRestartCustomizer:
+				customizerList = append(customizerList, flattenCustomizerWindowsRestart(&customizer))
+			case virtualmachineimagetemplate.ImageTemplateWindowsUpdateCustomizer:
+				customizerList = append(customizerList, flattenCustomizerWindowsUpdate(&customizer))
+			}
+		}
+
+		return customizerList
+	}
+
+	return customizerList
+}
+
+func flattenCustomizerFile(input *virtualmachineimagetemplate.ImageTemplateFileCustomizer) map[string]interface{} {
+	if input == nil {
+		return nil
+	}
+
+	result := make(map[string]interface{})
+	result["type"] = "File"
+
+	name := ""
+	if input.Name != nil {
+		name = *input.Name
+	}
+
+	result["name"] = name
+
+	if input.SourceUri != nil {
+		result["file_source_uri"] = *input.SourceUri
+	}
+
+	if input.Sha256Checksum != nil {
+		result["file_sha256_checksum"] = *input.Sha256Checksum
+	}
+
+	if input.Destination != nil {
+		result["file_destination_path"] = *input.Destination
+	}
+
+	return result
+}
+
+func flattenCustomizerShell(input *virtualmachineimagetemplate.ImageTemplateShellCustomizer) map[string]interface{} {
+	if input == nil {
+		return nil
+	}
+
+	result := make(map[string]interface{})
+	result["type"] = "Shell"
+
+	name := ""
+	if input.Name != nil {
+		name = *input.Name
+	}
+
+	result["name"] = name
+
+	if input.ScriptUri != nil {
+		result["shell_script_uri"] = *input.ScriptUri
+	}
+
+	if input.Sha256Checksum != nil {
+		result["shell_sha256_checksum"] = *input.Sha256Checksum
+	}
+
+	if input.Inline != nil {
+		result["shell_commands"] = *input.Inline
+	}
+
+	return result
+}
+
+func flattenCustomizerPowerShell(input *virtualmachineimagetemplate.ImageTemplatePowerShellCustomizer) map[string]interface{} {
+	if input == nil {
+		return nil
+	}
+
+	result := make(map[string]interface{})
+	result["type"] = "PowerShell"
+
+	name := ""
+	if input.Name != nil {
+		name = *input.Name
+	}
+
+	result["name"] = name
+
+	if input.ScriptUri != nil {
+		result["powershell_script_uri"] = *input.ScriptUri
+	}
+
+	if input.Sha256Checksum != nil {
+		result["powershell_sha256_checksum"] = *input.Sha256Checksum
+	}
+
+	if input.Inline != nil {
+		result["powershell_commands"] = *input.Inline
+	}
+
+	if input.RunAsSystem != nil {
+		result["powershell_run_as_system"] = *input.RunAsSystem
+	}
+
+	if input.RunElevated != nil {
+		result["powershell_run_elevated"] = *input.RunElevated
+	}
+
+	if input.ValidExitCodes != nil {
+		result["powershell_valid_exit_codes"] = *input.ValidExitCodes
+	}
+
+	return result
+}
+
+func flattenCustomizerWindowsRestart(input *virtualmachineimagetemplate.ImageTemplateRestartCustomizer) map[string]interface{} {
+	if input == nil {
+		return nil
+	}
+
+	result := make(map[string]interface{})
+	result["type"] = "WindowsRestart"
+
+	name := ""
+	if input.Name != nil {
+		name = *input.Name
+	}
+
+	result["name"] = name
+
+	if input.RestartCommand != nil {
+		result["windows_restart_command"] = *input.RestartCommand
+	}
+
+	if input.RestartCheckCommand != nil {
+		result["windows_restart_check_command"] = *input.RestartCheckCommand
+	}
+
+	if input.RestartTimeout != nil {
+		result["windows_restart_timeout"] = *input.RestartTimeout
+	}
+
+	return result
+}
+
+func flattenCustomizerWindowsUpdate(input *virtualmachineimagetemplate.ImageTemplateWindowsUpdateCustomizer) map[string]interface{} {
+	if input == nil {
+		return nil
+	}
+	result := make(map[string]interface{})
+
+	result["type"] = "WindowsUpdate"
+
+	name := ""
+	if input.Name != nil {
+		name = *input.Name
+	}
+
+	result["name"] = name
+
+	if input.SearchCriteria != nil {
+		result["windows_update_search_criteria"] = *input.SearchCriteria
+	}
+
+	if input.Filters != nil {
+		result["windows_update_filters"] = *input.Filters
+	}
+
+	if input.UpdateLimit != nil {
+		result["windows_update_limit"] = *input.UpdateLimit
+	}
+
+	return result
+}
+
+func distributionRunOutputNameSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeString,
+		Required: true,
+		ForceNew: true,
+		ValidateFunc: validation.StringMatch(
+			regexp.MustCompile("^[-_.a-zA-Z0-9]{1,64}$"),
+			"Run output name can only include alphanumeric characters, periods, underscores, hyphens, has a maximum length of 64 characters, and must be unique.",
+		),
+	}
+}
+
+// In the `customizer` block, when a certain `type` say "File" is specified, do not allow users to specify fields that do not belong to `File`.
+// Because once users specify those irrelevant fields, those values won't be sent to the backend service and they won't return from GET,
+// thus next time there will be diff shown which will force creating a new resource. So at the very beginning forbid users from doing this.
+func validateImageTemplateCustomizerInputForFileType(d *schema.ResourceData, customizer map[string]interface{}, index int) error {
+	sourceUri := customizer["file_source_uri"].(string)
+	if sourceUri == "" {
+		return fmt.Errorf("`file_source_uri` must be specified if the customizer type is File")
+	}
+
+	destinationPath := customizer["file_destination_path"].(string)
+	if destinationPath == "" {
+		return fmt.Errorf("`destination_path` must be specified if the customizer type is File")
+	}
+
+	excludeList := make([]string, 0)
+	excludeList = append(excludeList, fieldsOfShellCustomizer...)
+	excludeList = append(excludeList, fieldsOfPowerShellCustomizer...)
+	excludeList = append(excludeList, fieldsOfWindowsRestartCustomizer...)
+	excludeList = append(excludeList, fieldsOfWindowsUpdateCustomizer...)
+
+	if err := validateImageTemplateCustomizer(d, excludeList, index, "File"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateImageTemplateCustomizerInputForPowerShellType(d *schema.ResourceData, customizer map[string]interface{}, index int) error {
+	scriptUri := customizer["powershell_script_uri"].(string)
+	commandsRaw := customizer["powershell_commands"].([]interface{})
+
+	if (scriptUri == "" && len(commandsRaw) == 0) ||
+		(scriptUri != "" && len(commandsRaw) > 0) {
+		return fmt.Errorf("exactly one of `powershell_script_uri` and `powershell_commands` must be specified if the customizer type is PowerShell")
+	}
+
+	excludeList := make([]string, 0)
+	excludeList = append(excludeList, fieldsOfFileCustomizer...)
+	excludeList = append(excludeList, fieldsOfShellCustomizer...)
+	excludeList = append(excludeList, fieldsOfWindowsRestartCustomizer...)
+	excludeList = append(excludeList, fieldsOfWindowsUpdateCustomizer...)
+
+	if err := validateImageTemplateCustomizer(d, excludeList, index, "PowerShell"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateImageTemplateCustomizerInputForShellType(d *schema.ResourceData, customizer map[string]interface{}, index int) error {
+	scriptUri := customizer["shell_script_uri"].(string)
+	commandsRaw := customizer["shell_commands"].([]interface{})
+
+	if (scriptUri == "" && len(commandsRaw) == 0) ||
+		(scriptUri != "" && len(commandsRaw) > 0) {
+		return fmt.Errorf("exactly one of `shell_script_uri` and `shell_commands` must be specified if the customizer type is Shell")
+	}
+
+	excludeList := make([]string, 0)
+	excludeList = append(excludeList, fieldsOfFileCustomizer...)
+	excludeList = append(excludeList, fieldsOfPowerShellCustomizer...)
+	excludeList = append(excludeList, fieldsOfWindowsRestartCustomizer...)
+	excludeList = append(excludeList, fieldsOfWindowsUpdateCustomizer...)
+
+	if err := validateImageTemplateCustomizer(d, excludeList, index, "Shell"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateImageTemplateCustomizerInputForWindowsRestartType(d *schema.ResourceData, index int) error {
+	excludeList := make([]string, 0)
+	excludeList = append(excludeList, fieldsOfFileCustomizer...)
+	excludeList = append(excludeList, fieldsOfPowerShellCustomizer...)
+	excludeList = append(excludeList, fieldsOfShellCustomizer...)
+	excludeList = append(excludeList, fieldsOfWindowsUpdateCustomizer...)
+
+	if err := validateImageTemplateCustomizer(d, excludeList, index, "WindowsRestart"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateImageTemplateCustomizerInputForWindowsUpdateType(d *schema.ResourceData, index int) error {
+	excludeList := make([]string, 0)
+	excludeList = append(excludeList, fieldsOfFileCustomizer...)
+	excludeList = append(excludeList, fieldsOfPowerShellCustomizer...)
+	excludeList = append(excludeList, fieldsOfShellCustomizer...)
+	excludeList = append(excludeList, fieldsOfWindowsRestartCustomizer...)
+
+	if err := validateImageTemplateCustomizer(d, excludeList, index, "WindowsUpdate"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateImageTemplateCustomizer(d *schema.ResourceData, exclude []string, index int, currentType string) error {
+	if len(exclude) == 0 {
+		return nil
+	}
+
+	for _, excludeField := range exclude {
+		if _, ok := d.GetOk(fmt.Sprintf("customizer.%d.%s", index, excludeField)); ok {
+			return fmt.Errorf("`%s` should not be set in the `customizer` block when the customizer type is `%s`", excludeField, currentType)
+		}
+	}
+
+	return nil
+}
+
+func imageBuilderTemplateManagedImageNameAndResourceGroupName(input string) (string, string, error) {
+	imageName := ""
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return "", "", err
+	}
+
+	if imageName, err = id.PopSegment("images"); err != nil {
+		return "", "", err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return "", "", err
+	}
+
+	return imageName, id.ResourceGroup, nil
+}

--- a/internal/services/compute/image_builder_template_resource.go
+++ b/internal/services/compute/image_builder_template_resource.go
@@ -1,7 +1,9 @@
 package compute
 
 import (
+	"context"
 	"fmt"
+	"log"
 	"regexp"
 	"strings"
 	"time"
@@ -12,20 +14,125 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-01/images"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/validate"
 	networkValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
+
+var (
+	_ sdk.Resource           = ImageBuilderTemplateResource{}
+	_ sdk.ResourceWithUpdate = ImageBuilderTemplateResource{}
+)
+
+type ImageBuilderTemplateResource struct{}
+
+func (ImageBuilderTemplateResource) ModelObject() interface{} {
+	return &ImageBuilderTemplateResourceModel{}
+}
+
+func (ImageBuilderTemplateResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return virtualmachineimagetemplate.ValidateImageTemplateID
+}
+
+func (ImageBuilderTemplateResource) ResourceType() string {
+	return "azurerm_image_builder_template"
+}
+
+type ImageBuilderTemplateResourceModel struct {
+	Name                       string                                    `tfschema:"name"`
+	ResourceGroupName          string                                    `tfschema:"resource_group_name"`
+	Location                   string                                    `tfschema:"location"`
+	Identity                   []identity.ModelUserAssigned              `tfschema:"identity"`
+	BuildTimeoutMinutes        int64                                     `tfschema:"build_timeout_minutes"`
+	Customizer                 []ImageBuilderTemplateCustomizer          `tfschema:"customizer"`
+	DiskSizeGb                 int64                                     `tfschema:"disk_size_gb"`
+	Distributions              []ImageBuilderTemplateDistributions       `tfschema:"distributions"`
+	Size                       string                                    `tfschema:"size"`
+	SourceManagedImageId       string                                    `tfschema:"source_managed_image_id"`
+	SourcePlatformImage        []ImageBuilderTemplateSourcePlatformImage `tfschema:"source_platform_image"`
+	SourceSharedImageVersionId string                                    `tfschema:"source_shared_image_version_id"`
+	SubnetId                   string                                    `tfschema:"subnet_id"`
+	Tags                       map[string]string                         `tfschema:"tags"`
+}
+
+type ImageBuilderTemplateCustomizer struct {
+	Type                        string   `tfschema:"type"`
+	FileDestinationPath         string   `tfschema:"file_destination_path"`
+	FileSha256Checksum          string   `tfschema:"file_sha256_checksum"`
+	FileSourceUri               string   `tfschema:"file_source_uri"`
+	Name                        string   `tfschema:"name"`
+	PowershellCommands          []string `tfschema:"powershell_commands"`
+	PowershellRunAsSystem       bool     `tfschema:"powershell_run_as_system"`
+	PowershellRunElevated       bool     `tfschema:"powershell_run_elevated"`
+	PowershellScriptUri         string   `tfschema:"powershell_script_uri"`
+	PowershellSha256Checksum    string   `tfschema:"powershell_sha256_checksum"`
+	PowershellValidExitCodes    []int64  `tfschema:"powershell_valid_exit_codes"`
+	ShellCommands               []string `tfschema:"shell_commands"`
+	ShellScriptUri              string   `tfschema:"shell_script_uri"`
+	ShellSha256Checksum         string   `tfschema:"shell_sha256_checksum"`
+	WindowsRestartCheckCommand  string   `tfschema:"windows_restart_check_command"`
+	WindowsRestartCommand       string   `tfschema:"windows_restart_command"`
+	WindowsRestartTimeout       string   `tfschema:"windows_restart_timeout"`
+	WindowsUpdateFilters        []string `tfschema:"windows_update_filters"`
+	WindowsUpdateSearchCriteria string   `tfschema:"windows_update_search_criteria"`
+	WindowsUpdateLimit          int64    `tfschema:"windows_update_limit"`
+}
+
+type ImageBuilderTemplateDistributions struct {
+	ManagedImage []ImageBuilderTemplateDistributionsManagedImage `tfschema:"managed_image"`
+	SharedImage  []ImageBuilderTemplateDistributionsSharedImage  `tfschema:"shared_image"`
+	Vhd          []ImageBuilderTemplateDistributionsVhd          `tfschema:"vhd"`
+}
+
+type ImageBuilderTemplateDistributionsManagedImage struct {
+	Name              string            `tfschema:"name"`
+	ResourceGroupName string            `tfschema:"resource_group_name"`
+	Location          string            `tfschema:"location"`
+	RunOutputName     string            `tfschema:"run_output_name"`
+	Tags              map[string]string `tfschema:"tags"`
+}
+type ImageBuilderTemplateDistributionsSharedImage struct {
+	Id                 string                                                       `tfschema:"id"`
+	ReplicaRegions     []ImageBuilderTemplateDistributionsSharedImageReplicaRegions `tfschema:"replica_regions"`
+	RunOutputName      string                                                       `tfschema:"run_output_name"`
+	ExcludeFromLatest  bool                                                         `tfschema:"exclude_from_latest"`
+	StorageAccountType string                                                       `tfschema:"storage_account_type"`
+	Tags               map[string]string                                            `tfschema:"tags"`
+	Versioning         []ImageBuilderTemplateDistributionsSharedImageVersioning     `tfschema:"versioning"`
+}
+
+type ImageBuilderTemplateDistributionsVhd struct {
+	RunOutputName string            `tfschema:"run_output_name"`
+	Tags          map[string]string `tfschema:"tags"`
+}
+
+type ImageBuilderTemplateDistributionsSharedImageReplicaRegions struct {
+	Name string `tfschema:"name"`
+}
+type ImageBuilderTemplateDistributionsSharedImageVersioning struct {
+	Scheme string `tfschema:"scheme"`
+	Major  int64  `tfschema:"major"`
+}
+
+type ImageBuilderTemplateSourcePlatformImage struct {
+	Publisher string                                        `tfschema:"publisher"`
+	Offer     string                                        `tfschema:"offer"`
+	Sku       string                                        `tfschema:"sku"`
+	Version   string                                        `tfschema:"version"`
+	Plan      []ImageBuilderTemplateSourcePlatformImagePlan `tfschema:"plan"`
+}
+
+type ImageBuilderTemplateSourcePlatformImagePlan struct {
+	Name      string `tfschema:"name"`
+	Product   string `tfschema:"product"`
+	Publisher string `tfschema:"publisher"`
+}
 
 // This is to serve input validation for the customizer block.
 var (
@@ -36,733 +143,714 @@ var (
 	fieldsOfWindowsUpdateCustomizer  = []string{"windows_update_filters", "windows_update_search_criteria", "windows_update_limit"}
 )
 
-func resourceImageBuilderTemplate() *schema.Resource {
-	return &schema.Resource{
-		Create: resourceArmImageBuilderTemplateCreate,
-		Read:   resourceArmImageBuilderTemplateRead,
-		Update: resourceArmImageBuilderTemplateUpdate,
-		Delete: resourceArmImageBuilderTemplateDelete,
-
-		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := virtualmachineimagetemplate.ParseImageTemplateID(id)
-			return err
-		}),
-
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(30 * time.Minute),
-			Update: schema.DefaultTimeout(30 * time.Minute),
-			Read:   schema.DefaultTimeout(5 * time.Minute),
-			Delete: schema.DefaultTimeout(30 * time.Minute),
+func (ImageBuilderTemplateResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+			ValidateFunc: validation.StringMatch(
+				regexp.MustCompile("^[-_.a-zA-Z0-9]{1,64}$"),
+				"Image template name can only include alphanumeric characters, periods, underscores, hyphens, has a maximum length of 64 characters.",
+			),
 		},
 
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringMatch(
-					regexp.MustCompile("^[-_.a-zA-Z0-9]{1,64}$"),
-					"Image template name can only include alphanumeric characters, periods, underscores, hyphens, has a maximum length of 64 characters.",
-				),
-			},
+		"resource_group_name": commonschema.ResourceGroupName(),
 
-			"resource_group_name": commonschema.ResourceGroupName(),
+		"location": commonschema.Location(),
 
-			"location": commonschema.Location(),
-
-			// Though the 'None' type identity is declared in swagger, passing it to service triggers error: "Removing identity is not supported when creating or updating an image template.". So not expose it to users.
-			"identity": {
-				Type:     schema.TypeList,
-				Required: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"type": {
-							Type:     schema.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(identity.TypeUserAssigned),
-							}, false),
-						},
-						"identity_ids": {
-							Type:     schema.TypeSet,
-							Required: true,
-							Elem: &schema.Schema{
-								Type:         schema.TypeString,
-								ValidateFunc: commonids.ValidateUserAssignedIdentityID,
-							},
+		// Though the 'None' type identity is declared in swagger, passing it to service triggers error: "Removing identity is not supported when creating or updating an image template.". So not expose it to users.
+		"identity": {
+			Type:     schema.TypeList,
+			Required: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"type": {
+						Type:     schema.TypeString,
+						Required: true,
+						ValidateFunc: validation.StringInSlice([]string{
+							string(identity.TypeUserAssigned),
+						}, false),
+					},
+					"identity_ids": {
+						Type:     schema.TypeSet,
+						Required: true,
+						Elem: &schema.Schema{
+							Type:         schema.TypeString,
+							ValidateFunc: commonids.ValidateUserAssignedIdentityID,
 						},
 					},
 				},
 			},
+		},
 
-			"build_timeout_minutes": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				ForceNew:     true,
-				Default:      240,
-				ValidateFunc: validation.IntBetween(0, 960),
-			},
+		"build_timeout_minutes": {
+			Type:         schema.TypeInt,
+			Optional:     true,
+			ForceNew:     true,
+			Default:      240,
+			ValidateFunc: validation.IntBetween(0, 960),
+		},
 
-			// Fields in this block should not be assigned default values. Because fields mapped to Customizer Type A should not be specified when Customizer Type B is specified as the current customizer block type.
-			"customizer": {
-				Type:     schema.TypeList,
-				Optional: true,
-				ForceNew: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"type": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								"File",
-								"PowerShell",
-								"Shell",
-								"WindowsRestart",
-								"WindowsUpdate",
-							}, false),
-						},
+		// Fields in this block should not be assigned default values. Because fields mapped to Customizer Type A should not be specified when Customizer Type B is specified as the current customizer block type.
+		"customizer": {
+			Type:     schema.TypeList,
+			Optional: true,
+			ForceNew: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"type": {
+						Type:     schema.TypeString,
+						Required: true,
+						ForceNew: true,
+						ValidateFunc: validation.StringInSlice([]string{
+							"File",
+							"PowerShell",
+							"Shell",
+							"WindowsRestart",
+							"WindowsUpdate",
+						}, false),
+					},
 
-						"file_destination_path": {
+					"file_destination_path": {
+						Type:         schema.TypeString,
+						Optional:     true,
+						ForceNew:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+
+					// If not specify this property but only "file_source_uri" to the service, the service will calculate the sha256 of the file and return it.
+					// So set this property as Computed for possible future usage. So forth to other similar properties in the `customizer` block.
+					"file_sha256_checksum": {
+						Type:         schema.TypeString,
+						Optional:     true,
+						Computed:     true,
+						ForceNew:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+
+					"file_source_uri": {
+						Type:         schema.TypeString,
+						Optional:     true,
+						ForceNew:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+
+					"name": {
+						Type:         schema.TypeString,
+						Optional:     true,
+						ForceNew:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+
+					"powershell_commands": {
+						Type:     schema.TypeList,
+						Optional: true,
+						ForceNew: true,
+						Elem: &schema.Schema{
 							Type:         schema.TypeString,
-							Optional:     true,
-							ForceNew:     true,
 							ValidateFunc: validation.StringIsNotEmpty,
 						},
+					},
 
-						// If not specify this property but only "file_source_uri" to the service, the service will calculate the sha256 of the file and return it.
-						// So set this property as Computed for possible future usage. So forth to other similar properties in the `customizer` block.
-						"file_sha256_checksum": {
+					"powershell_run_as_system": {
+						Type:     schema.TypeBool,
+						Optional: true,
+						ForceNew: true,
+					},
+
+					"powershell_run_elevated": {
+						Type:     schema.TypeBool,
+						Optional: true,
+						ForceNew: true,
+					},
+
+					"powershell_script_uri": {
+						Type:         schema.TypeString,
+						Optional:     true,
+						ForceNew:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+
+					"powershell_sha256_checksum": {
+						Type:         schema.TypeString,
+						Optional:     true,
+						Computed:     true,
+						ForceNew:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+
+					"powershell_valid_exit_codes": {
+						Type:     schema.TypeList,
+						Optional: true,
+						ForceNew: true,
+						Elem: &schema.Schema{
+							Type: schema.TypeInt,
+						},
+					},
+
+					"shell_commands": {
+						Type:     schema.TypeList,
+						Optional: true,
+						ForceNew: true,
+						Elem: &schema.Schema{
 							Type:         schema.TypeString,
-							Optional:     true,
-							Computed:     true,
-							ForceNew:     true,
 							ValidateFunc: validation.StringIsNotEmpty,
 						},
+					},
 
-						"file_source_uri": {
+					"shell_script_uri": {
+						Type:         schema.TypeString,
+						Optional:     true,
+						ForceNew:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+
+					"shell_sha256_checksum": {
+						Type:         schema.TypeString,
+						Computed:     true,
+						Optional:     true,
+						ForceNew:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+
+					"windows_restart_check_command": {
+						Type:         schema.TypeString,
+						Optional:     true,
+						ForceNew:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+
+					"windows_restart_command": {
+						Type:         schema.TypeString,
+						Optional:     true,
+						ForceNew:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+
+					"windows_restart_timeout": {
+						Type:         schema.TypeString,
+						Optional:     true,
+						ForceNew:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+
+					"windows_update_filters": {
+						Type:     schema.TypeList,
+						Optional: true,
+						ForceNew: true,
+						Elem: &schema.Schema{
 							Type:         schema.TypeString,
-							Optional:     true,
-							ForceNew:     true,
 							ValidateFunc: validation.StringIsNotEmpty,
 						},
+					},
 
-						"name": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ForceNew:     true,
-							ValidateFunc: validation.StringIsNotEmpty,
-						},
+					"windows_update_search_criteria": {
+						Type:         schema.TypeString,
+						Optional:     true,
+						ForceNew:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
 
-						"powershell_commands": {
-							Type:     schema.TypeList,
-							Optional: true,
-							ForceNew: true,
-							Elem: &schema.Schema{
-								Type:         schema.TypeString,
-								ValidateFunc: validation.StringIsNotEmpty,
-							},
-						},
-
-						"powershell_run_as_system": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							ForceNew: true,
-						},
-
-						"powershell_run_elevated": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							ForceNew: true,
-						},
-
-						"powershell_script_uri": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ForceNew:     true,
-							ValidateFunc: validation.StringIsNotEmpty,
-						},
-
-						"powershell_sha256_checksum": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Computed:     true,
-							ForceNew:     true,
-							ValidateFunc: validation.StringIsNotEmpty,
-						},
-
-						"powershell_valid_exit_codes": {
-							Type:     schema.TypeList,
-							Optional: true,
-							ForceNew: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeInt,
-							},
-						},
-
-						"shell_commands": {
-							Type:     schema.TypeList,
-							Optional: true,
-							ForceNew: true,
-							Elem: &schema.Schema{
-								Type:         schema.TypeString,
-								ValidateFunc: validation.StringIsNotEmpty,
-							},
-						},
-
-						"shell_script_uri": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ForceNew:     true,
-							ValidateFunc: validation.StringIsNotEmpty,
-						},
-
-						"shell_sha256_checksum": {
-							Type:         schema.TypeString,
-							Computed:     true,
-							Optional:     true,
-							ForceNew:     true,
-							ValidateFunc: validation.StringIsNotEmpty,
-						},
-
-						"windows_restart_check_command": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ForceNew:     true,
-							ValidateFunc: validation.StringIsNotEmpty,
-						},
-
-						"windows_restart_command": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ForceNew:     true,
-							ValidateFunc: validation.StringIsNotEmpty,
-						},
-
-						"windows_restart_timeout": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ForceNew:     true,
-							ValidateFunc: validation.StringIsNotEmpty,
-						},
-
-						"windows_update_filters": {
-							Type:     schema.TypeList,
-							Optional: true,
-							ForceNew: true,
-							Elem: &schema.Schema{
-								Type:         schema.TypeString,
-								ValidateFunc: validation.StringIsNotEmpty,
-							},
-						},
-
-						"windows_update_search_criteria": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ForceNew:     true,
-							ValidateFunc: validation.StringIsNotEmpty,
-						},
-
-						"windows_update_limit": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							ForceNew: true,
-						},
+					"windows_update_limit": {
+						Type:     schema.TypeInt,
+						Optional: true,
+						ForceNew: true,
 					},
 				},
 			},
+		},
 
-			"disk_size_gb": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validate.DiskSizeGB,
-			},
+		"disk_size_gb": {
+			Type:         schema.TypeInt,
+			Optional:     true,
+			ForceNew:     true,
+			ValidateFunc: validate.DiskSizeGB,
+		},
 
-			"distributions": {
-				Type:     schema.TypeList,
-				Required: true,
-				ForceNew: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						// The array of this block is order insensitive. But there is a bug preventing using TypeSet for this block having a sub field `location` using StateFunc:
-						// https://github.com/hashicorp/terraform-plugin-sdk/issues/160.
-						// In detail, the symptom is specifying user friendly region say "West US 2" in the sub field `location` generated two blocks even if only specifying one block in .tf.
-						// Using normalized region say "westus2" does not have the symptom.
-						// Given this bug would break the core logic, use TypeList as a workaround.
-						// This justification also applies to the "distribution_shared_image" block below.
-						"managed_image": {
-							Type:     schema.TypeList,
-							Optional: true,
-							ForceNew: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"name": {
-										Type:         schema.TypeString,
-										Required:     true,
-										ForceNew:     true,
-										ValidateFunc: validation.StringIsNotEmpty,
-									},
-
-									"resource_group_name": commonschema.ResourceGroupName(),
-
-									"location": commonschema.Location(),
-
-									"run_output_name": distributionRunOutputNameSchema(),
-
-									"tags": commonschema.TagsForceNew(),
+		"distributions": {
+			Type:     schema.TypeList,
+			Required: true,
+			ForceNew: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					// The array of this block is order insensitive. But there is a bug preventing using TypeSet for this block having a sub field `location` using StateFunc:
+					// https://github.com/hashicorp/terraform-plugin-sdk/issues/160.
+					// In detail, the symptom is specifying user friendly region say "West US 2" in the sub field `location` generated two blocks even if only specifying one block in .tf.
+					// Using normalized region say "westus2" does not have the symptom.
+					// Given this bug would break the core logic, use TypeList as a workaround.
+					// This justification also applies to the "distribution_shared_image" block below.
+					"managed_image": {
+						Type:     schema.TypeList,
+						Optional: true,
+						ForceNew: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"name": {
+									Type:         schema.TypeString,
+									Required:     true,
+									ForceNew:     true,
+									ValidateFunc: validation.StringIsNotEmpty,
 								},
+
+								"resource_group_name": commonschema.ResourceGroupName(),
+
+								"location": commonschema.Location(),
+
+								"run_output_name": distributionRunOutputNameSchema(),
+
+								"tags": commonschema.TagsForceNew(),
 							},
 						},
+					},
 
-						"shared_image": {
-							Type:     schema.TypeList,
-							Optional: true,
-							ForceNew: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"id": {
-										Type:         schema.TypeString,
-										Required:     true,
-										ForceNew:     true,
-										ValidateFunc: azure.ValidateResourceID,
-									},
+					"shared_image": {
+						Type:     schema.TypeList,
+						Optional: true,
+						ForceNew: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"id": {
+									Type:         schema.TypeString,
+									Required:     true,
+									ForceNew:     true,
+									ValidateFunc: azure.ValidateResourceID,
+								},
 
-									// The latest swagger (ver: 2020-02-14) defines this type as []string. However, in native SIG Image Version, not only region name but replica count and storage type are supported for each region.
-									// So leave the type of this field as array of object here to serve future possible extensibility without bringing in breaking changes in user facing schema.
-									"replica_regions": {
-										Type:     schema.TypeList,
-										Required: true,
-										MinItems: 1,
-										ForceNew: true,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"name": {
-													Type:             schema.TypeString,
-													Required:         true,
-													ForceNew:         true,
-													ValidateFunc:     location.EnhancedValidate,
-													StateFunc:        location.StateFunc,
-													DiffSuppressFunc: location.DiffSuppressFunc,
-												},
+								// The latest swagger (ver: 2020-02-14) defines this type as []string. However, in native SIG Image Version, not only region name but replica count and storage type are supported for each region.
+								// So leave the type of this field as array of object here to serve future possible extensibility without bringing in breaking changes in user facing schema.
+								"replica_regions": {
+									Type:     schema.TypeList,
+									Required: true,
+									MinItems: 1,
+									ForceNew: true,
+									Elem: &schema.Resource{
+										Schema: map[string]*schema.Schema{
+											"name": {
+												Type:             schema.TypeString,
+												Required:         true,
+												ForceNew:         true,
+												ValidateFunc:     location.EnhancedValidate,
+												StateFunc:        location.StateFunc,
+												DiffSuppressFunc: location.DiffSuppressFunc,
 											},
 										},
 									},
+								},
 
-									"run_output_name": distributionRunOutputNameSchema(),
+								"run_output_name": distributionRunOutputNameSchema(),
 
-									"exclude_from_latest": {
-										Type:     schema.TypeBool,
-										Optional: true,
-										ForceNew: true,
-										Default:  false,
-									},
+								"exclude_from_latest": {
+									Type:     schema.TypeBool,
+									Optional: true,
+									ForceNew: true,
+									Default:  false,
+								},
 
-									"storage_account_type": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ForceNew:     true,
-										ValidateFunc: validation.StringInSlice(virtualmachineimagetemplate.PossibleValuesForSharedImageStorageAccountType(), false),
-									},
+								"storage_account_type": {
+									Type:         schema.TypeString,
+									Optional:     true,
+									ForceNew:     true,
+									ValidateFunc: validation.StringInSlice(virtualmachineimagetemplate.PossibleValuesForSharedImageStorageAccountType(), false),
+								},
 
-									"tags": commonschema.TagsForceNew(),
+								"tags": commonschema.TagsForceNew(),
 
-									"versioning": {
-										Type:     schema.TypeList,
-										Required: true,
-										ForceNew: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"scheme": {
-													Type:     schema.TypeString,
-													Required: true,
-													ForceNew: true,
-													ValidateFunc: validation.StringInSlice([]string{
-														"Source",
-														"Latest",
-													}, false),
-												},
-												"major": {
-													Type:     schema.TypeInt,
-													Optional: true,
-													ForceNew: true,
-												},
+								"versioning": {
+									Type:     schema.TypeList,
+									Required: true,
+									ForceNew: true,
+									MaxItems: 1,
+									Elem: &schema.Resource{
+										Schema: map[string]*schema.Schema{
+											"scheme": {
+												Type:     schema.TypeString,
+												Required: true,
+												ForceNew: true,
+												ValidateFunc: validation.StringInSlice([]string{
+													"Source",
+													"Latest",
+												}, false),
+											},
+											"major": {
+												Type:     schema.TypeInt,
+												Optional: true,
+												ForceNew: true,
 											},
 										},
 									},
 								},
 							},
 						},
+					},
 
-						"vhd": {
-							Type:     schema.TypeList,
-							Optional: true,
-							ForceNew: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"run_output_name": distributionRunOutputNameSchema(),
+					"vhd": {
+						Type:     schema.TypeList,
+						Optional: true,
+						ForceNew: true,
+						MaxItems: 1,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"run_output_name": distributionRunOutputNameSchema(),
 
-									"tags": commonschema.TagsForceNew(),
+								"tags": commonschema.TagsForceNew(),
+							},
+						},
+					},
+				},
+			},
+		},
+
+		"size": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			Default:      "Standard_D1_v2",
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"source_managed_image_id": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			ValidateFunc: images.ValidateImageID,
+			ExactlyOneOf: []string{"source_managed_image_id", "source_platform_image", "source_shared_image_version_id"},
+		},
+
+		"source_platform_image": {
+			Type:     schema.TypeList,
+			Optional: true,
+			ForceNew: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"publisher": {
+						Type:         schema.TypeString,
+						Required:     true,
+						ForceNew:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+
+					"offer": {
+						Type:         schema.TypeString,
+						Required:     true,
+						ForceNew:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+
+					"sku": {
+						Type:         schema.TypeString,
+						Required:     true,
+						ForceNew:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+
+					// If specify "Latest", the returned value is "latest ([a specific version])". I.e. in this situation the value returned by the service does not honor case sensitivity and adds more values.
+					// A rest api bug filed: https://github.com/Azure/azure-rest-api-specs/issues/11313
+					"version": {
+						Type:         schema.TypeString,
+						Required:     true,
+						ForceNew:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+						DiffSuppressFunc: func(_, old, new string, d *schema.ResourceData) bool {
+							return strings.Contains(strings.ToLower(old), "latest (") && strings.EqualFold(new, "latest")
+						},
+					},
+
+					"plan": {
+						Type:     schema.TypeList,
+						Optional: true,
+						ForceNew: true,
+						MaxItems: 1,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"name": {
+									Type:         schema.TypeString,
+									Required:     true,
+									ForceNew:     true,
+									ValidateFunc: validation.StringIsNotEmpty,
+								},
+
+								"product": {
+									Type:         schema.TypeString,
+									Required:     true,
+									ForceNew:     true,
+									ValidateFunc: validation.StringIsNotEmpty,
+								},
+
+								"publisher": {
+									Type:         schema.TypeString,
+									Required:     true,
+									ForceNew:     true,
+									ValidateFunc: validation.StringIsNotEmpty,
 								},
 							},
 						},
 					},
 				},
 			},
-
-			"size": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				Default:      "Standard_D1_v2",
-				ValidateFunc: validation.StringIsNotEmpty,
-			},
-
-			"source_managed_image_id": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: images.ValidateImageID,
-				ExactlyOneOf: []string{"source_managed_image_id", "source_platform_image", "source_shared_image_version_id"},
-			},
-
-			"source_platform_image": {
-				Type:     schema.TypeList,
-				Optional: true,
-				ForceNew: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"publisher": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ForceNew:     true,
-							ValidateFunc: validation.StringIsNotEmpty,
-						},
-
-						"offer": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ForceNew:     true,
-							ValidateFunc: validation.StringIsNotEmpty,
-						},
-
-						"sku": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ForceNew:     true,
-							ValidateFunc: validation.StringIsNotEmpty,
-						},
-
-						// If specify "Latest", the returned value is "latest ([a specific version])". I.e. in this situation the value returned by the service does not honor case sensitivity and adds more values.
-						// A rest api bug filed: https://github.com/Azure/azure-rest-api-specs/issues/11313
-						"version": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ForceNew:     true,
-							ValidateFunc: validation.StringIsNotEmpty,
-							DiffSuppressFunc: func(_, old, new string, d *schema.ResourceData) bool {
-								return strings.Contains(strings.ToLower(old), "latest (") && strings.EqualFold(new, "latest")
-							},
-						},
-
-						"plan": {
-							Type:     schema.TypeList,
-							Optional: true,
-							ForceNew: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"name": {
-										Type:         schema.TypeString,
-										Required:     true,
-										ForceNew:     true,
-										ValidateFunc: validation.StringIsNotEmpty,
-									},
-
-									"product": {
-										Type:         schema.TypeString,
-										Required:     true,
-										ForceNew:     true,
-										ValidateFunc: validation.StringIsNotEmpty,
-									},
-
-									"publisher": {
-										Type:         schema.TypeString,
-										Required:     true,
-										ForceNew:     true,
-										ValidateFunc: validation.StringIsNotEmpty,
-									},
-								},
-							},
-						},
-					},
-				},
-				ExactlyOneOf: []string{"source_managed_image_id", "source_platform_image", "source_shared_image_version_id"},
-			},
-
-			"source_shared_image_version_id": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validate.SharedImageVersionID,
-				ExactlyOneOf: []string{"source_managed_image_id", "source_platform_image", "source_shared_image_version_id"},
-			},
-
-			"subnet_id": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: networkValidate.SubnetID,
-			},
-
-			"tags": commonschema.Tags(),
+			ExactlyOneOf: []string{"source_managed_image_id", "source_platform_image", "source_shared_image_version_id"},
 		},
+
+		"source_shared_image_version_id": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			ValidateFunc: validate.SharedImageVersionID,
+			ExactlyOneOf: []string{"source_managed_image_id", "source_platform_image", "source_shared_image_version_id"},
+		},
+
+		"subnet_id": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			ValidateFunc: networkValidate.SubnetID,
+		},
+
+		"tags": commonschema.Tags(),
 	}
 }
 
-func resourceArmImageBuilderTemplateCreate(d *schema.ResourceData, meta interface{}) error {
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
-	client := meta.(*clients.Client).Compute.VirtualMachineImageTemplateClient
-	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
-	defer cancel()
-
-	name := d.Get("name").(string)
-	resourceGroup := d.Get("resource_group_name").(string)
-	id := virtualmachineimagetemplate.NewImageTemplateID(subscriptionId, resourceGroup, name)
-	resp, err := client.Get(ctx, id)
-	if err != nil {
-		if !response.WasNotFound(resp.HttpResponse) {
-			return fmt.Errorf("checking for the presence of existing Image Builder Template %q (Resource Group %q): %s", name, resourceGroup, err)
-		}
-	}
-
-	if !response.WasNotFound(resp.HttpResponse) {
-		return tf.ImportAsExistsError("azurerm_image_builder_template", id.ID())
-	}
-
-	location := d.Get("location").(string)
-
-	distribution, err := expandBasicImageTemplateDistributor(d.Get("distributions").([]interface{}), subscriptionId)
-	if err != nil {
-		return err
-	}
-
-	customizer, err := expandBasicImageTemplateCustomizer(d)
-	if err != nil {
-		return err
-	}
-	t := d.Get("tags").(map[string]interface{})
-
-	identityExpanded, err := identity.ExpandUserAssignedMap(d.Get("identity").([]interface{}))
-	if err != nil {
-		return fmt.Errorf("expanding `identity`: %+v", err)
-	}
-
-	parameters := virtualmachineimagetemplate.ImageTemplate{
-		Location: location,
-		Identity: *identityExpanded,
-		Properties: &virtualmachineimagetemplate.ImageTemplateProperties{
-			VMProfile: &virtualmachineimagetemplate.ImageTemplateVMProfile{
-				VMSize:       pointer.To(d.Get("size").(string)),
-				OsDiskSizeGB: pointer.To(int64(d.Get("disk_size_gb").(int))),
-			},
-
-			Source:                expandBasicImageTemplateSource(d.Get("source_managed_image_id").(string), d.Get("source_platform_image").([]interface{}), d.Get("source_shared_image_version_id").(string)),
-			Distribute:            *distribution,
-			Customize:             customizer,
-			BuildTimeoutInMinutes: pointer.To(int64(d.Get("build_timeout_minutes").(int))),
-		},
-
-		Tags: tags.Expand(t),
-	}
-
-	if v, ok := d.GetOk("subnet_id"); ok {
-		parameters.Properties.VMProfile.VnetConfig = &virtualmachineimagetemplate.VirtualNetworkConfig{
-			SubnetId: pointer.To(v.(string)),
-		}
-	}
-
-	err = client.CreateOrUpdateThenPoll(ctx, id, parameters)
-	if err != nil {
-		return fmt.Errorf("creating image builder template %q (Resource Group %q): %+v", name, resourceGroup, err)
-	}
-
-	d.SetId(id.ID())
-
-	return resourceArmImageBuilderTemplateRead(d, meta)
+func (ImageBuilderTemplateResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{}
 }
 
-func resourceArmImageBuilderTemplateRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Compute.VirtualMachineImageTemplateClient
-	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
-	defer cancel()
+func (r ImageBuilderTemplateResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Compute.VirtualMachineImageTemplateClient
+			subscriptionId := metadata.Client.Account.SubscriptionId
 
-	id, err := virtualmachineimagetemplate.ParseImageTemplateID(d.Id())
-	if err != nil {
-		return err
-	}
+			var model ImageBuilderTemplateResourceModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
 
-	resp, err := client.Get(ctx, *id)
-	if err != nil {
-		if response.WasNotFound(resp.HttpResponse) {
-			d.SetId("")
-			return nil
-		}
-
-		return fmt.Errorf("retrieving image builder template %q (Resource Group %q): %+v", id.ImageTemplateName, id.ResourceGroupName, err)
-	}
-
-	d.Set("name", id.ImageTemplateName)
-	d.Set("resource_group_name", id.ResourceGroupName)
-
-	if model := resp.Model; model != nil {
-		d.Set("location", location.Normalize(model.Location))
-
-		identityFlattened, err := identity.FlattenUserAssignedMap(&model.Identity)
-		if err != nil {
-			return fmt.Errorf("flattening `identity`: %+v", err)
-		}
-		if err := d.Set("identity", identityFlattened); err != nil {
-			return fmt.Errorf("setting `identity`: %+v", err)
-		}
-
-		if imageTemplateProperties := resp.Model.Properties; imageTemplateProperties != nil {
-			managedImageId, platformImage, sharedImageVersionId := flattenBasicImageTemplateSource(imageTemplateProperties.Source)
-
-			// only one among managedImageId / platformImage / sharedImageVersionId would be returned.
-			if managedImageId != "" {
-				if err := d.Set("source_managed_image_id", managedImageId); err != nil {
-					return fmt.Errorf("setting image template managed image source: %+v", err)
+			id := virtualmachineimagetemplate.NewImageTemplateID(subscriptionId, model.ResourceGroupName, model.Name)
+			resp, err := client.Get(ctx, id)
+			if err != nil {
+				if !response.WasNotFound(resp.HttpResponse) {
+					return fmt.Errorf("checking for the presence of existing Image Builder Template %q (Resource Group %q): %s", model.Name, model.ResourceGroupName, err)
 				}
 			}
 
-			if len(platformImage) > 0 {
-				if err := d.Set("source_platform_image", platformImage); err != nil {
-					return fmt.Errorf("setting image template platform image source: %+v", err)
-				}
+			if !response.WasNotFound(resp.HttpResponse) {
+				return metadata.ResourceRequiresImport(r.ResourceType(), id)
 			}
 
-			if sharedImageVersionId != "" {
-				if err := d.Set("source_shared_image_version_id", sharedImageVersionId); err != nil {
-					return fmt.Errorf("setting image template shared image version source: %+v", err)
-				}
-			}
-
-			flattenedDistributions, err := flattenBasicImageTemplateDistributor(&imageTemplateProperties.Distribute)
+			distribution, err := expandBasicImageTemplateDistributor(model.Distributions, subscriptionId)
 			if err != nil {
 				return err
 			}
 
-			if err := d.Set("distributions", flattenedDistributions); err != nil {
-				return fmt.Errorf("setting image template distribution: %+v", err)
+			customizer, err := expandBasicImageTemplateCustomizer(metadata.ResourceData, model.Customizer)
+			if err != nil {
+				return err
 			}
 
-			if err := d.Set("customizer", flattenBasicImageTemplateCustomizer(imageTemplateProperties.Customize)); err != nil {
-				return fmt.Errorf("setting `customizer`: %+v", err)
+			identityExpanded, err := identity.ExpandUserAssignedMapFromModel(model.Identity)
+			if err != nil {
+				return fmt.Errorf("expanding `identity`: %+v", err)
 			}
 
-			if err := d.Set("build_timeout_minutes", imageTemplateProperties.BuildTimeoutInMinutes); err != nil {
-				return fmt.Errorf("setting `build timeout minutes`: %+v", err)
+			parameters := virtualmachineimagetemplate.ImageTemplate{
+				Location: model.Location,
+				Identity: *identityExpanded,
+				Properties: &virtualmachineimagetemplate.ImageTemplateProperties{
+					VMProfile: &virtualmachineimagetemplate.ImageTemplateVMProfile{
+						VMSize:       &model.Size,
+						OsDiskSizeGB: &model.DiskSizeGb,
+					},
+
+					Source:                expandBasicImageTemplateSource(model.SourceManagedImageId, model.SourcePlatformImage, model.SourceSharedImageVersionId),
+					Distribute:            *distribution,
+					Customize:             customizer,
+					BuildTimeoutInMinutes: &model.BuildTimeoutMinutes,
+				},
+
+				Tags: &model.Tags,
 			}
 
-			if vmProfile := resp.Model.Properties.VMProfile; vmProfile != nil {
-				d.Set("size", vmProfile.VMSize)
-
-				d.Set("disk_size_gb", vmProfile.OsDiskSizeGB)
-
-				if vnetConfig := vmProfile.VnetConfig; vnetConfig != nil {
-					d.Set("subnet_id", vnetConfig.SubnetId)
+			if model.SubnetId != "" {
+				parameters.Properties.VMProfile.VnetConfig = &virtualmachineimagetemplate.VirtualNetworkConfig{
+					SubnetId: &model.SubnetId,
 				}
 			}
-		}
-		if err := tags.FlattenAndSet(d, model.Tags); err != nil {
-			return err
-		}
 
+			err = client.CreateOrUpdateThenPoll(ctx, id, parameters)
+			if err != nil {
+				return fmt.Errorf("creating image builder template %q (Resource Group %q): %+v", model.Name, model.ResourceGroupName, err)
+			}
+
+			metadata.SetID(id)
+
+			return nil
+		},
 	}
-
-	return nil
 }
 
-func resourceArmImageBuilderTemplateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Compute.VirtualMachineImageTemplateClient
-	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
-	defer cancel()
+func (r ImageBuilderTemplateResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Compute.VirtualMachineImageTemplateClient
 
-	id, err := virtualmachineimagetemplate.ParseImageTemplateID(d.Id())
-	if err != nil {
-		return err
+			state := ImageBuilderTemplateResourceModel{}
+
+			id, err := virtualmachineimagetemplate.ParseImageTemplateID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.Get(ctx, *id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					log.Printf("[DEBUG] %s was not found - removing from state!", *id)
+					return metadata.MarkAsGone(id)
+				}
+
+				return fmt.Errorf("retrieving image builder template %q (Resource Group %q): %+v", id.ImageTemplateName, id.ResourceGroupName, err)
+			}
+
+			state.Name = id.ImageTemplateName
+			state.ResourceGroupName = id.ResourceGroupName
+
+			if model := resp.Model; model != nil {
+				state.Location = location.Normalize(model.Location)
+
+				identityFlattened, err := identity.FlattenUserAssignedMapToModel(&model.Identity)
+				if err != nil {
+					return fmt.Errorf("flattening `identity`: %+v", err)
+				}
+				state.Identity = *identityFlattened
+
+				if imageTemplateProperties := resp.Model.Properties; imageTemplateProperties != nil {
+					managedImageId, platformImage, sharedImageVersionId := flattenBasicImageTemplateSource(imageTemplateProperties.Source)
+
+					// only one among managedImageId / platformImage / sharedImageVersionId would be returned.
+					if managedImageId != "" {
+						state.SourceManagedImageId = managedImageId
+					}
+					if len(platformImage) > 0 {
+						state.SourcePlatformImage = platformImage
+					}
+
+					if sharedImageVersionId != "" {
+						state.SourceSharedImageVersionId = sharedImageVersionId
+					}
+
+					flattenedDistributions, err := flattenBasicImageTemplateDistributor(&imageTemplateProperties.Distribute)
+					if err != nil {
+						return err
+					}
+
+					state.Distributions = flattenedDistributions
+					state.Customizer = flattenBasicImageTemplateCustomizer(imageTemplateProperties.Customize)
+					state.BuildTimeoutMinutes = *imageTemplateProperties.BuildTimeoutInMinutes
+
+					if vmProfile := resp.Model.Properties.VMProfile; vmProfile != nil {
+						state.Size = *vmProfile.VMSize
+						state.DiskSizeGb = *vmProfile.OsDiskSizeGB
+
+						if vnetConfig := vmProfile.VnetConfig; vnetConfig != nil {
+							state.SubnetId = *vnetConfig.SubnetId
+						}
+					}
+				}
+				state.Tags = pointer.From(model.Tags)
+			}
+
+			return metadata.Encode(&state)
+		},
 	}
-
-	parameters := virtualmachineimagetemplate.ImageTemplateUpdateParameters{}
-
-	if d.HasChange("identity") {
-		identityExpanded, err := identity.ExpandUserAssignedMap(d.Get("identity").([]interface{}))
-		if err != nil {
-			return fmt.Errorf("expanding `identity`: %+v", err)
-		}
-
-		parameters.Identity = identityExpanded
-	}
-
-	if d.HasChange("tags") {
-		parameters.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
-	}
-
-	err = client.UpdateThenPoll(ctx, *id, parameters)
-	if err != nil {
-		return fmt.Errorf("updating image builder template %q (Resource Group %q): %+v", id.ImageTemplateName, id.ResourceGroupName, err)
-	}
-
-	return resourceArmImageBuilderTemplateRead(d, meta)
 }
 
-func resourceArmImageBuilderTemplateDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Compute.VirtualMachineImageTemplateClient
-	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
-	defer cancel()
+func (r ImageBuilderTemplateResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Compute.VirtualMachineImageTemplateClient
 
-	id, err := virtualmachineimagetemplate.ParseImageTemplateID(d.Id())
-	if err != nil {
-		return err
+			var model ImageBuilderTemplateResourceModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+			id, err := virtualmachineimagetemplate.ParseImageTemplateID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			parameters := virtualmachineimagetemplate.ImageTemplateUpdateParameters{}
+
+			if metadata.ResourceData.HasChange("identity") {
+				identityExpanded, err := identity.ExpandUserAssignedMapFromModel(model.Identity)
+				if err != nil {
+					return fmt.Errorf("expanding `identity`: %+v", err)
+				}
+
+				parameters.Identity = identityExpanded
+			}
+
+			if metadata.ResourceData.HasChange("tags") {
+				parameters.Tags = &model.Tags
+			}
+
+			err = client.UpdateThenPoll(ctx, *id, parameters)
+			if err != nil {
+				return fmt.Errorf("updating image builder template %q (Resource Group %q): %+v", id.ImageTemplateName, id.ResourceGroupName, err)
+			}
+
+			return nil
+		},
 	}
-
-	err = client.DeleteThenPoll(ctx, *id)
-	if err != nil {
-		return fmt.Errorf("deleting image builder template %q (Resource Group %q): %+v", id.ImageTemplateName, id.ResourceGroupName, err)
-	}
-
-	return nil
 }
 
-func expandBasicImageTemplateSource(managedImageId string, platformImage []interface{}, sharedImageId string) virtualmachineimagetemplate.ImageTemplateSource {
+func (r ImageBuilderTemplateResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Compute.VirtualMachineImageTemplateClient
+
+			id, err := virtualmachineimagetemplate.ParseImageTemplateID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			err = client.DeleteThenPoll(ctx, *id)
+			if err != nil {
+				return fmt.Errorf("deleting image builder template %q (Resource Group %q): %+v", id.ImageTemplateName, id.ResourceGroupName, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func expandBasicImageTemplateSource(managedImageId string, platformImage []ImageBuilderTemplateSourcePlatformImage, sharedImageId string) virtualmachineimagetemplate.ImageTemplateSource {
 	if len(managedImageId) != 0 {
 		return &virtualmachineimagetemplate.ImageTemplateManagedImageSource{
 			ImageId: managedImageId,
 		}
 	}
 
-	if len(platformImage) != 0 && platformImage[0] != nil {
-		v := platformImage[0].(map[string]interface{})
+	if len(platformImage) != 0 {
+		v := platformImage[0]
 		result := &virtualmachineimagetemplate.ImageTemplatePlatformImageSource{
-			Publisher: pointer.To(v["publisher"].(string)),
-			Offer:     pointer.To(v["offer"].(string)),
-			Sku:       pointer.To(v["sku"].(string)),
-			Version:   pointer.To(v["version"].(string)),
+			Publisher: &v.Publisher,
+			Offer:     &v.Offer,
+			Sku:       &v.Sku,
+			Version:   &v.Version,
 		}
 
-		planRaw := v["plan"].([]interface{})
-		if len(planRaw) > 0 {
-			planTemp := planRaw[0].(map[string]interface{})
+		if len(v.Plan) > 0 {
+			planTemp := v.Plan[0]
 			result.PlanInfo = &virtualmachineimagetemplate.PlatformImagePurchasePlan{
-				PlanName:      planTemp["name"].(string),
-				PlanProduct:   planTemp["product"].(string),
-				PlanPublisher: planTemp["publisher"].(string),
+				PlanName:      planTemp.Name,
+				PlanProduct:   planTemp.Product,
+				PlanPublisher: planTemp.Publisher,
 			}
 		}
 
@@ -779,7 +867,7 @@ func expandBasicImageTemplateSource(managedImageId string, platformImage []inter
 	return nil
 }
 
-func flattenBasicImageTemplateSource(input virtualmachineimagetemplate.ImageTemplateSource) (string, []interface{}, string) {
+func flattenBasicImageTemplateSource(input virtualmachineimagetemplate.ImageTemplateSource) (string, []ImageBuilderTemplateSourcePlatformImage, string) {
 	if input != nil {
 		switch source := input.(type) {
 		case virtualmachineimagetemplate.ImageTemplateManagedImageSource:
@@ -802,69 +890,48 @@ func flattenSourceManagedImage(input *virtualmachineimagetemplate.ImageTemplateM
 	return ""
 }
 
-func flattenSourcePlatformImage(input *virtualmachineimagetemplate.ImageTemplatePlatformImageSource) []interface{} {
+func flattenSourcePlatformImage(input *virtualmachineimagetemplate.ImageTemplatePlatformImageSource) []ImageBuilderTemplateSourcePlatformImage {
 	if input == nil {
-		return []interface{}{}
+		return nil
 	}
 
-	publisher := ""
+	result := make([]ImageBuilderTemplateSourcePlatformImage, 0)
+
+	result = append(result, ImageBuilderTemplateSourcePlatformImage{
+		Plan: flattenImageBuilderTemplateSourcePlatformImagePlan(input.PlanInfo),
+	})
+
 	if input.Publisher != nil {
-		publisher = *input.Publisher
+		result[0].Publisher = *input.Publisher
 	}
 
-	offer := ""
 	if input.Offer != nil {
-		offer = *input.Offer
+		result[0].Offer = *input.Offer
 	}
 
-	sku := ""
 	if input.Sku != nil {
-		sku = *input.Sku
+		result[0].Sku = *input.Sku
 	}
 
-	version := ""
 	if input.Version != nil {
-		version = *input.Version
+		result[0].Version = *input.Version
 	}
-
-	return []interface{}{
-		map[string]interface{}{
-			"publisher": publisher,
-			"offer":     offer,
-			"sku":       sku,
-			"version":   version,
-			"plan":      flattenImageBuilderTemplateSourcePlatformImagePlan(input.PlanInfo),
-		},
-	}
+	return result
 }
 
-func flattenImageBuilderTemplateSourcePlatformImagePlan(input *virtualmachineimagetemplate.PlatformImagePurchasePlan) []interface{} {
+func flattenImageBuilderTemplateSourcePlatformImagePlan(input *virtualmachineimagetemplate.PlatformImagePurchasePlan) []ImageBuilderTemplateSourcePlatformImagePlan {
 	if input == nil {
-		return []interface{}{}
+		return nil
 	}
 
-	name := ""
-	if input.PlanName != "" {
-		name = input.PlanName
-	}
+	result := make([]ImageBuilderTemplateSourcePlatformImagePlan, 0)
 
-	product := ""
-	if input.PlanProduct != "" {
-		product = input.PlanProduct
-	}
-
-	publisher := ""
-	if input.PlanPublisher != "" {
-		publisher = input.PlanPublisher
-	}
-
-	return []interface{}{
-		map[string]interface{}{
-			"name":      name,
-			"product":   product,
-			"publisher": publisher,
-		},
-	}
+	result = append(result, ImageBuilderTemplateSourcePlatformImagePlan{
+		Name:      input.PlanName,
+		Product:   input.PlanProduct,
+		Publisher: input.PlanPublisher,
+	})
+	return result
 }
 
 func flattenSourceSharedImageVersion(input *virtualmachineimagetemplate.ImageTemplateSharedImageVersionSource) string {
@@ -875,88 +942,81 @@ func flattenSourceSharedImageVersion(input *virtualmachineimagetemplate.ImageTem
 	return ""
 }
 
-func expandBasicImageTemplateDistributor(distributions []interface{}, subscriptionId string) (*[]virtualmachineimagetemplate.ImageTemplateDistributor, error) {
+func expandBasicImageTemplateDistributor(distributions []ImageBuilderTemplateDistributions, subscriptionId string) (*[]virtualmachineimagetemplate.ImageTemplateDistributor, error) {
 	results := make([]virtualmachineimagetemplate.ImageTemplateDistributor, 0)
 	runOutputNameSet := make(map[string]bool)
 
 	if len(distributions) > 0 {
 		for _, v := range distributions {
-			if v != nil {
-				distributionItems := v.(map[string]interface{})
-				managedImages := distributionItems["managed_image"].([]interface{})
-				sharedImages := distributionItems["shared_image"].([]interface{})
-				vhds := distributionItems["vhd"].([]interface{})
+			managedImages := v.ManagedImage
+			sharedImages := v.SharedImage
+			vhds := v.Vhd
 
-				if len(managedImages) > 0 {
-					for _, managedImageRaw := range managedImages {
-						if managedImageRaw != nil {
-							managedImage := managedImageRaw.(map[string]interface{})
-							resourceGroupName := managedImage["resource_group_name"].(string)
-							runOutputName := managedImage["run_output_name"].(string)
-
-							_, existing := runOutputNameSet[runOutputName]
-							if existing {
-								return &results, fmt.Errorf("`run_output_name` must be unique among all distribution destinations. %q already exists", runOutputName)
-							} else {
-								runOutputNameSet[runOutputName] = true
-
-								results = append(results, virtualmachineimagetemplate.ImageTemplateManagedImageDistributor{
-									ImageId:       "/subscriptions/" + subscriptionId + "/resourceGroups/" + resourceGroupName + "/providers/Microsoft.Compute/images/" + managedImage["name"].(string),
-									Location:      managedImage["location"].(string),
-									RunOutputName: runOutputName,
-									ArtifactTags:  tags.Expand(managedImage["tags"].(map[string]interface{})),
-								})
-							}
-						}
-					}
-				}
-
-				if len(sharedImages) > 0 {
-					for _, sharedImageRaw := range sharedImages {
-						if sharedImageRaw != nil {
-							sharedImage := sharedImageRaw.(map[string]interface{})
-							runOutputName := sharedImage["run_output_name"].(string)
-
-							_, existing := runOutputNameSet[runOutputName]
-							if existing {
-								return &results, fmt.Errorf("`run_output_name` must be unique among all distribution destinations. %q already exists", runOutputName)
-							} else {
-								runOutputNameSet[runOutputName] = true
-								results = append(results, virtualmachineimagetemplate.ImageTemplateSharedImageDistributor{
-									GalleryImageId:     sharedImage["id"].(string),
-									ReplicationRegions: expandImageTemplateSharedImageDistributorReplicaRegions(sharedImage["replica_regions"].([]interface{})),
-									RunOutputName:      sharedImage["run_output_name"].(string),
-									ExcludeFromLatest:  pointer.To(sharedImage["exclude_from_latest"].(bool)),
-									StorageAccountType: pointer.To(virtualmachineimagetemplate.SharedImageStorageAccountType(sharedImage["storage_account_type"].(string))),
-									ArtifactTags:       tags.Expand(sharedImage["tags"].(map[string]interface{})),
-									Versioning:         expandImageTemplateSharedImageDistributorVersioning(sharedImage["versioning"].([]interface{})),
-								})
-							}
-						}
-					}
-				}
-
-				if len(vhds) > 0 {
-					for _, vhdRaw := range vhds {
-						if vhdRaw != nil {
-							vhd := vhdRaw.(map[string]interface{})
-							runOutputName := vhd["run_output_name"].(string)
-
-							_, existing := runOutputNameSet[runOutputName]
-							if existing {
-								return &results, fmt.Errorf("`run_output_name` must be unique among all distribution destinations. %q already exists", runOutputName)
-							} else {
-								runOutputNameSet[runOutputName] = true
-								results = append(results, virtualmachineimagetemplate.ImageTemplateVhdDistributor{
-									RunOutputName: vhd["run_output_name"].(string),
-									ArtifactTags:  tags.Expand(vhd["tags"].(map[string]interface{})),
-								})
-							}
-						}
-					}
-				}
-			} else {
+			if len(managedImages) == 0 && len(sharedImages) == 0 && len(vhds) == 0 {
 				return &results, fmt.Errorf("at least one of `managed_image`, `shared_image` and `vhd` is required to specify in `distributions`")
+			}
+
+			if len(managedImages) > 0 {
+				for _, managedImage := range managedImages {
+					resourceGroupName := managedImage.ResourceGroupName
+					runOutputName := managedImage.RunOutputName
+
+					_, existing := runOutputNameSet[runOutputName]
+					if existing {
+						return &results, fmt.Errorf("`run_output_name` must be unique among all distribution destinations. %q already exists", runOutputName)
+					} else {
+						runOutputNameSet[runOutputName] = true
+
+						results = append(results, virtualmachineimagetemplate.ImageTemplateManagedImageDistributor{
+							ImageId:       "/subscriptions/" + subscriptionId + "/resourceGroups/" + resourceGroupName + "/providers/Microsoft.Compute/images/" + managedImage.Name,
+							Location:      managedImage.Location,
+							RunOutputName: runOutputName,
+							ArtifactTags:  &managedImage.Tags,
+						})
+					}
+
+				}
+			}
+
+			if len(sharedImages) > 0 {
+				for _, sharedImage := range sharedImages {
+					// sharedImage := sharedImageRaw.(map[string]interface{})
+					runOutputName := sharedImage.RunOutputName
+
+					_, existing := runOutputNameSet[runOutputName]
+					if existing {
+						return &results, fmt.Errorf("`run_output_name` must be unique among all distribution destinations. %q already exists", runOutputName)
+					} else {
+						runOutputNameSet[runOutputName] = true
+						results = append(results, virtualmachineimagetemplate.ImageTemplateSharedImageDistributor{
+							GalleryImageId:     sharedImage.Id,
+							ReplicationRegions: expandImageTemplateSharedImageDistributorReplicaRegions(sharedImage.ReplicaRegions),
+							RunOutputName:      sharedImage.RunOutputName,
+							ExcludeFromLatest:  &sharedImage.ExcludeFromLatest,
+							StorageAccountType: pointer.To(virtualmachineimagetemplate.SharedImageStorageAccountType(sharedImage.StorageAccountType)),
+							ArtifactTags:       &sharedImage.Tags,
+							Versioning:         expandImageTemplateSharedImageDistributorVersioning(sharedImage.Versioning),
+						})
+					}
+				}
+			}
+
+			if len(vhds) > 0 {
+				for _, vhd := range vhds {
+					// vhd := vhdRaw.(map[string]interface{})
+					runOutputName := vhd.RunOutputName
+
+					_, existing := runOutputNameSet[runOutputName]
+					if existing {
+						return &results, fmt.Errorf("`run_output_name` must be unique among all distribution destinations. %q already exists", runOutputName)
+					} else {
+						runOutputNameSet[runOutputName] = true
+						results = append(results, virtualmachineimagetemplate.ImageTemplateVhdDistributor{
+							RunOutputName: vhd.RunOutputName,
+							ArtifactTags:  &vhd.Tags,
+						})
+					}
+				}
 			}
 		}
 	}
@@ -964,12 +1024,12 @@ func expandBasicImageTemplateDistributor(distributions []interface{}, subscripti
 	return &results, nil
 }
 
-func flattenBasicImageTemplateDistributor(input *[]virtualmachineimagetemplate.ImageTemplateDistributor) ([]interface{}, error) {
-	results := make([]interface{}, 0)
+func flattenBasicImageTemplateDistributor(input *[]virtualmachineimagetemplate.ImageTemplateDistributor) ([]ImageBuilderTemplateDistributions, error) {
+	results := make([]ImageBuilderTemplateDistributions, 0)
 
-	distributionManagedImages := make([]interface{}, 0)
-	distributionSharedImages := make([]interface{}, 0)
-	distributionVhds := make([]interface{}, 0)
+	distributionManagedImages := make([]ImageBuilderTemplateDistributionsManagedImage, 0)
+	distributionSharedImages := make([]ImageBuilderTemplateDistributionsSharedImage, 0)
+	distributionVhds := make([]ImageBuilderTemplateDistributionsVhd, 0)
 
 	if input != nil {
 		for _, v := range *input {
@@ -989,61 +1049,61 @@ func flattenBasicImageTemplateDistributor(input *[]virtualmachineimagetemplate.I
 		}
 	}
 
-	output := map[string]interface{}{
-		"managed_image": distributionManagedImages,
-		"shared_image":  distributionSharedImages,
-		"vhd":           distributionVhds,
+	output := ImageBuilderTemplateDistributions{
+		ManagedImage: distributionManagedImages,
+		SharedImage:  distributionSharedImages,
+		Vhd:          distributionVhds,
 	}
 
 	results = append(results, output)
 	return results, nil
 }
 
-func expandImageTemplateSharedImageDistributorReplicaRegions(input []interface{}) *[]string {
+func expandImageTemplateSharedImageDistributorReplicaRegions(input []ImageBuilderTemplateDistributionsSharedImageReplicaRegions) *[]string {
 	if input == nil {
 		return nil
 	}
 
 	result := make([]string, 0)
 	for _, v := range input {
-		result = append(result, v.(map[string]interface{})["name"].(string))
+		result = append(result, v.Name)
 	}
 
 	return &result
 }
 
-func expandImageTemplateSharedImageDistributorVersioning(input []interface{}) virtualmachineimagetemplate.DistributeVersioner {
+func expandImageTemplateSharedImageDistributorVersioning(input []ImageBuilderTemplateDistributionsSharedImageVersioning) virtualmachineimagetemplate.DistributeVersioner {
 	var result virtualmachineimagetemplate.DistributeVersioner
 	if len(input) > 0 {
-		config := input[0].(map[string]interface{})
+		config := input[0]
 
-		if v := config["scheme"].(string); v == "Latest" {
+		if v := config.Scheme; v == "Latest" {
 			result = virtualmachineimagetemplate.DistributeVersionerLatest{
-				Scheme: config["scheme"].(string),
-				Major:  pointer.To(config["major"].(int64)),
+				Scheme: config.Scheme,
+				Major:  &config.Major,
 			}
 		}
 
-		if v := config["scheme"].(string); v == "Source" {
+		if v := config.Scheme; v == "Source" {
 			result = virtualmachineimagetemplate.DistributeVersionerSource{
-				Scheme: config["scheme"].(string),
+				Scheme: config.Scheme,
 			}
 		}
 	}
 	return result
 }
 
-func flattenImageTemplateSharedImageDistributorVersioning(input virtualmachineimagetemplate.DistributeVersioner) []interface{} {
-	results := make([]interface{}, 0)
-	output := make(map[string]interface{})
+func flattenImageTemplateSharedImageDistributorVersioning(input virtualmachineimagetemplate.DistributeVersioner) []ImageBuilderTemplateDistributionsSharedImageVersioning {
+	results := make([]ImageBuilderTemplateDistributionsSharedImageVersioning, 0)
+	output := ImageBuilderTemplateDistributionsSharedImageVersioning{}
 
 	switch versioner := input.(type) {
 	case virtualmachineimagetemplate.DistributeVersionerLatest:
-		output["scheme"] = versioner.Scheme
-		output["major"] = versioner.Major
+		output.Scheme = versioner.Scheme
+		output.Major = *versioner.Major
 
 	case virtualmachineimagetemplate.DistributeVersionerSource:
-		output["scheme"] = versioner.Scheme
+		output.Scheme = versioner.Scheme
 	}
 
 	results = append(results, output)
@@ -1051,22 +1111,22 @@ func flattenImageTemplateSharedImageDistributorVersioning(input virtualmachineim
 	return results
 }
 
-func flattenImageTemplateSharedImageDistributorReplicaRegions(input *[]string) []interface{} {
-	results := make([]interface{}, 0)
+func flattenImageTemplateSharedImageDistributorReplicaRegions(input *[]string) []ImageBuilderTemplateDistributionsSharedImageReplicaRegions {
+	results := make([]ImageBuilderTemplateDistributionsSharedImageReplicaRegions, 0)
 
 	if input != nil {
 		for _, v := range *input {
-			output := make(map[string]interface{})
-			output["name"] = v
-			results = append(results, output)
+			results = append(results, ImageBuilderTemplateDistributionsSharedImageReplicaRegions{
+				Name: v,
+			})
 		}
 	}
 
 	return results
 }
 
-func flattenDistributionManagedImage(input *virtualmachineimagetemplate.ImageTemplateManagedImageDistributor) (map[string]interface{}, error) {
-	result := make(map[string]interface{})
+func flattenDistributionManagedImage(input *virtualmachineimagetemplate.ImageTemplateManagedImageDistributor) (ImageBuilderTemplateDistributionsManagedImage, error) {
+	result := ImageBuilderTemplateDistributionsManagedImage{}
 	if input == nil {
 		return result, nil
 	}
@@ -1083,79 +1143,64 @@ func flattenDistributionManagedImage(input *virtualmachineimagetemplate.ImageTem
 		resourceGroupName = resourceGroupNameReturned
 	}
 
-	result["name"] = imageName
-	result["resource_group_name"] = resourceGroupName
-
-	if input.Location != "" {
-		result["location"] = input.Location
-	}
-
-	if input.RunOutputName != "" {
-		result["run_output_name"] = input.RunOutputName
-	}
-
-	if input.ArtifactTags != nil {
-		result["tags"] = tags.Flatten(input.ArtifactTags)
-	}
+	result.Name = imageName
+	result.ResourceGroupName = resourceGroupName
+	result.Location = input.Location
+	result.RunOutputName = input.RunOutputName
+	result.Tags = *input.ArtifactTags
 
 	return result, nil
 }
 
-func flattenDistributionSharedImage(input *virtualmachineimagetemplate.ImageTemplateSharedImageDistributor) map[string]interface{} {
-	results := make(map[string]interface{})
+func flattenDistributionSharedImage(input *virtualmachineimagetemplate.ImageTemplateSharedImageDistributor) ImageBuilderTemplateDistributionsSharedImage {
+	results := ImageBuilderTemplateDistributionsSharedImage{}
 	if input == nil {
 		return results
 	}
 
-	if input.GalleryImageId != "" {
-		results["id"] = input.GalleryImageId
-	}
+	results.Id = input.GalleryImageId
 
 	if input.ReplicationRegions != nil {
-		results["replica_regions"] = flattenImageTemplateSharedImageDistributorReplicaRegions(input.ReplicationRegions)
+		results.ReplicaRegions = flattenImageTemplateSharedImageDistributorReplicaRegions(input.ReplicationRegions)
 	}
 
-	if input.RunOutputName != "" {
-		results["run_output_name"] = input.RunOutputName
-	}
+	results.RunOutputName = input.RunOutputName
 
 	if input.ExcludeFromLatest != nil {
-		results["exclude_from_latest"] = *input.ExcludeFromLatest
+		results.ExcludeFromLatest = *input.ExcludeFromLatest
 	}
 
 	if input.StorageAccountType != nil {
-		results["storage_account_type"] = string(*input.StorageAccountType)
+		results.StorageAccountType = string(*input.StorageAccountType)
 	}
 
 	if input.ArtifactTags != nil {
-		results["tags"] = tags.Flatten(input.ArtifactTags)
+		results.Tags = *input.ArtifactTags
 	}
 
-	results["versioning"] = flattenImageTemplateSharedImageDistributorVersioning(input.Versioning)
+	results.Versioning = flattenImageTemplateSharedImageDistributorVersioning(input.Versioning)
 	return results
 }
 
-func flattenDistributionVhd(input *virtualmachineimagetemplate.ImageTemplateVhdDistributor) map[string]interface{} {
-	results := make(map[string]interface{})
+func flattenDistributionVhd(input *virtualmachineimagetemplate.ImageTemplateVhdDistributor) ImageBuilderTemplateDistributionsVhd {
+	results := ImageBuilderTemplateDistributionsVhd{}
 	if input == nil {
 		return results
 	}
 
 	if input.RunOutputName != "" {
-		results["run_output_name"] = input.RunOutputName
+		results.RunOutputName = input.RunOutputName
 	}
 
 	if input.ArtifactTags != nil {
-		results["tags"] = tags.Flatten(input.ArtifactTags)
+		results.Tags = *input.ArtifactTags
 	}
 
 	return results
 }
 
 // Passing d as input rather its business subset because this function needs d.GetOK() to verify users' input to the `customizer` block is valid.
-func expandBasicImageTemplateCustomizer(d *schema.ResourceData) (*[]virtualmachineimagetemplate.ImageTemplateCustomizer, error) {
-	input := d.Get("customizer").([]interface{})
-
+func expandBasicImageTemplateCustomizer(d *schema.ResourceData, input []ImageBuilderTemplateCustomizer) (*[]virtualmachineimagetemplate.ImageTemplateCustomizer, error) {
 	if len(input) == 0 {
 		return nil, nil
 	}
@@ -1165,9 +1210,8 @@ func expandBasicImageTemplateCustomizer(d *schema.ResourceData) (*[]virtualmachi
 	// This index serves identifying the invalid input customizer block from the customizer block list.
 	i := 0
 
-	for _, customizerRaw := range input {
-		customizer := customizerRaw.(map[string]interface{})
-		t := customizer["type"].(string)
+	for _, customizer := range input {
+		t := customizer.Type
 
 		switch t {
 		case "File":
@@ -1176,10 +1220,10 @@ func expandBasicImageTemplateCustomizer(d *schema.ResourceData) (*[]virtualmachi
 			}
 
 			results = append(results, virtualmachineimagetemplate.ImageTemplateFileCustomizer{
-				Name:           pointer.To(customizer["name"].(string)),
-				SourceUri:      pointer.To(customizer["file_source_uri"].(string)),
-				Sha256Checksum: pointer.To(customizer["file_sha256_checksum"].(string)),
-				Destination:    pointer.To(customizer["file_destination_path"].(string)),
+				Name:           pointer.To(customizer.Name),
+				SourceUri:      pointer.To(customizer.FileSourceUri),
+				Sha256Checksum: pointer.To(customizer.FileSha256Checksum),
+				Destination:    pointer.To(customizer.FileDestinationPath),
 			})
 
 			i++
@@ -1189,13 +1233,13 @@ func expandBasicImageTemplateCustomizer(d *schema.ResourceData) (*[]virtualmachi
 			}
 
 			results = append(results, virtualmachineimagetemplate.ImageTemplatePowerShellCustomizer{
-				Name:           pointer.To(customizer["name"].(string)),
-				ScriptUri:      pointer.To(customizer["powershell_script_uri"].(string)),
-				Sha256Checksum: pointer.To(customizer["powershell_sha256_checksum"].(string)),
-				Inline:         utils.ExpandStringSlice(customizer["powershell_commands"].([]interface{})),
-				RunAsSystem:    pointer.To(customizer["powershell_run_as_system"].(bool)),
-				RunElevated:    pointer.To(customizer["powershell_run_elevated"].(bool)),
-				ValidExitCodes: utils.ExpandInt64Slice(customizer["powershell_valid_exit_codes"].([]interface{})),
+				Name:           pointer.To(customizer.Name),
+				ScriptUri:      pointer.To(customizer.PowershellScriptUri),
+				Sha256Checksum: pointer.To(customizer.PowershellSha256Checksum),
+				Inline:         pointer.To(customizer.PowershellCommands),
+				RunAsSystem:    pointer.To(customizer.PowershellRunAsSystem),
+				RunElevated:    pointer.To(customizer.PowershellRunElevated),
+				ValidExitCodes: pointer.To(customizer.PowershellValidExitCodes),
 			})
 
 			i++
@@ -1205,10 +1249,10 @@ func expandBasicImageTemplateCustomizer(d *schema.ResourceData) (*[]virtualmachi
 			}
 
 			results = append(results, virtualmachineimagetemplate.ImageTemplateShellCustomizer{
-				Name:           pointer.To(customizer["name"].(string)),
-				ScriptUri:      pointer.To(customizer["shell_script_uri"].(string)),
-				Sha256Checksum: pointer.To(customizer["shell_sha256_checksum"].(string)),
-				Inline:         utils.ExpandStringSlice(customizer["shell_commands"].([]interface{})),
+				Name:           pointer.To(customizer.Name),
+				ScriptUri:      pointer.To(customizer.ShellScriptUri),
+				Sha256Checksum: pointer.To(customizer.ShellSha256Checksum),
+				Inline:         pointer.To(customizer.ShellCommands),
 			})
 
 			i++
@@ -1218,10 +1262,10 @@ func expandBasicImageTemplateCustomizer(d *schema.ResourceData) (*[]virtualmachi
 			}
 
 			results = append(results, virtualmachineimagetemplate.ImageTemplateRestartCustomizer{
-				Name:                pointer.To(customizer["name"].(string)),
-				RestartCommand:      pointer.To(customizer["windows_restart_command"].(string)),
-				RestartCheckCommand: pointer.To(customizer["windows_restart_check_command"].(string)),
-				RestartTimeout:      pointer.To(customizer["windows_restart_timeout"].(string)),
+				Name:                pointer.To(customizer.Name),
+				RestartCommand:      pointer.To(customizer.WindowsRestartCommand),
+				RestartCheckCommand: pointer.To(customizer.WindowsRestartCheckCommand),
+				RestartTimeout:      pointer.To(customizer.WindowsRestartTimeout),
 			})
 
 			i++
@@ -1231,10 +1275,10 @@ func expandBasicImageTemplateCustomizer(d *schema.ResourceData) (*[]virtualmachi
 			}
 
 			results = append(results, virtualmachineimagetemplate.ImageTemplateWindowsUpdateCustomizer{
-				Name:           pointer.To(customizer["name"].(string)),
-				SearchCriteria: pointer.To(customizer["windows_update_search_criteria"].(string)),
-				Filters:        utils.ExpandStringSlice(customizer["windows_update_filters"].([]interface{})),
-				UpdateLimit:    pointer.To(int64(customizer["windows_update_limit"].(int))),
+				Name:           pointer.To(customizer.Name),
+				SearchCriteria: pointer.To(customizer.WindowsUpdateSearchCriteria),
+				Filters:        pointer.To(customizer.WindowsUpdateFilters),
+				UpdateLimit:    pointer.To(customizer.WindowsUpdateLimit),
 			})
 
 			i++
@@ -1244,8 +1288,8 @@ func expandBasicImageTemplateCustomizer(d *schema.ResourceData) (*[]virtualmachi
 	return &results, nil
 }
 
-func flattenBasicImageTemplateCustomizer(input *[]virtualmachineimagetemplate.ImageTemplateCustomizer) []interface{} {
-	customizerList := make([]interface{}, 0)
+func flattenBasicImageTemplateCustomizer(input *[]virtualmachineimagetemplate.ImageTemplateCustomizer) []ImageBuilderTemplateCustomizer {
+	customizerList := make([]ImageBuilderTemplateCustomizer, 0)
 
 	if input != nil {
 		for _, v := range *input {
@@ -1269,163 +1313,149 @@ func flattenBasicImageTemplateCustomizer(input *[]virtualmachineimagetemplate.Im
 	return customizerList
 }
 
-func flattenCustomizerFile(input *virtualmachineimagetemplate.ImageTemplateFileCustomizer) map[string]interface{} {
+func flattenCustomizerFile(input *virtualmachineimagetemplate.ImageTemplateFileCustomizer) ImageBuilderTemplateCustomizer {
+	result := ImageBuilderTemplateCustomizer{}
+
 	if input == nil {
-		return nil
+		return result
 	}
 
-	result := make(map[string]interface{})
-	result["type"] = "File"
+	result.Type = "File"
 
-	name := ""
 	if input.Name != nil {
-		name = *input.Name
+		result.Name = *input.Name
 	}
-
-	result["name"] = name
 
 	if input.SourceUri != nil {
-		result["file_source_uri"] = *input.SourceUri
+		result.FileSourceUri = *input.SourceUri
 	}
 
 	if input.Sha256Checksum != nil {
-		result["file_sha256_checksum"] = *input.Sha256Checksum
+		result.FileSha256Checksum = *input.Sha256Checksum
 	}
 
 	if input.Destination != nil {
-		result["file_destination_path"] = *input.Destination
+		result.FileDestinationPath = *input.Destination
 	}
 
 	return result
 }
 
-func flattenCustomizerShell(input *virtualmachineimagetemplate.ImageTemplateShellCustomizer) map[string]interface{} {
+func flattenCustomizerShell(input *virtualmachineimagetemplate.ImageTemplateShellCustomizer) ImageBuilderTemplateCustomizer {
+	result := ImageBuilderTemplateCustomizer{}
 	if input == nil {
-		return nil
+		return result
 	}
 
-	result := make(map[string]interface{})
-	result["type"] = "Shell"
+	result.Type = "Shell"
 
-	name := ""
 	if input.Name != nil {
-		name = *input.Name
+		result.Name = *input.Name
 	}
-
-	result["name"] = name
 
 	if input.ScriptUri != nil {
-		result["shell_script_uri"] = *input.ScriptUri
+		result.ShellScriptUri = *input.ScriptUri
 	}
 
 	if input.Sha256Checksum != nil {
-		result["shell_sha256_checksum"] = *input.Sha256Checksum
+		result.ShellSha256Checksum = *input.Sha256Checksum
 	}
 
 	if input.Inline != nil {
-		result["shell_commands"] = *input.Inline
+		result.ShellCommands = *input.Inline
 	}
 
 	return result
 }
 
-func flattenCustomizerPowerShell(input *virtualmachineimagetemplate.ImageTemplatePowerShellCustomizer) map[string]interface{} {
+func flattenCustomizerPowerShell(input *virtualmachineimagetemplate.ImageTemplatePowerShellCustomizer) ImageBuilderTemplateCustomizer {
+	result := ImageBuilderTemplateCustomizer{}
 	if input == nil {
-		return nil
+		return result
 	}
 
-	result := make(map[string]interface{})
-	result["type"] = "PowerShell"
+	result.Type = "PowerShell"
 
-	name := ""
 	if input.Name != nil {
-		name = *input.Name
+		result.Name = *input.Name
 	}
-
-	result["name"] = name
 
 	if input.ScriptUri != nil {
-		result["powershell_script_uri"] = *input.ScriptUri
+		result.PowershellScriptUri = *input.ScriptUri
 	}
 
 	if input.Sha256Checksum != nil {
-		result["powershell_sha256_checksum"] = *input.Sha256Checksum
+		result.PowershellSha256Checksum = *input.Sha256Checksum
 	}
 
 	if input.Inline != nil {
-		result["powershell_commands"] = *input.Inline
+		result.PowershellCommands = *input.Inline
 	}
 
 	if input.RunAsSystem != nil {
-		result["powershell_run_as_system"] = *input.RunAsSystem
+		result.PowershellRunAsSystem = pointer.From(input.RunAsSystem)
 	}
 
 	if input.RunElevated != nil {
-		result["powershell_run_elevated"] = *input.RunElevated
+		result.PowershellRunElevated = *input.RunElevated
 	}
 
 	if input.ValidExitCodes != nil {
-		result["powershell_valid_exit_codes"] = *input.ValidExitCodes
+		result.PowershellValidExitCodes = *input.ValidExitCodes
 	}
 
 	return result
 }
 
-func flattenCustomizerWindowsRestart(input *virtualmachineimagetemplate.ImageTemplateRestartCustomizer) map[string]interface{} {
+func flattenCustomizerWindowsRestart(input *virtualmachineimagetemplate.ImageTemplateRestartCustomizer) ImageBuilderTemplateCustomizer {
+	result := ImageBuilderTemplateCustomizer{}
 	if input == nil {
-		return nil
+		return result
 	}
 
-	result := make(map[string]interface{})
-	result["type"] = "WindowsRestart"
+	result.Type = "WindowsRestart"
 
-	name := ""
 	if input.Name != nil {
-		name = *input.Name
+		result.Name = *input.Name
 	}
-
-	result["name"] = name
 
 	if input.RestartCommand != nil {
-		result["windows_restart_command"] = *input.RestartCommand
+		result.WindowsRestartCommand = *input.RestartCommand
 	}
 
 	if input.RestartCheckCommand != nil {
-		result["windows_restart_check_command"] = *input.RestartCheckCommand
+		result.WindowsRestartCheckCommand = *input.RestartCheckCommand
 	}
 
 	if input.RestartTimeout != nil {
-		result["windows_restart_timeout"] = *input.RestartTimeout
+		result.WindowsRestartTimeout = *input.RestartTimeout
 	}
 
 	return result
 }
 
-func flattenCustomizerWindowsUpdate(input *virtualmachineimagetemplate.ImageTemplateWindowsUpdateCustomizer) map[string]interface{} {
+func flattenCustomizerWindowsUpdate(input *virtualmachineimagetemplate.ImageTemplateWindowsUpdateCustomizer) ImageBuilderTemplateCustomizer {
+	result := ImageBuilderTemplateCustomizer{}
 	if input == nil {
-		return nil
+		return result
 	}
-	result := make(map[string]interface{})
 
-	result["type"] = "WindowsUpdate"
+	result.Type = "WindowsUpdate"
 
-	name := ""
 	if input.Name != nil {
-		name = *input.Name
+		result.Name = *input.Name
 	}
-
-	result["name"] = name
 
 	if input.SearchCriteria != nil {
-		result["windows_update_search_criteria"] = *input.SearchCriteria
+		result.WindowsUpdateSearchCriteria = *input.SearchCriteria
 	}
 
 	if input.Filters != nil {
-		result["windows_update_filters"] = *input.Filters
+		result.WindowsUpdateFilters = *input.Filters
 	}
 
 	if input.UpdateLimit != nil {
-		result["windows_update_limit"] = *input.UpdateLimit
+		result.WindowsUpdateLimit = *input.UpdateLimit
 	}
 
 	return result
@@ -1446,13 +1476,13 @@ func distributionRunOutputNameSchema() *schema.Schema {
 // In the `customizer` block, when a certain `type` say "File" is specified, do not allow users to specify fields that do not belong to `File`.
 // Because once users specify those irrelevant fields, those values won't be sent to the backend service and they won't return from GET,
 // thus next time there will be diff shown which will force creating a new resource. So at the very beginning forbid users from doing this.
-func validateImageTemplateCustomizerInputForFileType(d *schema.ResourceData, customizer map[string]interface{}, index int) error {
-	sourceUri := customizer["file_source_uri"].(string)
+func validateImageTemplateCustomizerInputForFileType(d *schema.ResourceData, customizer ImageBuilderTemplateCustomizer, index int) error {
+	sourceUri := customizer.FileSourceUri
 	if sourceUri == "" {
 		return fmt.Errorf("`file_source_uri` must be specified if the customizer type is File")
 	}
 
-	destinationPath := customizer["file_destination_path"].(string)
+	destinationPath := customizer.FileDestinationPath
 	if destinationPath == "" {
 		return fmt.Errorf("`destination_path` must be specified if the customizer type is File")
 	}
@@ -1470,9 +1500,9 @@ func validateImageTemplateCustomizerInputForFileType(d *schema.ResourceData, cus
 	return nil
 }
 
-func validateImageTemplateCustomizerInputForPowerShellType(d *schema.ResourceData, customizer map[string]interface{}, index int) error {
-	scriptUri := customizer["powershell_script_uri"].(string)
-	commandsRaw := customizer["powershell_commands"].([]interface{})
+func validateImageTemplateCustomizerInputForPowerShellType(d *schema.ResourceData, customizer ImageBuilderTemplateCustomizer, index int) error {
+	scriptUri := customizer.PowershellScriptUri
+	commandsRaw := customizer.PowershellCommands
 
 	if (scriptUri == "" && len(commandsRaw) == 0) ||
 		(scriptUri != "" && len(commandsRaw) > 0) {
@@ -1492,9 +1522,9 @@ func validateImageTemplateCustomizerInputForPowerShellType(d *schema.ResourceDat
 	return nil
 }
 
-func validateImageTemplateCustomizerInputForShellType(d *schema.ResourceData, customizer map[string]interface{}, index int) error {
-	scriptUri := customizer["shell_script_uri"].(string)
-	commandsRaw := customizer["shell_commands"].([]interface{})
+func validateImageTemplateCustomizerInputForShellType(d *schema.ResourceData, customizer ImageBuilderTemplateCustomizer, index int) error {
+	scriptUri := customizer.ShellScriptUri
+	commandsRaw := customizer.ShellCommands
 
 	if (scriptUri == "" && len(commandsRaw) == 0) ||
 		(scriptUri != "" && len(commandsRaw) > 0) {

--- a/internal/services/compute/image_builder_template_resource.go
+++ b/internal/services/compute/image_builder_template_resource.go
@@ -974,7 +974,6 @@ func expandBasicImageTemplateDistributor(distributions []ImageBuilderTemplateDis
 							ArtifactTags:  &managedImage.Tags,
 						})
 					}
-
 				}
 			}
 
@@ -1587,7 +1586,7 @@ func validateImageTemplateCustomizer(d *schema.ResourceData, exclude []string, i
 }
 
 func imageBuilderTemplateManagedImageNameAndResourceGroupName(input string) (string, string, error) {
-	imageName := ""
+	var imageName string
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {
 		return "", "", err

--- a/internal/services/compute/image_builder_template_resource_test.go
+++ b/internal/services/compute/image_builder_template_resource_test.go
@@ -1,0 +1,1298 @@
+package compute_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type ImageBuilderTemplateResource struct{}
+
+func TestAccAzureRMImageBuilderTemplate_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_image_builder_template", "test")
+	r := ImageBuilderTemplateResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccAzureRMImageBuilderTemplate_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_image_builder_template", "test")
+	r := ImageBuilderTemplateResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func TestAccAzureRMImageBuilderTemplate_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_image_builder_template", "test")
+	r := ImageBuilderTemplateResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("customizer.0.shell_sha256_checksum").HasValue("2c6ff6902a4a52deee69e8db26d0036a53388651008aaf31795bb20dabd21fd8"),
+				check.That(data.ResourceName).Key("customizer.1.shell_sha256_checksum").HasValue("ade4c5214c3c675e92c66e2d067a870c5b81b9844b3de3cc72c49ff36425fc93"),
+				check.That(data.ResourceName).Key("customizer.2.file_sha256_checksum").HasValue("d9715d72889fb1a0463d06ce9e89d1d2bd33b2c5e5362a736db6f5a25e601a58"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccAzureRMImageBuilderTemplate_tags_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_image_builder_template", "test")
+	r := ImageBuilderTemplateResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.tags_update(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccAzureRMImageBuilderTemplate_identity_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_image_builder_template", "test")
+	r := ImageBuilderTemplateResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.identity_update(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccAzureRMImageBuilderTemplate_vnet(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_image_builder_template", "test")
+	r := ImageBuilderTemplateResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.vnet(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccAzureRMImageBuilderTemplate_windowsPlatformSource(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_image_builder_template", "test")
+	r := ImageBuilderTemplateResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.windowsPlatformSource(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("customizer.0.powershell_sha256_checksum").HasValue("0607c084bdde8ef843cd8b7668e54a37ed07446bb642fe791ba79307a0828ea5"),
+				check.That(data.ResourceName).Key("customizer.2.file_sha256_checksum").HasValue("d9715d72889fb1a0463d06ce9e89d1d2bd33b2c5e5362a736db6f5a25e601a58"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccAzureRMImageBuilderTemplate_managedImageSource(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_image_builder_template", "test")
+	linuxVMResourceName := "azurerm_linux_virtual_machine.source"
+	r := ImageBuilderTemplateResource{}
+	rLinuxVMResource := LinuxVirtualMachineResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: rLinuxVMResource.imageFromExistingMachinePrep(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(linuxVMResourceName).ExistsInAzure(rLinuxVMResource),
+				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(data), "azurerm_linux_virtual_machine.source"),
+			),
+		},
+		{
+			Config: r.imageBuilderTemplateFromImage(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+// This test case could pass in testing functionality but failed in the end due to conflict happened in resource deletion:
+// shared image could not be deleted due to its nested shared image version still exist, while the latter declared deletion succeeded already.
+// Issue filed to Azure service team: https://github.com/Azure/azure-rest-api-specs/issues/11559.
+func TestAccAzureRMImageBuilderTemplate_sharedImageGallerySource(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_image_builder_template", "test")
+	linuxVMResourceName := "azurerm_linux_virtual_machine.source"
+	r := ImageBuilderTemplateResource{}
+	rLinuxVMResource := LinuxVirtualMachineResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: rLinuxVMResource.imageFromExistingMachinePrep(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(linuxVMResourceName).ExistsInAzure(rLinuxVMResource),
+				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(data), "azurerm_linux_virtual_machine.source"),
+			),
+		},
+		{
+			Config: r.imageBuilderTemplateFromSharedImageGallery(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccAzureRMImageBuilderTemplate_purchasePlanSource(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_image_builder_template", "test")
+	r := ImageBuilderTemplateResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.purchasePlanSource(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccAzureRMImageBuilderTemplate_vhdDistribution(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_image_builder_template", "test")
+	r := ImageBuilderTemplateResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.vhdDistribution(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccAzureRMImageBuilderTemplate_sharedImageDistribution(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_image_builder_template", "test")
+	r := ImageBuilderTemplateResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.sharedImageDistribution(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccAzureRMImageBuilderTemplate_multipleDistribution(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_image_builder_template", "test")
+	r := ImageBuilderTemplateResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.multipleDistribution(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (r ImageBuilderTemplateResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := virtualmachineimagetemplate.ParseImageTemplateID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.Compute.VirtualMachineImageTemplateClient.Get(ctx, *id)
+	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			return pointer.To(false), nil
+		}
+
+		return nil, fmt.Errorf("retrieving Image Builder Template: %q (Resource Group %q): %+v", id.ImageTemplateName, id.ResourceGroupName, err)
+	}
+
+	return pointer.To(true), nil
+}
+
+func (r ImageBuilderTemplateResource) Destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := virtualmachineimagetemplate.ParseImageTemplateID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := client.Compute.VirtualMachineImageTemplateClient.Delete(ctx, *id); err != nil {
+		return nil, fmt.Errorf("deleting Image Builder Template %q (Resource Group %q): %+v", id.ImageTemplateName, id.ResourceGroupName, err)
+	}
+
+	return pointer.To(true), nil
+}
+
+func (r ImageBuilderTemplateResource) basic(data acceptance.TestData) string {
+	roleTemplate := r.roleTemplate(data)
+	distributionManagedImageTemplate := r.distributionManagedImageTemplate(data)
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+%[3]s
+
+resource "azurerm_image_builder_template" "test" {
+  name                = "acctestIBT-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+
+  source_platform_image {
+    publisher = "canonical"
+    offer     = "ubuntu-24_04-lts"
+    sku       = "server-gen1"
+    version   = "latest"
+  }
+
+  tags = {
+    ENV = "Test"
+  }
+
+  distributions {
+%[4]s
+  }
+
+  depends_on = [
+    azurerm_role_assignment.test
+  ]
+}
+`, data.RandomInteger, data.Locations.Primary, roleTemplate, distributionManagedImageTemplate)
+}
+
+func (r ImageBuilderTemplateResource) requiresImport(data acceptance.TestData) string {
+	template := r.basic(data)
+	distributionManagedImageTemplate := r.distributionManagedImageTemplate(data)
+
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_image_builder_template" "import" {
+  name                = azurerm_image_builder_template.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+
+  source_platform_image {
+    publisher = "canonical"
+    offer     = "ubuntu-24_04-lts"
+    sku       = "server-gen1"
+    version   = "latest"
+  }
+
+  tags = {
+    ENV = "Test"
+  }
+  distributions {
+%s
+  }
+}
+`, template, distributionManagedImageTemplate)
+}
+
+func (r ImageBuilderTemplateResource) tags_update(data acceptance.TestData) string {
+	roleTemplate := r.roleTemplate(data)
+	distributionManagedImageTemplate := r.distributionManagedImageTemplate(data)
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+%s
+
+resource "azurerm_image_builder_template" "test" {
+  name                = "acctestIBT-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+
+  source_platform_image {
+    publisher = "canonical"
+    offer     = "ubuntu-24_04-lts"
+    sku       = "server-gen1"
+    version   = "latest"
+  }
+
+  tags = {
+    ENV         = "Test"
+    cost-center = "Ops"
+  }
+
+  distributions {
+%s
+  }
+
+  depends_on = [
+    azurerm_role_assignment.test
+  ]
+}
+`, data.RandomInteger, data.Locations.Primary, roleTemplate, data.RandomInteger, distributionManagedImageTemplate)
+}
+
+func (r ImageBuilderTemplateResource) identity_update(data acceptance.TestData) string {
+	roleTemplate := r.roleTemplate(data)
+	distributionManagedImageTemplate := r.distributionManagedImageTemplate(data)
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+%s
+
+resource "azurerm_user_assigned_identity" "test1" {
+  name                = "acctestUAI-%d-1"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_role_definition" "test1" {
+  name  = "acctestRD-%d-1"
+  scope = azurerm_resource_group.test.id
+
+  permissions {
+    actions = [
+      "Microsoft.Compute/galleries/read",
+      "Microsoft.Compute/galleries/images/read",
+      "Microsoft.Compute/galleries/images/versions/read",
+      "Microsoft.Compute/galleries/images/versions/write",
+      "Microsoft.Compute/images/write",
+      "Microsoft.Compute/images/read",
+      "Microsoft.Compute/images/delete"
+    ]
+    not_actions = []
+  }
+
+  assignable_scopes = [
+    azurerm_resource_group.test.id,
+  ]
+}
+
+resource "azurerm_role_assignment" "test1" {
+  scope              = azurerm_resource_group.test.id
+  role_definition_id = azurerm_role_definition.test1.role_definition_resource_id
+  principal_id       = azurerm_user_assigned_identity.test1.principal_id
+}
+
+resource "azurerm_image_builder_template" "test" {
+  name                = "acctestIBT-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test1.id]
+  }
+
+  source_platform_image {
+    publisher = "canonical"
+    offer     = "ubuntu-24_04-lts"
+    sku       = "server-gen1"
+    version   = "latest"
+  }
+
+  tags = {
+    ENV = "Test"
+  }
+  distributions {
+%s
+  }
+
+  depends_on = [
+    azurerm_role_assignment.test
+  ]
+}
+`, data.RandomInteger, data.Locations.Primary, roleTemplate, data.RandomInteger, data.RandomInteger, data.RandomInteger, distributionManagedImageTemplate)
+}
+
+func (r ImageBuilderTemplateResource) vnet(data acceptance.TestData) string {
+	roleTemplate := r.roleTemplate(data)
+	distributionManagedImageTemplate := r.distributionManagedImageTemplate(data)
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_resource_group" "test1" {
+  name     = "acctestRG-vnet-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_virtual_network" "test1" {
+  name                = "acctestVnet-%[1]d"
+  location            = azurerm_resource_group.test1.location
+  resource_group_name = azurerm_resource_group.test1.name
+  address_space       = ["10.0.0.0/16"]
+}
+
+resource "azurerm_subnet" "test1" {
+  name                                          = "acctestSubnet-%[1]d"
+  resource_group_name                           = azurerm_resource_group.test1.name
+  virtual_network_name                          = azurerm_virtual_network.test1.name
+  address_prefixes                              = ["10.0.1.0/24"]
+  private_link_service_network_policies_enabled = false
+}
+
+resource "azurerm_network_security_group" "test1" {
+  name                = "acctestNSG-%[1]d"
+  location            = azurerm_resource_group.test1.location
+  resource_group_name = azurerm_resource_group.test1.name
+}
+
+resource "azurerm_network_security_rule" "test1" {
+  name                        = "acctestNSR-%[1]d"
+  priority                    = 400
+  direction                   = "Inbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  destination_port_ranges     = ["60000", "60001"]
+  source_port_range           = "*"
+  source_address_prefix       = "AzureLoadBalancer"
+  destination_address_prefix  = "VirtualNetwork"
+  resource_group_name         = azurerm_resource_group.test1.name
+  network_security_group_name = azurerm_network_security_group.test1.name
+}
+
+resource "azurerm_subnet_network_security_group_association" "test1" {
+  subnet_id                 = azurerm_subnet.test1.id
+  network_security_group_id = azurerm_network_security_group.test1.id
+}
+
+%[3]s
+
+resource "azurerm_role_definition" "test1" {
+  name  = "acctestRD-vnet-%[1]d"
+  scope = azurerm_resource_group.test1.id
+
+  permissions {
+    actions = [
+      "Microsoft.Network/virtualNetworks/read",
+      "Microsoft.Network/virtualNetworks/subnets/join/action"
+    ]
+    not_actions = []
+  }
+
+  assignable_scopes = [
+    azurerm_resource_group.test1.id,
+  ]
+}
+
+resource "azurerm_role_assignment" "test1" {
+  scope              = azurerm_resource_group.test1.id
+  role_definition_id = azurerm_role_definition.test1.role_definition_resource_id
+  principal_id       = azurerm_user_assigned_identity.test.principal_id
+}
+
+
+resource "azurerm_image_builder_template" "test" {
+  name                = "acctestIBT-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  subnet_id           = azurerm_subnet.test1.id
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+
+  source_platform_image {
+    publisher = "canonical"
+    offer     = "ubuntu-24_04-lts"
+    sku       = "server-gen1"
+    version   = "latest"
+  }
+
+  tags = {
+    ENV = "Test"
+  }
+
+  distributions {
+%[4]s
+  }
+
+  depends_on = [
+    azurerm_role_assignment.test,
+    azurerm_role_assignment.test1
+  ]
+
+}
+`, data.RandomInteger, data.Locations.Primary, roleTemplate, distributionManagedImageTemplate)
+}
+
+func (r ImageBuilderTemplateResource) complete(data acceptance.TestData) string {
+	roleTemplate := r.roleTemplate(data)
+	distributionManagedImageTemplate := r.distributionManagedImageTemplate(data)
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+%[3]s
+
+resource "azurerm_image_builder_template" "test" {
+  name                = "acctestIBT-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+
+  source_platform_image {
+    publisher = "canonical"
+    offer     = "ubuntu-24_04-lts"
+    sku       = "server-gen1"
+    version   = "latest"
+  }
+
+  build_timeout_minutes = "60"
+  size                  = "Standard_D2_v2"
+  disk_size_gb          = "10"
+
+  tags = {
+    ENV = "Test"
+  }
+
+  customizer {
+    type             = "Shell"
+    name             = "RunScriptFromSource"
+    shell_script_uri = "https://raw.githubusercontent.com/danielsollondon/azvmimagebuilder/4afbd7858fb8918edc459a7f09ace43b570d027e/quickquickstarts/customizeScript.sh"
+  }
+
+  customizer {
+    type             = "Shell"
+    name             = "CheckSumCompareShellScript"
+    shell_script_uri = "https://raw.githubusercontent.com/danielsollondon/azvmimagebuilder/4afbd7858fb8918edc459a7f09ace43b570d027e/quickquickstarts/customizeScript2.sh"
+  }
+
+  customizer {
+    type                  = "File"
+    name                  = "downloadBuildArtifacts"
+    file_source_uri       = "https://raw.githubusercontent.com/danielsollondon/azvmimagebuilder/4afbd7858fb8918edc459a7f09ace43b570d027e/quickquickstarts/exampleArtifacts/buildArtifacts/index.html"
+    file_destination_path = "/tmp/index.html"
+  }
+
+  customizer {
+    type           = "Shell"
+    name           = "setupBuildPath"
+    shell_commands = ["sudo mkdir -p /buildArtifacts", "sudo cp /tmp/index.html /buildArtifacts/index.html"]
+  }
+
+  customizer {
+    type           = "Shell"
+    name           = "InstallUpgrades"
+    shell_commands = ["sudo apt install unattended-upgrades"]
+  }
+
+  distributions {
+%[4]s
+  }
+
+  depends_on = [
+    azurerm_role_assignment.test
+  ]
+}
+`, data.RandomInteger, data.Locations.Primary, roleTemplate, distributionManagedImageTemplate)
+}
+
+func (r ImageBuilderTemplateResource) purchasePlanSource(data acceptance.TestData) string {
+	roleTemplate := r.roleTemplate(data)
+	distributionManagedImageTemplate := r.distributionManagedImageTemplate(data)
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+%[3]s
+
+resource "azurerm_image_builder_template" "test" {
+  name                = "acctestIBT-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+
+  source_platform_image {
+    publisher = "RedHat"
+    offer     = "rhel-byos"
+    sku       = "rhel-lvm75"
+    version   = "latest"
+    plan {
+      name      = "rhel-lvm75"
+      product   = "rhel-byos"
+      publisher = "redhat"
+    }
+  }
+
+  tags = {
+    ENV = "Test"
+  }
+
+  distributions {
+%[4]s
+  }
+
+  depends_on = [
+    azurerm_role_assignment.test
+  ]
+}
+`, data.RandomInteger, data.Locations.Primary, roleTemplate, distributionManagedImageTemplate)
+}
+
+func (r ImageBuilderTemplateResource) windowsPlatformSource(data acceptance.TestData) string {
+	roleTemplate := r.roleTemplate(data)
+	distributionManagedImageTemplate := r.distributionManagedImageTemplate(data)
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+%[3]s
+
+resource "azurerm_image_builder_template" "test" {
+  name                = "acctestIBT-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+
+  source_platform_image {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2019-Datacenter"
+    version   = "latest"
+  }
+
+  tags = {
+    ENV = "Test"
+  }
+
+  customizer {
+    type                       = "PowerShell"
+    name                       = "CreateBuildPath"
+    powershell_run_elevated    = false
+    powershell_script_uri      = "https://raw.githubusercontent.com/danielsollondon/azvmimagebuilder/4afbd7858fb8918edc459a7f09ace43b570d027e/testPsScript.ps1"
+    powershell_sha256_checksum = "0607c084bdde8ef843cd8b7668e54a37ed07446bb642fe791ba79307a0828ea5"
+  }
+
+  customizer {
+    type                          = "WindowsRestart"
+    name                          = "winRestart"
+    windows_restart_command       = "shutdown /r /f /t 0"
+    windows_restart_timeout       = "5m"
+    windows_restart_check_command = "echo Azure-Image-Builder-Restarted-the-VM > c:\\buildArtifacts\\azureImageBuilderRestart.txt"
+  }
+
+  customizer {
+    type                  = "File"
+    name                  = "downloadBuildArtifacts"
+    file_source_uri       = "https://raw.githubusercontent.com/danielsollondon/azvmimagebuilder/4afbd7858fb8918edc459a7f09ace43b570d027e/quickquickstarts/exampleArtifacts/buildArtifacts/index.html"
+    file_destination_path = "c:\\buildArtifacts\\index.html"
+    file_sha256_checksum  = "d9715d72889fb1a0463d06ce9e89d1d2bd33b2c5e5362a736db6f5a25e601a58"
+  }
+
+  customizer {
+    type                     = "PowerShell"
+    name                     = "settingUpMgmtAgtPath"
+    powershell_run_elevated  = true
+    powershell_run_as_system = true
+    powershell_commands      = ["mkdir c:\\buildActions", "echo Azure-Image-Builder-Was-Here > c:\\buildActions\\buildActionsOutput.txt"]
+  }
+
+  customizer {
+    type                           = "WindowsUpdate"
+    name                           = "winUpdate"
+    windows_update_filters         = ["exclude:$_.Title -like '*Preview*'", "include:$true"]
+    windows_update_search_criteria = "IsInstalled=0"
+    windows_update_limit           = 20
+  }
+
+  distributions {
+%[4]s
+  }
+
+  depends_on = [
+    azurerm_role_assignment.test
+  ]
+}
+`, data.RandomInteger, data.Locations.Primary, roleTemplate, distributionManagedImageTemplate)
+}
+
+func (r ImageBuilderTemplateResource) vhdDistribution(data acceptance.TestData) string {
+	roleTemplate := r.roleTemplate(data)
+	distributionVHDTemplate := r.distributionVHDTemplate(data)
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+%[3]s
+
+resource "azurerm_image_builder_template" "test" {
+  name                = "acctestIBT-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+
+  source_platform_image {
+    publisher = "canonical"
+    offer     = "ubuntu-24_04-lts"
+    sku       = "server-gen1"
+    version   = "latest"
+  }
+
+  tags = {
+    ENV = "Test"
+  }
+
+  distributions {
+%[4]s
+  }
+
+  depends_on = [
+    azurerm_role_assignment.test
+  ]
+}
+`, data.RandomInteger, data.Locations.Primary, roleTemplate, distributionVHDTemplate)
+}
+
+func (r ImageBuilderTemplateResource) sharedImageDistribution(data acceptance.TestData) string {
+	roleTemplate := r.roleTemplate(data)
+	distributionSharedImageTemplate := r.distributionSharedImageTemplate(data)
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+%[3]s
+
+resource "azurerm_shared_image_gallery" "test" {
+  name                = "acctestSIG%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_shared_image" "test" {
+  name                = "acctest-IMG-%[1]d"
+  gallery_name        = azurerm_shared_image_gallery.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  os_type             = "Linux"
+  identifier {
+    publisher = "canonical"
+    offer     = "ubuntu-24_04-lts"
+    sku       = "server-gen1"
+  }
+}
+
+resource "azurerm_image_builder_template" "test" {
+  name                = "acctestIBT-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+
+  source_platform_image {
+    publisher = "canonical"
+    offer     = "ubuntu-24_04-lts"
+    sku       = "server-gen1"
+    version   = "latest"
+  }
+
+  tags = {
+    ENV = "Test"
+  }
+
+  distributions {
+%[4]s
+  }
+
+  depends_on = [
+    azurerm_role_assignment.test
+  ]
+}
+`, data.RandomInteger, data.Locations.Primary, roleTemplate, distributionSharedImageTemplate)
+}
+
+func (r ImageBuilderTemplateResource) multipleDistribution(data acceptance.TestData) string {
+	roleTemplate := r.roleTemplate(data)
+	distributionManagedImageTemplate := r.distributionManagedImageTemplate(data)
+	distributionVHDTemplate := r.distributionVHDTemplate(data)
+	distributionSharedImageTemplate := r.distributionSharedImageTemplate(data)
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+%[3]s
+
+resource "azurerm_shared_image_gallery" "test" {
+  name                = "acctestSIG%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_shared_image" "test" {
+  name                = "acctest-IMG-%[1]d"
+  gallery_name        = azurerm_shared_image_gallery.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  os_type             = "Linux"
+  identifier {
+    publisher = "canonical"
+    offer     = "ubuntu-24_04-lts"
+    sku       = "server-gen1"
+  }
+}
+
+resource "azurerm_shared_image_gallery" "test1" {
+  name                = "acctestSIG%[1]dtest1"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_shared_image" "test1" {
+  name                = "acctest-IMG-%[1]d-test1"
+  gallery_name        = azurerm_shared_image_gallery.test1.name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  os_type             = "Linux"
+  identifier {
+    publisher = "canonical"
+    offer     = "ubuntu-24_04-lts"
+    sku       = "server-gen1"
+  }
+}
+
+resource "azurerm_image_builder_template" "test" {
+  name                = "acctestIBT-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+
+  source_platform_image {
+    publisher = "canonical"
+    offer     = "ubuntu-24_04-lts"
+    sku       = "server-gen1"
+    version   = "latest"
+  }
+
+  tags = {
+    ENV = "Test"
+  }
+
+  distributions {
+%[4]s
+
+    managed_image {
+      name                = "acctestDistManagedImg-%[1]d-1"
+      resource_group_name = azurerm_resource_group.test.name
+      location            = azurerm_resource_group.test.location
+      run_output_name     = "acctest-managedImage-RunOutputName-%[1]d-1"
+      tags = {
+        ENV = "Test"
+      }
+    }
+
+%[5]s
+
+%[6]s
+
+    shared_image {
+      id = azurerm_shared_image.test1.id
+      replica_regions {
+        name = azurerm_resource_group.test.location
+      }
+      run_output_name = "acctest-sharedImage-RunOutputName-%[1]d-1"
+      versioning {
+        scheme = "Source"
+      }
+      tags = {
+        ENV = "Test"
+      }
+    }
+  }
+
+  depends_on = [
+    azurerm_role_assignment.test
+  ]
+}
+`, data.RandomInteger, data.Locations.Primary, roleTemplate, distributionManagedImageTemplate, distributionVHDTemplate, distributionSharedImageTemplate)
+}
+
+func (r ImageBuilderTemplateResource) imageBuilderTemplateFromImage(data acceptance.TestData) string {
+	rLinuxVMResource := LinuxVirtualMachineResource{}
+
+	template := rLinuxVMResource.imageFromExistingMachinePrep(data)
+
+	roleTemplate := r.roleTemplate(data)
+	distributionManagedImageTemplate := r.distributionManagedImageTemplate(data)
+
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_image" "test" {
+  name                      = "capture"
+  location                  = azurerm_resource_group.test.location
+  resource_group_name       = azurerm_resource_group.test.name
+  source_virtual_machine_id = azurerm_linux_virtual_machine.source.id
+}
+
+%s
+
+resource "azurerm_image_builder_template" "test" {
+  name                = "acctestIBT-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+
+  source_managed_image_id = azurerm_image.test.id
+
+  tags = {
+    ENV = "Test"
+  }
+
+  distributions {
+%s
+  }
+
+  depends_on = [
+    azurerm_role_assignment.test
+  ]
+}
+`, template, roleTemplate, data.RandomInteger, distributionManagedImageTemplate)
+}
+
+func (r ImageBuilderTemplateResource) imageBuilderTemplateFromSharedImageGallery(data acceptance.TestData) string {
+	rLinuxVMResource := LinuxVirtualMachineResource{}
+	template := rLinuxVMResource.imageFromExistingMachinePrep(data)
+
+	roleTemplate := r.roleTemplate(data)
+	distributionManagedImageTemplate := r.distributionManagedImageTemplate(data)
+
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_image" "test" {
+  name                      = "capture"
+  location                  = azurerm_resource_group.test.location
+  resource_group_name       = azurerm_resource_group.test.name
+  source_virtual_machine_id = azurerm_linux_virtual_machine.source.id
+}
+
+resource "azurerm_shared_image_gallery" "test" {
+  name                = "acctestSIG%[3]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_shared_image" "test" {
+  name                = "acctest-gallery-image"
+  gallery_name        = azurerm_shared_image_gallery.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  os_type             = "Linux"
+
+  identifier {
+    publisher = "AcceptanceTest-Publisher"
+    offer     = "AcceptanceTest-Offer"
+    sku       = "AcceptanceTest-Sku"
+  }
+}
+
+resource "azurerm_shared_image_version" "test" {
+  name                = "0.0.1"
+  gallery_name        = azurerm_shared_image.test.gallery_name
+  image_name          = azurerm_shared_image.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  managed_image_id    = azurerm_image.test.id
+
+  target_region {
+    name                   = azurerm_resource_group.test.location
+    regional_replica_count = "1"
+    storage_account_type   = "Standard_LRS"
+  }
+}
+
+%[2]s
+
+resource "azurerm_image_builder_template" "test" {
+  name                = "acctestIBT-%[3]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+
+  source_shared_image_version_id = azurerm_shared_image_version.test.id
+
+  tags = {
+    ENV = "Test"
+  }
+
+  distributions {
+%[4]s
+  }
+
+  depends_on = [
+    azurerm_role_assignment.test
+  ]
+}
+`, template, roleTemplate, data.RandomInteger, distributionManagedImageTemplate)
+}
+
+func (r ImageBuilderTemplateResource) roleTemplate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctestUAI-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_role_definition" "test" {
+  name  = "acctestRD-%d"
+  scope = azurerm_resource_group.test.id
+
+  permissions {
+    actions = [
+      "Microsoft.Compute/galleries/read",
+      "Microsoft.Compute/galleries/images/read",
+      "Microsoft.Compute/galleries/images/versions/read",
+      "Microsoft.Compute/galleries/images/versions/write",
+      "Microsoft.Compute/images/write",
+      "Microsoft.Compute/images/read",
+      "Microsoft.Compute/images/delete"
+    ]
+    not_actions = []
+  }
+
+  assignable_scopes = [
+    azurerm_resource_group.test.id,
+  ]
+}
+
+resource "azurerm_role_assignment" "test" {
+  scope              = azurerm_resource_group.test.id
+  role_definition_id = azurerm_role_definition.test.role_definition_resource_id
+  principal_id       = azurerm_user_assigned_identity.test.principal_id
+}
+`, data.RandomInteger, data.RandomInteger)
+}
+
+func (r ImageBuilderTemplateResource) distributionManagedImageTemplate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+managed_image {
+  name                = "acctestDistManagedImg-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  run_output_name     = "acctest-managedImage-RunOutputName-%[1]d"
+  tags = {
+    ENV = "Test"
+  }
+}
+`, data.RandomInteger)
+}
+
+func (r ImageBuilderTemplateResource) distributionSharedImageTemplate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+shared_image {
+  id = azurerm_shared_image.test.id
+  replica_regions {
+    name = azurerm_resource_group.test.location
+  }
+  replica_regions {
+    name = "westus2"
+  }
+  run_output_name      = "acctest-sharedImage-RunOutputName-%[1]d"
+  storage_account_type = "Standard_ZRS"
+  exclude_from_latest  = true
+  versioning {
+    scheme = "Source"
+  }
+  tags = {
+    ENV = "Test"
+  }
+}
+`, data.RandomInteger)
+}
+
+func (r ImageBuilderTemplateResource) distributionVHDTemplate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+vhd {
+  run_output_name = "acctest-vhd-RunOutputName-%[1]d"
+  tags = {
+    ENV = "Test"
+  }
+}
+`, data.RandomInteger)
+}

--- a/internal/services/compute/registration.go
+++ b/internal/services/compute/registration.go
@@ -63,6 +63,7 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_dedicated_host_group":                   resourceDedicatedHostGroup(),
 		"azurerm_disk_encryption_set":                    resourceDiskEncryptionSet(),
 		"azurerm_image":                                  resourceImage(),
+		"azurerm_image_builder_template":                 resourceImageBuilderTemplate(),
 		"azurerm_managed_disk":                           resourceManagedDisk(),
 		"azurerm_disk_access":                            resourceDiskAccess(),
 		"azurerm_marketplace_agreement":                  resourceMarketplaceAgreement(),

--- a/internal/services/compute/registration.go
+++ b/internal/services/compute/registration.go
@@ -63,7 +63,6 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_dedicated_host_group":                   resourceDedicatedHostGroup(),
 		"azurerm_disk_encryption_set":                    resourceDiskEncryptionSet(),
 		"azurerm_image":                                  resourceImage(),
-		"azurerm_image_builder_template":                 resourceImageBuilderTemplate(),
 		"azurerm_managed_disk":                           resourceManagedDisk(),
 		"azurerm_disk_access":                            resourceDiskAccess(),
 		"azurerm_marketplace_agreement":                  resourceMarketplaceAgreement(),
@@ -105,6 +104,7 @@ func (r Registration) Resources() []sdk.Resource {
 		VirtualMachineRestorePointResource{},
 		VirtualMachineGalleryApplicationAssignmentResource{},
 		VirtualMachineScaleSetStandbyPoolResource{},
+		ImageBuilderTemplateResource{},
 	}
 }
 

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/README.md
@@ -1,0 +1,174 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate` Documentation
+
+The `virtualmachineimagetemplate` SDK allows for interaction with Azure Resource Manager `imagebuilder` (API Version `2024-02-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+import "github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate"
+```
+
+
+### Client Initialization
+
+```go
+client := virtualmachineimagetemplate.NewVirtualMachineImageTemplateClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `VirtualMachineImageTemplateClient.Cancel`
+
+```go
+ctx := context.TODO()
+id := virtualmachineimagetemplate.NewImageTemplateID("12345678-1234-9876-4563-123456789012", "example-resource-group", "imageTemplateName")
+
+if err := client.CancelThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VirtualMachineImageTemplateClient.CreateOrUpdate`
+
+```go
+ctx := context.TODO()
+id := virtualmachineimagetemplate.NewImageTemplateID("12345678-1234-9876-4563-123456789012", "example-resource-group", "imageTemplateName")
+
+payload := virtualmachineimagetemplate.ImageTemplate{
+	// ...
+}
+
+
+if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VirtualMachineImageTemplateClient.Delete`
+
+```go
+ctx := context.TODO()
+id := virtualmachineimagetemplate.NewImageTemplateID("12345678-1234-9876-4563-123456789012", "example-resource-group", "imageTemplateName")
+
+if err := client.DeleteThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VirtualMachineImageTemplateClient.Get`
+
+```go
+ctx := context.TODO()
+id := virtualmachineimagetemplate.NewImageTemplateID("12345678-1234-9876-4563-123456789012", "example-resource-group", "imageTemplateName")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `VirtualMachineImageTemplateClient.GetRunOutput`
+
+```go
+ctx := context.TODO()
+id := virtualmachineimagetemplate.NewRunOutputID("12345678-1234-9876-4563-123456789012", "example-resource-group", "imageTemplateName", "runOutputName")
+
+read, err := client.GetRunOutput(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `VirtualMachineImageTemplateClient.List`
+
+```go
+ctx := context.TODO()
+id := commonids.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+
+// alternatively `client.List(ctx, id)` can be used to do batched pagination
+items, err := client.ListComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `VirtualMachineImageTemplateClient.ListByResourceGroup`
+
+```go
+ctx := context.TODO()
+id := commonids.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+
+// alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
+items, err := client.ListByResourceGroupComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `VirtualMachineImageTemplateClient.ListRunOutputs`
+
+```go
+ctx := context.TODO()
+id := virtualmachineimagetemplate.NewImageTemplateID("12345678-1234-9876-4563-123456789012", "example-resource-group", "imageTemplateName")
+
+// alternatively `client.ListRunOutputs(ctx, id)` can be used to do batched pagination
+items, err := client.ListRunOutputsComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `VirtualMachineImageTemplateClient.Run`
+
+```go
+ctx := context.TODO()
+id := virtualmachineimagetemplate.NewImageTemplateID("12345678-1234-9876-4563-123456789012", "example-resource-group", "imageTemplateName")
+
+if err := client.RunThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `VirtualMachineImageTemplateClient.Update`
+
+```go
+ctx := context.TODO()
+id := virtualmachineimagetemplate.NewImageTemplateID("12345678-1234-9876-4563-123456789012", "example-resource-group", "imageTemplateName")
+
+payload := virtualmachineimagetemplate.ImageTemplateUpdateParameters{
+	// ...
+}
+
+
+if err := client.UpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/client.go
@@ -1,0 +1,26 @@
+package virtualmachineimagetemplate
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualMachineImageTemplateClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewVirtualMachineImageTemplateClientWithBaseURI(sdkApi sdkEnv.Api) (*VirtualMachineImageTemplateClient, error) {
+	client, err := resourcemanager.NewClient(sdkApi, "virtualmachineimagetemplate", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating VirtualMachineImageTemplateClient: %+v", err)
+	}
+
+	return &VirtualMachineImageTemplateClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/constants.go
@@ -1,0 +1,416 @@
+package virtualmachineimagetemplate
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AutoRunState string
+
+const (
+	AutoRunStateDisabled AutoRunState = "Disabled"
+	AutoRunStateEnabled  AutoRunState = "Enabled"
+)
+
+func PossibleValuesForAutoRunState() []string {
+	return []string{
+		string(AutoRunStateDisabled),
+		string(AutoRunStateEnabled),
+	}
+}
+
+func (s *AutoRunState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseAutoRunState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseAutoRunState(input string) (*AutoRunState, error) {
+	vals := map[string]AutoRunState{
+		"disabled": AutoRunStateDisabled,
+		"enabled":  AutoRunStateEnabled,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := AutoRunState(input)
+	return &out, nil
+}
+
+type OnBuildError string
+
+const (
+	OnBuildErrorAbort   OnBuildError = "abort"
+	OnBuildErrorCleanup OnBuildError = "cleanup"
+)
+
+func PossibleValuesForOnBuildError() []string {
+	return []string{
+		string(OnBuildErrorAbort),
+		string(OnBuildErrorCleanup),
+	}
+}
+
+func (s *OnBuildError) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseOnBuildError(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseOnBuildError(input string) (*OnBuildError, error) {
+	vals := map[string]OnBuildError{
+		"abort":   OnBuildErrorAbort,
+		"cleanup": OnBuildErrorCleanup,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := OnBuildError(input)
+	return &out, nil
+}
+
+type ProvisioningErrorCode string
+
+const (
+	ProvisioningErrorCodeBadCustomizerType           ProvisioningErrorCode = "BadCustomizerType"
+	ProvisioningErrorCodeBadDistributeType           ProvisioningErrorCode = "BadDistributeType"
+	ProvisioningErrorCodeBadManagedImageSource       ProvisioningErrorCode = "BadManagedImageSource"
+	ProvisioningErrorCodeBadPIRSource                ProvisioningErrorCode = "BadPIRSource"
+	ProvisioningErrorCodeBadSharedImageDistribute    ProvisioningErrorCode = "BadSharedImageDistribute"
+	ProvisioningErrorCodeBadSharedImageVersionSource ProvisioningErrorCode = "BadSharedImageVersionSource"
+	ProvisioningErrorCodeBadSourceType               ProvisioningErrorCode = "BadSourceType"
+	ProvisioningErrorCodeBadStagingResourceGroup     ProvisioningErrorCode = "BadStagingResourceGroup"
+	ProvisioningErrorCodeBadValidatorType            ProvisioningErrorCode = "BadValidatorType"
+	ProvisioningErrorCodeNoCustomizerScript          ProvisioningErrorCode = "NoCustomizerScript"
+	ProvisioningErrorCodeNoValidatorScript           ProvisioningErrorCode = "NoValidatorScript"
+	ProvisioningErrorCodeOther                       ProvisioningErrorCode = "Other"
+	ProvisioningErrorCodeServerError                 ProvisioningErrorCode = "ServerError"
+	ProvisioningErrorCodeUnsupportedCustomizerType   ProvisioningErrorCode = "UnsupportedCustomizerType"
+	ProvisioningErrorCodeUnsupportedValidatorType    ProvisioningErrorCode = "UnsupportedValidatorType"
+)
+
+func PossibleValuesForProvisioningErrorCode() []string {
+	return []string{
+		string(ProvisioningErrorCodeBadCustomizerType),
+		string(ProvisioningErrorCodeBadDistributeType),
+		string(ProvisioningErrorCodeBadManagedImageSource),
+		string(ProvisioningErrorCodeBadPIRSource),
+		string(ProvisioningErrorCodeBadSharedImageDistribute),
+		string(ProvisioningErrorCodeBadSharedImageVersionSource),
+		string(ProvisioningErrorCodeBadSourceType),
+		string(ProvisioningErrorCodeBadStagingResourceGroup),
+		string(ProvisioningErrorCodeBadValidatorType),
+		string(ProvisioningErrorCodeNoCustomizerScript),
+		string(ProvisioningErrorCodeNoValidatorScript),
+		string(ProvisioningErrorCodeOther),
+		string(ProvisioningErrorCodeServerError),
+		string(ProvisioningErrorCodeUnsupportedCustomizerType),
+		string(ProvisioningErrorCodeUnsupportedValidatorType),
+	}
+}
+
+func (s *ProvisioningErrorCode) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseProvisioningErrorCode(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseProvisioningErrorCode(input string) (*ProvisioningErrorCode, error) {
+	vals := map[string]ProvisioningErrorCode{
+		"badcustomizertype":           ProvisioningErrorCodeBadCustomizerType,
+		"baddistributetype":           ProvisioningErrorCodeBadDistributeType,
+		"badmanagedimagesource":       ProvisioningErrorCodeBadManagedImageSource,
+		"badpirsource":                ProvisioningErrorCodeBadPIRSource,
+		"badsharedimagedistribute":    ProvisioningErrorCodeBadSharedImageDistribute,
+		"badsharedimageversionsource": ProvisioningErrorCodeBadSharedImageVersionSource,
+		"badsourcetype":               ProvisioningErrorCodeBadSourceType,
+		"badstagingresourcegroup":     ProvisioningErrorCodeBadStagingResourceGroup,
+		"badvalidatortype":            ProvisioningErrorCodeBadValidatorType,
+		"nocustomizerscript":          ProvisioningErrorCodeNoCustomizerScript,
+		"novalidatorscript":           ProvisioningErrorCodeNoValidatorScript,
+		"other":                       ProvisioningErrorCodeOther,
+		"servererror":                 ProvisioningErrorCodeServerError,
+		"unsupportedcustomizertype":   ProvisioningErrorCodeUnsupportedCustomizerType,
+		"unsupportedvalidatortype":    ProvisioningErrorCodeUnsupportedValidatorType,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ProvisioningErrorCode(input)
+	return &out, nil
+}
+
+type ProvisioningState string
+
+const (
+	ProvisioningStateCanceled  ProvisioningState = "Canceled"
+	ProvisioningStateCreating  ProvisioningState = "Creating"
+	ProvisioningStateDeleting  ProvisioningState = "Deleting"
+	ProvisioningStateFailed    ProvisioningState = "Failed"
+	ProvisioningStateSucceeded ProvisioningState = "Succeeded"
+	ProvisioningStateUpdating  ProvisioningState = "Updating"
+)
+
+func PossibleValuesForProvisioningState() []string {
+	return []string{
+		string(ProvisioningStateCanceled),
+		string(ProvisioningStateCreating),
+		string(ProvisioningStateDeleting),
+		string(ProvisioningStateFailed),
+		string(ProvisioningStateSucceeded),
+		string(ProvisioningStateUpdating),
+	}
+}
+
+func (s *ProvisioningState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseProvisioningState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseProvisioningState(input string) (*ProvisioningState, error) {
+	vals := map[string]ProvisioningState{
+		"canceled":  ProvisioningStateCanceled,
+		"creating":  ProvisioningStateCreating,
+		"deleting":  ProvisioningStateDeleting,
+		"failed":    ProvisioningStateFailed,
+		"succeeded": ProvisioningStateSucceeded,
+		"updating":  ProvisioningStateUpdating,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ProvisioningState(input)
+	return &out, nil
+}
+
+type RunState string
+
+const (
+	RunStateCanceled           RunState = "Canceled"
+	RunStateCanceling          RunState = "Canceling"
+	RunStateFailed             RunState = "Failed"
+	RunStatePartiallySucceeded RunState = "PartiallySucceeded"
+	RunStateRunning            RunState = "Running"
+	RunStateSucceeded          RunState = "Succeeded"
+)
+
+func PossibleValuesForRunState() []string {
+	return []string{
+		string(RunStateCanceled),
+		string(RunStateCanceling),
+		string(RunStateFailed),
+		string(RunStatePartiallySucceeded),
+		string(RunStateRunning),
+		string(RunStateSucceeded),
+	}
+}
+
+func (s *RunState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseRunState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseRunState(input string) (*RunState, error) {
+	vals := map[string]RunState{
+		"canceled":           RunStateCanceled,
+		"canceling":          RunStateCanceling,
+		"failed":             RunStateFailed,
+		"partiallysucceeded": RunStatePartiallySucceeded,
+		"running":            RunStateRunning,
+		"succeeded":          RunStateSucceeded,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := RunState(input)
+	return &out, nil
+}
+
+type RunSubState string
+
+const (
+	RunSubStateBuilding     RunSubState = "Building"
+	RunSubStateCustomizing  RunSubState = "Customizing"
+	RunSubStateDistributing RunSubState = "Distributing"
+	RunSubStateOptimizing   RunSubState = "Optimizing"
+	RunSubStateQueued       RunSubState = "Queued"
+	RunSubStateValidating   RunSubState = "Validating"
+)
+
+func PossibleValuesForRunSubState() []string {
+	return []string{
+		string(RunSubStateBuilding),
+		string(RunSubStateCustomizing),
+		string(RunSubStateDistributing),
+		string(RunSubStateOptimizing),
+		string(RunSubStateQueued),
+		string(RunSubStateValidating),
+	}
+}
+
+func (s *RunSubState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseRunSubState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseRunSubState(input string) (*RunSubState, error) {
+	vals := map[string]RunSubState{
+		"building":     RunSubStateBuilding,
+		"customizing":  RunSubStateCustomizing,
+		"distributing": RunSubStateDistributing,
+		"optimizing":   RunSubStateOptimizing,
+		"queued":       RunSubStateQueued,
+		"validating":   RunSubStateValidating,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := RunSubState(input)
+	return &out, nil
+}
+
+type SharedImageStorageAccountType string
+
+const (
+	SharedImageStorageAccountTypePremiumLRS  SharedImageStorageAccountType = "Premium_LRS"
+	SharedImageStorageAccountTypeStandardLRS SharedImageStorageAccountType = "Standard_LRS"
+	SharedImageStorageAccountTypeStandardZRS SharedImageStorageAccountType = "Standard_ZRS"
+)
+
+func PossibleValuesForSharedImageStorageAccountType() []string {
+	return []string{
+		string(SharedImageStorageAccountTypePremiumLRS),
+		string(SharedImageStorageAccountTypeStandardLRS),
+		string(SharedImageStorageAccountTypeStandardZRS),
+	}
+}
+
+func (s *SharedImageStorageAccountType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseSharedImageStorageAccountType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseSharedImageStorageAccountType(input string) (*SharedImageStorageAccountType, error) {
+	vals := map[string]SharedImageStorageAccountType{
+		"premium_lrs":  SharedImageStorageAccountTypePremiumLRS,
+		"standard_lrs": SharedImageStorageAccountTypeStandardLRS,
+		"standard_zrs": SharedImageStorageAccountTypeStandardZRS,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SharedImageStorageAccountType(input)
+	return &out, nil
+}
+
+type VMBootOptimizationState string
+
+const (
+	VMBootOptimizationStateDisabled VMBootOptimizationState = "Disabled"
+	VMBootOptimizationStateEnabled  VMBootOptimizationState = "Enabled"
+)
+
+func PossibleValuesForVMBootOptimizationState() []string {
+	return []string{
+		string(VMBootOptimizationStateDisabled),
+		string(VMBootOptimizationStateEnabled),
+	}
+}
+
+func (s *VMBootOptimizationState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseVMBootOptimizationState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseVMBootOptimizationState(input string) (*VMBootOptimizationState, error) {
+	vals := map[string]VMBootOptimizationState{
+		"disabled": VMBootOptimizationStateDisabled,
+		"enabled":  VMBootOptimizationStateEnabled,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := VMBootOptimizationState(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/id_imagetemplate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/id_imagetemplate.go
@@ -1,0 +1,130 @@
+package virtualmachineimagetemplate
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&ImageTemplateId{})
+}
+
+var _ resourceids.ResourceId = &ImageTemplateId{}
+
+// ImageTemplateId is a struct representing the Resource ID for a Image Template
+type ImageTemplateId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	ImageTemplateName string
+}
+
+// NewImageTemplateID returns a new ImageTemplateId struct
+func NewImageTemplateID(subscriptionId string, resourceGroupName string, imageTemplateName string) ImageTemplateId {
+	return ImageTemplateId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		ImageTemplateName: imageTemplateName,
+	}
+}
+
+// ParseImageTemplateID parses 'input' into a ImageTemplateId
+func ParseImageTemplateID(input string) (*ImageTemplateId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&ImageTemplateId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := ImageTemplateId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseImageTemplateIDInsensitively parses 'input' case-insensitively into a ImageTemplateId
+// note: this method should only be used for API response data and not user input
+func ParseImageTemplateIDInsensitively(input string) (*ImageTemplateId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&ImageTemplateId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := ImageTemplateId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *ImageTemplateId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.ImageTemplateName, ok = input.Parsed["imageTemplateName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "imageTemplateName", input)
+	}
+
+	return nil
+}
+
+// ValidateImageTemplateID checks that 'input' can be parsed as a Image Template ID
+func ValidateImageTemplateID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseImageTemplateID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Image Template ID
+func (id ImageTemplateId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.VirtualMachineImages/imageTemplates/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.ImageTemplateName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Image Template ID
+func (id ImageTemplateId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftVirtualMachineImages", "Microsoft.VirtualMachineImages", "Microsoft.VirtualMachineImages"),
+		resourceids.StaticSegment("staticImageTemplates", "imageTemplates", "imageTemplates"),
+		resourceids.UserSpecifiedSegment("imageTemplateName", "imageTemplateName"),
+	}
+}
+
+// String returns a human-readable description of this Image Template ID
+func (id ImageTemplateId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Image Template Name: %q", id.ImageTemplateName),
+	}
+	return fmt.Sprintf("Image Template (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/id_runoutput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/id_runoutput.go
@@ -1,0 +1,139 @@
+package virtualmachineimagetemplate
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&RunOutputId{})
+}
+
+var _ resourceids.ResourceId = &RunOutputId{}
+
+// RunOutputId is a struct representing the Resource ID for a Run Output
+type RunOutputId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	ImageTemplateName string
+	RunOutputName     string
+}
+
+// NewRunOutputID returns a new RunOutputId struct
+func NewRunOutputID(subscriptionId string, resourceGroupName string, imageTemplateName string, runOutputName string) RunOutputId {
+	return RunOutputId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		ImageTemplateName: imageTemplateName,
+		RunOutputName:     runOutputName,
+	}
+}
+
+// ParseRunOutputID parses 'input' into a RunOutputId
+func ParseRunOutputID(input string) (*RunOutputId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&RunOutputId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := RunOutputId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseRunOutputIDInsensitively parses 'input' case-insensitively into a RunOutputId
+// note: this method should only be used for API response data and not user input
+func ParseRunOutputIDInsensitively(input string) (*RunOutputId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&RunOutputId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := RunOutputId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *RunOutputId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.ImageTemplateName, ok = input.Parsed["imageTemplateName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "imageTemplateName", input)
+	}
+
+	if id.RunOutputName, ok = input.Parsed["runOutputName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "runOutputName", input)
+	}
+
+	return nil
+}
+
+// ValidateRunOutputID checks that 'input' can be parsed as a Run Output ID
+func ValidateRunOutputID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseRunOutputID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Run Output ID
+func (id RunOutputId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.VirtualMachineImages/imageTemplates/%s/runOutputs/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.ImageTemplateName, id.RunOutputName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Run Output ID
+func (id RunOutputId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftVirtualMachineImages", "Microsoft.VirtualMachineImages", "Microsoft.VirtualMachineImages"),
+		resourceids.StaticSegment("staticImageTemplates", "imageTemplates", "imageTemplates"),
+		resourceids.UserSpecifiedSegment("imageTemplateName", "imageTemplateName"),
+		resourceids.StaticSegment("staticRunOutputs", "runOutputs", "runOutputs"),
+		resourceids.UserSpecifiedSegment("runOutputName", "runOutputName"),
+	}
+}
+
+// String returns a human-readable description of this Run Output ID
+func (id RunOutputId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Image Template Name: %q", id.ImageTemplateName),
+		fmt.Sprintf("Run Output Name: %q", id.RunOutputName),
+	}
+	return fmt.Sprintf("Run Output (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/method_cancel.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/method_cancel.go
@@ -1,0 +1,71 @@
+package virtualmachineimagetemplate
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CancelOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// Cancel ...
+func (c VirtualMachineImageTemplateClient) Cancel(ctx context.Context, id ImageTemplateId) (result CancelOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusNoContent,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/cancel", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// CancelThenPoll performs Cancel then polls until it's completed
+func (c VirtualMachineImageTemplateClient) CancelThenPoll(ctx context.Context, id ImageTemplateId) error {
+	result, err := c.Cancel(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Cancel: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Cancel: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/method_createorupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/method_createorupdate.go
@@ -1,0 +1,75 @@
+package virtualmachineimagetemplate
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOrUpdateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *ImageTemplate
+}
+
+// CreateOrUpdate ...
+func (c VirtualMachineImageTemplateClient) CreateOrUpdate(ctx context.Context, id ImageTemplateId, input ImageTemplate) (result CreateOrUpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// CreateOrUpdateThenPoll performs CreateOrUpdate then polls until it's completed
+func (c VirtualMachineImageTemplateClient) CreateOrUpdateThenPoll(ctx context.Context, id ImageTemplateId, input ImageTemplate) error {
+	result, err := c.CreateOrUpdate(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing CreateOrUpdate: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after CreateOrUpdate: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/method_delete.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/method_delete.go
@@ -1,0 +1,70 @@
+package virtualmachineimagetemplate
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// Delete ...
+func (c VirtualMachineImageTemplateClient) Delete(ctx context.Context, id ImageTemplateId) (result DeleteOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusNoContent,
+		},
+		HttpMethod: http.MethodDelete,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// DeleteThenPoll performs Delete then polls until it's completed
+func (c VirtualMachineImageTemplateClient) DeleteThenPoll(ctx context.Context, id ImageTemplateId) error {
+	result, err := c.Delete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Delete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Delete: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/method_get.go
@@ -1,0 +1,53 @@
+package virtualmachineimagetemplate
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *ImageTemplate
+}
+
+// Get ...
+func (c VirtualMachineImageTemplateClient) Get(ctx context.Context, id ImageTemplateId) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model ImageTemplate
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/method_getrunoutput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/method_getrunoutput.go
@@ -1,0 +1,53 @@
+package virtualmachineimagetemplate
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetRunOutputOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *RunOutput
+}
+
+// GetRunOutput ...
+func (c VirtualMachineImageTemplateClient) GetRunOutput(ctx context.Context, id RunOutputId) (result GetRunOutputOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model RunOutput
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/method_list.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/method_list.go
@@ -1,0 +1,106 @@
+package virtualmachineimagetemplate
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]ImageTemplate
+}
+
+type ListCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []ImageTemplate
+}
+
+type ListCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// List ...
+func (c VirtualMachineImageTemplateClient) List(ctx context.Context, id commonids.SubscriptionId) (result ListOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &ListCustomPager{},
+		Path:       fmt.Sprintf("%s/providers/Microsoft.VirtualMachineImages/imageTemplates", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]ImageTemplate `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListComplete retrieves all the results into a single object
+func (c VirtualMachineImageTemplateClient) ListComplete(ctx context.Context, id commonids.SubscriptionId) (ListCompleteResult, error) {
+	return c.ListCompleteMatchingPredicate(ctx, id, ImageTemplateOperationPredicate{})
+}
+
+// ListCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c VirtualMachineImageTemplateClient) ListCompleteMatchingPredicate(ctx context.Context, id commonids.SubscriptionId, predicate ImageTemplateOperationPredicate) (result ListCompleteResult, err error) {
+	items := make([]ImageTemplate, 0)
+
+	resp, err := c.List(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/method_listbyresourcegroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/method_listbyresourcegroup.go
@@ -1,0 +1,106 @@
+package virtualmachineimagetemplate
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListByResourceGroupOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]ImageTemplate
+}
+
+type ListByResourceGroupCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []ImageTemplate
+}
+
+type ListByResourceGroupCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListByResourceGroupCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// ListByResourceGroup ...
+func (c VirtualMachineImageTemplateClient) ListByResourceGroup(ctx context.Context, id commonids.ResourceGroupId) (result ListByResourceGroupOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &ListByResourceGroupCustomPager{},
+		Path:       fmt.Sprintf("%s/providers/Microsoft.VirtualMachineImages/imageTemplates", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]ImageTemplate `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListByResourceGroupComplete retrieves all the results into a single object
+func (c VirtualMachineImageTemplateClient) ListByResourceGroupComplete(ctx context.Context, id commonids.ResourceGroupId) (ListByResourceGroupCompleteResult, error) {
+	return c.ListByResourceGroupCompleteMatchingPredicate(ctx, id, ImageTemplateOperationPredicate{})
+}
+
+// ListByResourceGroupCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c VirtualMachineImageTemplateClient) ListByResourceGroupCompleteMatchingPredicate(ctx context.Context, id commonids.ResourceGroupId, predicate ImageTemplateOperationPredicate) (result ListByResourceGroupCompleteResult, err error) {
+	items := make([]ImageTemplate, 0)
+
+	resp, err := c.ListByResourceGroup(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListByResourceGroupCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/method_listrunoutputs.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/method_listrunoutputs.go
@@ -1,0 +1,105 @@
+package virtualmachineimagetemplate
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListRunOutputsOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]RunOutput
+}
+
+type ListRunOutputsCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []RunOutput
+}
+
+type ListRunOutputsCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListRunOutputsCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// ListRunOutputs ...
+func (c VirtualMachineImageTemplateClient) ListRunOutputs(ctx context.Context, id ImageTemplateId) (result ListRunOutputsOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &ListRunOutputsCustomPager{},
+		Path:       fmt.Sprintf("%s/runOutputs", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]RunOutput `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListRunOutputsComplete retrieves all the results into a single object
+func (c VirtualMachineImageTemplateClient) ListRunOutputsComplete(ctx context.Context, id ImageTemplateId) (ListRunOutputsCompleteResult, error) {
+	return c.ListRunOutputsCompleteMatchingPredicate(ctx, id, RunOutputOperationPredicate{})
+}
+
+// ListRunOutputsCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c VirtualMachineImageTemplateClient) ListRunOutputsCompleteMatchingPredicate(ctx context.Context, id ImageTemplateId, predicate RunOutputOperationPredicate) (result ListRunOutputsCompleteResult, err error) {
+	items := make([]RunOutput, 0)
+
+	resp, err := c.ListRunOutputs(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListRunOutputsCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/method_run.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/method_run.go
@@ -1,0 +1,71 @@
+package virtualmachineimagetemplate
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RunOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// Run ...
+func (c VirtualMachineImageTemplateClient) Run(ctx context.Context, id ImageTemplateId) (result RunOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusNoContent,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/run", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// RunThenPoll performs Run then polls until it's completed
+func (c VirtualMachineImageTemplateClient) RunThenPoll(ctx context.Context, id ImageTemplateId) error {
+	result, err := c.Run(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Run: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Run: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/method_update.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/method_update.go
@@ -1,0 +1,75 @@
+package virtualmachineimagetemplate
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *ImageTemplate
+}
+
+// Update ...
+func (c VirtualMachineImageTemplateClient) Update(ctx context.Context, id ImageTemplateId, input ImageTemplateUpdateParameters) (result UpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPatch,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// UpdateThenPoll performs Update then polls until it's completed
+func (c VirtualMachineImageTemplateClient) UpdateThenPoll(ctx context.Context, id ImageTemplateId, input ImageTemplateUpdateParameters) error {
+	result, err := c.Update(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Update: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Update: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_distributeversioner.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_distributeversioner.go
@@ -1,0 +1,83 @@
+package virtualmachineimagetemplate
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DistributeVersioner interface {
+	DistributeVersioner() BaseDistributeVersionerImpl
+}
+
+var _ DistributeVersioner = BaseDistributeVersionerImpl{}
+
+type BaseDistributeVersionerImpl struct {
+	Scheme string `json:"scheme"`
+}
+
+func (s BaseDistributeVersionerImpl) DistributeVersioner() BaseDistributeVersionerImpl {
+	return s
+}
+
+var _ DistributeVersioner = RawDistributeVersionerImpl{}
+
+// RawDistributeVersionerImpl is returned when the Discriminated Value doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawDistributeVersionerImpl struct {
+	distributeVersioner BaseDistributeVersionerImpl
+	Type                string
+	Values              map[string]interface{}
+}
+
+func (s RawDistributeVersionerImpl) DistributeVersioner() BaseDistributeVersionerImpl {
+	return s.distributeVersioner
+}
+
+func UnmarshalDistributeVersionerImplementation(input []byte) (DistributeVersioner, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling DistributeVersioner into map[string]interface: %+v", err)
+	}
+
+	var value string
+	if v, ok := temp["scheme"]; ok {
+		value = fmt.Sprintf("%v", v)
+	}
+
+	if strings.EqualFold(value, "Latest") {
+		var out DistributeVersionerLatest
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into DistributeVersionerLatest: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "Source") {
+		var out DistributeVersionerSource
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into DistributeVersionerSource: %+v", err)
+		}
+		return out, nil
+	}
+
+	var parent BaseDistributeVersionerImpl
+	if err := json.Unmarshal(input, &parent); err != nil {
+		return nil, fmt.Errorf("unmarshaling into BaseDistributeVersionerImpl: %+v", err)
+	}
+
+	return RawDistributeVersionerImpl{
+		distributeVersioner: parent,
+		Type:                value,
+		Values:              temp,
+	}, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_distributeversionerlatest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_distributeversionerlatest.go
@@ -1,0 +1,50 @@
+package virtualmachineimagetemplate
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DistributeVersioner = DistributeVersionerLatest{}
+
+type DistributeVersionerLatest struct {
+	Major *int64 `json:"major,omitempty"`
+
+	// Fields inherited from DistributeVersioner
+
+	Scheme string `json:"scheme"`
+}
+
+func (s DistributeVersionerLatest) DistributeVersioner() BaseDistributeVersionerImpl {
+	return BaseDistributeVersionerImpl{
+		Scheme: s.Scheme,
+	}
+}
+
+var _ json.Marshaler = DistributeVersionerLatest{}
+
+func (s DistributeVersionerLatest) MarshalJSON() ([]byte, error) {
+	type wrapper DistributeVersionerLatest
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling DistributeVersionerLatest: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling DistributeVersionerLatest: %+v", err)
+	}
+
+	decoded["scheme"] = "Latest"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling DistributeVersionerLatest: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_distributeversionersource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_distributeversionersource.go
@@ -1,0 +1,49 @@
+package virtualmachineimagetemplate
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DistributeVersioner = DistributeVersionerSource{}
+
+type DistributeVersionerSource struct {
+
+	// Fields inherited from DistributeVersioner
+
+	Scheme string `json:"scheme"`
+}
+
+func (s DistributeVersionerSource) DistributeVersioner() BaseDistributeVersionerImpl {
+	return BaseDistributeVersionerImpl{
+		Scheme: s.Scheme,
+	}
+}
+
+var _ json.Marshaler = DistributeVersionerSource{}
+
+func (s DistributeVersionerSource) MarshalJSON() ([]byte, error) {
+	type wrapper DistributeVersionerSource
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling DistributeVersionerSource: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling DistributeVersionerSource: %+v", err)
+	}
+
+	decoded["scheme"] = "Source"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling DistributeVersionerSource: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplate.go
@@ -1,0 +1,20 @@
+package virtualmachineimagetemplate
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ImageTemplate struct {
+	Id         *string                  `json:"id,omitempty"`
+	Identity   identity.UserAssignedMap `json:"identity"`
+	Location   string                   `json:"location"`
+	Name       *string                  `json:"name,omitempty"`
+	Properties *ImageTemplateProperties `json:"properties,omitempty"`
+	SystemData *systemdata.SystemData   `json:"systemData,omitempty"`
+	Tags       *map[string]string       `json:"tags,omitempty"`
+	Type       *string                  `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplateautorun.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplateautorun.go
@@ -1,0 +1,8 @@
+package virtualmachineimagetemplate
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ImageTemplateAutoRun struct {
+	State *AutoRunState `json:"state,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplatecustomizer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplatecustomizer.go
@@ -1,0 +1,108 @@
+package virtualmachineimagetemplate
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ImageTemplateCustomizer interface {
+	ImageTemplateCustomizer() BaseImageTemplateCustomizerImpl
+}
+
+var _ ImageTemplateCustomizer = BaseImageTemplateCustomizerImpl{}
+
+type BaseImageTemplateCustomizerImpl struct {
+	Name *string `json:"name,omitempty"`
+	Type string  `json:"type"`
+}
+
+func (s BaseImageTemplateCustomizerImpl) ImageTemplateCustomizer() BaseImageTemplateCustomizerImpl {
+	return s
+}
+
+var _ ImageTemplateCustomizer = RawImageTemplateCustomizerImpl{}
+
+// RawImageTemplateCustomizerImpl is returned when the Discriminated Value doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawImageTemplateCustomizerImpl struct {
+	imageTemplateCustomizer BaseImageTemplateCustomizerImpl
+	Type                    string
+	Values                  map[string]interface{}
+}
+
+func (s RawImageTemplateCustomizerImpl) ImageTemplateCustomizer() BaseImageTemplateCustomizerImpl {
+	return s.imageTemplateCustomizer
+}
+
+func UnmarshalImageTemplateCustomizerImplementation(input []byte) (ImageTemplateCustomizer, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling ImageTemplateCustomizer into map[string]interface: %+v", err)
+	}
+
+	var value string
+	if v, ok := temp["type"]; ok {
+		value = fmt.Sprintf("%v", v)
+	}
+
+	if strings.EqualFold(value, "File") {
+		var out ImageTemplateFileCustomizer
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into ImageTemplateFileCustomizer: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "PowerShell") {
+		var out ImageTemplatePowerShellCustomizer
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into ImageTemplatePowerShellCustomizer: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "WindowsRestart") {
+		var out ImageTemplateRestartCustomizer
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into ImageTemplateRestartCustomizer: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "Shell") {
+		var out ImageTemplateShellCustomizer
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into ImageTemplateShellCustomizer: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "WindowsUpdate") {
+		var out ImageTemplateWindowsUpdateCustomizer
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into ImageTemplateWindowsUpdateCustomizer: %+v", err)
+		}
+		return out, nil
+	}
+
+	var parent BaseImageTemplateCustomizerImpl
+	if err := json.Unmarshal(input, &parent); err != nil {
+		return nil, fmt.Errorf("unmarshaling into BaseImageTemplateCustomizerImpl: %+v", err)
+	}
+
+	return RawImageTemplateCustomizerImpl{
+		imageTemplateCustomizer: parent,
+		Type:                    value,
+		Values:                  temp,
+	}, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplatedistributor.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplatedistributor.go
@@ -1,0 +1,93 @@
+package virtualmachineimagetemplate
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ImageTemplateDistributor interface {
+	ImageTemplateDistributor() BaseImageTemplateDistributorImpl
+}
+
+var _ ImageTemplateDistributor = BaseImageTemplateDistributorImpl{}
+
+type BaseImageTemplateDistributorImpl struct {
+	ArtifactTags  *map[string]string `json:"artifactTags,omitempty"`
+	RunOutputName string             `json:"runOutputName"`
+	Type          string             `json:"type"`
+}
+
+func (s BaseImageTemplateDistributorImpl) ImageTemplateDistributor() BaseImageTemplateDistributorImpl {
+	return s
+}
+
+var _ ImageTemplateDistributor = RawImageTemplateDistributorImpl{}
+
+// RawImageTemplateDistributorImpl is returned when the Discriminated Value doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawImageTemplateDistributorImpl struct {
+	imageTemplateDistributor BaseImageTemplateDistributorImpl
+	Type                     string
+	Values                   map[string]interface{}
+}
+
+func (s RawImageTemplateDistributorImpl) ImageTemplateDistributor() BaseImageTemplateDistributorImpl {
+	return s.imageTemplateDistributor
+}
+
+func UnmarshalImageTemplateDistributorImplementation(input []byte) (ImageTemplateDistributor, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling ImageTemplateDistributor into map[string]interface: %+v", err)
+	}
+
+	var value string
+	if v, ok := temp["type"]; ok {
+		value = fmt.Sprintf("%v", v)
+	}
+
+	if strings.EqualFold(value, "ManagedImage") {
+		var out ImageTemplateManagedImageDistributor
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into ImageTemplateManagedImageDistributor: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "SharedImage") {
+		var out ImageTemplateSharedImageDistributor
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into ImageTemplateSharedImageDistributor: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "VHD") {
+		var out ImageTemplateVhdDistributor
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into ImageTemplateVhdDistributor: %+v", err)
+		}
+		return out, nil
+	}
+
+	var parent BaseImageTemplateDistributorImpl
+	if err := json.Unmarshal(input, &parent); err != nil {
+		return nil, fmt.Errorf("unmarshaling into BaseImageTemplateDistributorImpl: %+v", err)
+	}
+
+	return RawImageTemplateDistributorImpl{
+		imageTemplateDistributor: parent,
+		Type:                     value,
+		Values:                   temp,
+	}, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplatefilecustomizer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplatefilecustomizer.go
@@ -1,0 +1,54 @@
+package virtualmachineimagetemplate
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ImageTemplateCustomizer = ImageTemplateFileCustomizer{}
+
+type ImageTemplateFileCustomizer struct {
+	Destination    *string `json:"destination,omitempty"`
+	Sha256Checksum *string `json:"sha256Checksum,omitempty"`
+	SourceUri      *string `json:"sourceUri,omitempty"`
+
+	// Fields inherited from ImageTemplateCustomizer
+
+	Name *string `json:"name,omitempty"`
+	Type string  `json:"type"`
+}
+
+func (s ImageTemplateFileCustomizer) ImageTemplateCustomizer() BaseImageTemplateCustomizerImpl {
+	return BaseImageTemplateCustomizerImpl{
+		Name: s.Name,
+		Type: s.Type,
+	}
+}
+
+var _ json.Marshaler = ImageTemplateFileCustomizer{}
+
+func (s ImageTemplateFileCustomizer) MarshalJSON() ([]byte, error) {
+	type wrapper ImageTemplateFileCustomizer
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling ImageTemplateFileCustomizer: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling ImageTemplateFileCustomizer: %+v", err)
+	}
+
+	decoded["type"] = "File"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling ImageTemplateFileCustomizer: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplatefilevalidator.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplatefilevalidator.go
@@ -1,0 +1,54 @@
+package virtualmachineimagetemplate
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ImageTemplateInVMValidator = ImageTemplateFileValidator{}
+
+type ImageTemplateFileValidator struct {
+	Destination    *string `json:"destination,omitempty"`
+	Sha256Checksum *string `json:"sha256Checksum,omitempty"`
+	SourceUri      *string `json:"sourceUri,omitempty"`
+
+	// Fields inherited from ImageTemplateInVMValidator
+
+	Name *string `json:"name,omitempty"`
+	Type string  `json:"type"`
+}
+
+func (s ImageTemplateFileValidator) ImageTemplateInVMValidator() BaseImageTemplateInVMValidatorImpl {
+	return BaseImageTemplateInVMValidatorImpl{
+		Name: s.Name,
+		Type: s.Type,
+	}
+}
+
+var _ json.Marshaler = ImageTemplateFileValidator{}
+
+func (s ImageTemplateFileValidator) MarshalJSON() ([]byte, error) {
+	type wrapper ImageTemplateFileValidator
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling ImageTemplateFileValidator: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling ImageTemplateFileValidator: %+v", err)
+	}
+
+	decoded["type"] = "File"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling ImageTemplateFileValidator: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplateinvmvalidator.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplateinvmvalidator.go
@@ -1,0 +1,92 @@
+package virtualmachineimagetemplate
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ImageTemplateInVMValidator interface {
+	ImageTemplateInVMValidator() BaseImageTemplateInVMValidatorImpl
+}
+
+var _ ImageTemplateInVMValidator = BaseImageTemplateInVMValidatorImpl{}
+
+type BaseImageTemplateInVMValidatorImpl struct {
+	Name *string `json:"name,omitempty"`
+	Type string  `json:"type"`
+}
+
+func (s BaseImageTemplateInVMValidatorImpl) ImageTemplateInVMValidator() BaseImageTemplateInVMValidatorImpl {
+	return s
+}
+
+var _ ImageTemplateInVMValidator = RawImageTemplateInVMValidatorImpl{}
+
+// RawImageTemplateInVMValidatorImpl is returned when the Discriminated Value doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawImageTemplateInVMValidatorImpl struct {
+	imageTemplateInVMValidator BaseImageTemplateInVMValidatorImpl
+	Type                       string
+	Values                     map[string]interface{}
+}
+
+func (s RawImageTemplateInVMValidatorImpl) ImageTemplateInVMValidator() BaseImageTemplateInVMValidatorImpl {
+	return s.imageTemplateInVMValidator
+}
+
+func UnmarshalImageTemplateInVMValidatorImplementation(input []byte) (ImageTemplateInVMValidator, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling ImageTemplateInVMValidator into map[string]interface: %+v", err)
+	}
+
+	var value string
+	if v, ok := temp["type"]; ok {
+		value = fmt.Sprintf("%v", v)
+	}
+
+	if strings.EqualFold(value, "File") {
+		var out ImageTemplateFileValidator
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into ImageTemplateFileValidator: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "PowerShell") {
+		var out ImageTemplatePowerShellValidator
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into ImageTemplatePowerShellValidator: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "Shell") {
+		var out ImageTemplateShellValidator
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into ImageTemplateShellValidator: %+v", err)
+		}
+		return out, nil
+	}
+
+	var parent BaseImageTemplateInVMValidatorImpl
+	if err := json.Unmarshal(input, &parent); err != nil {
+		return nil, fmt.Errorf("unmarshaling into BaseImageTemplateInVMValidatorImpl: %+v", err)
+	}
+
+	return RawImageTemplateInVMValidatorImpl{
+		imageTemplateInVMValidator: parent,
+		Type:                       value,
+		Values:                     temp,
+	}, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplatelastrunstatus.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplatelastrunstatus.go
@@ -1,0 +1,42 @@
+package virtualmachineimagetemplate
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ImageTemplateLastRunStatus struct {
+	EndTime     *string      `json:"endTime,omitempty"`
+	Message     *string      `json:"message,omitempty"`
+	RunState    *RunState    `json:"runState,omitempty"`
+	RunSubState *RunSubState `json:"runSubState,omitempty"`
+	StartTime   *string      `json:"startTime,omitempty"`
+}
+
+func (o *ImageTemplateLastRunStatus) GetEndTimeAsTime() (*time.Time, error) {
+	if o.EndTime == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.EndTime, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *ImageTemplateLastRunStatus) SetEndTimeAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.EndTime = &formatted
+}
+
+func (o *ImageTemplateLastRunStatus) GetStartTimeAsTime() (*time.Time, error) {
+	if o.StartTime == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.StartTime, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *ImageTemplateLastRunStatus) SetStartTimeAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.StartTime = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplatemanagedimagedistributor.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplatemanagedimagedistributor.go
@@ -1,0 +1,55 @@
+package virtualmachineimagetemplate
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ImageTemplateDistributor = ImageTemplateManagedImageDistributor{}
+
+type ImageTemplateManagedImageDistributor struct {
+	ImageId  string `json:"imageId"`
+	Location string `json:"location"`
+
+	// Fields inherited from ImageTemplateDistributor
+
+	ArtifactTags  *map[string]string `json:"artifactTags,omitempty"`
+	RunOutputName string             `json:"runOutputName"`
+	Type          string             `json:"type"`
+}
+
+func (s ImageTemplateManagedImageDistributor) ImageTemplateDistributor() BaseImageTemplateDistributorImpl {
+	return BaseImageTemplateDistributorImpl{
+		ArtifactTags:  s.ArtifactTags,
+		RunOutputName: s.RunOutputName,
+		Type:          s.Type,
+	}
+}
+
+var _ json.Marshaler = ImageTemplateManagedImageDistributor{}
+
+func (s ImageTemplateManagedImageDistributor) MarshalJSON() ([]byte, error) {
+	type wrapper ImageTemplateManagedImageDistributor
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling ImageTemplateManagedImageDistributor: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling ImageTemplateManagedImageDistributor: %+v", err)
+	}
+
+	decoded["type"] = "ManagedImage"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling ImageTemplateManagedImageDistributor: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplatemanagedimagesource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplatemanagedimagesource.go
@@ -1,0 +1,50 @@
+package virtualmachineimagetemplate
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ImageTemplateSource = ImageTemplateManagedImageSource{}
+
+type ImageTemplateManagedImageSource struct {
+	ImageId string `json:"imageId"`
+
+	// Fields inherited from ImageTemplateSource
+
+	Type string `json:"type"`
+}
+
+func (s ImageTemplateManagedImageSource) ImageTemplateSource() BaseImageTemplateSourceImpl {
+	return BaseImageTemplateSourceImpl{
+		Type: s.Type,
+	}
+}
+
+var _ json.Marshaler = ImageTemplateManagedImageSource{}
+
+func (s ImageTemplateManagedImageSource) MarshalJSON() ([]byte, error) {
+	type wrapper ImageTemplateManagedImageSource
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling ImageTemplateManagedImageSource: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling ImageTemplateManagedImageSource: %+v", err)
+	}
+
+	decoded["type"] = "ManagedImage"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling ImageTemplateManagedImageSource: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplateplatformimagesource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplateplatformimagesource.go
@@ -1,0 +1,55 @@
+package virtualmachineimagetemplate
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ImageTemplateSource = ImageTemplatePlatformImageSource{}
+
+type ImageTemplatePlatformImageSource struct {
+	ExactVersion *string                    `json:"exactVersion,omitempty"`
+	Offer        *string                    `json:"offer,omitempty"`
+	PlanInfo     *PlatformImagePurchasePlan `json:"planInfo,omitempty"`
+	Publisher    *string                    `json:"publisher,omitempty"`
+	Sku          *string                    `json:"sku,omitempty"`
+	Version      *string                    `json:"version,omitempty"`
+
+	// Fields inherited from ImageTemplateSource
+
+	Type string `json:"type"`
+}
+
+func (s ImageTemplatePlatformImageSource) ImageTemplateSource() BaseImageTemplateSourceImpl {
+	return BaseImageTemplateSourceImpl{
+		Type: s.Type,
+	}
+}
+
+var _ json.Marshaler = ImageTemplatePlatformImageSource{}
+
+func (s ImageTemplatePlatformImageSource) MarshalJSON() ([]byte, error) {
+	type wrapper ImageTemplatePlatformImageSource
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling ImageTemplatePlatformImageSource: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling ImageTemplatePlatformImageSource: %+v", err)
+	}
+
+	decoded["type"] = "PlatformImage"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling ImageTemplatePlatformImageSource: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplatepowershellcustomizer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplatepowershellcustomizer.go
@@ -1,0 +1,57 @@
+package virtualmachineimagetemplate
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ImageTemplateCustomizer = ImageTemplatePowerShellCustomizer{}
+
+type ImageTemplatePowerShellCustomizer struct {
+	Inline         *[]string `json:"inline,omitempty"`
+	RunAsSystem    *bool     `json:"runAsSystem,omitempty"`
+	RunElevated    *bool     `json:"runElevated,omitempty"`
+	ScriptUri      *string   `json:"scriptUri,omitempty"`
+	Sha256Checksum *string   `json:"sha256Checksum,omitempty"`
+	ValidExitCodes *[]int64  `json:"validExitCodes,omitempty"`
+
+	// Fields inherited from ImageTemplateCustomizer
+
+	Name *string `json:"name,omitempty"`
+	Type string  `json:"type"`
+}
+
+func (s ImageTemplatePowerShellCustomizer) ImageTemplateCustomizer() BaseImageTemplateCustomizerImpl {
+	return BaseImageTemplateCustomizerImpl{
+		Name: s.Name,
+		Type: s.Type,
+	}
+}
+
+var _ json.Marshaler = ImageTemplatePowerShellCustomizer{}
+
+func (s ImageTemplatePowerShellCustomizer) MarshalJSON() ([]byte, error) {
+	type wrapper ImageTemplatePowerShellCustomizer
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling ImageTemplatePowerShellCustomizer: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling ImageTemplatePowerShellCustomizer: %+v", err)
+	}
+
+	decoded["type"] = "PowerShell"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling ImageTemplatePowerShellCustomizer: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplatepowershellvalidator.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplatepowershellvalidator.go
@@ -1,0 +1,57 @@
+package virtualmachineimagetemplate
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ImageTemplateInVMValidator = ImageTemplatePowerShellValidator{}
+
+type ImageTemplatePowerShellValidator struct {
+	Inline         *[]string `json:"inline,omitempty"`
+	RunAsSystem    *bool     `json:"runAsSystem,omitempty"`
+	RunElevated    *bool     `json:"runElevated,omitempty"`
+	ScriptUri      *string   `json:"scriptUri,omitempty"`
+	Sha256Checksum *string   `json:"sha256Checksum,omitempty"`
+	ValidExitCodes *[]int64  `json:"validExitCodes,omitempty"`
+
+	// Fields inherited from ImageTemplateInVMValidator
+
+	Name *string `json:"name,omitempty"`
+	Type string  `json:"type"`
+}
+
+func (s ImageTemplatePowerShellValidator) ImageTemplateInVMValidator() BaseImageTemplateInVMValidatorImpl {
+	return BaseImageTemplateInVMValidatorImpl{
+		Name: s.Name,
+		Type: s.Type,
+	}
+}
+
+var _ json.Marshaler = ImageTemplatePowerShellValidator{}
+
+func (s ImageTemplatePowerShellValidator) MarshalJSON() ([]byte, error) {
+	type wrapper ImageTemplatePowerShellValidator
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling ImageTemplatePowerShellValidator: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling ImageTemplatePowerShellValidator: %+v", err)
+	}
+
+	decoded["type"] = "PowerShell"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling ImageTemplatePowerShellValidator: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplateproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplateproperties.go
@@ -1,0 +1,111 @@
+package virtualmachineimagetemplate
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ImageTemplateProperties struct {
+	AutoRun                   *ImageTemplateAutoRun                 `json:"autoRun,omitempty"`
+	BuildTimeoutInMinutes     *int64                                `json:"buildTimeoutInMinutes,omitempty"`
+	Customize                 *[]ImageTemplateCustomizer            `json:"customize,omitempty"`
+	Distribute                []ImageTemplateDistributor            `json:"distribute"`
+	ErrorHandling             *ImageTemplatePropertiesErrorHandling `json:"errorHandling,omitempty"`
+	ExactStagingResourceGroup *string                               `json:"exactStagingResourceGroup,omitempty"`
+	LastRunStatus             *ImageTemplateLastRunStatus           `json:"lastRunStatus,omitempty"`
+	ManagedResourceTags       *map[string]string                    `json:"managedResourceTags,omitempty"`
+	Optimize                  *ImageTemplatePropertiesOptimize      `json:"optimize,omitempty"`
+	ProvisioningError         *ProvisioningError                    `json:"provisioningError,omitempty"`
+	ProvisioningState         *ProvisioningState                    `json:"provisioningState,omitempty"`
+	Source                    ImageTemplateSource                   `json:"source"`
+	StagingResourceGroup      *string                               `json:"stagingResourceGroup,omitempty"`
+	VMProfile                 *ImageTemplateVMProfile               `json:"vmProfile,omitempty"`
+	Validate                  *ImageTemplatePropertiesValidate      `json:"validate,omitempty"`
+}
+
+var _ json.Unmarshaler = &ImageTemplateProperties{}
+
+func (s *ImageTemplateProperties) UnmarshalJSON(bytes []byte) error {
+	var decoded struct {
+		AutoRun                   *ImageTemplateAutoRun                 `json:"autoRun,omitempty"`
+		BuildTimeoutInMinutes     *int64                                `json:"buildTimeoutInMinutes,omitempty"`
+		ErrorHandling             *ImageTemplatePropertiesErrorHandling `json:"errorHandling,omitempty"`
+		ExactStagingResourceGroup *string                               `json:"exactStagingResourceGroup,omitempty"`
+		LastRunStatus             *ImageTemplateLastRunStatus           `json:"lastRunStatus,omitempty"`
+		ManagedResourceTags       *map[string]string                    `json:"managedResourceTags,omitempty"`
+		Optimize                  *ImageTemplatePropertiesOptimize      `json:"optimize,omitempty"`
+		ProvisioningError         *ProvisioningError                    `json:"provisioningError,omitempty"`
+		ProvisioningState         *ProvisioningState                    `json:"provisioningState,omitempty"`
+		StagingResourceGroup      *string                               `json:"stagingResourceGroup,omitempty"`
+		VMProfile                 *ImageTemplateVMProfile               `json:"vmProfile,omitempty"`
+		Validate                  *ImageTemplatePropertiesValidate      `json:"validate,omitempty"`
+	}
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+
+	s.AutoRun = decoded.AutoRun
+	s.BuildTimeoutInMinutes = decoded.BuildTimeoutInMinutes
+	s.ErrorHandling = decoded.ErrorHandling
+	s.ExactStagingResourceGroup = decoded.ExactStagingResourceGroup
+	s.LastRunStatus = decoded.LastRunStatus
+	s.ManagedResourceTags = decoded.ManagedResourceTags
+	s.Optimize = decoded.Optimize
+	s.ProvisioningError = decoded.ProvisioningError
+	s.ProvisioningState = decoded.ProvisioningState
+	s.StagingResourceGroup = decoded.StagingResourceGroup
+	s.VMProfile = decoded.VMProfile
+	s.Validate = decoded.Validate
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling ImageTemplateProperties into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["customize"]; ok {
+		var listTemp []json.RawMessage
+		if err := json.Unmarshal(v, &listTemp); err != nil {
+			return fmt.Errorf("unmarshaling Customize into list []json.RawMessage: %+v", err)
+		}
+
+		output := make([]ImageTemplateCustomizer, 0)
+		for i, val := range listTemp {
+			impl, err := UnmarshalImageTemplateCustomizerImplementation(val)
+			if err != nil {
+				return fmt.Errorf("unmarshaling index %d field 'Customize' for 'ImageTemplateProperties': %+v", i, err)
+			}
+			output = append(output, impl)
+		}
+		s.Customize = &output
+	}
+
+	if v, ok := temp["distribute"]; ok {
+		var listTemp []json.RawMessage
+		if err := json.Unmarshal(v, &listTemp); err != nil {
+			return fmt.Errorf("unmarshaling Distribute into list []json.RawMessage: %+v", err)
+		}
+
+		output := make([]ImageTemplateDistributor, 0)
+		for i, val := range listTemp {
+			impl, err := UnmarshalImageTemplateDistributorImplementation(val)
+			if err != nil {
+				return fmt.Errorf("unmarshaling index %d field 'Distribute' for 'ImageTemplateProperties': %+v", i, err)
+			}
+			output = append(output, impl)
+		}
+		s.Distribute = output
+	}
+
+	if v, ok := temp["source"]; ok {
+		impl, err := UnmarshalImageTemplateSourceImplementation(v)
+		if err != nil {
+			return fmt.Errorf("unmarshaling field 'Source' for 'ImageTemplateProperties': %+v", err)
+		}
+		s.Source = impl
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplatepropertieserrorhandling.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplatepropertieserrorhandling.go
@@ -1,0 +1,9 @@
+package virtualmachineimagetemplate
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ImageTemplatePropertiesErrorHandling struct {
+	OnCustomizerError *OnBuildError `json:"onCustomizerError,omitempty"`
+	OnValidationError *OnBuildError `json:"onValidationError,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplatepropertiesoptimize.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplatepropertiesoptimize.go
@@ -1,0 +1,8 @@
+package virtualmachineimagetemplate
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ImageTemplatePropertiesOptimize struct {
+	VMBoot *ImageTemplatePropertiesOptimizeVMBoot `json:"vmBoot,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplatepropertiesoptimizevmboot.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplatepropertiesoptimizevmboot.go
@@ -1,0 +1,8 @@
+package virtualmachineimagetemplate
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ImageTemplatePropertiesOptimizeVMBoot struct {
+	State *VMBootOptimizationState `json:"state,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplatepropertiesvalidate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplatepropertiesvalidate.go
@@ -1,0 +1,54 @@
+package virtualmachineimagetemplate
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ImageTemplatePropertiesValidate struct {
+	ContinueDistributeOnFailure *bool                         `json:"continueDistributeOnFailure,omitempty"`
+	InVMValidations             *[]ImageTemplateInVMValidator `json:"inVMValidations,omitempty"`
+	SourceValidationOnly        *bool                         `json:"sourceValidationOnly,omitempty"`
+}
+
+var _ json.Unmarshaler = &ImageTemplatePropertiesValidate{}
+
+func (s *ImageTemplatePropertiesValidate) UnmarshalJSON(bytes []byte) error {
+	var decoded struct {
+		ContinueDistributeOnFailure *bool `json:"continueDistributeOnFailure,omitempty"`
+		SourceValidationOnly        *bool `json:"sourceValidationOnly,omitempty"`
+	}
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+
+	s.ContinueDistributeOnFailure = decoded.ContinueDistributeOnFailure
+	s.SourceValidationOnly = decoded.SourceValidationOnly
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling ImageTemplatePropertiesValidate into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["inVMValidations"]; ok {
+		var listTemp []json.RawMessage
+		if err := json.Unmarshal(v, &listTemp); err != nil {
+			return fmt.Errorf("unmarshaling InVMValidations into list []json.RawMessage: %+v", err)
+		}
+
+		output := make([]ImageTemplateInVMValidator, 0)
+		for i, val := range listTemp {
+			impl, err := UnmarshalImageTemplateInVMValidatorImplementation(val)
+			if err != nil {
+				return fmt.Errorf("unmarshaling index %d field 'InVMValidations' for 'ImageTemplatePropertiesValidate': %+v", i, err)
+			}
+			output = append(output, impl)
+		}
+		s.InVMValidations = &output
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplaterestartcustomizer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplaterestartcustomizer.go
@@ -1,0 +1,54 @@
+package virtualmachineimagetemplate
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ImageTemplateCustomizer = ImageTemplateRestartCustomizer{}
+
+type ImageTemplateRestartCustomizer struct {
+	RestartCheckCommand *string `json:"restartCheckCommand,omitempty"`
+	RestartCommand      *string `json:"restartCommand,omitempty"`
+	RestartTimeout      *string `json:"restartTimeout,omitempty"`
+
+	// Fields inherited from ImageTemplateCustomizer
+
+	Name *string `json:"name,omitempty"`
+	Type string  `json:"type"`
+}
+
+func (s ImageTemplateRestartCustomizer) ImageTemplateCustomizer() BaseImageTemplateCustomizerImpl {
+	return BaseImageTemplateCustomizerImpl{
+		Name: s.Name,
+		Type: s.Type,
+	}
+}
+
+var _ json.Marshaler = ImageTemplateRestartCustomizer{}
+
+func (s ImageTemplateRestartCustomizer) MarshalJSON() ([]byte, error) {
+	type wrapper ImageTemplateRestartCustomizer
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling ImageTemplateRestartCustomizer: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling ImageTemplateRestartCustomizer: %+v", err)
+	}
+
+	decoded["type"] = "WindowsRestart"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling ImageTemplateRestartCustomizer: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplatesharedimagedistributor.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplatesharedimagedistributor.go
@@ -1,0 +1,101 @@
+package virtualmachineimagetemplate
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ImageTemplateDistributor = ImageTemplateSharedImageDistributor{}
+
+type ImageTemplateSharedImageDistributor struct {
+	ExcludeFromLatest  *bool                          `json:"excludeFromLatest,omitempty"`
+	GalleryImageId     string                         `json:"galleryImageId"`
+	ReplicationRegions *[]string                      `json:"replicationRegions,omitempty"`
+	StorageAccountType *SharedImageStorageAccountType `json:"storageAccountType,omitempty"`
+	TargetRegions      *[]TargetRegion                `json:"targetRegions,omitempty"`
+	Versioning         DistributeVersioner            `json:"versioning"`
+
+	// Fields inherited from ImageTemplateDistributor
+
+	ArtifactTags  *map[string]string `json:"artifactTags,omitempty"`
+	RunOutputName string             `json:"runOutputName"`
+	Type          string             `json:"type"`
+}
+
+func (s ImageTemplateSharedImageDistributor) ImageTemplateDistributor() BaseImageTemplateDistributorImpl {
+	return BaseImageTemplateDistributorImpl{
+		ArtifactTags:  s.ArtifactTags,
+		RunOutputName: s.RunOutputName,
+		Type:          s.Type,
+	}
+}
+
+var _ json.Marshaler = ImageTemplateSharedImageDistributor{}
+
+func (s ImageTemplateSharedImageDistributor) MarshalJSON() ([]byte, error) {
+	type wrapper ImageTemplateSharedImageDistributor
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling ImageTemplateSharedImageDistributor: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling ImageTemplateSharedImageDistributor: %+v", err)
+	}
+
+	decoded["type"] = "SharedImage"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling ImageTemplateSharedImageDistributor: %+v", err)
+	}
+
+	return encoded, nil
+}
+
+var _ json.Unmarshaler = &ImageTemplateSharedImageDistributor{}
+
+func (s *ImageTemplateSharedImageDistributor) UnmarshalJSON(bytes []byte) error {
+	var decoded struct {
+		ExcludeFromLatest  *bool                          `json:"excludeFromLatest,omitempty"`
+		GalleryImageId     string                         `json:"galleryImageId"`
+		ReplicationRegions *[]string                      `json:"replicationRegions,omitempty"`
+		StorageAccountType *SharedImageStorageAccountType `json:"storageAccountType,omitempty"`
+		TargetRegions      *[]TargetRegion                `json:"targetRegions,omitempty"`
+		ArtifactTags       *map[string]string             `json:"artifactTags,omitempty"`
+		RunOutputName      string                         `json:"runOutputName"`
+		Type               string                         `json:"type"`
+	}
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+
+	s.ExcludeFromLatest = decoded.ExcludeFromLatest
+	s.GalleryImageId = decoded.GalleryImageId
+	s.ReplicationRegions = decoded.ReplicationRegions
+	s.StorageAccountType = decoded.StorageAccountType
+	s.TargetRegions = decoded.TargetRegions
+	s.ArtifactTags = decoded.ArtifactTags
+	s.RunOutputName = decoded.RunOutputName
+	s.Type = decoded.Type
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling ImageTemplateSharedImageDistributor into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["versioning"]; ok {
+		impl, err := UnmarshalDistributeVersionerImplementation(v)
+		if err != nil {
+			return fmt.Errorf("unmarshaling field 'Versioning' for 'ImageTemplateSharedImageDistributor': %+v", err)
+		}
+		s.Versioning = impl
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplatesharedimageversionsource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplatesharedimageversionsource.go
@@ -1,0 +1,51 @@
+package virtualmachineimagetemplate
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ImageTemplateSource = ImageTemplateSharedImageVersionSource{}
+
+type ImageTemplateSharedImageVersionSource struct {
+	ExactVersion   *string `json:"exactVersion,omitempty"`
+	ImageVersionId string  `json:"imageVersionId"`
+
+	// Fields inherited from ImageTemplateSource
+
+	Type string `json:"type"`
+}
+
+func (s ImageTemplateSharedImageVersionSource) ImageTemplateSource() BaseImageTemplateSourceImpl {
+	return BaseImageTemplateSourceImpl{
+		Type: s.Type,
+	}
+}
+
+var _ json.Marshaler = ImageTemplateSharedImageVersionSource{}
+
+func (s ImageTemplateSharedImageVersionSource) MarshalJSON() ([]byte, error) {
+	type wrapper ImageTemplateSharedImageVersionSource
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling ImageTemplateSharedImageVersionSource: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling ImageTemplateSharedImageVersionSource: %+v", err)
+	}
+
+	decoded["type"] = "SharedImageVersion"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling ImageTemplateSharedImageVersionSource: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplateshellcustomizer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplateshellcustomizer.go
@@ -1,0 +1,54 @@
+package virtualmachineimagetemplate
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ImageTemplateCustomizer = ImageTemplateShellCustomizer{}
+
+type ImageTemplateShellCustomizer struct {
+	Inline         *[]string `json:"inline,omitempty"`
+	ScriptUri      *string   `json:"scriptUri,omitempty"`
+	Sha256Checksum *string   `json:"sha256Checksum,omitempty"`
+
+	// Fields inherited from ImageTemplateCustomizer
+
+	Name *string `json:"name,omitempty"`
+	Type string  `json:"type"`
+}
+
+func (s ImageTemplateShellCustomizer) ImageTemplateCustomizer() BaseImageTemplateCustomizerImpl {
+	return BaseImageTemplateCustomizerImpl{
+		Name: s.Name,
+		Type: s.Type,
+	}
+}
+
+var _ json.Marshaler = ImageTemplateShellCustomizer{}
+
+func (s ImageTemplateShellCustomizer) MarshalJSON() ([]byte, error) {
+	type wrapper ImageTemplateShellCustomizer
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling ImageTemplateShellCustomizer: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling ImageTemplateShellCustomizer: %+v", err)
+	}
+
+	decoded["type"] = "Shell"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling ImageTemplateShellCustomizer: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplateshellvalidator.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplateshellvalidator.go
@@ -1,0 +1,54 @@
+package virtualmachineimagetemplate
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ImageTemplateInVMValidator = ImageTemplateShellValidator{}
+
+type ImageTemplateShellValidator struct {
+	Inline         *[]string `json:"inline,omitempty"`
+	ScriptUri      *string   `json:"scriptUri,omitempty"`
+	Sha256Checksum *string   `json:"sha256Checksum,omitempty"`
+
+	// Fields inherited from ImageTemplateInVMValidator
+
+	Name *string `json:"name,omitempty"`
+	Type string  `json:"type"`
+}
+
+func (s ImageTemplateShellValidator) ImageTemplateInVMValidator() BaseImageTemplateInVMValidatorImpl {
+	return BaseImageTemplateInVMValidatorImpl{
+		Name: s.Name,
+		Type: s.Type,
+	}
+}
+
+var _ json.Marshaler = ImageTemplateShellValidator{}
+
+func (s ImageTemplateShellValidator) MarshalJSON() ([]byte, error) {
+	type wrapper ImageTemplateShellValidator
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling ImageTemplateShellValidator: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling ImageTemplateShellValidator: %+v", err)
+	}
+
+	decoded["type"] = "Shell"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling ImageTemplateShellValidator: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplatesource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplatesource.go
@@ -1,0 +1,91 @@
+package virtualmachineimagetemplate
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ImageTemplateSource interface {
+	ImageTemplateSource() BaseImageTemplateSourceImpl
+}
+
+var _ ImageTemplateSource = BaseImageTemplateSourceImpl{}
+
+type BaseImageTemplateSourceImpl struct {
+	Type string `json:"type"`
+}
+
+func (s BaseImageTemplateSourceImpl) ImageTemplateSource() BaseImageTemplateSourceImpl {
+	return s
+}
+
+var _ ImageTemplateSource = RawImageTemplateSourceImpl{}
+
+// RawImageTemplateSourceImpl is returned when the Discriminated Value doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawImageTemplateSourceImpl struct {
+	imageTemplateSource BaseImageTemplateSourceImpl
+	Type                string
+	Values              map[string]interface{}
+}
+
+func (s RawImageTemplateSourceImpl) ImageTemplateSource() BaseImageTemplateSourceImpl {
+	return s.imageTemplateSource
+}
+
+func UnmarshalImageTemplateSourceImplementation(input []byte) (ImageTemplateSource, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling ImageTemplateSource into map[string]interface: %+v", err)
+	}
+
+	var value string
+	if v, ok := temp["type"]; ok {
+		value = fmt.Sprintf("%v", v)
+	}
+
+	if strings.EqualFold(value, "ManagedImage") {
+		var out ImageTemplateManagedImageSource
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into ImageTemplateManagedImageSource: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "PlatformImage") {
+		var out ImageTemplatePlatformImageSource
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into ImageTemplatePlatformImageSource: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "SharedImageVersion") {
+		var out ImageTemplateSharedImageVersionSource
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into ImageTemplateSharedImageVersionSource: %+v", err)
+		}
+		return out, nil
+	}
+
+	var parent BaseImageTemplateSourceImpl
+	if err := json.Unmarshal(input, &parent); err != nil {
+		return nil, fmt.Errorf("unmarshaling into BaseImageTemplateSourceImpl: %+v", err)
+	}
+
+	return RawImageTemplateSourceImpl{
+		imageTemplateSource: parent,
+		Type:                value,
+		Values:              temp,
+	}, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplateupdateparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplateupdateparameters.go
@@ -1,0 +1,14 @@
+package virtualmachineimagetemplate
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ImageTemplateUpdateParameters struct {
+	Identity   *identity.UserAssignedMap                `json:"identity,omitempty"`
+	Properties *ImageTemplateUpdateParametersProperties `json:"properties,omitempty"`
+	Tags       *map[string]string                       `json:"tags,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplateupdateparametersproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplateupdateparametersproperties.go
@@ -1,0 +1,51 @@
+package virtualmachineimagetemplate
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ImageTemplateUpdateParametersProperties struct {
+	Distribute *[]ImageTemplateDistributor `json:"distribute,omitempty"`
+	VMProfile  *ImageTemplateVMProfile     `json:"vmProfile,omitempty"`
+}
+
+var _ json.Unmarshaler = &ImageTemplateUpdateParametersProperties{}
+
+func (s *ImageTemplateUpdateParametersProperties) UnmarshalJSON(bytes []byte) error {
+	var decoded struct {
+		VMProfile *ImageTemplateVMProfile `json:"vmProfile,omitempty"`
+	}
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+
+	s.VMProfile = decoded.VMProfile
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling ImageTemplateUpdateParametersProperties into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["distribute"]; ok {
+		var listTemp []json.RawMessage
+		if err := json.Unmarshal(v, &listTemp); err != nil {
+			return fmt.Errorf("unmarshaling Distribute into list []json.RawMessage: %+v", err)
+		}
+
+		output := make([]ImageTemplateDistributor, 0)
+		for i, val := range listTemp {
+			impl, err := UnmarshalImageTemplateDistributorImplementation(val)
+			if err != nil {
+				return fmt.Errorf("unmarshaling index %d field 'Distribute' for 'ImageTemplateUpdateParametersProperties': %+v", i, err)
+			}
+			output = append(output, impl)
+		}
+		s.Distribute = &output
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplatevhddistributor.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplatevhddistributor.go
@@ -1,0 +1,54 @@
+package virtualmachineimagetemplate
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ImageTemplateDistributor = ImageTemplateVhdDistributor{}
+
+type ImageTemplateVhdDistributor struct {
+	Uri *string `json:"uri,omitempty"`
+
+	// Fields inherited from ImageTemplateDistributor
+
+	ArtifactTags  *map[string]string `json:"artifactTags,omitempty"`
+	RunOutputName string             `json:"runOutputName"`
+	Type          string             `json:"type"`
+}
+
+func (s ImageTemplateVhdDistributor) ImageTemplateDistributor() BaseImageTemplateDistributorImpl {
+	return BaseImageTemplateDistributorImpl{
+		ArtifactTags:  s.ArtifactTags,
+		RunOutputName: s.RunOutputName,
+		Type:          s.Type,
+	}
+}
+
+var _ json.Marshaler = ImageTemplateVhdDistributor{}
+
+func (s ImageTemplateVhdDistributor) MarshalJSON() ([]byte, error) {
+	type wrapper ImageTemplateVhdDistributor
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling ImageTemplateVhdDistributor: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling ImageTemplateVhdDistributor: %+v", err)
+	}
+
+	decoded["type"] = "VHD"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling ImageTemplateVhdDistributor: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplatevmprofile.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplatevmprofile.go
@@ -1,0 +1,11 @@
+package virtualmachineimagetemplate
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ImageTemplateVMProfile struct {
+	OsDiskSizeGB           *int64                `json:"osDiskSizeGB,omitempty"`
+	UserAssignedIdentities *[]string             `json:"userAssignedIdentities,omitempty"`
+	VMSize                 *string               `json:"vmSize,omitempty"`
+	VnetConfig             *VirtualNetworkConfig `json:"vnetConfig,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplatewindowsupdatecustomizer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_imagetemplatewindowsupdatecustomizer.go
@@ -1,0 +1,54 @@
+package virtualmachineimagetemplate
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ImageTemplateCustomizer = ImageTemplateWindowsUpdateCustomizer{}
+
+type ImageTemplateWindowsUpdateCustomizer struct {
+	Filters        *[]string `json:"filters,omitempty"`
+	SearchCriteria *string   `json:"searchCriteria,omitempty"`
+	UpdateLimit    *int64    `json:"updateLimit,omitempty"`
+
+	// Fields inherited from ImageTemplateCustomizer
+
+	Name *string `json:"name,omitempty"`
+	Type string  `json:"type"`
+}
+
+func (s ImageTemplateWindowsUpdateCustomizer) ImageTemplateCustomizer() BaseImageTemplateCustomizerImpl {
+	return BaseImageTemplateCustomizerImpl{
+		Name: s.Name,
+		Type: s.Type,
+	}
+}
+
+var _ json.Marshaler = ImageTemplateWindowsUpdateCustomizer{}
+
+func (s ImageTemplateWindowsUpdateCustomizer) MarshalJSON() ([]byte, error) {
+	type wrapper ImageTemplateWindowsUpdateCustomizer
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling ImageTemplateWindowsUpdateCustomizer: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling ImageTemplateWindowsUpdateCustomizer: %+v", err)
+	}
+
+	decoded["type"] = "WindowsUpdate"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling ImageTemplateWindowsUpdateCustomizer: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_platformimagepurchaseplan.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_platformimagepurchaseplan.go
@@ -1,0 +1,10 @@
+package virtualmachineimagetemplate
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PlatformImagePurchasePlan struct {
+	PlanName      string `json:"planName"`
+	PlanProduct   string `json:"planProduct"`
+	PlanPublisher string `json:"planPublisher"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_provisioningerror.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_provisioningerror.go
@@ -1,0 +1,9 @@
+package virtualmachineimagetemplate
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ProvisioningError struct {
+	Message               *string                `json:"message,omitempty"`
+	ProvisioningErrorCode *ProvisioningErrorCode `json:"provisioningErrorCode,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_runoutput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_runoutput.go
@@ -1,0 +1,16 @@
+package virtualmachineimagetemplate
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RunOutput struct {
+	Id         *string                `json:"id,omitempty"`
+	Name       *string                `json:"name,omitempty"`
+	Properties *RunOutputProperties   `json:"properties,omitempty"`
+	SystemData *systemdata.SystemData `json:"systemData,omitempty"`
+	Type       *string                `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_runoutputproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_runoutputproperties.go
@@ -1,0 +1,10 @@
+package virtualmachineimagetemplate
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RunOutputProperties struct {
+	ArtifactId        *string            `json:"artifactId,omitempty"`
+	ArtifactUri       *string            `json:"artifactUri,omitempty"`
+	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_targetregion.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_targetregion.go
@@ -1,0 +1,10 @@
+package virtualmachineimagetemplate
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TargetRegion struct {
+	Name               string                         `json:"name"`
+	ReplicaCount       *int64                         `json:"replicaCount,omitempty"`
+	StorageAccountType *SharedImageStorageAccountType `json:"storageAccountType,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_virtualnetworkconfig.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/model_virtualnetworkconfig.go
@@ -1,0 +1,10 @@
+package virtualmachineimagetemplate
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualNetworkConfig struct {
+	ContainerInstanceSubnetId *string `json:"containerInstanceSubnetId,omitempty"`
+	ProxyVMSize               *string `json:"proxyVmSize,omitempty"`
+	SubnetId                  *string `json:"subnetId,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/predicates.go
@@ -1,0 +1,55 @@
+package virtualmachineimagetemplate
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ImageTemplateOperationPredicate struct {
+	Id       *string
+	Location *string
+	Name     *string
+	Type     *string
+}
+
+func (p ImageTemplateOperationPredicate) Matches(input ImageTemplate) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Location != nil && *p.Location != input.Location {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}
+
+type RunOutputOperationPredicate struct {
+	Id   *string
+	Name *string
+	Type *string
+}
+
+func (p RunOutputOperationPredicate) Matches(input RunOutput) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate/version.go
@@ -1,0 +1,10 @@
+package virtualmachineimagetemplate
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2024-02-01"
+
+func userAgent() string {
+	return "hashicorp/go-azure-sdk/virtualmachineimagetemplate/2024-02-01"
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -646,6 +646,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2024-07-10/priv
 github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2024-07-10/privatelinkscopes
 github.com/hashicorp/go-azure-sdk/resource-manager/hybridkubernetes/2021-10-01/connectedclusters
 github.com/hashicorp/go-azure-sdk/resource-manager/hybridkubernetes/2024-01-01/connectedclusters
+github.com/hashicorp/go-azure-sdk/resource-manager/imagebuilder/2024-02-01/virtualmachineimagetemplate
 github.com/hashicorp/go-azure-sdk/resource-manager/insights/2015-04-01/activitylogs
 github.com/hashicorp/go-azure-sdk/resource-manager/insights/2018-03-01/metricalerts
 github.com/hashicorp/go-azure-sdk/resource-manager/insights/2018-04-16/scheduledqueryrules

--- a/website/docs/r/image_builder_template.html.markdown
+++ b/website/docs/r/image_builder_template.html.markdown
@@ -1,0 +1,293 @@
+---
+subcategory: "Compute"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_image_builder_template"
+description: |-
+  Manages an Image template that can be used to create virtual machine images.
+---
+
+# azurerm_image_builder_template
+
+Manages an Image template that can be used to create virtual machine images.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_user_assigned_identity" "example" {
+  name                = "identityName"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+}
+
+resource "azurerm_role_definition" "example" {
+  name  = "roleDefName"
+  scope = azurerm_resource_group.example.id
+
+  permissions {
+    actions = [
+      "Microsoft.Compute/images/write",
+      "Microsoft.Compute/images/read",
+      "Microsoft.Compute/images/delete"
+    ]
+    not_actions = []
+  }
+
+  assignable_scopes = [
+    azurerm_resource_group.example.id,
+  ]
+}
+
+resource "azurerm_role_assignment" "example" {
+  scope              = azurerm_resource_group.example.id
+  role_definition_id = azurerm_role_definition.example.role_definition_resource_id
+  principal_id       = azurerm_user_assigned_identity.example.principal_id
+}
+
+resource "azurerm_image_builder_template" "example" {
+  name                = "acctest"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.example.id]
+  }
+
+  source_platform_image {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "18.04-LTS"
+    version   = "latest"
+  }
+
+  distributions {
+    managed_image {
+      name                = "accTestImg1"
+      resource_group_name = azurerm_resource_group.example.name
+      location            = azurerm_resource_group.example.location
+      run_output_name     = "ouputName"
+    }
+  }
+
+  depends_on = [
+    azurerm_role_assignment.example
+  ]
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the Image Builder Template. Changing this forces a new resource to be created.
+
+* `resource_group_name` - (Required) The name of the resource group in which the Image Builder Template should exist. Changing this forces a new resource to be created.
+
+* `location` - (Required) The Azure Region where the Image Builder Template should exist. Changing this forces a new resource to be created.
+
+* `distributions` - (Required) A `distributions` block as defined below. Changing this forces a new resource to be created.
+
+* `identity` - (Required) An `identity` block as defined below.
+
+---
+
+* `build_timeout_minutes` - (Optional) Maximum duration to wait while building the image template. Defaults to `240`. Changing this forces a new resource to be created.
+
+* `customizer` - (Optional) A `customizer` block as defined below. Changing this forces a new resource to be created.
+
+-> **Note** Azure Image Builder will run through the customizers in sequential order. Any failure in any customizer will fail the build process.
+
+* `disk_size_gb` - (Optional) Size of the OS disk in GB. Defaults to 0 to leave the same size as the source image. You can only increase the size of the OS Disk (Win and Linux) but cannot reduce the OS Disk size to smaller than the size from the source image. Changing this forces a new resource to be created.
+
+* `size` - (Optional) Size of the virtual machine used to build, customize and capture images. Defaults to `Standard_D1_v2`. Changing this forces a new resource to be created.
+
+* `source_managed_image_id` - (Optional) The ID of an image source that is a managed image. Changing this forces a new resource to be created.
+
+* `source_platform_image` - (Optional) A `source_platform_image` block as defined below. Changing this forces a new resource to be created.
+
+* `source_shared_image_version_id` - (Optional) The ID of an image source that is an image version in a shared image gallery. Changing this forces a new resource to be created.
+
+-> **NOTE** Exactly one of `source_managed_image_id`, `source_platform_image` and `source_shared_image_version_id` is required to specify.
+
+* `subnet_id` - (Optional) The ID of the subnet that the virtual machine used to build, customize and capture images. Changing this forces a new resource to be created.
+
+-> **Note** If you specify a VNET, Azure Image Builder does not use a public IP address. Communication from Azure Image Builder Service to the build VM uses Azure Private Link technology. Private Link service requires an IP from the given VNET and subnet. Currently, Azure doesn’t support Network Policies on these IPs. Hence, network policies need to be disabled on the subnet, to do which, you need to ensure `enforce_private_link_service_network_policies` is set to `true` in your `azurerm_subnet` resource.
+
+* `tags` - (Optional) A mapping of tags to assign to the resource.
+
+---
+
+A `customizer` block supports the following:
+
+* `type` - (Required) The type of customization tool you want to use on the Image. Possible values are `File`, `PowerShell`, `Shell` `WindowsRestart` and `WindowsUpdate`. If you use `File` for example, you should only specify properties starting with `file_`, otherwise it will result into error
+
+* `file_destination_path` - (Optional) The absolute path where the file will be downloaded to the VM. This must be specified when the customizer type is `File`. Changing this forces a new resource to be created.
+
+* `file_sha256_checksum` - (Optional) SHA256 checksum of the file provided in the `file_source_uri` field below. Changing this forces a new resource to be created.
+
+* `file_source_uri` - (Optional) The URI of the file to be uploaded for customizing the VM. This must be specified when the customizer type is `File`. Changing this forces a new resource to be created.
+
+* `name` - (Optional) The name of the customizer. Changing this forces a new resource to be created.
+
+* `powershell_commands` - (Optional) List of PowerShell commands to execute. Changing this forces a new resource to be created.
+
+* `powershell_run_as_system` - (Optional) Whether the PowerShell script will be run with elevated privileges using the local system user? Changing this forces a new resource to be created.
+
+* `powershell_run_elevated` - (Optional) Whether the PowerShell script will be run with elevated privileges? Changing this forces a new resource to be created.
+
+-> **Note** Setting `powershell_run_as_system` only takes effect when `powershell_run_elevated` is set to true when the customizer type is `PowerShell`.
+
+* `powershell_script_uri` - (Optional) URI of the PowerShell script to be run for customizing. Changing this forces a new resource to be created.
+
+-> **Note** Exactly one of `powershell_commands` and `powershell_script_uri` must be specified when the customizer type is `PowerShell`.
+
+* `powershell_sha256_checksum` - (Optional) SHA256 checksum of the power shell script provided in the `powershell_script_uri` above. Changing this forces a new resource to be created.
+
+* `powershell_valid_exit_codes` - (Optional) List of valid exit codes that can be returned from commands/scripts. Changing this forces a new resource to be created.
+
+* `shell_commands` - (Optional) List of shell commands to execute. Changing this forces a new resource to be created.
+
+* `shell_script_uri` - (Optional) URI of the shell script to be run for customizing. Changing this forces a new resource to be created.
+
+-> **Note** Exactly one of `shell_commands` and `shell_script_uri` must be specified when the customizer type is `Shell`.
+
+* `shell_sha256_checksum` - (Optional) SHA256 checksum of the shell script provided in the `shell_script_uri` above. Changing this forces a new resource to be created.
+
+* `windows_restart_check_command` - (Optional) Command to check if restart succeeded. Changing this forces a new resource to be created.
+
+* `windows_restart_command` - (Optional) Command to execute the restart. Changing this forces a new resource to be created.
+
+* `windows_restart_timeout` - (Optional) Restart timeout specified as a string of magnitude and unit, e.g. '5m' (5 minutes) or '2h' (2 hours). Changing this forces a new resource to be created.
+
+* `windows_update_filters` - (Optional) List of filters to select updates to apply. Changing this forces a new resource to be created.
+
+* `windows_update_search_criteria` - (Optional) Criteria to search updates. More to refer to https://github.com/rgl/packer-provisioner-windows-update. Changing this forces a new resource to be created.
+
+* `windows_update_limit` - (Optional) Maximum number of updates to apply at a time. Changing this forces a new resource to be created.
+
+---
+
+A `distributions` block supports the following:
+
+* `managed_image` - (Optional) A `managed_image` block as defined below. Changing this forces a new resource to be created.
+
+* `shared_image` - (Optional) A `shared_image` block as defined below. Changing this forces a new resource to be created.
+
+* `vhd` - (Optional) A `vhd` block as defined below. Changing this forces a new resource to be created.
+
+-> **NOTE** At least one of `managed_image`, `shared_image` and `vhd` is required to specify in `distributions`.
+
+---
+
+An `identity` block supports the following:
+
+* `type` - (Required) The type of Managed Identity which should be assigned to the Image Builder Template. Currently only `UserAssigned` is supported. Changing this forces a new resource to be created.
+
+* `identity_ids` - (Required) The list of user assigned identities associated with the image template. Currently only 1 id is allowed. Changing this forces a new resource to be created.
+
+---
+
+A `managed_image` block supports the following:
+
+* `name` - (Required) The name of the to be generated image. Changing this forces a new resource to be created.
+
+* `location` - (Required) The Azure Region where the to be generated Image will exist. Changing this forces a new resource to be created.
+
+* `resource_group_name` - (Required) The name of the Resource Group where the to be generated image will exist. Changing this forces a new resource to be created.
+
+* `run_output_name` - (Required) The name to be used for the associated RunOutput. Changing this forces a new resource to be created.
+
+* `tags` - (Optional) A mapping of tags to assign to the to be generated image. Changing this forces a new resource to be created.
+
+---
+
+A `plan` block supports the following:
+
+* `name` - (Required) The name of the Marketplace Image this Image Builder Template should be created from. Changing this forces a new resource to be created.
+
+* `product` - (Required) The product of the Marketplace Image this Image Builder Template should be created from. Changing this forces a new resource to be created.
+
+* `publisher` - (Required) The publisher of the Marketplace Image this Image Builder Template should be created from. Changing this forces a new resource to be created.
+
+---
+
+A `shared_image` block supports the following:
+
+* `id` - (Required) ID of the shared image gallery image. Changing this forces a new resource to be created.
+
+* `replica_regions` - (Required) A `replica_regions` block as defined below. Changing this forces a new resource to be created.
+
+* `run_output_name` - (Required) The name to be used for the associated RunOutput. Changing this forces a new resource to be created.
+
+* `exclude_from_latest` - (Optional) Should the to be created Image Version be excluded from the `latest` filter? If set to `true` this Image Version won't be returned for the `latest` version. Defaults to `false`. Changing this forces a new resource to be created.
+
+* `storage_account_type` - (Optional) The storage account type to store the to be created Image Version. Possible values are `Standard_LRS` and `Standard_ZRS`. Changing this forces a new resource to be created.
+
+* `tags` - (Optional) A mapping of tags to assign to the to be generated shared image version. Changing this forces a new resource to be created.
+
+* `versioning` - (Required) A `versioning` block as defined below. Changing this forces a new resource to be created.
+
+---
+
+A `source_platform_image` block supports the following:
+
+* `publisher` - (Required) The publisher of the image used to create the Image Builder Template. Changing this forces a new resource to be created.
+
+* `offer` - (Required) The offer of the image used to create the Image Builder Template. Changing this forces a new resource to be created.
+
+* `sku` - (Required) The sku of the image used to create the Image Builder Template. Changing this forces a new resource to be created.
+
+* `version` - (Required) The version of the image used to create the Image Builder Template. Changing this forces a new resource to be created.
+
+* `plan` - (Optional) A `plan` block as defined above. Changing this forces a new resource to be created.
+
+---
+
+A `replica_regions` block supports the following:
+
+* `name` - (Required) The Azure Region in which the to be created Shared Image Version should exist. Changing this forces a new resource to be created.
+
+---
+
+A `versioning` block supports the following:
+
+* `scheme` - (Required) Version numbering scheme to be used. Possible values are `Source` and `Latest`. Changing this forces a new resource to be created.
+
+* `major` - (Optional) Major version for the generated version number. Determine what is "latest" based on versions with this value as the major version. Possible values are `Source` and `Latest`. Changing this forces a new resource to be created.
+
+
+---
+
+A `vhd` block supports the following:
+
+* `run_output_name` - (Required) The name to be used for the associated RunOutput. Changing this forces a new resource to be created.
+
+* `tags` - (Optional) A mapping of tags to assign to the to be generated vhd. Changing this forces a new resource to be created.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the Image Builder Template.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Image Builder Template.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Image Builder Template.
+* `update` - (Defaults to 30 minutes) Used when updating the Image Builder Template.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Image Builder Template.
+
+## Import
+
+Image Builder Templates can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_image_builder_template.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.VirtualMachineImages/imageTemplates/imagebuildertemplate1
+```

--- a/website/docs/r/image_builder_template.html.markdown
+++ b/website/docs/r/image_builder_template.html.markdown
@@ -100,7 +100,7 @@ The following arguments are supported:
 
 * `customizer` - (Optional) A `customizer` block as defined below. Changing this forces a new resource to be created.
 
--> **Note** Azure Image Builder will run through the customizers in sequential order. Any failure in any customizer will fail the build process.
+-> **Note:** Azure Image Builder will run through the customizers in sequential order. Any failure in any customizer will fail the build process.
 
 * `disk_size_gb` - (Optional) Size of the OS disk in GB. Defaults to 0 to leave the same size as the source image. You can only increase the size of the OS Disk (Win and Linux) but cannot reduce the OS Disk size to smaller than the size from the source image. Changing this forces a new resource to be created.
 
@@ -112,11 +112,11 @@ The following arguments are supported:
 
 * `source_shared_image_version_id` - (Optional) The ID of an image source that is an image version in a shared image gallery. Changing this forces a new resource to be created.
 
--> **NOTE** Exactly one of `source_managed_image_id`, `source_platform_image` and `source_shared_image_version_id` is required to specify.
+-> **Note:** Exactly one of `source_managed_image_id`, `source_platform_image` and `source_shared_image_version_id` is required to specify.
 
 * `subnet_id` - (Optional) The ID of the subnet that the virtual machine used to build, customize and capture images. Changing this forces a new resource to be created.
 
--> **Note** If you specify a VNET, Azure Image Builder does not use a public IP address. Communication from Azure Image Builder Service to the build VM uses Azure Private Link technology. Private Link service requires an IP from the given VNET and subnet. Currently, Azure doesn’t support Network Policies on these IPs. Hence, network policies need to be disabled on the subnet, to do which, you need to ensure `enforce_private_link_service_network_policies` is set to `true` in your `azurerm_subnet` resource.
+-> **Note:** If you specify a VNET, Azure Image Builder does not use a public IP address. Communication from Azure Image Builder Service to the build VM uses Azure Private Link technology. Private Link service requires an IP from the given VNET and subnet. Currently, Azure doesn’t support Network Policies on these IPs. Hence, network policies need to be disabled on the subnet, to do which, you need to ensure `enforce_private_link_service_network_policies` is set to `true` in your `azurerm_subnet` resource.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
@@ -140,11 +140,11 @@ A `customizer` block supports the following:
 
 * `powershell_run_elevated` - (Optional) Whether the PowerShell script will be run with elevated privileges? Changing this forces a new resource to be created.
 
--> **Note** Setting `powershell_run_as_system` only takes effect when `powershell_run_elevated` is set to true when the customizer type is `PowerShell`.
+-> **Note:** Setting `powershell_run_as_system` only takes effect when `powershell_run_elevated` is set to true when the customizer type is `PowerShell`.
 
 * `powershell_script_uri` - (Optional) URI of the PowerShell script to be run for customizing. Changing this forces a new resource to be created.
 
--> **Note** Exactly one of `powershell_commands` and `powershell_script_uri` must be specified when the customizer type is `PowerShell`.
+-> **Note:** Exactly one of `powershell_commands` and `powershell_script_uri` must be specified when the customizer type is `PowerShell`.
 
 * `powershell_sha256_checksum` - (Optional) SHA256 checksum of the power shell script provided in the `powershell_script_uri` above. Changing this forces a new resource to be created.
 
@@ -154,7 +154,7 @@ A `customizer` block supports the following:
 
 * `shell_script_uri` - (Optional) URI of the shell script to be run for customizing. Changing this forces a new resource to be created.
 
--> **Note** Exactly one of `shell_commands` and `shell_script_uri` must be specified when the customizer type is `Shell`.
+-> **Note:** Exactly one of `shell_commands` and `shell_script_uri` must be specified when the customizer type is `Shell`.
 
 * `shell_sha256_checksum` - (Optional) SHA256 checksum of the shell script provided in the `shell_script_uri` above. Changing this forces a new resource to be created.
 
@@ -180,7 +180,7 @@ A `distributions` block supports the following:
 
 * `vhd` - (Optional) A `vhd` block as defined below. Changing this forces a new resource to be created.
 
--> **NOTE** At least one of `managed_image`, `shared_image` and `vhd` is required to specify in `distributions`.
+-> **Note:** At least one of `managed_image`, `shared_image` and `vhd` is required to specify in `distributions`.
 
 ---
 
@@ -291,3 +291,9 @@ Image Builder Templates can be imported using the `resource id`, e.g.
 ```shell
 terraform import azurerm_image_builder_template.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.VirtualMachineImages/imageTemplates/imagebuildertemplate1
 ```
+
+## API Providers
+<!-- This section is generated, changes will be overwritten -->
+This resource uses the following Azure API Providers:
+
+* `Microsoft.VirtualMachineImages` - 2024-02-01


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Five years ago [this PR](https://github.com/hashicorp/terraform-provider-azurerm/pull/9204) was closed for a few reasons that mainly centred around the resources suitability for Terraform.

Since then there have been changes to AIB templates as well as Terraform which leads me to believe this resource does make sense now.

Now that Terraform Actions are available there is now a sensible mechanism to run the template (although this PR doesn't define that new action). This resource just defines the template but does not run it.

AIB also got support for scheduling image templates based on updates to marketplace images so in some use cases running the image template manually is not a requirement.

Huge credit to @mybayern1974 who put in the work all those years ago, this PR leans on that very heavily.

I am seeing a consistent error with test `TestAccAzureRMImageBuilderTemplate_identity_update` which seems to indicate more properties other than `identity` are being changed although as far as I can tell that's not the case.
```
=== NAME  TestAccAzureRMImageBuilderTemplate_identity_update
    testcase.go:192: Step 4/9 error: Error running apply: exit status 1
        
        Error: updating image builder template "acctestIBT-260228235605606232" (Resource Group "acctestRG-260228235605606232"): performing Update: unexpected status 400 (400 Bad Request) with error: ValidationFailed: Validation failed: Only changing one identity to another is supported in PATCH
        
          with azurerm_image_builder_template.test,
          on terraform_plugin_test.tf line 110, in resource "azurerm_image_builder_template" "test":
         110: resource "azurerm_image_builder_template" "test" {
        
        updating image builder template "acctestIBT-260228235605606232" (Resource
        Group "acctestRG-260228235605606232"): performing Update: unexpected status
        400 (400 Bad Request) with error: ValidationFailed: Validation failed: Only
        changing one identity to another is supported in PATCH
```

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* New Resource: `azurerm_image_builder_template`  [GH-31860]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/29770
Depends on https://github.com/hashicorp/pandora/pull/5232

## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
