### PR TITLE
`azurerm_analysis_services_server` - fix multiple issues

### DIFF
--- a/internal/services/analysisservices/analysis_services_server_resource.go
+++ b/internal/services/analysisservices/analysis_services_server_resource.go
@@ -92,8 +92,9 @@ func resourceAnalysisServicesServer() *pluginsdk.Resource {
 			},
 
 			"ipv4_firewall_rule": {
-				Type:     pluginsdk.TypeSet,
-				Optional: true,
+				Type:         pluginsdk.TypeSet,
+				Optional:     true,
+				RequiredWith: []string{"power_bi_service_enabled"},
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"name": {
@@ -175,15 +176,6 @@ func resourceAnalysisServicesServerCreate(d *pluginsdk.ResourceData, meta interf
 			IPV4FirewallSettings: expandAnalysisServicesServerFirewallSettings(d),
 		},
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
-	}
-
-	if v, ok := d.GetOk("power_bi_service_enabled"); ok {
-		if analysisServicesServer.Properties.IPV4FirewallSettings == nil {
-			analysisServicesServer.Properties.IPV4FirewallSettings = &servers.IPv4FirewallSettings{
-				FirewallRules: pointer.To(make([]servers.IPv4FirewallRule, 0)),
-			}
-		}
-		analysisServicesServer.Properties.IPV4FirewallSettings.EnablePowerBIService = pointer.To(v.(bool))
 	}
 
 	if querypoolConnectionMode, ok := d.GetOk("querypool_connection_mode"); ok {
@@ -315,15 +307,6 @@ func resourceAnalysisServicesServerUpdate(d *pluginsdk.ResourceData, meta interf
 		},
 	}
 
-	if d.HasChange("power_bi_service_enabled") {
-		if analysisServicesServer.Properties.IPV4FirewallSettings == nil {
-			analysisServicesServer.Properties.IPV4FirewallSettings = &servers.IPv4FirewallSettings{
-				FirewallRules: pointer.To(make([]servers.IPv4FirewallRule, 0)),
-			}
-		}
-		analysisServicesServer.Properties.IPV4FirewallSettings.EnablePowerBIService = pointer.To(d.Get("power_bi_service_enabled").(bool))
-	}
-
 	if containerUri, ok := d.GetOk("backup_blob_container_uri"); ok {
 		analysisServicesServer.Properties.BackupBlobContainerUri = pointer.To(containerUri.(string))
 	}
@@ -374,25 +357,32 @@ func expandAnalysisServicesServerAdminUsers(d *pluginsdk.ResourceData) *servers.
 }
 
 func expandAnalysisServicesServerFirewallSettings(d *pluginsdk.ResourceData) *servers.IPv4FirewallSettings {
-	firewallRules := d.Get("ipv4_firewall_rule").(*pluginsdk.Set).List()
+	fwRules := make([]servers.IPv4FirewallRule, 0)
+	result := servers.IPv4FirewallSettings{}
 
-	if len(firewallRules) == 0 {
-		return nil
+	if !pluginsdk.IsExplicitlyNullInConfig(d, "power_bi_service_enabled") {
+		result.EnablePowerBIService = pointer.To(d.Get("power_bi_service_enabled").(bool))
+		// when `power_bi_service_enabled` is specified, we must send at least an empty array for `FirewallRules`
+		// otherwise the API errors out with a 400.
+		result.FirewallRules = &fwRules
 	}
 
-	firewallSettings := servers.IPv4FirewallSettings{}
-	fwRules := make([]servers.IPv4FirewallRule, len(firewallRules))
-	for i, v := range firewallRules {
+	firewallRules := d.Get("ipv4_firewall_rule").(*pluginsdk.Set).List()
+	if len(firewallRules) == 0 {
+		return &result
+	}
+
+	for _, v := range firewallRules {
 		fwRule := v.(map[string]interface{})
-		fwRules[i] = servers.IPv4FirewallRule{
+		fwRules = append(fwRules, servers.IPv4FirewallRule{
 			FirewallRuleName: pointer.To(fwRule["name"].(string)),
 			RangeStart:       pointer.To(fwRule["range_start"].(string)),
 			RangeEnd:         pointer.To(fwRule["range_end"].(string)),
-		}
+		})
 	}
-	firewallSettings.FirewallRules = &fwRules
+	result.FirewallRules = &fwRules
 
-	return &firewallSettings
+	return &result
 }
 
 func flattenAnalysisServicesServerFirewallSettings(serverProperties *servers.AnalysisServicesServerProperties) (*bool, *pluginsdk.Set) {

--- a/internal/services/analysisservices/analysis_services_server_resource_test.go
+++ b/internal/services/analysisservices/analysis_services_server_resource_test.go
@@ -93,15 +93,7 @@ func TestAccAnalysisServicesServer_firewallSettings(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.firewallSettings1(data, true),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("ipv4_firewall_rule.#").HasValue("0"),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.firewallSettings2(data, false),
+			Config: r.firewallSettingsSingleRule(data, false),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("ipv4_firewall_rule.#").HasValue("1"),
@@ -109,10 +101,41 @@ func TestAccAnalysisServicesServer_firewallSettings(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.firewallSettings3(data, true),
+			Config: r.firewallSettingsNoRules(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("ipv4_firewall_rule.#").HasValue("0"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.firewallSettingsSingleRule(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("ipv4_firewall_rule.#").HasValue("1"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.firewallSettingsMultipleRules(data, true),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("ipv4_firewall_rule.#").HasValue("2"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.firewallSettingsMultipleRules(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("ipv4_firewall_rule.#").HasValue("2"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.firewallSettingsRemoved(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
@@ -300,7 +323,7 @@ resource "azurerm_analysis_services_server" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, connectionMode)
 }
 
-func (t AnalysisServicesServerResource) firewallSettings1(data acceptance.TestData, enablePowerBIService bool) string {
+func (t AnalysisServicesServerResource) firewallSettingsNoRules(data acceptance.TestData, enablePowerBIService bool) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -321,7 +344,7 @@ resource "azurerm_analysis_services_server" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, enablePowerBIService)
 }
 
-func (t AnalysisServicesServerResource) firewallSettings2(data acceptance.TestData, enablePowerBIService bool) string {
+func (t AnalysisServicesServerResource) firewallSettingsSingleRule(data acceptance.TestData, enablePowerBIService bool) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -348,7 +371,7 @@ resource "azurerm_analysis_services_server" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, enablePowerBIService)
 }
 
-func (t AnalysisServicesServerResource) firewallSettings3(data acceptance.TestData, enablePowerBIService bool) string {
+func (t AnalysisServicesServerResource) firewallSettingsMultipleRules(data acceptance.TestData, enablePowerBIService bool) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -379,6 +402,26 @@ resource "azurerm_analysis_services_server" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, enablePowerBIService)
+}
+
+func (t AnalysisServicesServerResource) firewallSettingsRemoved(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-analysis-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_analysis_services_server" "test" {
+  name                = "acctestass%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "B1"
+}
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (t AnalysisServicesServerResource) adminUsers(data acceptance.TestData, adminUsers []string) string {

--- a/website/docs/r/analysis_services_server.html.markdown
+++ b/website/docs/r/analysis_services_server.html.markdown
@@ -60,6 +60,8 @@ The following arguments are supported:
 
 * `power_bi_service_enabled` - (Optional) Indicates if the Power BI service is allowed to access or not.
 
+~> **Note:** `power_bi_service_enabled` is required when `ipv4_firewall_rule` is defined.
+
 * `ipv4_firewall_rule` - (Optional) One or more `ipv4_firewall_rule` block(s) as defined below.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

- Fixes an issue where `power_bi_service_enabled = false` was not sent to the API on Creation, causing a 400 error
- Fixes an issue that prevented adding/removing `ipv4_firewall_rule` blocks without changing `power_bi_service_enabled`
- Adds additional validation requiring `power_bi_service_enabled` to be set when one or more `ipv4_firewall_rule` blocks are configured


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<img width="344" height="205" alt="image" src="https://github.com/user-attachments/assets/1f6c08b9-3ad9-44d7-bbbd-56575aee0209" />

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #28047

Supersedes #29744

## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
