### PR TITLE
New Data Sources: `azurerm_data_protection_backup_policy_*` (blob_storage, disk, kubernetes_cluster, mysql_flexible_server, postgresql_flexible_server)

### DIFF
--- a/examples/data-protection/main.tf
+++ b/examples/data-protection/main.tf
@@ -1,0 +1,99 @@
+# Copyright IBM Corp. 2014, 2025
+# SPDX-License-Identifier: MPL-2.0
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "${var.prefix}-dataprotection-rg"
+  location = var.location
+}
+
+resource "azurerm_data_protection_backup_vault" "example" {
+  name                = "${var.prefix}-dataprotection-vault"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  datastore_type      = "VaultStore"
+  redundancy          = "LocallyRedundant"
+  soft_delete         = "Off"
+}
+
+resource "azurerm_data_protection_backup_policy_blob_storage" "example" {
+  name                                  = "${var.prefix}-blob-policy"
+  vault_id                              = azurerm_data_protection_backup_vault.example.id
+  operational_default_retention_duration = "P30D"
+}
+
+data "azurerm_data_protection_backup_policy_blob_storage" "example" {
+  name     = azurerm_data_protection_backup_policy_blob_storage.example.name
+  vault_id = azurerm_data_protection_backup_vault.example.id
+}
+
+resource "azurerm_data_protection_backup_policy_disk" "example" {
+  name                            = "${var.prefix}-disk-policy"
+  vault_id                        = azurerm_data_protection_backup_vault.example.id
+  backup_repeating_time_intervals = ["R/2025-01-01T00:00:00+00:00/PT4H"]
+  default_retention_duration      = "P7D"
+}
+
+data "azurerm_data_protection_backup_policy_disk" "example" {
+  name     = azurerm_data_protection_backup_policy_disk.example.name
+  vault_id = azurerm_data_protection_backup_vault.example.id
+}
+
+resource "azurerm_data_protection_backup_policy_kubernetes_cluster" "example" {
+  name                = "${var.prefix}-k8s-policy"
+  resource_group_name = azurerm_resource_group.example.name
+  vault_name          = azurerm_data_protection_backup_vault.example.name
+
+  backup_repeating_time_intervals = ["R/2025-01-01T06:00:00+00:00/P1W"]
+
+  default_retention_rule {
+    life_cycle {
+      duration        = "P7D"
+      data_store_type = "OperationalStore"
+    }
+  }
+}
+
+data "azurerm_data_protection_backup_policy_kubernetes_cluster" "example" {
+  name     = azurerm_data_protection_backup_policy_kubernetes_cluster.example.name
+  vault_id = azurerm_data_protection_backup_vault.example.id
+}
+
+resource "azurerm_data_protection_backup_policy_mysql_flexible_server" "example" {
+  name                            = "${var.prefix}-mysql-policy"
+  vault_id                        = azurerm_data_protection_backup_vault.example.id
+  backup_repeating_time_intervals = ["R/2025-01-01T06:00:00+00:00/P1W"]
+
+  default_retention_rule {
+    life_cycle {
+      duration        = "P4M"
+      data_store_type = "VaultStore"
+    }
+  }
+}
+
+data "azurerm_data_protection_backup_policy_mysql_flexible_server" "example" {
+  name     = azurerm_data_protection_backup_policy_mysql_flexible_server.example.name
+  vault_id = azurerm_data_protection_backup_vault.example.id
+}
+
+resource "azurerm_data_protection_backup_policy_postgresql_flexible_server" "example" {
+  name                            = "${var.prefix}-psql-policy"
+  vault_id                        = azurerm_data_protection_backup_vault.example.id
+  backup_repeating_time_intervals = ["R/2025-01-01T06:00:00+00:00/P1W"]
+
+  default_retention_rule {
+    life_cycle {
+      duration        = "P4M"
+      data_store_type = "VaultStore"
+    }
+  }
+}
+
+data "azurerm_data_protection_backup_policy_postgresql_flexible_server" "example" {
+  name     = azurerm_data_protection_backup_policy_postgresql_flexible_server.example.name
+  vault_id = azurerm_data_protection_backup_vault.example.id
+}

--- a/examples/data-protection/outputs.tf
+++ b/examples/data-protection/outputs.tf
@@ -1,0 +1,22 @@
+# Copyright IBM Corp. 2014, 2025
+# SPDX-License-Identifier: MPL-2.0
+
+output "blob_policy_id" {
+  value = data.azurerm_data_protection_backup_policy_blob_storage.example.id
+}
+
+output "disk_policy_id" {
+  value = data.azurerm_data_protection_backup_policy_disk.example.id
+}
+
+output "kubernetes_policy_id" {
+  value = data.azurerm_data_protection_backup_policy_kubernetes_cluster.example.id
+}
+
+output "mysql_flex_policy_id" {
+  value = data.azurerm_data_protection_backup_policy_mysql_flexible_server.example.id
+}
+
+output "psql_flex_policy_id" {
+  value = data.azurerm_data_protection_backup_policy_postgresql_flexible_server.example.id
+}

--- a/examples/data-protection/variables.tf
+++ b/examples/data-protection/variables.tf
@@ -1,0 +1,12 @@
+# Copyright IBM Corp. 2014, 2025
+# SPDX-License-Identifier: MPL-2.0
+
+variable "location" {
+  type    = string
+  default = "Germany West Central"
+}
+
+variable "prefix" {
+  type    = string
+  default = "test"
+}

--- a/internal/services/dataprotection/data_protection_backup_policy_blob_storage_data_source.go
+++ b/internal/services/dataprotection/data_protection_backup_policy_blob_storage_data_source.go
@@ -1,0 +1,388 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package dataprotection
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2025-09-01/basebackuppolicyresources"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type BackupPolicyBlobStorageDataSourceModel struct {
+	Name                                string                                           `tfschema:"name"`
+	VaultId                             string                                           `tfschema:"vault_id"`
+	BackupRepeatingTimeIntervals        []string                                         `tfschema:"backup_repeating_time_intervals"`
+	OperationalDefaultRetentionDuration string                                           `tfschema:"operational_default_retention_duration"`
+	RetentionRule                       []BackupPolicyBlobStorageDataSourceRetentionRule `tfschema:"retention_rule"`
+	TimeZone                            string                                           `tfschema:"time_zone"`
+	VaultDefaultRetentionDuration       string                                           `tfschema:"vault_default_retention_duration"`
+}
+
+type BackupPolicyBlobStorageDataSourceRetentionRule struct {
+	Name      string                                       `tfschema:"name"`
+	Criteria  []BackupPolicyBlobStorageDataSourceCriteria  `tfschema:"criteria"`
+	LifeCycle []BackupPolicyBlobStorageDataSourceLifeCycle `tfschema:"life_cycle"`
+	Priority  int64                                        `tfschema:"priority"`
+}
+
+type BackupPolicyBlobStorageDataSourceCriteria struct {
+	AbsoluteCriteria     string   `tfschema:"absolute_criteria"`
+	DaysOfMonth          []int64  `tfschema:"days_of_month"`
+	DaysOfWeek           []string `tfschema:"days_of_week"`
+	MonthsOfYear         []string `tfschema:"months_of_year"`
+	ScheduledBackupTimes []string `tfschema:"scheduled_backup_times"`
+	WeeksOfMonth         []string `tfschema:"weeks_of_month"`
+}
+
+type BackupPolicyBlobStorageDataSourceLifeCycle struct {
+	DataStoreType string `tfschema:"data_store_type"`
+	Duration      string `tfschema:"duration"`
+}
+
+type DataProtectionBackupPolicyBlobStorageDataSource struct{}
+
+var _ sdk.DataSource = DataProtectionBackupPolicyBlobStorageDataSource{}
+
+func (r DataProtectionBackupPolicyBlobStorageDataSource) ResourceType() string {
+	return "azurerm_data_protection_backup_policy_blob_storage"
+}
+
+func (r DataProtectionBackupPolicyBlobStorageDataSource) ModelObject() interface{} {
+	return &BackupPolicyBlobStorageDataSourceModel{}
+}
+
+func (r DataProtectionBackupPolicyBlobStorageDataSource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"vault_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: basebackuppolicyresources.ValidateBackupVaultID,
+		},
+	}
+}
+
+func (r DataProtectionBackupPolicyBlobStorageDataSource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"backup_repeating_time_intervals": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+
+		"operational_default_retention_duration": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"retention_rule": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"name": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+
+					"criteria": {
+						Type:     pluginsdk.TypeList,
+						Computed: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"absolute_criteria": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+
+								"days_of_month": {
+									Type:     pluginsdk.TypeSet,
+									Computed: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeInt,
+									},
+								},
+
+								"days_of_week": {
+									Type:     pluginsdk.TypeSet,
+									Computed: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+
+								"months_of_year": {
+									Type:     pluginsdk.TypeSet,
+									Computed: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+
+								"scheduled_backup_times": {
+									Type:     pluginsdk.TypeSet,
+									Computed: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+
+								"weeks_of_month": {
+									Type:     pluginsdk.TypeSet,
+									Computed: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+							},
+						},
+					},
+
+					"life_cycle": {
+						Type:     pluginsdk.TypeList,
+						Computed: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"data_store_type": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+
+								"duration": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+							},
+						},
+					},
+
+					"priority": {
+						Type:     pluginsdk.TypeInt,
+						Computed: true,
+					},
+				},
+			},
+		},
+
+		"time_zone": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"vault_default_retention_duration": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+	}
+}
+
+func (r DataProtectionBackupPolicyBlobStorageDataSource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.DataProtection.BackupPolicyClient
+
+			var model BackupPolicyBlobStorageDataSourceModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			vaultId, err := basebackuppolicyresources.ParseBackupVaultID(model.VaultId)
+			if err != nil {
+				return err
+			}
+
+			id := basebackuppolicyresources.NewBackupPolicyID(vaultId.SubscriptionId, vaultId.ResourceGroupName, vaultId.BackupVaultName, model.Name)
+
+			resp, err := client.BackupPoliciesGet(ctx, id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return fmt.Errorf("%s was not found", id)
+				}
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+
+			state := BackupPolicyBlobStorageDataSourceModel{
+				Name:    id.BackupPolicyName,
+				VaultId: vaultId.ID(),
+			}
+
+			if respModel := resp.Model; respModel != nil {
+				if properties, ok := respModel.Properties.(basebackuppolicyresources.BackupPolicy); ok {
+					state.BackupRepeatingTimeIntervals = flattenBackupPolicyBackupRepeatingTimeIntervals(properties.PolicyRules)
+					state.TimeZone = flattenBackupPolicyBackupTimeZone(properties.PolicyRules)
+					state.OperationalDefaultRetentionDuration = flattenBackupPolicyBlobStorageDataSourceDefaultRetentionDuration(properties.PolicyRules, basebackuppolicyresources.DataStoreTypesOperationalStore)
+					state.VaultDefaultRetentionDuration = flattenBackupPolicyBlobStorageDataSourceDefaultRetentionDuration(properties.PolicyRules, basebackuppolicyresources.DataStoreTypesVaultStore)
+					state.RetentionRule = flattenBackupPolicyBlobStorageDataSourceRetentionRules(properties.PolicyRules)
+				}
+			}
+
+			metadata.SetID(id)
+			return metadata.Encode(&state)
+		},
+	}
+}
+
+func flattenBackupPolicyBlobStorageDataSourceDefaultRetentionDuration(input []basebackuppolicyresources.BasePolicyRule, dsType basebackuppolicyresources.DataStoreTypes) string {
+	if input == nil {
+		return ""
+	}
+
+	for _, item := range input {
+		if retentionRule, ok := item.(basebackuppolicyresources.AzureRetentionRule); ok && retentionRule.IsDefault != nil && *retentionRule.IsDefault {
+			if len(retentionRule.Lifecycles) > 0 {
+				if deleteOption, ok := (retentionRule.Lifecycles)[0].DeleteAfter.(basebackuppolicyresources.AbsoluteDeleteOption); ok {
+					if (retentionRule.Lifecycles)[0].SourceDataStore.DataStoreType == dsType {
+						return deleteOption.Duration
+					}
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func flattenBackupPolicyBlobStorageDataSourceRetentionRules(input []basebackuppolicyresources.BasePolicyRule) []BackupPolicyBlobStorageDataSourceRetentionRule {
+	results := make([]BackupPolicyBlobStorageDataSourceRetentionRule, 0)
+	if len(input) == 0 {
+		return results
+	}
+
+	var taggingCriterias []basebackuppolicyresources.TaggingCriteria
+	for _, item := range input {
+		if backupRule, ok := item.(basebackuppolicyresources.AzureBackupRule); ok {
+			if trigger, ok := backupRule.Trigger.(basebackuppolicyresources.ScheduleBasedTriggerContext); ok {
+				if trigger.TaggingCriteria != nil {
+					taggingCriterias = trigger.TaggingCriteria
+				}
+			}
+		}
+	}
+
+	for _, item := range input {
+		if retentionRule, ok := item.(basebackuppolicyresources.AzureRetentionRule); ok && (retentionRule.IsDefault == nil || !*retentionRule.IsDefault) {
+			name := retentionRule.Name
+			var taggingPriority int64
+			var taggingCriteria []BackupPolicyBlobStorageDataSourceCriteria
+			for _, criteria := range taggingCriterias {
+				if strings.EqualFold(criteria.TagInfo.TagName, name) {
+					taggingPriority = criteria.TaggingPriority
+					taggingCriteria = flattenBackupPolicyBlobStorageDataSourceCriteria(criteria.Criteria)
+					break
+				}
+			}
+
+			var lifeCycle []BackupPolicyBlobStorageDataSourceLifeCycle
+			if v := retentionRule.Lifecycles; len(v) > 0 {
+				lifeCycle = flattenBackupPolicyBlobStorageDataSourceLifeCycles(v, basebackuppolicyresources.DataStoreTypesVaultStore)
+			}
+			results = append(results, BackupPolicyBlobStorageDataSourceRetentionRule{
+				Name:      name,
+				Priority:  taggingPriority,
+				Criteria:  taggingCriteria,
+				LifeCycle: lifeCycle,
+			})
+		}
+	}
+	return results
+}
+
+func flattenBackupPolicyBlobStorageDataSourceLifeCycles(input []basebackuppolicyresources.SourceLifeCycle, dsType basebackuppolicyresources.DataStoreTypes) []BackupPolicyBlobStorageDataSourceLifeCycle {
+	results := make([]BackupPolicyBlobStorageDataSourceLifeCycle, 0)
+	if input == nil {
+		return results
+	}
+
+	for _, item := range input {
+		var duration string
+		dataStoreType := item.SourceDataStore.DataStoreType
+		if deleteOption, ok := item.DeleteAfter.(basebackuppolicyresources.AbsoluteDeleteOption); ok {
+			if dataStoreType == dsType {
+				duration = deleteOption.Duration
+			} else {
+				continue
+			}
+		}
+
+		results = append(results, BackupPolicyBlobStorageDataSourceLifeCycle{
+			Duration:      duration,
+			DataStoreType: string(dataStoreType),
+		})
+	}
+	return results
+}
+
+func flattenBackupPolicyBlobStorageDataSourceCriteria(input *[]basebackuppolicyresources.BackupCriteria) []BackupPolicyBlobStorageDataSourceCriteria {
+	results := make([]BackupPolicyBlobStorageDataSourceCriteria, 0)
+	if input == nil {
+		return results
+	}
+
+	for _, item := range *input {
+		if criteria, ok := item.(basebackuppolicyresources.ScheduleBasedBackupCriteria); ok {
+			var absoluteCriteria string
+			if criteria.AbsoluteCriteria != nil && len(*criteria.AbsoluteCriteria) > 0 {
+				absoluteCriteria = string((*criteria.AbsoluteCriteria)[0])
+			}
+			var daysOfWeek []string
+			if criteria.DaysOfTheWeek != nil {
+				daysOfWeek = make([]string, 0)
+				for _, item := range *criteria.DaysOfTheWeek {
+					daysOfWeek = append(daysOfWeek, (string)(item))
+				}
+			}
+			var daysOfMonth []int64
+			if criteria.DaysOfMonth != nil {
+				daysOfMonth = make([]int64, 0)
+				for _, item := range *criteria.DaysOfMonth {
+					daysOfMonth = append(daysOfMonth, pointer.From(item.Date))
+				}
+			}
+			var monthsOfYear []string
+			if criteria.MonthsOfYear != nil {
+				monthsOfYear = make([]string, 0)
+				for _, item := range *criteria.MonthsOfYear {
+					monthsOfYear = append(monthsOfYear, (string)(item))
+				}
+			}
+			var weeksOfMonth []string
+			if criteria.WeeksOfTheMonth != nil {
+				weeksOfMonth = make([]string, 0)
+				for _, item := range *criteria.WeeksOfTheMonth {
+					weeksOfMonth = append(weeksOfMonth, (string)(item))
+				}
+			}
+			var scheduleTimes []string
+			if criteria.ScheduleTimes != nil {
+				scheduleTimes = make([]string, 0)
+				scheduleTimes = append(scheduleTimes, *criteria.ScheduleTimes...)
+			}
+
+			results = append(results, BackupPolicyBlobStorageDataSourceCriteria{
+				AbsoluteCriteria:     absoluteCriteria,
+				DaysOfWeek:           daysOfWeek,
+				DaysOfMonth:          daysOfMonth,
+				MonthsOfYear:         monthsOfYear,
+				WeeksOfMonth:         weeksOfMonth,
+				ScheduledBackupTimes: scheduleTimes,
+			})
+		}
+	}
+	return results
+}

--- a/internal/services/dataprotection/data_protection_backup_policy_blob_storage_data_source_test.go
+++ b/internal/services/dataprotection/data_protection_backup_policy_blob_storage_data_source_test.go
@@ -1,0 +1,41 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package dataprotection_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+type DataProtectionBackupPolicyBlobStorageDataSource struct{}
+
+func TestAccDataProtectionBackupPolicyBlobStorageDataSource_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_data_protection_backup_policy_blob_storage", "test")
+	r := DataProtectionBackupPolicyBlobStorageDataSource{}
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(DataProtectionBackupPolicyBlobStorageResource{}),
+				check.That(data.ResourceName).Key("name").Exists(),
+				check.That(data.ResourceName).Key("vault_id").Exists(),
+				check.That(data.ResourceName).Key("operational_default_retention_duration").HasValue("P30D"),
+			),
+		},
+	})
+}
+
+func (r DataProtectionBackupPolicyBlobStorageDataSource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_data_protection_backup_policy_blob_storage" "test" {
+  name     = azurerm_data_protection_backup_policy_blob_storage.test.name
+  vault_id = azurerm_data_protection_backup_vault.test.id
+}
+`, DataProtectionBackupPolicyBlobStorageResource{}.basic(data))
+}

--- a/internal/services/dataprotection/data_protection_backup_policy_disk_data_source.go
+++ b/internal/services/dataprotection/data_protection_backup_policy_disk_data_source.go
@@ -1,0 +1,252 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package dataprotection
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2025-09-01/basebackuppolicyresources"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type BackupPolicyDiskDataSourceModel struct {
+	Name                         string                                    `tfschema:"name"`
+	VaultId                      string                                    `tfschema:"vault_id"`
+	BackupRepeatingTimeIntervals []string                                  `tfschema:"backup_repeating_time_intervals"`
+	DefaultRetentionDuration     string                                    `tfschema:"default_retention_duration"`
+	RetentionRule                []BackupPolicyDiskDataSourceRetentionRule `tfschema:"retention_rule"`
+	TimeZone                     string                                    `tfschema:"time_zone"`
+}
+
+type BackupPolicyDiskDataSourceRetentionRule struct {
+	Name     string                               `tfschema:"name"`
+	Duration string                               `tfschema:"duration"`
+	Criteria []BackupPolicyDiskDataSourceCriteria `tfschema:"criteria"`
+	Priority int64                                `tfschema:"priority"`
+}
+
+type BackupPolicyDiskDataSourceCriteria struct {
+	AbsoluteCriteria string `tfschema:"absolute_criteria"`
+}
+
+type DataProtectionBackupPolicyDiskDataSource struct{}
+
+var _ sdk.DataSource = DataProtectionBackupPolicyDiskDataSource{}
+
+func (r DataProtectionBackupPolicyDiskDataSource) ResourceType() string {
+	return "azurerm_data_protection_backup_policy_disk"
+}
+
+func (r DataProtectionBackupPolicyDiskDataSource) ModelObject() interface{} {
+	return &BackupPolicyDiskDataSourceModel{}
+}
+
+func (r DataProtectionBackupPolicyDiskDataSource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"vault_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: basebackuppolicyresources.ValidateBackupVaultID,
+		},
+	}
+}
+
+func (r DataProtectionBackupPolicyDiskDataSource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"backup_repeating_time_intervals": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+
+		"default_retention_duration": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"retention_rule": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"name": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+
+					"duration": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+
+					"criteria": {
+						Type:     pluginsdk.TypeList,
+						Computed: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"absolute_criteria": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+							},
+						},
+					},
+
+					"priority": {
+						Type:     pluginsdk.TypeInt,
+						Computed: true,
+					},
+				},
+			},
+		},
+
+		"time_zone": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+	}
+}
+
+func (r DataProtectionBackupPolicyDiskDataSource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.DataProtection.BackupPolicyClient
+
+			var model BackupPolicyDiskDataSourceModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			vaultId, err := basebackuppolicyresources.ParseBackupVaultID(model.VaultId)
+			if err != nil {
+				return err
+			}
+
+			id := basebackuppolicyresources.NewBackupPolicyID(vaultId.SubscriptionId, vaultId.ResourceGroupName, vaultId.BackupVaultName, model.Name)
+
+			resp, err := client.BackupPoliciesGet(ctx, id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return fmt.Errorf("%s was not found", id)
+				}
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+
+			state := BackupPolicyDiskDataSourceModel{
+				Name:    id.BackupPolicyName,
+				VaultId: vaultId.ID(),
+			}
+
+			if respModel := resp.Model; respModel != nil {
+				if properties, ok := respModel.Properties.(basebackuppolicyresources.BackupPolicy); ok {
+					state.BackupRepeatingTimeIntervals = flattenBackupPolicyBackupRepeatingTimeIntervals(properties.PolicyRules)
+					state.TimeZone = flattenBackupPolicyBackupTimeZone(properties.PolicyRules)
+					state.DefaultRetentionDuration = flattenBackupPolicyDiskDataSourceDefaultRetentionDuration(properties.PolicyRules)
+					state.RetentionRule = flattenBackupPolicyDiskDataSourceRetentionRules(properties.PolicyRules)
+				}
+			}
+
+			metadata.SetID(id)
+			return metadata.Encode(&state)
+		},
+	}
+}
+
+func flattenBackupPolicyDiskDataSourceDefaultRetentionDuration(input []basebackuppolicyresources.BasePolicyRule) string {
+	if len(input) == 0 {
+		return ""
+	}
+
+	for _, item := range input {
+		if retentionRule, ok := item.(basebackuppolicyresources.AzureRetentionRule); ok && retentionRule.IsDefault != nil && *retentionRule.IsDefault {
+			if len(retentionRule.Lifecycles) > 0 {
+				if deleteOption, ok := (retentionRule.Lifecycles)[0].DeleteAfter.(basebackuppolicyresources.AbsoluteDeleteOption); ok {
+					return deleteOption.Duration
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func flattenBackupPolicyDiskDataSourceRetentionRules(input []basebackuppolicyresources.BasePolicyRule) []BackupPolicyDiskDataSourceRetentionRule {
+	results := make([]BackupPolicyDiskDataSourceRetentionRule, 0)
+	if len(input) == 0 {
+		return results
+	}
+
+	var taggingCriterias []basebackuppolicyresources.TaggingCriteria
+	for _, item := range input {
+		if backupRule, ok := item.(basebackuppolicyresources.AzureBackupRule); ok {
+			if trigger, ok := backupRule.Trigger.(basebackuppolicyresources.ScheduleBasedTriggerContext); ok {
+				if trigger.TaggingCriteria != nil {
+					taggingCriterias = trigger.TaggingCriteria
+				}
+			}
+		}
+	}
+
+	for _, item := range input {
+		if retentionRule, ok := item.(basebackuppolicyresources.AzureRetentionRule); ok && (retentionRule.IsDefault == nil || !*retentionRule.IsDefault) {
+			name := retentionRule.Name
+			var taggingPriority int64
+			var taggingCriteria []BackupPolicyDiskDataSourceCriteria
+			for _, criteria := range taggingCriterias {
+				if strings.EqualFold(criteria.TagInfo.TagName, name) {
+					taggingPriority = criteria.TaggingPriority
+					taggingCriteria = flattenBackupPolicyDiskDataSourceCriteria(criteria.Criteria)
+				}
+			}
+			var duration string
+			if len(retentionRule.Lifecycles) > 0 {
+				if deleteOption, ok := (retentionRule.Lifecycles)[0].DeleteAfter.(basebackuppolicyresources.AbsoluteDeleteOption); ok {
+					duration = deleteOption.Duration
+				}
+			}
+			results = append(results, BackupPolicyDiskDataSourceRetentionRule{
+				Name:     name,
+				Priority: taggingPriority,
+				Criteria: taggingCriteria,
+				Duration: duration,
+			})
+		}
+	}
+	return results
+}
+
+func flattenBackupPolicyDiskDataSourceCriteria(input *[]basebackuppolicyresources.BackupCriteria) []BackupPolicyDiskDataSourceCriteria {
+	results := make([]BackupPolicyDiskDataSourceCriteria, 0)
+	if input == nil {
+		return results
+	}
+
+	for _, item := range *input {
+		if criteria, ok := item.(basebackuppolicyresources.ScheduleBasedBackupCriteria); ok {
+			var absoluteCriteria string
+			if criteria.AbsoluteCriteria != nil && len(*criteria.AbsoluteCriteria) > 0 {
+				absoluteCriteria = string((*criteria.AbsoluteCriteria)[0])
+			}
+
+			results = append(results, BackupPolicyDiskDataSourceCriteria{
+				AbsoluteCriteria: absoluteCriteria,
+			})
+		}
+	}
+	return results
+}

--- a/internal/services/dataprotection/data_protection_backup_policy_disk_data_source_test.go
+++ b/internal/services/dataprotection/data_protection_backup_policy_disk_data_source_test.go
@@ -1,0 +1,42 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package dataprotection_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+type DataProtectionBackupPolicyDiskDataSource struct{}
+
+func TestAccDataProtectionBackupPolicyDiskDataSource_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_data_protection_backup_policy_disk", "test")
+	r := DataProtectionBackupPolicyDiskDataSource{}
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(DataProtectionBackupPolicyDiskResource{}),
+				check.That(data.ResourceName).Key("name").Exists(),
+				check.That(data.ResourceName).Key("vault_id").Exists(),
+				check.That(data.ResourceName).Key("default_retention_duration").HasValue("P7D"),
+				check.That(data.ResourceName).Key("backup_repeating_time_intervals.#").HasValue("1"),
+			),
+		},
+	})
+}
+
+func (r DataProtectionBackupPolicyDiskDataSource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_data_protection_backup_policy_disk" "test" {
+  name     = azurerm_data_protection_backup_policy_disk.test.name
+  vault_id = azurerm_data_protection_backup_vault.test.id
+}
+`, DataProtectionBackupPolicyDiskResource{}.basic(data))
+}

--- a/internal/services/dataprotection/data_protection_backup_policy_helpers.go
+++ b/internal/services/dataprotection/data_protection_backup_policy_helpers.go
@@ -1,0 +1,35 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package dataprotection
+
+import (
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2025-09-01/basebackuppolicyresources"
+)
+
+func flattenBackupPolicyBackupRepeatingTimeIntervals(input []basebackuppolicyresources.BasePolicyRule) []string {
+	for _, item := range input {
+		if backupRule, ok := item.(basebackuppolicyresources.AzureBackupRule); ok {
+			if backupRule.Trigger != nil {
+				if trigger, ok := backupRule.Trigger.(basebackuppolicyresources.ScheduleBasedTriggerContext); ok {
+					return trigger.Schedule.RepeatingTimeIntervals
+				}
+			}
+		}
+	}
+	return make([]string, 0)
+}
+
+func flattenBackupPolicyBackupTimeZone(input []basebackuppolicyresources.BasePolicyRule) string {
+	for _, item := range input {
+		if backupRule, ok := item.(basebackuppolicyresources.AzureBackupRule); ok {
+			if backupRule.Trigger != nil {
+				if trigger, ok := backupRule.Trigger.(basebackuppolicyresources.ScheduleBasedTriggerContext); ok {
+					return pointer.From(trigger.Schedule.TimeZone)
+				}
+			}
+		}
+	}
+	return ""
+}

--- a/internal/services/dataprotection/data_protection_backup_policy_kubernetes_cluster_data_source.go
+++ b/internal/services/dataprotection/data_protection_backup_policy_kubernetes_cluster_data_source.go
@@ -1,0 +1,223 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package dataprotection
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2025-09-01/basebackuppolicyresources"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type BackupPolicyKubernatesClusterDataSourceModel struct {
+	Name                         string                 `tfschema:"name"`
+	VaultId                      string                 `tfschema:"vault_id"`
+	BackupRepeatingTimeIntervals []string               `tfschema:"backup_repeating_time_intervals"`
+	DefaultRetentionRule         []DefaultRetentionRule `tfschema:"default_retention_rule"`
+	RetentionRule                []RetentionRule        `tfschema:"retention_rule"`
+	TimeZone                     string                 `tfschema:"time_zone"`
+}
+
+type DataProtectionBackupPolicyKubernatesClusterDataSource struct{}
+
+var _ sdk.DataSource = DataProtectionBackupPolicyKubernatesClusterDataSource{}
+
+func (r DataProtectionBackupPolicyKubernatesClusterDataSource) ResourceType() string {
+	return "azurerm_data_protection_backup_policy_kubernetes_cluster"
+}
+
+func (r DataProtectionBackupPolicyKubernatesClusterDataSource) ModelObject() interface{} {
+	return &BackupPolicyKubernatesClusterDataSourceModel{}
+}
+
+func (r DataProtectionBackupPolicyKubernatesClusterDataSource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"vault_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: basebackuppolicyresources.ValidateBackupVaultID,
+		},
+	}
+}
+
+func (r DataProtectionBackupPolicyKubernatesClusterDataSource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"backup_repeating_time_intervals": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+
+		"default_retention_rule": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"life_cycle": {
+						Type:     pluginsdk.TypeList,
+						Computed: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"data_store_type": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+
+								"duration": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		"retention_rule": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"name": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+
+					"criteria": {
+						Type:     pluginsdk.TypeList,
+						Computed: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"absolute_criteria": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+
+								"days_of_week": {
+									Type:     pluginsdk.TypeSet,
+									Computed: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+
+								"months_of_year": {
+									Type:     pluginsdk.TypeSet,
+									Computed: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+
+								"scheduled_backup_times": {
+									Type:     pluginsdk.TypeSet,
+									Computed: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+
+								"weeks_of_month": {
+									Type:     pluginsdk.TypeSet,
+									Computed: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+							},
+						},
+					},
+
+					"life_cycle": {
+						Type:     pluginsdk.TypeList,
+						Computed: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"data_store_type": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+
+								"duration": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+							},
+						},
+					},
+
+					"priority": {
+						Type:     pluginsdk.TypeInt,
+						Computed: true,
+					},
+				},
+			},
+		},
+
+		"time_zone": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+	}
+}
+
+func (r DataProtectionBackupPolicyKubernatesClusterDataSource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.DataProtection.BackupPolicyClient
+
+			var model BackupPolicyKubernatesClusterDataSourceModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			vaultId, err := basebackuppolicyresources.ParseBackupVaultID(model.VaultId)
+			if err != nil {
+				return err
+			}
+
+			id := basebackuppolicyresources.NewBackupPolicyID(vaultId.SubscriptionId, vaultId.ResourceGroupName, vaultId.BackupVaultName, model.Name)
+
+			resp, err := client.BackupPoliciesGet(ctx, id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return fmt.Errorf("%s was not found", id)
+				}
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+
+			state := BackupPolicyKubernatesClusterDataSourceModel{
+				Name:    id.BackupPolicyName,
+				VaultId: vaultId.ID(),
+			}
+
+			if respModel := resp.Model; respModel != nil {
+				if properties, ok := respModel.Properties.(basebackuppolicyresources.BackupPolicy); ok {
+					state.BackupRepeatingTimeIntervals = flattenBackupPolicyKubernetesClusterBackupRuleArray(&properties.PolicyRules)
+					state.TimeZone = flattenBackupPolicyKubernetesClusterBackupTimeZone(&properties.PolicyRules)
+					state.DefaultRetentionRule = flattenBackupPolicyKubernetesClusterDefaultRetentionRule(&properties.PolicyRules)
+					state.RetentionRule = flattenBackupPolicyKubernetesClusterRetentionRules(&properties.PolicyRules)
+				}
+			}
+
+			metadata.SetID(id)
+			return metadata.Encode(&state)
+		},
+	}
+}

--- a/internal/services/dataprotection/data_protection_backup_policy_kubernetes_cluster_data_source_test.go
+++ b/internal/services/dataprotection/data_protection_backup_policy_kubernetes_cluster_data_source_test.go
@@ -1,0 +1,45 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package dataprotection_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+type DataProtectionBackupPolicyKubernetesClusterDataSource struct{}
+
+func TestAccDataProtectionBackupPolicyKubernetesClusterDataSource_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_data_protection_backup_policy_kubernetes_cluster", "test")
+	r := DataProtectionBackupPolicyKubernetesClusterDataSource{}
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(DataProtectionBackupPolicyKubernetesClusterResource{}),
+				check.That(data.ResourceName).Key("name").Exists(),
+				check.That(data.ResourceName).Key("vault_id").Exists(),
+				check.That(data.ResourceName).Key("backup_repeating_time_intervals.#").HasValue("1"),
+				check.That(data.ResourceName).Key("default_retention_rule.#").HasValue("1"),
+				check.That(data.ResourceName).Key("retention_rule.#").HasValue("1"),
+				check.That(data.ResourceName).Key("default_retention_rule.0.life_cycle.0.duration").HasValue("P7D"),
+				check.That(data.ResourceName).Key("default_retention_rule.0.life_cycle.0.data_store_type").HasValue("OperationalStore"),
+			),
+		},
+	})
+}
+
+func (r DataProtectionBackupPolicyKubernetesClusterDataSource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_data_protection_backup_policy_kubernetes_cluster" "test" {
+  name     = azurerm_data_protection_backup_policy_kubernetes_cluster.test.name
+  vault_id = azurerm_data_protection_backup_vault.test.id
+}
+`, DataProtectionBackupPolicyKubernetesClusterResource{}.basic(data))
+}

--- a/internal/services/dataprotection/data_protection_backup_policy_mysql_flexible_server_data_source.go
+++ b/internal/services/dataprotection/data_protection_backup_policy_mysql_flexible_server_data_source.go
@@ -1,0 +1,223 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package dataprotection
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2025-09-01/basebackuppolicyresources"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type BackupPolicyMySQLFlexibleServerDataSourceModel struct {
+	Name                         string                                                `tfschema:"name"`
+	VaultId                      string                                                `tfschema:"vault_id"`
+	BackupRepeatingTimeIntervals []string                                              `tfschema:"backup_repeating_time_intervals"`
+	DefaultRetentionRule         []BackupPolicyMySQLFlexibleServerDefaultRetentionRule `tfschema:"default_retention_rule"`
+	RetentionRule                []BackupPolicyMySQLFlexibleServerRetentionRule        `tfschema:"retention_rule"`
+	TimeZone                     string                                                `tfschema:"time_zone"`
+}
+
+type DataProtectionBackupPolicyMySQLFlexibleServerDataSource struct{}
+
+var _ sdk.DataSource = DataProtectionBackupPolicyMySQLFlexibleServerDataSource{}
+
+func (r DataProtectionBackupPolicyMySQLFlexibleServerDataSource) ResourceType() string {
+	return "azurerm_data_protection_backup_policy_mysql_flexible_server"
+}
+
+func (r DataProtectionBackupPolicyMySQLFlexibleServerDataSource) ModelObject() interface{} {
+	return &BackupPolicyMySQLFlexibleServerDataSourceModel{}
+}
+
+func (r DataProtectionBackupPolicyMySQLFlexibleServerDataSource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"vault_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: basebackuppolicyresources.ValidateBackupVaultID,
+		},
+	}
+}
+
+func (r DataProtectionBackupPolicyMySQLFlexibleServerDataSource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"backup_repeating_time_intervals": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+
+		"default_retention_rule": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"life_cycle": {
+						Type:     pluginsdk.TypeList,
+						Computed: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"data_store_type": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+
+								"duration": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		"retention_rule": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"name": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+
+					"criteria": {
+						Type:     pluginsdk.TypeList,
+						Computed: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"absolute_criteria": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+
+								"days_of_week": {
+									Type:     pluginsdk.TypeSet,
+									Computed: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+
+								"months_of_year": {
+									Type:     pluginsdk.TypeSet,
+									Computed: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+
+								"scheduled_backup_times": {
+									Type:     pluginsdk.TypeSet,
+									Computed: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+
+								"weeks_of_month": {
+									Type:     pluginsdk.TypeSet,
+									Computed: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+							},
+						},
+					},
+
+					"life_cycle": {
+						Type:     pluginsdk.TypeList,
+						Computed: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"data_store_type": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+
+								"duration": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+							},
+						},
+					},
+
+					"priority": {
+						Type:     pluginsdk.TypeInt,
+						Computed: true,
+					},
+				},
+			},
+		},
+
+		"time_zone": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+	}
+}
+
+func (r DataProtectionBackupPolicyMySQLFlexibleServerDataSource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.DataProtection.BackupPolicyClient
+
+			var model BackupPolicyMySQLFlexibleServerDataSourceModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			vaultId, err := basebackuppolicyresources.ParseBackupVaultID(model.VaultId)
+			if err != nil {
+				return err
+			}
+
+			id := basebackuppolicyresources.NewBackupPolicyID(vaultId.SubscriptionId, vaultId.ResourceGroupName, vaultId.BackupVaultName, model.Name)
+
+			resp, err := client.BackupPoliciesGet(ctx, id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return fmt.Errorf("%s was not found", id)
+				}
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+
+			state := BackupPolicyMySQLFlexibleServerDataSourceModel{
+				Name:    id.BackupPolicyName,
+				VaultId: vaultId.ID(),
+			}
+
+			if respModel := resp.Model; respModel != nil {
+				if properties, ok := respModel.Properties.(basebackuppolicyresources.BackupPolicy); ok {
+					state.BackupRepeatingTimeIntervals = flattenBackupPolicyMySQLFlexibleServerBackupRules(properties.PolicyRules)
+					state.TimeZone = flattenBackupPolicyMySQLFlexibleServerBackupTimeZone(properties.PolicyRules)
+					state.DefaultRetentionRule = flattenBackupPolicyMySQLFlexibleServerDefaultRetentionRule(properties.PolicyRules)
+					state.RetentionRule = flattenBackupPolicyMySQLFlexibleServerRetentionRules(properties.PolicyRules)
+				}
+			}
+
+			metadata.SetID(id)
+			return metadata.Encode(&state)
+		},
+	}
+}

--- a/internal/services/dataprotection/data_protection_backup_policy_mysql_flexible_server_data_source_test.go
+++ b/internal/services/dataprotection/data_protection_backup_policy_mysql_flexible_server_data_source_test.go
@@ -1,0 +1,44 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package dataprotection_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+type DataProtectionBackupPolicyMySQLFlexibleServerDataSource struct{}
+
+func TestAccDataProtectionBackupPolicyMySQLFlexibleServerDataSource_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_data_protection_backup_policy_mysql_flexible_server", "test")
+	r := DataProtectionBackupPolicyMySQLFlexibleServerDataSource{}
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(DataProtectionBackupPolicyMysqlFlexibleServerResource{}),
+				check.That(data.ResourceName).Key("name").Exists(),
+				check.That(data.ResourceName).Key("vault_id").Exists(),
+				check.That(data.ResourceName).Key("backup_repeating_time_intervals.#").HasValue("1"),
+				check.That(data.ResourceName).Key("default_retention_rule.#").HasValue("1"),
+				check.That(data.ResourceName).Key("default_retention_rule.0.life_cycle.0.duration").HasValue("P4M"),
+				check.That(data.ResourceName).Key("default_retention_rule.0.life_cycle.0.data_store_type").HasValue("VaultStore"),
+			),
+		},
+	})
+}
+
+func (r DataProtectionBackupPolicyMySQLFlexibleServerDataSource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_data_protection_backup_policy_mysql_flexible_server" "test" {
+  name     = azurerm_data_protection_backup_policy_mysql_flexible_server.test.name
+  vault_id = azurerm_data_protection_backup_vault.test.id
+}
+`, DataProtectionBackupPolicyMysqlFlexibleServerResource{}.basic(data))
+}

--- a/internal/services/dataprotection/data_protection_backup_policy_postgresql_flexible_server_data_source.go
+++ b/internal/services/dataprotection/data_protection_backup_policy_postgresql_flexible_server_data_source.go
@@ -1,0 +1,223 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package dataprotection
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2025-09-01/basebackuppolicyresources"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type BackupPolicyPostgreSQLFlexibleServerDataSourceModel struct {
+	Name                         string                                                     `tfschema:"name"`
+	VaultId                      string                                                     `tfschema:"vault_id"`
+	BackupRepeatingTimeIntervals []string                                                   `tfschema:"backup_repeating_time_intervals"`
+	DefaultRetentionRule         []BackupPolicyPostgreSQLFlexibleServerDefaultRetentionRule `tfschema:"default_retention_rule"`
+	RetentionRule                []BackupPolicyPostgreSQLFlexibleServerRetentionRule        `tfschema:"retention_rule"`
+	TimeZone                     string                                                     `tfschema:"time_zone"`
+}
+
+type DataProtectionBackupPolicyPostgreSQLFlexibleServerDataSource struct{}
+
+var _ sdk.DataSource = DataProtectionBackupPolicyPostgreSQLFlexibleServerDataSource{}
+
+func (r DataProtectionBackupPolicyPostgreSQLFlexibleServerDataSource) ResourceType() string {
+	return "azurerm_data_protection_backup_policy_postgresql_flexible_server"
+}
+
+func (r DataProtectionBackupPolicyPostgreSQLFlexibleServerDataSource) ModelObject() interface{} {
+	return &BackupPolicyPostgreSQLFlexibleServerDataSourceModel{}
+}
+
+func (r DataProtectionBackupPolicyPostgreSQLFlexibleServerDataSource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"vault_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: basebackuppolicyresources.ValidateBackupVaultID,
+		},
+	}
+}
+
+func (r DataProtectionBackupPolicyPostgreSQLFlexibleServerDataSource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"backup_repeating_time_intervals": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+
+		"default_retention_rule": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"life_cycle": {
+						Type:     pluginsdk.TypeList,
+						Computed: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"data_store_type": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+
+								"duration": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		"retention_rule": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"name": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+
+					"criteria": {
+						Type:     pluginsdk.TypeList,
+						Computed: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"absolute_criteria": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+
+								"days_of_week": {
+									Type:     pluginsdk.TypeSet,
+									Computed: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+
+								"months_of_year": {
+									Type:     pluginsdk.TypeSet,
+									Computed: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+
+								"scheduled_backup_times": {
+									Type:     pluginsdk.TypeSet,
+									Computed: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+
+								"weeks_of_month": {
+									Type:     pluginsdk.TypeSet,
+									Computed: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+							},
+						},
+					},
+
+					"life_cycle": {
+						Type:     pluginsdk.TypeList,
+						Computed: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"data_store_type": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+
+								"duration": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
+								},
+							},
+						},
+					},
+
+					"priority": {
+						Type:     pluginsdk.TypeInt,
+						Computed: true,
+					},
+				},
+			},
+		},
+
+		"time_zone": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+	}
+}
+
+func (r DataProtectionBackupPolicyPostgreSQLFlexibleServerDataSource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.DataProtection.BackupPolicyClient
+
+			var model BackupPolicyPostgreSQLFlexibleServerDataSourceModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			vaultId, err := basebackuppolicyresources.ParseBackupVaultID(model.VaultId)
+			if err != nil {
+				return err
+			}
+
+			id := basebackuppolicyresources.NewBackupPolicyID(vaultId.SubscriptionId, vaultId.ResourceGroupName, vaultId.BackupVaultName, model.Name)
+
+			resp, err := client.BackupPoliciesGet(ctx, id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return fmt.Errorf("%s was not found", id)
+				}
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+
+			state := BackupPolicyPostgreSQLFlexibleServerDataSourceModel{
+				Name:    id.BackupPolicyName,
+				VaultId: vaultId.ID(),
+			}
+
+			if respModel := resp.Model; respModel != nil {
+				if properties, ok := respModel.Properties.(basebackuppolicyresources.BackupPolicy); ok {
+					state.BackupRepeatingTimeIntervals = flattenBackupPolicyPostgreSQLFlexibleServerBackupRules(properties.PolicyRules)
+					state.TimeZone = flattenBackupPolicyPostgreSQLFlexibleServerBackupTimeZone(properties.PolicyRules)
+					state.DefaultRetentionRule = flattenBackupPolicyPostgreSQLFlexibleServerDefaultRetentionRule(properties.PolicyRules)
+					state.RetentionRule = flattenBackupPolicyPostgreSQLFlexibleServerRetentionRules(properties.PolicyRules)
+				}
+			}
+
+			metadata.SetID(id)
+			return metadata.Encode(&state)
+		},
+	}
+}

--- a/internal/services/dataprotection/data_protection_backup_policy_postgresql_flexible_server_data_source_test.go
+++ b/internal/services/dataprotection/data_protection_backup_policy_postgresql_flexible_server_data_source_test.go
@@ -1,0 +1,44 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package dataprotection_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+type DataProtectionBackupPolicyPostgreSQLFlexibleServerDataSource struct{}
+
+func TestAccDataProtectionBackupPolicyPostgreSQLFlexibleServerDataSource_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_data_protection_backup_policy_postgresql_flexible_server", "test")
+	r := DataProtectionBackupPolicyPostgreSQLFlexibleServerDataSource{}
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(DataProtectionBackupPolicyPostgresqlFlexibleServerResource{}),
+				check.That(data.ResourceName).Key("name").Exists(),
+				check.That(data.ResourceName).Key("vault_id").Exists(),
+				check.That(data.ResourceName).Key("backup_repeating_time_intervals.#").HasValue("1"),
+				check.That(data.ResourceName).Key("default_retention_rule.#").HasValue("1"),
+				check.That(data.ResourceName).Key("default_retention_rule.0.life_cycle.0.duration").HasValue("P4M"),
+				check.That(data.ResourceName).Key("default_retention_rule.0.life_cycle.0.data_store_type").HasValue("VaultStore"),
+			),
+		},
+	})
+}
+
+func (r DataProtectionBackupPolicyPostgreSQLFlexibleServerDataSource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_data_protection_backup_policy_postgresql_flexible_server" "test" {
+  name     = azurerm_data_protection_backup_policy_postgresql_flexible_server.test.name
+  vault_id = azurerm_data_protection_backup_vault.test.id
+}
+`, DataProtectionBackupPolicyPostgresqlFlexibleServerResource{}.basic(data))
+}

--- a/internal/services/dataprotection/registration.go
+++ b/internal/services/dataprotection/registration.go
@@ -85,7 +85,13 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 
 // DataSources returns a list of Data Sources supported by this Service
 func (r Registration) DataSources() []sdk.DataSource {
-	return []sdk.DataSource{}
+	return []sdk.DataSource{
+		DataProtectionBackupPolicyBlobStorageDataSource{},
+		DataProtectionBackupPolicyDiskDataSource{},
+		DataProtectionBackupPolicyKubernatesClusterDataSource{},
+		DataProtectionBackupPolicyMySQLFlexibleServerDataSource{},
+		DataProtectionBackupPolicyPostgreSQLFlexibleServerDataSource{},
+	}
 }
 
 // Resources returns a list of Resources supported by this Service

--- a/website/docs/d/data_protection_backup_policy_blob_storage.html.markdown
+++ b/website/docs/d/data_protection_backup_policy_blob_storage.html.markdown
@@ -1,0 +1,92 @@
+---
+subcategory: "DataProtection"
+layout: "azurerm"
+page_title: "Azure Resource Manager: Data Source: azurerm_data_protection_backup_policy_blob_storage"
+description: |-
+  Gets information about an existing Backup Policy (Blob Storage).
+---
+
+# Data Source: azurerm_data_protection_backup_policy_blob_storage
+
+Use this data source to access information about an existing Backup Policy (Blob Storage).
+
+## Example Usage
+
+```hcl
+data "azurerm_data_protection_backup_policy_blob_storage" "example" {
+  name     = "existing-backup-policy"
+  vault_id = data.azurerm_data_protection_backup_vault.example.id
+}
+
+output "id" {
+  value = data.azurerm_data_protection_backup_policy_blob_storage.example.id
+}
+```
+
+## Arguments Reference
+
+* `name` - (Required) Specifies the name of the Backup Policy.
+
+* `vault_id` - (Required) Specifies the ID of the Backup Vault.
+
+## Attributes Reference
+
+* `id` - The ID of the Backup Policy.
+
+* `backup_repeating_time_intervals` - The backup repeating time intervals.
+
+* `operational_default_retention_duration` - The duration of operational default retention rule.
+
+* `retention_rule` - A `retention_rule` block as defined below.
+
+* `time_zone` - The time zone used by the backup schedule.
+
+* `vault_default_retention_duration` - The duration of vault default retention rule.
+
+---
+
+A `retention_rule` block exports the following:
+
+* `criteria` - A `criteria` block as defined below.
+
+* `life_cycle` - A `life_cycle` block as defined below.
+
+* `name` - The name of the retention rule.
+
+* `priority` - The priority of the rule.
+
+---
+
+A `criteria` block exports the following:
+
+* `absolute_criteria` - The absolute criteria.
+
+* `days_of_month` - The days of the month.
+
+* `days_of_week` - The days of the week.
+
+* `months_of_year` - The months of the year.
+
+* `scheduled_backup_times` - The scheduled backup times.
+
+* `weeks_of_month` - The weeks of the month.
+
+---
+
+A `life_cycle` block exports the following:
+
+* `data_store_type` - The type of data store.
+
+* `duration` - The retention duration.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/configure#define-operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Backup Policy.
+
+## API Providers
+<!-- This section is generated, changes will be overwritten -->
+This data source uses the following Azure API Providers:
+
+* `Microsoft.DataProtection` - 2025-09-01

--- a/website/docs/d/data_protection_backup_policy_disk.html.markdown
+++ b/website/docs/d/data_protection_backup_policy_disk.html.markdown
@@ -1,0 +1,72 @@
+---
+subcategory: "DataProtection"
+layout: "azurerm"
+page_title: "Azure Resource Manager: Data Source: azurerm_data_protection_backup_policy_disk"
+description: |-
+  Gets information about an existing Backup Policy (Disk).
+---
+
+# Data Source: azurerm_data_protection_backup_policy_disk
+
+Use this data source to access information about an existing Backup Policy (Disk).
+
+## Example Usage
+
+```hcl
+data "azurerm_data_protection_backup_policy_disk" "example" {
+  name     = "existing-backup-policy"
+  vault_id = data.azurerm_data_protection_backup_vault.example.id
+}
+
+output "id" {
+  value = data.azurerm_data_protection_backup_policy_disk.example.id
+}
+```
+
+## Arguments Reference
+
+* `name` - (Required) Specifies the name of the Backup Policy.
+
+* `vault_id` - (Required) Specifies the ID of the Backup Vault.
+
+## Attributes Reference
+
+* `id` - The ID of the Backup Policy.
+
+* `backup_repeating_time_intervals` - The backup repeating time intervals.
+
+* `default_retention_duration` - The duration of default retention rule.
+
+* `retention_rule` - A `retention_rule` block as defined below.
+
+* `time_zone` - The time zone used by the backup schedule.
+
+---
+
+A `retention_rule` block exports the following:
+
+* `criteria` - A `criteria` block as defined below.
+
+* `duration` - The retention duration.
+
+* `name` - The name of the retention rule.
+
+* `priority` - The priority of the rule.
+
+---
+
+A `criteria` block exports the following:
+
+* `absolute_criteria` - The absolute criteria.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/configure#define-operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Backup Policy.
+
+## API Providers
+<!-- This section is generated, changes will be overwritten -->
+This data source uses the following Azure API Providers:
+
+* `Microsoft.DataProtection` - 2025-09-01

--- a/website/docs/d/data_protection_backup_policy_kubernetes_cluster.html.markdown
+++ b/website/docs/d/data_protection_backup_policy_kubernetes_cluster.html.markdown
@@ -1,0 +1,94 @@
+---
+subcategory: "DataProtection"
+layout: "azurerm"
+page_title: "Azure Resource Manager: Data Source: azurerm_data_protection_backup_policy_kubernetes_cluster"
+description: |-
+  Gets information about an existing Backup Policy (Kubernetes Cluster).
+---
+
+# Data Source: azurerm_data_protection_backup_policy_kubernetes_cluster
+
+Use this data source to access information about an existing Backup Policy (Kubernetes Cluster).
+
+## Example Usage
+
+```hcl
+data "azurerm_data_protection_backup_policy_kubernetes_cluster" "example" {
+  name     = "existing-backup-policy"
+  vault_id = data.azurerm_data_protection_backup_vault.example.id
+}
+
+output "id" {
+  value = data.azurerm_data_protection_backup_policy_kubernetes_cluster.example.id
+}
+```
+
+## Arguments Reference
+
+* `name` - (Required) Specifies the name of the Backup Policy.
+
+* `vault_id` - (Required) Specifies the ID of the Backup Vault.
+
+## Attributes Reference
+
+* `id` - The ID of the Backup Policy.
+
+* `backup_repeating_time_intervals` - The backup repeating time intervals.
+
+* `default_retention_rule` - A `default_retention_rule` block as defined below.
+
+* `retention_rule` - A `retention_rule` block as defined below.
+
+* `time_zone` - The time zone used by the backup schedule.
+
+---
+
+A `default_retention_rule` block exports the following:
+
+* `life_cycle` - A `life_cycle` block as defined below.
+
+---
+
+A `retention_rule` block exports the following:
+
+* `criteria` - A `criteria` block as defined below.
+
+* `life_cycle` - A `life_cycle` block as defined below.
+
+* `name` - The name of the retention rule.
+
+* `priority` - The priority of the rule.
+
+---
+
+A `criteria` block exports the following:
+
+* `absolute_criteria` - The absolute criteria.
+
+* `days_of_week` - The days of the week.
+
+* `months_of_year` - The months of the year.
+
+* `scheduled_backup_times` - The scheduled backup times.
+
+* `weeks_of_month` - The weeks of the month.
+
+---
+
+A `life_cycle` block exports the following:
+
+* `data_store_type` - The type of data store.
+
+* `duration` - The retention duration.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/configure#define-operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Backup Policy.
+
+## API Providers
+<!-- This section is generated, changes will be overwritten -->
+This data source uses the following Azure API Providers:
+
+* `Microsoft.DataProtection` - 2025-09-01

--- a/website/docs/d/data_protection_backup_policy_mysql_flexible_server.html.markdown
+++ b/website/docs/d/data_protection_backup_policy_mysql_flexible_server.html.markdown
@@ -1,0 +1,94 @@
+---
+subcategory: "DataProtection"
+layout: "azurerm"
+page_title: "Azure Resource Manager: Data Source: azurerm_data_protection_backup_policy_mysql_flexible_server"
+description: |-
+  Gets information about an existing Backup Policy (MySQL Flexible Server).
+---
+
+# Data Source: azurerm_data_protection_backup_policy_mysql_flexible_server
+
+Use this data source to access information about an existing Backup Policy (MySQL Flexible Server).
+
+## Example Usage
+
+```hcl
+data "azurerm_data_protection_backup_policy_mysql_flexible_server" "example" {
+  name     = "existing-backup-policy"
+  vault_id = data.azurerm_data_protection_backup_vault.example.id
+}
+
+output "id" {
+  value = data.azurerm_data_protection_backup_policy_mysql_flexible_server.example.id
+}
+```
+
+## Arguments Reference
+
+* `name` - (Required) Specifies the name of the Backup Policy.
+
+* `vault_id` - (Required) Specifies the ID of the Backup Vault.
+
+## Attributes Reference
+
+* `id` - The ID of the Backup Policy.
+
+* `backup_repeating_time_intervals` - The backup repeating time intervals.
+
+* `default_retention_rule` - A `default_retention_rule` block as defined below.
+
+* `retention_rule` - A `retention_rule` block as defined below.
+
+* `time_zone` - The time zone used by the backup schedule.
+
+---
+
+A `default_retention_rule` block exports the following:
+
+* `life_cycle` - A `life_cycle` block as defined below.
+
+---
+
+A `retention_rule` block exports the following:
+
+* `criteria` - A `criteria` block as defined below.
+
+* `life_cycle` - A `life_cycle` block as defined below.
+
+* `name` - The name of the retention rule.
+
+* `priority` - The priority of the rule.
+
+---
+
+A `criteria` block exports the following:
+
+* `absolute_criteria` - The absolute criteria.
+
+* `days_of_week` - The days of the week.
+
+* `months_of_year` - The months of the year.
+
+* `scheduled_backup_times` - The scheduled backup times.
+
+* `weeks_of_month` - The weeks of the month.
+
+---
+
+A `life_cycle` block exports the following:
+
+* `data_store_type` - The type of data store.
+
+* `duration` - The retention duration.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/configure#define-operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Backup Policy.
+
+## API Providers
+<!-- This section is generated, changes will be overwritten -->
+This data source uses the following Azure API Providers:
+
+* `Microsoft.DataProtection` - 2025-09-01

--- a/website/docs/d/data_protection_backup_policy_postgresql_flexible_server.html.markdown
+++ b/website/docs/d/data_protection_backup_policy_postgresql_flexible_server.html.markdown
@@ -1,0 +1,94 @@
+---
+subcategory: "DataProtection"
+layout: "azurerm"
+page_title: "Azure Resource Manager: Data Source: azurerm_data_protection_backup_policy_postgresql_flexible_server"
+description: |-
+  Gets information about an existing Backup Policy (PostgreSQL Flexible Server).
+---
+
+# Data Source: azurerm_data_protection_backup_policy_postgresql_flexible_server
+
+Use this data source to access information about an existing Backup Policy (PostgreSQL Flexible Server).
+
+## Example Usage
+
+```hcl
+data "azurerm_data_protection_backup_policy_postgresql_flexible_server" "example" {
+  name     = "existing-backup-policy"
+  vault_id = data.azurerm_data_protection_backup_vault.example.id
+}
+
+output "id" {
+  value = data.azurerm_data_protection_backup_policy_postgresql_flexible_server.example.id
+}
+```
+
+## Arguments Reference
+
+* `name` - (Required) Specifies the name of the Backup Policy.
+
+* `vault_id` - (Required) Specifies the ID of the Backup Vault.
+
+## Attributes Reference
+
+* `id` - The ID of the Backup Policy.
+
+* `backup_repeating_time_intervals` - The backup repeating time intervals.
+
+* `default_retention_rule` - A `default_retention_rule` block as defined below.
+
+* `retention_rule` - A `retention_rule` block as defined below.
+
+* `time_zone` - The time zone used by the backup schedule.
+
+---
+
+A `default_retention_rule` block exports the following:
+
+* `life_cycle` - A `life_cycle` block as defined below.
+
+---
+
+A `retention_rule` block exports the following:
+
+* `criteria` - A `criteria` block as defined below.
+
+* `life_cycle` - A `life_cycle` block as defined below.
+
+* `name` - The name of the retention rule.
+
+* `priority` - The priority of the rule.
+
+---
+
+A `criteria` block exports the following:
+
+* `absolute_criteria` - The absolute criteria.
+
+* `days_of_week` - The days of the week.
+
+* `months_of_year` - The months of the year.
+
+* `scheduled_backup_times` - The scheduled backup times.
+
+* `weeks_of_month` - The weeks of the month.
+
+---
+
+A `life_cycle` block exports the following:
+
+* `data_store_type` - The type of data store.
+
+* `duration` - The retention duration.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/configure#define-operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Backup Policy.
+
+## API Providers
+<!-- This section is generated, changes will be overwritten -->
+This data source uses the following Azure API Providers:
+
+* `Microsoft.DataProtection` - 2025-09-01


### PR DESCRIPTION
#### Community Note

* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review

#### PR Checklist

- [x] Have you followed the guidelines in our [Contributing Documentation](../contributing/README.md)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [x] Have you used a meaningful PR description to help maintainers and other users understand this change and help prevent duplicate work?
`azurerm_data_protection_backup_policy_blob_storage` - new data source
`azurerm_data_protection_backup_policy_disk` - new data source
`azurerm_data_protection_backup_policy_kubernetes_cluster` - new data source
`azurerm_data_protection_backup_policy_mysql_flexible_server` - new data source
`azurerm_data_protection_backup_policy_postgresql_flexible_server` - new data source
- [x] Do your changes close any open issues? If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.

#### New Feature Submissions

- [x] Does your submission include Test coverage as described in the [Contribution Guide](../contributing/topics/guide-new-resource.md) and the tests pass? (if this is not possible for any reason, please include details of why below)

#### Documentation Changes

- [x] Documentation is written in International English.
- [x] Documentation is written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.

#### Description

This PR adds five new data sources for reading existing Data Protection Backup Policies:

- `azurerm_data_protection_backup_policy_blob_storage`
- `azurerm_data_protection_backup_policy_disk`
- `azurerm_data_protection_backup_policy_kubernetes_cluster`
- `azurerm_data_protection_backup_policy_mysql_flexible_server`
- `azurerm_data_protection_backup_policy_postgresql_flexible_server`

These data sources allow users to look up existing backup policies by name and vault ID, which is useful when policies are managed outside of Terraform or shared across multiple configurations. Each data source returns the full policy configuration including retention rules and backup schedules.

Acceptance test output:

```
--- PASS: TestAccDataProtectionBackupPolicyBlobStorageDataSource_basic (135.14s)
--- PASS: TestAccDataProtectionBackupPolicyDiskDataSource_basic (137.37s)
--- PASS: TestAccDataProtectionBackupPolicyKubernetesClusterDataSource_basic (135.50s)
--- PASS: TestAccDataProtectionBackupPolicyMySQLFlexibleServerDataSource_basic (144.50s)
--- PASS: TestAccDataProtectionBackupPolicyPostgreSQLFlexibleServerDataSource_basic (135.30s)
```

#### Related Issue(s)

Resolves #27900

#### Change Log

* `azurerm_data_protection_backup_policy_blob_storage` - new data source
* `azurerm_data_protection_backup_policy_disk` - new data source
* `azurerm_data_protection_backup_policy_kubernetes_cluster` - new data source
* `azurerm_data_protection_backup_policy_mysql_flexible_server` - new data source
* `azurerm_data_protection_backup_policy_postgresql_flexible_server` - new data source

- [ ] Bug Fix
- [x] New Feature

> **Note:** If this PR changes meaningfully during the course of review please update the title and description as required.