### PR TITLE
azurerm_static_site - fix app_settings not being read correctly

### DIFF
--- a/internal/services/web/static_site_resource.go
+++ b/internal/services/web/static_site_resource.go
@@ -241,7 +241,7 @@ func resourceStaticSiteRead(d *pluginsdk.ResourceData, meta interface{}) error {
 		return fmt.Errorf("making Read request for app settings on %s: %+v", id, err)
 	}
 
-	if err := d.Set("app_settings", appSettingsResp.Properties); err != nil {
+	if err := d.Set("app_settings", flattenStaticSiteAppSettings(appSettingsResp.Properties)); err != nil {
 		return fmt.Errorf("setting `app_settings`: %s", err)
 	}
 
@@ -326,6 +326,18 @@ func expandStaticSiteAppSettings(d *pluginsdk.ResourceData) map[string]*string {
 
 	for k, v := range input {
 		output[k] = pointer.To(v.(string))
+	}
+
+	return output
+}
+
+func flattenStaticSiteAppSettings(input map[string]*string) map[string]interface{} {
+	output := make(map[string]interface{}, len(input))
+
+	for k, v := range input {
+		if v != nil {
+			output[k] = *v
+		}
 	}
 
 	return output


### PR DESCRIPTION
#### Community Note

* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review

#### PR Checklist

- [X] Have you followed the guidelines in our [Contributing Documentation](../contributing/README.md)?
- [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [X] Have you used a meaningful PR description to help maintainers and other users understand this change and help prevent duplicate work?

#### Changes to existing Resource / Data Source

- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your resource or datasource changes?
- [ ] Have you successfully run tests with your changes locally?

#### Testing

<img width="1428" height="196" alt="image" src="https://github.com/user-attachments/assets/e7cf12a0-7cdd-4f20-9c6b-f15bfdfcef9c" />

#### Description

The `app_settings` property on `azurerm_static_site` was not being read correctly. The `Read` function was setting `app_settings` directly from the API response type `map[string]*string`, but Terraform expects `map[string]interface{}`. This caused the state to not reflect the actual values from Azure.

This PR:
- Adds a `flattenStaticSiteAppSettings` helper that converts `map[string]*string` to `map[string]interface{}` with nil-safety
- Uses the new helper in the `Read` function so `app_settings` is stored correctly in state

#### Change Log

* `azurerm_static_site` - fix `app_settings` not being read correctly [GH-00000]

- [X] Bug Fix
- [ ] New Feature