### PR TITLE
mssql: prevent panic when max_size_bytes exceeds 32-bit

### DIFF
--- a/internal/services/mssql/helper/elasticpool.go
+++ b/internal/services/mssql/helper/elasticpool.go
@@ -298,7 +298,18 @@ func MSSQLElasticPoolValidateSKU(diff *pluginsdk.ResourceDiff) error {
 	// Convert Bytes to Gigabytes only if
 	// 'max_size_bytes' has changed
 	if diff.HasChange("max_size_bytes") {
-		s.MaxSizeGb = float64(maxSizeBytes.(int) / 1024 / 1024 / 1024)
+		switch t := maxSizeBytes.(type) {
+		case nil:
+			s.MaxSizeGb = 0
+		case int:
+			s.MaxSizeGb = float64(t) / 1073741824
+		case int64:
+			s.MaxSizeGb = float64(t) / 1073741824
+		case float64:
+			s.MaxSizeGb = t / 1073741824
+		default:
+			return fmt.Errorf("unexpected type for max_size_bytes: %T", maxSizeBytes)
+		}
 	}
 
 	// Check to see if the name describes a vCore type SKU

--- a/internal/services/mssql/mssql_elasticpool_data_source.go
+++ b/internal/services/mssql/mssql_elasticpool_data_source.go
@@ -42,7 +42,7 @@ func dataSourceMsSqlElasticpool() *pluginsdk.Resource {
 			"location": commonschema.LocationComputed(),
 
 			"max_size_bytes": {
-				Type:     pluginsdk.TypeInt,
+				Type:     pluginsdk.TypeFloat,
 				Computed: true,
 			},
 
@@ -139,8 +139,10 @@ func dataSourceMsSqlElasticpoolRead(d *pluginsdk.ResourceData, meta interface{})
 		}
 
 		if props := model.Properties; props != nil {
-			d.Set("max_size_gb", float64(*props.MaxSizeBytes/int64(1073741824)))
-			d.Set("max_size_bytes", props.MaxSizeBytes)
+			if props.MaxSizeBytes != nil {
+				d.Set("max_size_gb", float64(*props.MaxSizeBytes)/1073741824)
+				d.Set("max_size_bytes", float64(*props.MaxSizeBytes))
+			}
 			d.Set("zone_redundant", props.ZoneRedundant)
 
 			licenseType := ""

--- a/internal/services/mssql/mssql_elasticpool_resource.go
+++ b/internal/services/mssql/mssql_elasticpool_resource.go
@@ -159,11 +159,11 @@ func resourceMsSqlElasticPool() *pluginsdk.Resource {
 			},
 
 			"max_size_bytes": {
-				Type:          pluginsdk.TypeInt,
+				Type:          pluginsdk.TypeFloat,
 				Optional:      true,
 				Computed:      true,
 				ConflictsWith: []string{"max_size_gb"},
-				ValidateFunc:  validation.IntAtLeast(0),
+				ValidateFunc:  validation.FloatAtLeast(0),
 			},
 
 			"max_size_gb": {
@@ -282,7 +282,16 @@ func resourceMsSqlElasticPoolCreateUpdate(d *pluginsdk.ResourceData, meta interf
 			elasticPool.Properties.MaxSizeBytes = pointer.To(int64(maxSizeBytes))
 		}
 	} else if v, ok := d.GetOk("max_size_bytes"); ok {
-		elasticPool.Properties.MaxSizeBytes = pointer.To(int64(v.(int)))
+		switch t := v.(type) {
+		case int:
+			elasticPool.Properties.MaxSizeBytes = pointer.To(int64(t))
+		case int64:
+			elasticPool.Properties.MaxSizeBytes = pointer.To(t)
+		case float64:
+			elasticPool.Properties.MaxSizeBytes = pointer.To(int64(t))
+		default:
+			return fmt.Errorf("unexpected type for max_size_bytes: %T", v)
+		}
 	}
 
 	err := client.CreateOrUpdateThenPoll(ctx, id, elasticPool)
@@ -336,8 +345,10 @@ func resourceMssqlElasticPoolSetFlatten(d *pluginsdk.ResourceData, id *commonids
 				enclaveType = string(pointer.From(v))
 			}
 			d.Set("enclave_type", enclaveType)
-			d.Set("max_size_gb", pointer.To(float64(*props.MaxSizeBytes)/1073741824))
-			d.Set("max_size_bytes", pointer.To(props.MaxSizeBytes))
+			if props.MaxSizeBytes != nil {
+				d.Set("max_size_gb", float64(*props.MaxSizeBytes)/1073741824)
+				d.Set("max_size_bytes", float64(*props.MaxSizeBytes))
+			}
 			d.Set("zone_redundant", pointer.From(props.ZoneRedundant))
 
 			licenseType := string(elasticpools.ElasticPoolLicenseTypeLicenseIncluded)


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

Fixes a provider panic when azurerm_mssql_elasticpool.max_size_bytes in state exceeds the 32-bit integer range (e.g. 858993459200). This could crash terraform plan after importing an elastic pool.

This PR updates max_size_bytes to be stored as a float in schema/state and safely converts values during expand/flatten and SKU validation to prevent the overflow.

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 
go test ./...

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* azurerm_mssql_elasticpool - prevent panic when max_size_bytes exceeds 32-bit range [GH-31779]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #31779


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->
Used AI assistance for code review guidance and drafting PR description.
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
