### PR TITLE
Only get full resource information if IncludeResouce is true for storage_account

### DIFF
--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -2101,14 +2101,29 @@ func resourceStorageAccountRead(d *pluginsdk.ResourceData, meta interface{}) err
 		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	if err := resourceStorageAccountFlatten(ctx, d, *id, resp.Model, meta); err != nil {
+	if err := resourceStorageAccountFlatten(ctx, d, *id, resp.Model, meta, true); err != nil {
 		return fmt.Errorf("encoding %s: %+v", *id, err)
 	}
 
 	return nil
 }
 
-func resourceStorageAccountFlatten(ctx context.Context, d *pluginsdk.ResourceData, id commonids.StorageAccountId, account *storageaccounts.StorageAccount, meta interface{}) error {
+func resourceStorageAccountFlatten(ctx context.Context, d *pluginsdk.ResourceData, id commonids.StorageAccountId, account *storageaccounts.StorageAccount, meta interface{}, includeResource bool) error {
+	if account == nil {
+		return fmt.Errorf("unable to locate %q", id)
+	}
+
+	d.Set("name", id.StorageAccountName)
+	d.Set("resource_group_name", id.ResourceGroupName)
+
+	if err := pluginsdk.SetResourceIdentityData(d, pointer.To(id)); err != nil {
+		return fmt.Errorf("setting resource identity data: %+v", err)
+	}
+
+	if !includeResource {
+		return nil
+	}
+
 	storageClient := meta.(*clients.Client).Storage.ResourceManager
 	storageUtils := meta.(*clients.Client).Storage
 	client := storageClient.StorageAccounts
@@ -2123,13 +2138,6 @@ func resourceStorageAccountFlatten(ctx context.Context, d *pluginsdk.ResourceDat
 	if err != nil {
 		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
-
-	if account == nil {
-		return fmt.Errorf("unable to locate %q", id)
-	}
-
-	d.Set("name", id.StorageAccountName)
-	d.Set("resource_group_name", id.ResourceGroupName)
 
 	listKeysOpts := storageaccounts.DefaultListKeysOperationOptions()
 	listKeysOpts.Expand = pointer.To(storageaccounts.ListKeyExpandKerb)
@@ -2303,10 +2311,6 @@ func resourceStorageAccountFlatten(ctx context.Context, d *pluginsdk.ResourceDat
 
 	endpoints := flattenAccountEndpoints(primaryEndpoints, secondaryEndpoints, routingPreference)
 	endpoints.set(d)
-
-	if err = pluginsdk.SetResourceIdentityData(d, pointer.To(id)); err != nil {
-		return fmt.Errorf("setting resource identity data: %+v", err)
-	}
 
 	keys, err := client.ListKeys(ctx, id, listKeysOpts)
 	if err != nil {

--- a/internal/services/storage/storage_account_resource_list.go
+++ b/internal/services/storage/storage_account_resource_list.go
@@ -88,30 +88,14 @@ func (r StorageAccountListResource) List(ctx context.Context, request list.ListR
 
 			rd.SetId(id.ID())
 
-			if err := resourceStorageAccountFlatten(ctx, rd, *id, pointer.To(account), metadata.Client); err != nil {
+			if err := resourceStorageAccountFlatten(ctx, rd, *id, pointer.To(account), metadata.Client, request.IncludeResource); err != nil {
 				sdk.SetErrorDiagnosticAndPushListResult(result, push, "encoding Resource data", err)
 				return
 			}
 
-			tfTypeIdentity, err := rd.TfTypeIdentityState()
-			if err != nil {
-				sdk.SetErrorDiagnosticAndPushListResult(result, push, "converting Identity State", err)
-				return
-			}
-
-			if err := result.Identity.Set(ctx, *tfTypeIdentity); err != nil {
-				sdk.SetErrorDiagnosticAndPushListResult(result, push, "setting Identity data", err)
-				return
-			}
-
-			tfTypeResource, err := rd.TfTypeResourceState()
-			if err != nil {
-				sdk.SetErrorDiagnosticAndPushListResult(result, push, "converting Resource State data", err)
-				return
-			}
-
-			if err := result.Resource.Set(ctx, *tfTypeResource); err != nil {
-				sdk.SetErrorDiagnosticAndPushListResult(result, push, "setting Resource data", err)
+			sdk.EncodeListResult(ctx, rd, &result)
+			if result.Diagnostics.HasError() {
+				push(result)
 				return
 			}
 

--- a/internal/services/storage/storage_account_resource_list_test.go
+++ b/internal/services/storage/storage_account_resource_list_test.go
@@ -32,14 +32,21 @@ func TestAccStorageAccount_list_basic(t *testing.T) {
 			},
 			{
 				Query:  true,
-				Config: r.basicQuery(data),
+				Config: r.basicQuery(),
 				QueryResultChecks: []querycheck.QueryResultCheck{
 					querycheck.ExpectLengthAtLeast(listResourceAddress, 3),
 				},
 			},
 			{
 				Query:  true,
-				Config: r.basicQueryByResourceGroup(data),
+				Config: r.basicQueryByResourceGroup(data, false),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLength(listResourceAddress, 3),
+				},
+			},
+			{
+				Query:  true,
+				Config: r.basicQueryByResourceGroup(data, true),
 				QueryResultChecks: []querycheck.QueryResultCheck{
 					querycheck.ExpectLength(listResourceAddress, 3),
 				},
@@ -76,7 +83,7 @@ resource "azurerm_storage_account" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
 
-func (r StorageAccountResource) basicQuery(_ acceptance.TestData) string {
+func (r StorageAccountResource) basicQuery() string {
 	return `
 list "azurerm_storage_account" "test" {
   provider = azurerm
@@ -84,13 +91,14 @@ list "azurerm_storage_account" "test" {
 }`
 }
 
-func (r StorageAccountResource) basicQueryByResourceGroup(data acceptance.TestData) string {
+func (r StorageAccountResource) basicQueryByResourceGroup(data acceptance.TestData, includeResource bool) string {
 	return fmt.Sprintf(`
 list "azurerm_storage_account" "test" {
   provider = azurerm
   config {
-    resource_group_name = "acctestRG-storage-%d"
+    resource_group_name = "acctestRG-storage-%[1]d"
   }
+  include_resource = %[2]t
 }
-`, data.RandomInteger)
+`, data.RandomInteger, includeResource)
 }

--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -1853,7 +1853,7 @@ func TestAccStorageAccount_invalidAccountKindForAccessTier(t *testing.T) {
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config:      r.invalidAccountKindForAccessTier(data),
-			ExpectError: regexp.MustCompile("`access_tier` is only available for accounts of kind set to one of:"),
+			ExpectError: regexp.MustCompile("`access_tier` is only available for accounts where `kind` is set to one of:"),
 		},
 	})
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
