### PR TITLE
`azurerm_mssql_server` - use `PATCH` to do update instead of `PUT`

### DIFF
--- a/internal/services/mssql/mssql_server_resource.go
+++ b/internal/services/mssql/mssql_server_resource.go
@@ -482,6 +482,8 @@ func resourceMsSqlServerUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 		}
 	}
 
+	// The `AzureADOnlyAuthentication` cannot be updated by `serversClient`,
+	// Service return `Invalid value given for parameter AzureADOnlyAuthentication. Specify a valid parameter value.` in that case.
 	if d.HasChange("azuread_administrator") && d.HasChange("azuread_administrator.0.azuread_authentication_only") {
 		if aadOnlyAuthenticationEnabled := expandMsSqlServerAADOnlyAuthentication(d.Get("azuread_administrator").([]interface{})); aadOnlyAuthenticationEnabled {
 			aadOnlyAuthenticationProps := serverazureadonlyauthentications.ServerAzureADOnlyAuthentication{

--- a/internal/services/mssql/mssql_server_resource.go
+++ b/internal/services/mssql/mssql_server_resource.go
@@ -510,14 +510,15 @@ func resourceMsSqlServerUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 		}
 	}
 
-	connection := serverconnectionpolicies.ServerConnectionPolicy{
-		Properties: &serverconnectionpolicies.ServerConnectionPolicyProperties{
-			ConnectionType: serverconnectionpolicies.ServerConnectionType(d.Get("connection_policy").(string)),
-		},
-	}
-
-	if err = connectionClient.CreateOrUpdateThenPoll(ctx, *id, connection); err != nil {
-		return fmt.Errorf("updating Connection Policy for %s: %+v", id, err)
+	if d.HasChange("connection_policy") {
+		connection := serverconnectionpolicies.ServerConnectionPolicy{
+			Properties: &serverconnectionpolicies.ServerConnectionPolicyProperties{
+				ConnectionType: serverconnectionpolicies.ServerConnectionType(d.Get("connection_policy").(string)),
+			},
+		}
+		if err = connectionClient.CreateOrUpdateThenPoll(ctx, *id, connection); err != nil {
+			return fmt.Errorf("updating Connection Policy for %s: %+v", id, err)
+		}
 	}
 
 	if d.HasChange("express_vulnerability_assessment_enabled") {

--- a/internal/services/mssql/mssql_server_resource.go
+++ b/internal/services/mssql/mssql_server_resource.go
@@ -384,14 +384,11 @@ func resourceMsSqlServerUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	if d.HasChanges("tags", "identity", "transparent_data_encryption_key_vault_key_id", "primary_user_assigned_identity_id",
-		"public_network_access_enabled", "outbound_network_restriction_enabled",
-		"administrator_login_password", "administrator_login_password_wo_version", "minimum_tls_version") {
+	payload := &servers.ServerUpdate{}
+	requireUpdate := false
 
-		payload := &servers.ServerUpdate{
-			Properties: &servers.ServerProperties{},
-		}
-
+	if d.HasChanges("tags", "identity") {
+		requireUpdate = true
 		if d.HasChange("tags") {
 			payload.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
 		}
@@ -403,6 +400,13 @@ func resourceMsSqlServerUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 			}
 			payload.Identity = expanded
 		}
+	}
+
+	if d.HasChanges("transparent_data_encryption_key_vault_key_id", "primary_user_assigned_identity_id",
+		"public_network_access_enabled", "outbound_network_restriction_enabled",
+		"administrator_login_password", "administrator_login_password_wo_version", "minimum_tls_version") {
+		requireUpdate = true
+		payload.Properties = &servers.ServerProperties{}
 
 		if d.HasChange("transparent_data_encryption_key_vault_key_id") {
 			keyId, err := keyvault.ParseNestedItemID(d.Get("transparent_data_encryption_key_vault_key_id").(string), keyvault.VersionTypeVersioned, keyvault.NestedItemTypeKey)
@@ -413,7 +417,9 @@ func resourceMsSqlServerUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 		}
 
 		if d.HasChange("primary_user_assigned_identity_id") {
-			payload.Properties.PrimaryUserAssignedIdentityId = pointer.To(d.Get("primary_user_assigned_identity_id").(string))
+			if v, ok := d.GetOk("primary_user_assigned_identity_id"); ok {
+				payload.Properties.PrimaryUserAssignedIdentityId = pointer.To(v.(string))
+			}
 		}
 
 		if d.HasChange("public_network_access_enabled") {
@@ -449,7 +455,9 @@ func resourceMsSqlServerUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 		if d.HasChange("minimum_tls_version") {
 			payload.Properties.MinimalTlsVersion = pointer.To(servers.MinimalTlsVersion(d.Get("minimum_tls_version").(string)))
 		}
+	}
 
+	if requireUpdate {
 		if err := client.UpdateThenPoll(ctx, *id, *payload); err != nil {
 			return fmt.Errorf("updating %s: %+v", id, err)
 		}

--- a/internal/services/mssql/mssql_server_resource.go
+++ b/internal/services/mssql/mssql_server_resource.go
@@ -423,18 +423,16 @@ func resourceMsSqlServerUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 		}
 
 		if d.HasChange("public_network_access_enabled") {
+			payload.Properties.PublicNetworkAccess = pointer.To(servers.ServerPublicNetworkAccessFlagDisabled)
 			if d.Get("public_network_access_enabled").(bool) {
 				payload.Properties.PublicNetworkAccess = pointer.To(servers.ServerPublicNetworkAccessFlagEnabled)
-			} else {
-				payload.Properties.PublicNetworkAccess = pointer.To(servers.ServerPublicNetworkAccessFlagDisabled)
 			}
 		}
 
 		if d.HasChange("outbound_network_restriction_enabled") {
+			payload.Properties.RestrictOutboundNetworkAccess = pointer.To(servers.ServerNetworkAccessFlagDisabled)
 			if d.Get("outbound_network_restriction_enabled").(bool) {
 				payload.Properties.RestrictOutboundNetworkAccess = pointer.To(servers.ServerNetworkAccessFlagEnabled)
-			} else {
-				payload.Properties.RestrictOutboundNetworkAccess = pointer.To(servers.ServerNetworkAccessFlagDisabled)
 			}
 		}
 

--- a/internal/services/mssql/mssql_server_resource.go
+++ b/internal/services/mssql/mssql_server_resource.go
@@ -416,10 +416,10 @@ func resourceMsSqlServerUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 			payload.Properties.KeyId = pointer.To(keyId.ID())
 		}
 
+		// The `primary_user_assigned_identity_id` is an `O+C` property, when it's being removed from configuration.
+		// `HasChange()` will be `true`, but `GetOk()` will be `false`. So use `d.Get()` to read the value.
 		if d.HasChange("primary_user_assigned_identity_id") {
-			if v, ok := d.GetOk("primary_user_assigned_identity_id"); ok {
-				payload.Properties.PrimaryUserAssignedIdentityId = pointer.To(v.(string))
-			}
+			payload.Properties.PrimaryUserAssignedIdentityId = pointer.To(d.Get("primary_user_assigned_identity_id").(string))
 		}
 
 		if d.HasChange("public_network_access_enabled") {

--- a/internal/services/mssql/mssql_server_resource.go
+++ b/internal/services/mssql/mssql_server_resource.go
@@ -384,12 +384,14 @@ func resourceMsSqlServerUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	existing, err := client.Get(ctx, *id, servers.DefaultGetOperationOptions())
-	if err != nil {
-		return fmt.Errorf("retrieving %s: %+v", id, err)
-	}
+	if d.HasChanges("tags", "identity", "transparent_data_encryption_key_vault_key_id", "primary_user_assigned_identity_id",
+		"public_network_access_enabled", "outbound_network_restriction_enabled",
+		"administrator_login_password", "administrator_login_password_wo_version", "minimum_tls_version") {
 
-	if payload := existing.Model; payload != nil {
+		payload := &servers.ServerUpdate{
+			Properties: &servers.ServerProperties{},
+		}
+
 		if d.HasChange("tags") {
 			payload.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
 		}
@@ -410,19 +412,24 @@ func resourceMsSqlServerUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 			payload.Properties.KeyId = pointer.To(keyId.ID())
 		}
 
-		if primaryUserAssignedIdentityID, ok := d.GetOk("primary_user_assigned_identity_id"); ok {
-			payload.Properties.PrimaryUserAssignedIdentityId = pointer.To(primaryUserAssignedIdentityID.(string))
+		if d.HasChange("primary_user_assigned_identity_id") {
+			payload.Properties.PrimaryUserAssignedIdentityId = pointer.To(d.Get("primary_user_assigned_identity_id").(string))
 		}
 
-		payload.Properties.PublicNetworkAccess = pointer.To(servers.ServerPublicNetworkAccessFlagDisabled)
-		payload.Properties.RestrictOutboundNetworkAccess = pointer.To(servers.ServerNetworkAccessFlagDisabled)
-
-		if v := d.Get("public_network_access_enabled"); v.(bool) {
-			payload.Properties.PublicNetworkAccess = pointer.To(servers.ServerPublicNetworkAccessFlagEnabled)
+		if d.HasChange("public_network_access_enabled") {
+			if d.Get("public_network_access_enabled").(bool) {
+				payload.Properties.PublicNetworkAccess = pointer.To(servers.ServerPublicNetworkAccessFlagEnabled)
+			} else {
+				payload.Properties.PublicNetworkAccess = pointer.To(servers.ServerPublicNetworkAccessFlagDisabled)
+			}
 		}
 
-		if v := d.Get("outbound_network_restriction_enabled"); v.(bool) {
-			payload.Properties.RestrictOutboundNetworkAccess = pointer.To(servers.ServerNetworkAccessFlagEnabled)
+		if d.HasChange("outbound_network_restriction_enabled") {
+			if d.Get("outbound_network_restriction_enabled").(bool) {
+				payload.Properties.RestrictOutboundNetworkAccess = pointer.To(servers.ServerNetworkAccessFlagEnabled)
+			} else {
+				payload.Properties.RestrictOutboundNetworkAccess = pointer.To(servers.ServerNetworkAccessFlagDisabled)
+			}
 		}
 
 		if d.HasChange("administrator_login_password") {
@@ -443,8 +450,7 @@ func resourceMsSqlServerUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 			payload.Properties.MinimalTlsVersion = pointer.To(servers.MinimalTlsVersion(d.Get("minimum_tls_version").(string)))
 		}
 
-		err := client.CreateOrUpdateThenPoll(ctx, *id, *payload)
-		if err != nil {
+		if err := client.UpdateThenPoll(ctx, *id, *payload); err != nil {
 			return fmt.Errorf("updating %s: %+v", id, err)
 		}
 	}

--- a/internal/services/mssql/mssql_server_resource.go
+++ b/internal/services/mssql/mssql_server_resource.go
@@ -384,83 +384,6 @@ func resourceMsSqlServerUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	payload := &servers.ServerUpdate{}
-	requireUpdate := false
-
-	if d.HasChanges("tags", "identity") {
-		requireUpdate = true
-		if d.HasChange("tags") {
-			payload.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
-		}
-
-		if d.HasChange("identity") {
-			expanded, err := identity.ExpandLegacySystemAndUserAssignedMap(d.Get("identity").([]interface{}))
-			if err != nil {
-				return fmt.Errorf("expanding `identity`: %+v", err)
-			}
-			payload.Identity = expanded
-		}
-	}
-
-	if d.HasChanges("transparent_data_encryption_key_vault_key_id", "primary_user_assigned_identity_id",
-		"public_network_access_enabled", "outbound_network_restriction_enabled",
-		"administrator_login_password", "administrator_login_password_wo_version", "minimum_tls_version") {
-		requireUpdate = true
-		payload.Properties = &servers.ServerProperties{}
-
-		if d.HasChange("transparent_data_encryption_key_vault_key_id") {
-			keyId, err := keyvault.ParseNestedItemID(d.Get("transparent_data_encryption_key_vault_key_id").(string), keyvault.VersionTypeVersioned, keyvault.NestedItemTypeKey)
-			if err != nil {
-				return err
-			}
-			payload.Properties.KeyId = pointer.To(keyId.ID())
-		}
-
-		// The `primary_user_assigned_identity_id` is an `O+C` property, when it's being removed from configuration.
-		// `HasChange()` will be `true`, but `GetOk()` will be `false`. So use `d.Get()` to read the value.
-		if d.HasChange("primary_user_assigned_identity_id") {
-			payload.Properties.PrimaryUserAssignedIdentityId = pointer.To(d.Get("primary_user_assigned_identity_id").(string))
-		}
-
-		if d.HasChange("public_network_access_enabled") {
-			payload.Properties.PublicNetworkAccess = pointer.To(servers.ServerPublicNetworkAccessFlagDisabled)
-			if d.Get("public_network_access_enabled").(bool) {
-				payload.Properties.PublicNetworkAccess = pointer.To(servers.ServerPublicNetworkAccessFlagEnabled)
-			}
-		}
-
-		if d.HasChange("outbound_network_restriction_enabled") {
-			payload.Properties.RestrictOutboundNetworkAccess = pointer.To(servers.ServerNetworkAccessFlagDisabled)
-			if d.Get("outbound_network_restriction_enabled").(bool) {
-				payload.Properties.RestrictOutboundNetworkAccess = pointer.To(servers.ServerNetworkAccessFlagEnabled)
-			}
-		}
-
-		if d.HasChange("administrator_login_password") {
-			payload.Properties.AdministratorLoginPassword = pointer.To(d.Get("administrator_login_password").(string))
-		}
-
-		if d.HasChange("administrator_login_password_wo_version") {
-			woAdminLoginPassword, err := pluginsdk.GetWriteOnly(d, "administrator_login_password_wo", cty.String)
-			if err != nil {
-				return err
-			}
-			if !woAdminLoginPassword.IsNull() {
-				payload.Properties.AdministratorLoginPassword = pointer.To(woAdminLoginPassword.AsString())
-			}
-		}
-
-		if d.HasChange("minimum_tls_version") {
-			payload.Properties.MinimalTlsVersion = pointer.To(servers.MinimalTlsVersion(d.Get("minimum_tls_version").(string)))
-		}
-	}
-
-	if requireUpdate {
-		if err := client.UpdateThenPoll(ctx, *id, *payload); err != nil {
-			return fmt.Errorf("updating %s: %+v", id, err)
-		}
-	}
-
 	if d.HasChange("azuread_administrator") {
 		log.Printf("[INFO] Expanding 'azuread_administrator' to see if we need Create or Delete")
 		if adminProps := expandMsSqlServerAdministrator(d.Get("azuread_administrator").([]interface{})); adminProps != nil {
@@ -515,6 +438,73 @@ func resourceMsSqlServerUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 					return fmt.Errorf("waiting for the deletion of the Azure Active Directory Only Administrator: %+v", err)
 				}
 			}
+		}
+	}
+
+	existing, err := client.Get(ctx, *id, servers.DefaultGetOperationOptions())
+	if err != nil {
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	if payload := existing.Model; payload != nil {
+		if d.HasChange("tags") {
+			payload.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
+		}
+
+		if d.HasChange("identity") {
+			expanded, err := identity.ExpandLegacySystemAndUserAssignedMap(d.Get("identity").([]interface{}))
+			if err != nil {
+				return fmt.Errorf("expanding `identity`: %+v", err)
+			}
+			payload.Identity = expanded
+		}
+
+		if d.HasChange("transparent_data_encryption_key_vault_key_id") {
+			keyId, err := keyvault.ParseNestedItemID(d.Get("transparent_data_encryption_key_vault_key_id").(string), keyvault.VersionTypeVersioned, keyvault.NestedItemTypeKey)
+			if err != nil {
+				return err
+			}
+			payload.Properties.KeyId = pointer.To(keyId.ID())
+		}
+
+		// The `primary_user_assigned_identity_id` is an `O+C` property, when it's being removed from configuration.
+		// `HasChange()` will be `true`, but `GetOk()` will be `false`. So use `d.Get()` to read the value.
+		if d.HasChange("primary_user_assigned_identity_id") {
+			payload.Properties.PrimaryUserAssignedIdentityId = pointer.To(d.Get("primary_user_assigned_identity_id").(string))
+		}
+
+		payload.Properties.PublicNetworkAccess = pointer.To(servers.ServerPublicNetworkAccessFlagDisabled)
+		payload.Properties.RestrictOutboundNetworkAccess = pointer.To(servers.ServerNetworkAccessFlagDisabled)
+
+		if v := d.Get("public_network_access_enabled"); v.(bool) {
+			payload.Properties.PublicNetworkAccess = pointer.To(servers.ServerPublicNetworkAccessFlagEnabled)
+		}
+
+		if v := d.Get("outbound_network_restriction_enabled"); v.(bool) {
+			payload.Properties.RestrictOutboundNetworkAccess = pointer.To(servers.ServerNetworkAccessFlagEnabled)
+		}
+
+		if d.HasChange("administrator_login_password") {
+			payload.Properties.AdministratorLoginPassword = pointer.To(d.Get("administrator_login_password").(string))
+		}
+
+		if d.HasChange("administrator_login_password_wo_version") {
+			woAdminLoginPassword, err := pluginsdk.GetWriteOnly(d, "administrator_login_password_wo", cty.String)
+			if err != nil {
+				return err
+			}
+			if !woAdminLoginPassword.IsNull() {
+				payload.Properties.AdministratorLoginPassword = pointer.To(woAdminLoginPassword.AsString())
+			}
+		}
+
+		if d.HasChange("minimum_tls_version") {
+			payload.Properties.MinimalTlsVersion = pointer.To(servers.MinimalTlsVersion(d.Get("minimum_tls_version").(string)))
+		}
+
+		err := client.CreateOrUpdateThenPoll(ctx, *id, *payload)
+		if err != nil {
+			return fmt.Errorf("updating %s: %+v", id, err)
 		}
 	}
 

--- a/internal/services/mssql/mssql_server_resource_test.go
+++ b/internal/services/mssql/mssql_server_resource_test.go
@@ -280,6 +280,35 @@ func TestAccMsSqlServer_azureadAuthenticationOnlyWithIdentityUpdate(t *testing.T
 	})
 }
 
+func TestAccMsSqlServer_azureadAuthenticationOnlyWithPolicy(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mssql_server", "test")
+	r := MssqlServerResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.azureadAuthenticationOnlyWithPolicy(data, false, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("administrator_login_password"),
+		{
+			Config: r.azureadAuthenticationOnlyWithPolicy(data, false, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("administrator_login_password"),
+		{
+			Config: r.azureadAuthenticationOnlyWithPolicy(data, true, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("administrator_login_password"),
+	})
+}
+
 func TestAccMsSqlServer_TDECMKServerDeployment(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_server", "test")
 	r := MssqlServerResource{}
@@ -837,6 +866,62 @@ resource "azurerm_mssql_server" "test" {
   primary_user_assigned_identity_id = azurerm_user_assigned_identity.test.id
 }
 `, r.template(data), data.RandomInteger, enableAzureadAuthenticationOnly)
+}
+
+func (r MssqlServerResource) azureadAuthenticationOnlyWithPolicy(data acceptance.TestData, enableAzureadAuthenticationOnly bool, enablePolicy bool) string {
+	policyAssignment := ""
+	if enablePolicy {
+		policyAssignment = `
+data "azurerm_policy_definition" "test" {
+  display_name = "Azure SQL Database should have Microsoft Entra-only authentication enabled during creation"
+}
+
+resource "azurerm_resource_group_policy_assignment" "test" {
+  name                 = "acctestpa-mssql"
+  resource_group_id    = azurerm_resource_group.test.id
+  policy_definition_id = data.azurerm_policy_definition.test.id
+}
+`
+	}
+
+	return fmt.Sprintf(`
+%s
+
+provider "azuread" {}
+
+data "azurerm_client_config" "test" {}
+
+resource "azurerm_user_assigned_identity" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  name                = "test_identity_1"
+}
+
+resource "azurerm_mssql_server" "test" {
+  name                         = "acctestsqlserver%[2]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  location                     = azurerm_resource_group.test.location
+  version                      = "12.0"
+  minimum_tls_version          = "1.2"
+  administrator_login          = "missadministrator"
+  administrator_login_password = "thisIsKat11"
+
+  azuread_administrator {
+    login_username              = "AzureAD Admin"
+    object_id                   = data.azurerm_client_config.test.object_id
+    azuread_authentication_only = %[3]t
+  }
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+
+  primary_user_assigned_identity_id = azurerm_user_assigned_identity.test.id
+}
+
+%[4]s
+`, r.template(data), data.RandomInteger, enableAzureadAuthenticationOnly, policyAssignment)
 }
 
 func (r MssqlServerResource) tdeCMKServerDeployment(data acceptance.TestData) string {

--- a/internal/services/mssql/mssql_server_resource_test.go
+++ b/internal/services/mssql/mssql_server_resource_test.go
@@ -728,7 +728,7 @@ func (r MssqlServerResource) userAssignedIdentity(data acceptance.TestData) stri
 resource "azurerm_user_assigned_identity" "test1" {
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  name                = "test_identity_1"
+  name                = "acctest_identity_1"
 }
 
 resource "azurerm_user_assigned_identity" "test2" {
@@ -840,7 +840,7 @@ data "azurerm_client_config" "test" {}
 resource "azurerm_user_assigned_identity" "test" {
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  name                = "test_identity_1"
+  name                = "acctest_identity_1"
 }
 
 resource "azurerm_mssql_server" "test" {
@@ -894,7 +894,7 @@ data "azurerm_client_config" "test" {}
 resource "azurerm_user_assigned_identity" "test" {
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  name                = "test_identity_1"
+  name                = "acctest_identity_1"
 }
 
 resource "azurerm_mssql_server" "test" {

--- a/internal/services/mssql/mssql_server_resource_test.go
+++ b/internal/services/mssql/mssql_server_resource_test.go
@@ -872,14 +872,15 @@ func (r MssqlServerResource) azureadAuthenticationOnlyWithPolicy(data acceptance
 	policyAssignment := ""
 	if enablePolicy {
 		policyAssignment = `
-data "azurerm_policy_definition" "test" {
-  display_name = "Azure SQL Database should have Microsoft Entra-only authentication enabled during creation"
+data "azurerm_policy_definition_built_in" "test" {
+  # Azure SQL built-in policy definition: https://learn.microsoft.com/azure/azure-sql/database/policy-reference
+  name = "abda6d70-9778-44e7-84a8-06713e6db027"
 }
 
 resource "azurerm_resource_group_policy_assignment" "test" {
   name                 = "acctestpa-mssql"
   resource_group_id    = azurerm_resource_group.test.id
-  policy_definition_id = data.azurerm_policy_definition.test.id
+  policy_definition_id = data.azurerm_policy_definition_built_in.test.id
 }
 `
 	}


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->
Use `UpdateThenPoll()` to do update instead of `CreateOrUpdateThenPoll()`.

There is a bug reported internally. 
When the server is created with `azuread_authentication_only = false`, then enable an Azure policy `Azure SQL Database should have Microsoft Entra-only authentication enabled during creation`, then try to update `azuread_authentication_only = true` will be forbidden by the policy since the first PUT request carry the out-of-dated value of `azuread_authentication_only` (false)

The first `CreateOrUpdateThenPoll()` in the old code still includes old value (false) of `azuread_authentication_only`,  and was blocked by the policy.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<img width="1169" height="885" alt="image" src="https://github.com/user-attachments/assets/59617547-6222-4258-9342-363ce1742951" />

The failed one is as same as the failure on `main`
<img width="1662" height="1021" alt="image" src="https://github.com/user-attachments/assets/3c9e2e00-5eed-4d23-bbd2-3c848d7f92b7" />

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_mssql_server` - use `PATCH` to do update instead of `PUT` [GH-31901]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

Used AI to review changes.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
