### PR TITLE
[Contributor Docs:] Clarify reference documentation standards

### DIFF
--- a/contributing/topics/reference-documentation-standards.md
+++ b/contributing/topics/reference-documentation-standards.md
@@ -20,20 +20,8 @@ Each resource/data source must include an example, general guidelines for exampl
 The following conventions apply to code fences:
 
 - Use the most specific code fence language that matches the snippet.
-- Avoid unlabeled fences unless there is a strong reason to omit the language.
 - Terraform configuration should use `hcl` code fences. Do not use `terraform` code fences for HCL configuration blocks.
-- Terraform CLI commands (`terraform init`, `terraform plan`, `terraform apply`, `terraform import`, `terraform state`, etc.) should use `shell` code fences.
-- CLI transcripts containing commands and output together should use `shell` or `bash`.
-- Bash scripts and POSIX shell examples should use `bash`.
-- PowerShell snippets should use `powershell`.
-- JSON snippets should use `json`.
-- YAML snippets should use `yaml`.
-- Markdown examples should use `markdown`.
-- Generic plain text output or logs where no language fits should use `text`.
-
 - Keep Terraform examples copy/pasteable and self-contained.
-- Use `hcl` for the configuration itself and `shell` for the commands used to run it.
-- Do not default everything to `shell` when a more specific fence language fits the content.
 
 ## Arguments
 
@@ -53,7 +41,7 @@ Arguments in the documentation are expected to be ordered as follows:
 The following conventions apply to argument descriptions:
 
 - Descriptions should be concise, avoid adding too much detail, links to external documentation, etc. If more detail must be added, use a [note](#notes).
-- If an argument has `ForceNew: true`, its description must end with `Changing this forces a new <resource name> to be created.`
+- If an argument has `ForceNew: true`, its description must end with `Changing this forces a new resource to be created.`
 - If the argument has validation allowing only specific inputs, e.g. `validation.StringInSlice()`, these must be documented using `` Possible values are `value1`, `value2`, and `value3. ``. Other common entries include:
   - Arguments with a single allowed value: `` The only possible value is `value1`. ``
   - Arguments allowing a range of values, e.g. `validation.IntBetween()`: `` Possible values range between `1` and `100`. ``


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This updates the contributor reference documentation standards to make several existing conventions explicit and easier to apply consistently.

The main changes are:
- add a dedicated `Code Fences` section documenting the preferred fence language by content type, including `hcl` for Terraform configuration and `shell` for Terraform CLI commands
- clarify example naming guidance so example values should be simple, resource-appropriate, and valid for the field's naming restrictions and validation
- explicitly document ordering rules for nested block arguments and nested block attributes
- clarify block entry wording, including use of the correct indefinite article (`A` or `An`)
- clean up related wording and examples for consistency and readability

This is a documentation-only change intended to make contributor guidance clearer and reduce ambiguity during docs review.

## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [X] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [X] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

N/A

## Testing 

N/A

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

N/A

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [X] Enhancement
- [ ] Breaking Change


## Related Issue(s)

N/A


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [X] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
