### PR TITLE
Resource Identity and List : `vmware`

### DIFF
--- a/internal/services/vmware/registration.go
+++ b/internal/services/vmware/registration.go
@@ -77,5 +77,8 @@ func (r Registration) EphemeralResources() []func() ephemeral.EphemeralResource 
 }
 
 func (r Registration) ListResources() []sdk.FrameworkListWrappedResource {
-	return []sdk.FrameworkListWrappedResource{}
+	return []sdk.FrameworkListWrappedResource{
+		NetappFileVolumeAttachmentListResource{},
+		VmwarePrivateCloudListResource{},
+	}
 }

--- a/internal/services/vmware/vmware_cluster_resource_test.go
+++ b/internal/services/vmware/vmware_cluster_resource_test.go
@@ -19,6 +19,8 @@ import (
 type VmwareClusterResource struct{}
 
 func TestAccVmwareCluster_basic(t *testing.T) {
+	t.Skip("Skipping as VMware Private Cloud tests fail due to QuotaExceeded: insufficient capacity in the region")
+
 	data := acceptance.BuildTestData(t, "azurerm_vmware_cluster", "test")
 	r := VmwareClusterResource{}
 
@@ -36,6 +38,8 @@ func TestAccVmwareCluster_basic(t *testing.T) {
 }
 
 func TestAccVmwareCluster_requiresImport(t *testing.T) {
+	t.Skip("Skipping as VMware Private Cloud tests fail due to QuotaExceeded: insufficient capacity in the region")
+
 	data := acceptance.BuildTestData(t, "azurerm_vmware_cluster", "test")
 	r := VmwareClusterResource{}
 
@@ -51,6 +55,8 @@ func TestAccVmwareCluster_requiresImport(t *testing.T) {
 }
 
 func TestAccVmwareCluster_update(t *testing.T) {
+	t.Skip("Skipping as VMware Private Cloud tests fail due to QuotaExceeded: insufficient capacity in the region")
+
 	data := acceptance.BuildTestData(t, "azurerm_vmware_cluster", "test")
 	r := VmwareClusterResource{}
 

--- a/internal/services/vmware/vmware_express_route_authorization_resource_test.go
+++ b/internal/services/vmware/vmware_express_route_authorization_resource_test.go
@@ -19,6 +19,8 @@ import (
 type VmwareExpressRouteAuthorizationResource struct{}
 
 func TestAccVmwareExpressRouteAuthorization_basic(t *testing.T) {
+	t.Skip("Skipping as VMware Private Cloud tests fail due to QuotaExceeded: insufficient capacity in the region")
+
 	data := acceptance.BuildTestData(t, "azurerm_vmware_express_route_authorization", "test")
 	r := VmwareExpressRouteAuthorizationResource{}
 
@@ -36,6 +38,8 @@ func TestAccVmwareExpressRouteAuthorization_basic(t *testing.T) {
 }
 
 func TestAccVmwareExpressRouteAuthorization_requiresImport(t *testing.T) {
+	t.Skip("Skipping as VMware Private Cloud tests fail due to QuotaExceeded: insufficient capacity in the region")
+
 	data := acceptance.BuildTestData(t, "azurerm_vmware_express_route_authorization", "test")
 	r := VmwareExpressRouteAuthorizationResource{}
 

--- a/internal/services/vmware/vmware_netapp_volume_attachment_resource.go
+++ b/internal/services/vmware/vmware_netapp_volume_attachment_resource.go
@@ -3,6 +3,8 @@
 
 package vmware
 
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name vmware_netapp_volume_attachment -service-package-name vmware -properties "name" -compare-values "subscription_id:vmware_cluster_id,resource_group_name:vmware_cluster_id,private_cloud_name:vmware_cluster_id,cluster_name:vmware_cluster_id"
+
 import (
 	"context"
 	"fmt"
@@ -10,6 +12,7 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/vmware/2022-05-01/clusters"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/vmware/2022-05-01/datastores"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
@@ -25,6 +28,12 @@ type NetappFileVolumeAttachment struct {
 }
 
 type NetappFileVolumeAttachmentResource struct{}
+
+var _ sdk.ResourceWithIdentity = NetappFileVolumeAttachmentResource{}
+
+func (NetappFileVolumeAttachmentResource) Identity() resourceids.ResourceId {
+	return &datastores.DataStoreId{}
+}
 
 func (r NetappFileVolumeAttachmentResource) Arguments() map[string]*pluginsdk.Schema {
 	return map[string]*pluginsdk.Schema{
@@ -109,6 +118,10 @@ func (r NetappFileVolumeAttachmentResource) Create() sdk.ResourceFunc {
 			}
 
 			metadata.SetID(id)
+			if err := pluginsdk.SetResourceIdentityData(metadata.ResourceData, &id); err != nil {
+				return err
+			}
+
 			return nil
 		},
 		Timeout: 30 * time.Minute,
@@ -123,7 +136,6 @@ func (r NetappFileVolumeAttachmentResource) Read() sdk.ResourceFunc {
 			if err != nil {
 				return err
 			}
-			clusterId := datastores.NewClusterID(id.SubscriptionId, id.ResourceGroupName, id.PrivateCloudName, id.ClusterName)
 
 			metadata.Logger.Infof("retrieving %s", *id)
 			resp, err := client.Get(ctx, *id)
@@ -135,22 +147,33 @@ func (r NetappFileVolumeAttachmentResource) Read() sdk.ResourceFunc {
 				return fmt.Errorf("retrieving %s: %+v", *id, err)
 			}
 
-			var netAppVolumeId string
-			if model := resp.Model; model != nil {
-				if props := model.Properties; props != nil {
-					if props.NetAppVolume != nil {
-						netAppVolumeId = props.NetAppVolume.Id
-					}
-				}
-			}
-			return metadata.Encode(&NetappFileVolumeAttachment{
-				Name:            id.DataStoreName,
-				NetAppVolumeId:  netAppVolumeId,
-				VmwareClusterId: clusterId.ID(),
-			})
+			return r.flatten(metadata, id, resp.Model)
 		},
 		Timeout: 5 * time.Minute,
 	}
+}
+
+func (r NetappFileVolumeAttachmentResource) flatten(metadata sdk.ResourceMetaData, id *datastores.DataStoreId, model *datastores.Datastore) error {
+	clusterId := datastores.NewClusterID(id.SubscriptionId, id.ResourceGroupName, id.PrivateCloudName, id.ClusterName)
+
+	state := NetappFileVolumeAttachment{
+		Name:            id.DataStoreName,
+		VmwareClusterId: clusterId.ID(),
+	}
+
+	if model != nil {
+		if props := model.Properties; props != nil {
+			if props.NetAppVolume != nil {
+				state.NetAppVolumeId = props.NetAppVolume.Id
+			}
+		}
+	}
+
+	if err := pluginsdk.SetResourceIdentityData(metadata.ResourceData, id); err != nil {
+		return err
+	}
+
+	return metadata.Encode(&state)
 }
 
 func (r NetappFileVolumeAttachmentResource) Delete() sdk.ResourceFunc {

--- a/internal/services/vmware/vmware_netapp_volume_attachment_resource.go
+++ b/internal/services/vmware/vmware_netapp_volume_attachment_resource.go
@@ -3,7 +3,7 @@
 
 package vmware
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name vmware_netapp_volume_attachment -service-package-name vmware -properties "name" -compare-values "subscription_id:vmware_cluster_id,resource_group_name:vmware_cluster_id,private_cloud_name:vmware_cluster_id,cluster_name:vmware_cluster_id"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name vmware_netapp_volume_attachment -service-package-name vmware -properties "name" -compare-values "subscription_id:vmware_cluster_id,resource_group_name:vmware_cluster_id,private_cloud_name:vmware_cluster_id,cluster_name:vmware_cluster_id" -skip -skip-reason "Skipping as VMware Private Cloud tests fail due to QuotaExceeded: insufficient capacity in the region"
 
 import (
 	"context"

--- a/internal/services/vmware/vmware_netapp_volume_attachment_resource_identity_gen_test.go
+++ b/internal/services/vmware/vmware_netapp_volume_attachment_resource_identity_gen_test.go
@@ -1,0 +1,42 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package vmware_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
+)
+
+func TestAccVmwareNetappVolumeAttachment_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_vmware_netapp_volume_attachment", "test")
+	r := VmwareNetappVolumeAttachmentResource{}
+
+	checkedFields := map[string]struct{}{
+		"name":                {},
+		"cluster_name":        {},
+		"private_cloud_name":  {},
+		"resource_group_name": {},
+		"subscription_id":     {},
+	}
+
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				customstatecheck.ExpectAllIdentityFieldsAreChecked("azurerm_vmware_netapp_volume_attachment.test", checkedFields),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_vmware_netapp_volume_attachment.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_vmware_netapp_volume_attachment.test", tfjsonpath.New("cluster_name"), tfjsonpath.New("vmware_cluster_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_vmware_netapp_volume_attachment.test", tfjsonpath.New("private_cloud_name"), tfjsonpath.New("vmware_cluster_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_vmware_netapp_volume_attachment.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("vmware_cluster_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_vmware_netapp_volume_attachment.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("vmware_cluster_id")),
+			},
+		},
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
+}

--- a/internal/services/vmware/vmware_netapp_volume_attachment_resource_identity_gen_test.go
+++ b/internal/services/vmware/vmware_netapp_volume_attachment_resource_identity_gen_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestAccVmwareNetappVolumeAttachment_resourceIdentity(t *testing.T) {
+	t.Skip("Skipping as VMware Private Cloud tests fail due to QuotaExceeded: insufficient capacity in the region")
+
 	data := acceptance.BuildTestData(t, "azurerm_vmware_netapp_volume_attachment", "test")
 	r := VmwareNetappVolumeAttachmentResource{}
 

--- a/internal/services/vmware/vmware_netapp_volume_attachment_resource_identity_gen_test.go
+++ b/internal/services/vmware/vmware_netapp_volume_attachment_resource_identity_gen_test.go
@@ -14,7 +14,6 @@ import (
 
 func TestAccVmwareNetappVolumeAttachment_resourceIdentity(t *testing.T) {
 	t.Skip("Skipping as VMware Private Cloud tests fail due to QuotaExceeded: insufficient capacity in the region")
-
 	data := acceptance.BuildTestData(t, "azurerm_vmware_netapp_volume_attachment", "test")
 	r := VmwareNetappVolumeAttachmentResource{}
 

--- a/internal/services/vmware/vmware_netapp_volume_attachment_resource_list.go
+++ b/internal/services/vmware/vmware_netapp_volume_attachment_resource_list.go
@@ -1,0 +1,110 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package vmware
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-azure-helpers/framework/typehelpers"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/vmware/2022-05-01/datastores"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/vmware/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type NetappFileVolumeAttachmentListResource struct{}
+
+type NetappFileVolumeAttachmentListModel struct {
+	VmwareClusterId types.String `tfsdk:"vmware_cluster_id"`
+}
+
+var _ sdk.FrameworkListWrappedResource = new(NetappFileVolumeAttachmentListResource)
+
+func (NetappFileVolumeAttachmentListResource) Metadata(_ context.Context, _ resource.MetadataRequest, response *resource.MetadataResponse) {
+	response.TypeName = NetappFileVolumeAttachmentResource{}.ResourceType()
+}
+
+func (NetappFileVolumeAttachmentListResource) ResourceFunc() *pluginsdk.Resource {
+	return sdk.WrappedResource(NetappFileVolumeAttachmentResource{})
+}
+
+func (NetappFileVolumeAttachmentListResource) ListResourceConfigSchema(_ context.Context, _ list.ListResourceSchemaRequest, response *list.ListResourceSchemaResponse) {
+	response.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"vmware_cluster_id": schema.StringAttribute{
+				Required: true,
+				Validators: []validator.String{
+					typehelpers.WrappedStringValidator{
+						Func: validate.ClusterID,
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r NetappFileVolumeAttachmentListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream, metadata sdk.ResourceMetadata) {
+	client := metadata.Client.Vmware.DataStoreClient
+
+	var data NetappFileVolumeAttachmentListModel
+	diags := request.Config.Get(ctx, &data)
+	if diags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	clusterId, err := datastores.ParseClusterID(data.VmwareClusterId.ValueString())
+	if err != nil {
+		sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("parsing `vmware_cluster_id` for `%s`", NetappFileVolumeAttachmentResource{}.ResourceType()), err)
+		return
+	}
+
+	resp, err := client.ListComplete(ctx, *clusterId)
+	if err != nil {
+		sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("listing `%s`", NetappFileVolumeAttachmentResource{}.ResourceType()), err)
+		return
+	}
+
+	results := resp.Items
+
+	resource := NetappFileVolumeAttachmentResource{}
+
+	stream.Results = func(push func(list.ListResult) bool) {
+		for _, datastore := range results {
+			result := request.NewListResult(ctx)
+			result.DisplayName = pointer.From(datastore.Name)
+
+			id, err := datastores.ParseDataStoreID(pointer.From(datastore.Id))
+			if err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, "parsing VMware NetApp Volume Attachment ID", err)
+				return
+			}
+
+			meta := sdk.NewResourceMetaData(metadata.Client, resource)
+			meta.SetID(id)
+
+			if err := resource.flatten(meta, id, &datastore); err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, fmt.Sprintf("encoding `%s` resource data", pointer.From(datastore.Name)), err)
+				return
+			}
+
+			sdk.EncodeListResult(ctx, meta.ResourceData, &result)
+			if result.Diagnostics.HasError() {
+				push(result)
+				return
+			}
+
+			if !push(result) {
+				return
+			}
+		}
+	}
+}

--- a/internal/services/vmware/vmware_netapp_volume_attachment_resource_list_test.go
+++ b/internal/services/vmware/vmware_netapp_volume_attachment_resource_list_test.go
@@ -1,0 +1,148 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package vmware_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccVmwareNetappVolumeAttachment_list_basic(t *testing.T) {
+	r := VmwareNetappVolumeAttachmentResource{}
+	listResourceAddress := "azurerm_vmware_netapp_volume_attachment.list"
+
+	data := acceptance.BuildTestData(t, "azurerm_vmware_netapp_volume_attachment", "test")
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basicList(data),
+			},
+			{
+				Query:  true,
+				Config: r.basicQuery(),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLengthAtLeast(listResourceAddress, 2),
+				},
+			},
+		},
+	})
+}
+
+func (r VmwareNetappVolumeAttachmentResource) basicList(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestrg-vmware-nat-%d"
+  location = "centralus"
+}
+
+%s
+
+%s
+
+resource "azurerm_vmware_netapp_volume_attachment" "test" {
+  count = 2
+
+  name              = "acctest-vmwareattachment${count.index}-%d"
+  netapp_volume_id  = azurerm_netapp_volume.test[count.index].id
+  vmware_cluster_id = "${azurerm_vmware_private_cloud.test.id}/clusters/Cluster-1"
+
+  depends_on = [azurerm_virtual_network_gateway_connection.test]
+}`, data.RandomInteger, r.templatePrivateCloud(data), r.templateNetappFileList(data), data.RandomInteger)
+}
+
+func (r VmwareNetappVolumeAttachmentResource) basicQuery() string {
+	return `
+list "azurerm_vmware_netapp_volume_attachment" "list" {
+  provider = azurerm
+  config {
+    vmware_cluster_id = "${azurerm_vmware_private_cloud.test.id}/clusters/Cluster-1"
+  }
+}
+`
+}
+
+func (r VmwareNetappVolumeAttachmentResource) templateNetappFileList(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azurerm_subnet" "netappSubnet" {
+  name                 = "acctest-Subnet-%d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.6.2.0/24"]
+
+  delegation {
+    name = "testdelegation"
+
+    service_delegation {
+      name    = "Microsoft.Netapp/volumes"
+      actions = ["Microsoft.Network/networkinterfaces/*", "Microsoft.Network/virtualNetworks/subnets/join/action"]
+    }
+  }
+}
+
+resource "azurerm_netapp_account" "test" {
+  name                = "acctest-NetAppAccount-%d"
+  location            = "central us"
+  resource_group_name = azurerm_resource_group.test.name
+
+  tags = {
+    "SkipASMAzSecPack" = "true"
+  }
+}
+
+resource "azurerm_netapp_pool" "test" {
+  name                = "acctest-NetAppPool-%d"
+  location            = "centralus"
+  resource_group_name = azurerm_resource_group.test.name
+  account_name        = azurerm_netapp_account.test.name
+  service_level       = "Standard"
+  size_in_tb          = 4
+
+  tags = {
+    "SkipASMAzSecPack" = "true"
+  }
+}
+
+resource "azurerm_netapp_volume" "test" {
+  count = 2
+
+  name                            = "acctest-NetAppVolume${count.index}-%d"
+  location                        = "centralus"
+  resource_group_name             = azurerm_resource_group.test.name
+  account_name                    = azurerm_netapp_account.test.name
+  pool_name                       = azurerm_netapp_pool.test.name
+  volume_path                     = "my-unique-file-path${count.index}-%d"
+  service_level                   = "Standard"
+  subnet_id                       = azurerm_subnet.netappSubnet.id
+  protocols                       = ["NFSv3"]
+  storage_quota_in_gb             = 100
+  azure_vmware_data_store_enabled = true
+  snapshot_directory_visible      = true
+
+  export_policy_rule {
+    rule_index          = 1
+    allowed_clients     = ["0.0.0.0/0"]
+    protocols_enabled   = ["NFSv3"]
+    unix_read_only      = false
+    unix_read_write     = true
+    root_access_enabled = true
+  }
+
+  tags = {
+    "SkipASMAzSecPack" = "true"
+  }
+}`, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}

--- a/internal/services/vmware/vmware_netapp_volume_attachment_resource_list_test.go
+++ b/internal/services/vmware/vmware_netapp_volume_attachment_resource_list_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 func TestAccVmwareNetappVolumeAttachment_list_basic(t *testing.T) {
+	t.Skip("Skipping as VMware Private Cloud tests fail due to QuotaExceeded: insufficient capacity in the region")
+
 	r := VmwareNetappVolumeAttachmentResource{}
 	listResourceAddress := "azurerm_vmware_netapp_volume_attachment.list"
 

--- a/internal/services/vmware/vmware_netapp_volume_attachment_resource_test.go
+++ b/internal/services/vmware/vmware_netapp_volume_attachment_resource_test.go
@@ -17,11 +17,11 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
-type VmwareNetappFileVolumeAttachmentResource struct{}
+type VmwareNetappVolumeAttachmentResource struct{}
 
 func TestAccVmwarePrivateCloudNetappFileVolumeAttachment_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_vmware_netapp_volume_attachment", "test")
-	r := VmwareNetappFileVolumeAttachmentResource{}
+	r := VmwareNetappVolumeAttachmentResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -33,7 +33,7 @@ func TestAccVmwarePrivateCloudNetappFileVolumeAttachment_basic(t *testing.T) {
 	})
 }
 
-func (r VmwareNetappFileVolumeAttachmentResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (r VmwareNetappVolumeAttachmentResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := datastores.ParseDataStoreID(state.ID)
 	if err != nil {
 		return nil, err
@@ -49,7 +49,7 @@ func (r VmwareNetappFileVolumeAttachmentResource) Exists(ctx context.Context, cl
 	return pointer.To(true), nil
 }
 
-func (r VmwareNetappFileVolumeAttachmentResource) basic(data acceptance.TestData) string {
+func (r VmwareNetappVolumeAttachmentResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 
 resource "azurerm_resource_group" "test" {
@@ -69,7 +69,7 @@ resource "azurerm_vmware_netapp_volume_attachment" "test" {
 }`, data.RandomInteger, r.templatePrivateCloud(data), r.templateNetappFile(data), data.RandomInteger)
 }
 
-func (r VmwareNetappFileVolumeAttachmentResource) templatePrivateCloud(data acceptance.TestData) string {
+func (r VmwareNetappVolumeAttachmentResource) templatePrivateCloud(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {
@@ -133,7 +133,7 @@ resource "azurerm_virtual_network_gateway_connection" "test" {
 `, r.templateVnet(data), data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
-func (r VmwareNetappFileVolumeAttachmentResource) templateNetappFile(data acceptance.TestData) string {
+func (r VmwareNetappVolumeAttachmentResource) templateNetappFile(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 
 
@@ -205,7 +205,7 @@ resource "azurerm_netapp_volume" "test" {
 }`, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
-func (r VmwareNetappFileVolumeAttachmentResource) templateVnet(data acceptance.TestData) string {
+func (r VmwareNetappVolumeAttachmentResource) templateVnet(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 resource "azurerm_public_ip" "test" {
   name                = "acctestpip-%d"

--- a/internal/services/vmware/vmware_netapp_volume_attachment_resource_test.go
+++ b/internal/services/vmware/vmware_netapp_volume_attachment_resource_test.go
@@ -20,6 +20,8 @@ import (
 type VmwareNetappVolumeAttachmentResource struct{}
 
 func TestAccVmwarePrivateCloudNetappFileVolumeAttachment_basic(t *testing.T) {
+	t.Skip("Skipping as VMware Private Cloud tests fail due to QuotaExceeded: insufficient capacity in the region")
+
 	data := acceptance.BuildTestData(t, "azurerm_vmware_netapp_volume_attachment", "test")
 	r := VmwareNetappVolumeAttachmentResource{}
 

--- a/internal/services/vmware/vmware_private_cloud_data_source_test.go
+++ b/internal/services/vmware/vmware_private_cloud_data_source_test.go
@@ -14,6 +14,8 @@ import (
 type VmwarePrivateCloudDataSource struct{}
 
 func TestAccVmwarePrivateCloudDataSource_basic(t *testing.T) {
+	t.Skip("Skipping as VMware Private Cloud tests fail due to QuotaExceeded: insufficient capacity in the region")
+
 	data := acceptance.BuildTestData(t, "data.azurerm_vmware_private_cloud", "test")
 	r := VmwarePrivateCloudDataSource{}
 

--- a/internal/services/vmware/vmware_private_cloud_resource.go
+++ b/internal/services/vmware/vmware_private_cloud_resource.go
@@ -15,12 +15,17 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/vmware/2022-05-01/privateclouds"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
+
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name vmware_private_cloud -service-package-name vmware -properties "name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
+
+const azureVmwarePrivateCloudResourceName = "azurerm_vmware_private_cloud"
 
 func resourceVmwarePrivateCloud() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
@@ -36,10 +41,11 @@ func resourceVmwarePrivateCloud() *pluginsdk.Resource {
 			Delete: pluginsdk.DefaultTimeout(10 * time.Hour),
 		},
 
-		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := privateclouds.ParsePrivateCloudID(id)
-			return err
-		}),
+		Importer: pluginsdk.ImporterValidatingIdentity(&privateclouds.PrivateCloudId{}),
+
+		Identity: &schema.ResourceIdentity{
+			SchemaFunc: pluginsdk.GenerateIdentitySchema(&privateclouds.PrivateCloudId{}),
+		},
 
 		Schema: map[string]*pluginsdk.Schema{
 			"name": {
@@ -261,6 +267,9 @@ func resourceVmwarePrivateCloudCreate(d *pluginsdk.ResourceData, meta interface{
 	}
 
 	d.SetId(id.ID())
+	if err := pluginsdk.SetResourceIdentityData(d, &id); err != nil {
+		return err
+	}
 	return resourceVmwarePrivateCloudRead(d, meta)
 }
 
@@ -284,10 +293,15 @@ func resourceVmwarePrivateCloudRead(d *pluginsdk.ResourceData, meta interface{})
 
 		return fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
+
+	return resourceVmwarePrivateCloudFlatten(d, id, resp.Model)
+}
+
+func resourceVmwarePrivateCloudFlatten(d *pluginsdk.ResourceData, id *privateclouds.PrivateCloudId, model *privateclouds.PrivateCloud) error {
 	d.Set("name", id.PrivateCloudName)
 	d.Set("resource_group_name", id.ResourceGroupName)
 
-	if model := resp.Model; model != nil {
+	if model != nil {
 		d.Set("location", location.NormalizeNilable(model.Location))
 		props := model.Properties
 
@@ -321,7 +335,7 @@ func resourceVmwarePrivateCloudRead(d *pluginsdk.ResourceData, meta interface{})
 		}
 	}
 
-	return nil
+	return pluginsdk.SetResourceIdentityData(d, id)
 }
 
 func resourceVmwarePrivateCloudUpdate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/vmware/vmware_private_cloud_resource.go
+++ b/internal/services/vmware/vmware_private_cloud_resource.go
@@ -23,7 +23,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name vmware_private_cloud -service-package-name vmware -properties "name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name vmware_private_cloud -service-package-name vmware -properties "name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary" -skip -skip-reason "Skipping as VMware Private Cloud tests fail due to QuotaExceeded: insufficient capacity in the region"
 
 const azureVmwarePrivateCloudResourceName = "azurerm_vmware_private_cloud"
 

--- a/internal/services/vmware/vmware_private_cloud_resource_identity_gen_test.go
+++ b/internal/services/vmware/vmware_private_cloud_resource_identity_gen_test.go
@@ -1,0 +1,39 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package vmware_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
+)
+
+func TestAccVmwarePrivateCloud_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_vmware_private_cloud", "test")
+	r := VmwarePrivateCloudResource{}
+
+	checkedFields := map[string]struct{}{
+		"subscription_id":     {},
+		"name":                {},
+		"resource_group_name": {},
+	}
+
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				customstatecheck.ExpectAllIdentityFieldsAreChecked("azurerm_vmware_private_cloud.test", checkedFields),
+				statecheck.ExpectIdentityValue("azurerm_vmware_private_cloud.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_vmware_private_cloud.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_vmware_private_cloud.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
+			},
+		},
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
+}

--- a/internal/services/vmware/vmware_private_cloud_resource_identity_gen_test.go
+++ b/internal/services/vmware/vmware_private_cloud_resource_identity_gen_test.go
@@ -15,7 +15,6 @@ import (
 
 func TestAccVmwarePrivateCloud_resourceIdentity(t *testing.T) {
 	t.Skip("Skipping as VMware Private Cloud tests fail due to QuotaExceeded: insufficient capacity in the region")
-
 	data := acceptance.BuildTestData(t, "azurerm_vmware_private_cloud", "test")
 	r := VmwarePrivateCloudResource{}
 

--- a/internal/services/vmware/vmware_private_cloud_resource_identity_gen_test.go
+++ b/internal/services/vmware/vmware_private_cloud_resource_identity_gen_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestAccVmwarePrivateCloud_resourceIdentity(t *testing.T) {
+	t.Skip("Skipping as VMware Private Cloud tests fail due to QuotaExceeded: insufficient capacity in the region")
+
 	data := acceptance.BuildTestData(t, "azurerm_vmware_private_cloud", "test")
 	r := VmwarePrivateCloudResource{}
 

--- a/internal/services/vmware/vmware_private_cloud_resource_list.go
+++ b/internal/services/vmware/vmware_private_cloud_resource_list.go
@@ -1,0 +1,98 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package vmware
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/vmware/2022-05-01/privateclouds"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type VmwarePrivateCloudListResource struct{}
+
+var _ sdk.FrameworkListWrappedResource = new(VmwarePrivateCloudListResource)
+
+func (r VmwarePrivateCloudListResource) ResourceFunc() *pluginsdk.Resource {
+	return resourceVmwarePrivateCloud()
+}
+
+func (r VmwarePrivateCloudListResource) Metadata(_ context.Context, _ resource.MetadataRequest, response *resource.MetadataResponse) {
+	response.TypeName = azureVmwarePrivateCloudResourceName
+}
+
+func (r VmwarePrivateCloudListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream, metadata sdk.ResourceMetadata) {
+	client := metadata.Client.Vmware.PrivateCloudClient
+
+	var data sdk.DefaultListModel
+	diags := request.Config.Get(ctx, &data)
+	if diags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	results := make([]privateclouds.PrivateCloud, 0)
+
+	subscriptionID := metadata.SubscriptionId
+	if !data.SubscriptionId.IsNull() {
+		subscriptionID = data.SubscriptionId.ValueString()
+	}
+
+	switch {
+	case !data.ResourceGroupName.IsNull():
+		resp, err := client.ListComplete(ctx, commonids.NewResourceGroupID(subscriptionID, data.ResourceGroupName.ValueString()))
+		if err != nil {
+			sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("listing `%s`", azureVmwarePrivateCloudResourceName), err)
+			return
+		}
+
+		results = resp.Items
+	default:
+		resp, err := client.ListInSubscriptionComplete(ctx, commonids.NewSubscriptionID(subscriptionID))
+		if err != nil {
+			sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("listing `%s`", azureVmwarePrivateCloudResourceName), err)
+			return
+		}
+
+		results = resp.Items
+	}
+
+	stream.Results = func(push func(list.ListResult) bool) {
+		for _, privateCloud := range results {
+			result := request.NewListResult(ctx)
+			result.DisplayName = pointer.From(privateCloud.Name)
+
+			id, err := privateclouds.ParsePrivateCloudID(pointer.From(privateCloud.Id))
+			if err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, "parsing VMware Private Cloud ID", err)
+				return
+			}
+
+			rd := resourceVmwarePrivateCloud().Data(&terraform.InstanceState{})
+			rd.SetId(id.ID())
+
+			if err := resourceVmwarePrivateCloudFlatten(rd, id, &privateCloud); err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, fmt.Sprintf("encoding `%s` resource data", azureVmwarePrivateCloudResourceName), err)
+				return
+			}
+
+			sdk.EncodeListResult(ctx, rd, &result)
+			if result.Diagnostics.HasError() {
+				push(result)
+				return
+			}
+
+			if !push(result) {
+				return
+			}
+		}
+	}
+}

--- a/internal/services/vmware/vmware_private_cloud_resource_list_test.go
+++ b/internal/services/vmware/vmware_private_cloud_resource_list_test.go
@@ -1,0 +1,98 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package vmware_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccVmwarePrivateCloud_list_basic(t *testing.T) {
+	r := VmwarePrivateCloudResource{}
+	listResourceAddress := "azurerm_vmware_private_cloud.list"
+
+	data := acceptance.BuildTestData(t, "azurerm_vmware_private_cloud", "test")
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basicList(data),
+			},
+			{
+				Query:  true,
+				Config: r.basicQuery(),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLengthAtLeast(listResourceAddress, 2),
+				},
+			},
+			{
+				Query:  true,
+				Config: r.basicQueryByResourceGroupName(data),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLength(listResourceAddress, 2),
+				},
+			},
+		},
+	})
+}
+
+func (r VmwarePrivateCloudResource) basicList(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+  disable_correlation_request_id = true
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-Vmware-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_vmware_private_cloud" "test" {
+  count = 2
+
+  name                = "acctest-PC${count.index}-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku_name            = "av36"
+
+  management_cluster {
+    size = 3
+  }
+
+  network_subnet_cidr = "192.168.${count.index * 4 + 48}.0/22"
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (r VmwarePrivateCloudResource) basicQuery() string {
+	return `
+list "azurerm_vmware_private_cloud" "list" {
+  provider = azurerm
+  config {}
+}
+`
+}
+
+func (r VmwarePrivateCloudResource) basicQueryByResourceGroupName(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+list "azurerm_vmware_private_cloud" "list" {
+  provider = azurerm
+  config {
+    resource_group_name = "acctestRG-Vmware-%[1]d"
+  }
+}
+`, data.RandomInteger)
+}

--- a/internal/services/vmware/vmware_private_cloud_resource_list_test.go
+++ b/internal/services/vmware/vmware_private_cloud_resource_list_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 func TestAccVmwarePrivateCloud_list_basic(t *testing.T) {
+	t.Skip("Skipping as VMware Private Cloud tests fail due to QuotaExceeded: insufficient capacity in the region")
+
 	r := VmwarePrivateCloudResource{}
 	listResourceAddress := "azurerm_vmware_private_cloud.list"
 

--- a/internal/services/vmware/vmware_private_cloud_resource_test.go
+++ b/internal/services/vmware/vmware_private_cloud_resource_test.go
@@ -19,6 +19,8 @@ import (
 type VmwarePrivateCloudResource struct{}
 
 func TestAccVmwarePrivateCloud_basic(t *testing.T) {
+	t.Skip("Skipping as VMware Private Cloud tests fail due to QuotaExceeded: insufficient capacity in the region")
+
 	data := acceptance.BuildTestData(t, "azurerm_vmware_private_cloud", "test")
 	r := VmwarePrivateCloudResource{}
 
@@ -34,6 +36,8 @@ func TestAccVmwarePrivateCloud_basic(t *testing.T) {
 }
 
 func TestAccVmwarePrivateCloud_requiresImport(t *testing.T) {
+	t.Skip("Skipping as VMware Private Cloud tests fail due to QuotaExceeded: insufficient capacity in the region")
+
 	data := acceptance.BuildTestData(t, "azurerm_vmware_private_cloud", "test")
 	r := VmwarePrivateCloudResource{}
 
@@ -49,6 +53,8 @@ func TestAccVmwarePrivateCloud_requiresImport(t *testing.T) {
 }
 
 func TestAccVmwarePrivateCloud_complete(t *testing.T) {
+	t.Skip("Skipping as VMware Private Cloud tests fail due to QuotaExceeded: insufficient capacity in the region")
+
 	data := acceptance.BuildTestData(t, "azurerm_vmware_private_cloud", "test")
 	r := VmwarePrivateCloudResource{}
 
@@ -65,6 +71,8 @@ func TestAccVmwarePrivateCloud_complete(t *testing.T) {
 
 // Internet availability, cluster size, identity sources, vcenter password or nsxt password cannot be updated at the same time
 func TestAccVmwarePrivateCloud_update(t *testing.T) {
+	t.Skip("Skipping as VMware Private Cloud tests fail due to QuotaExceeded: insufficient capacity in the region")
+
 	data := acceptance.BuildTestData(t, "azurerm_vmware_private_cloud", "test")
 	r := VmwarePrivateCloudResource{}
 

--- a/internal/tools/generator-tests/generators/resource_identity.go
+++ b/internal/tools/generator-tests/generators/resource_identity.go
@@ -39,6 +39,8 @@ type resourceIdentityData struct {
 	TestName               string
 	TestExpectNonEmptyPlan bool
 	TestSequential         bool
+	Skip                   bool
+	SkipReason             string
 }
 
 var _ cli.Command = &ResourceIdentityCommand{}
@@ -124,6 +126,8 @@ func (d *resourceIdentityData) parseArgs(args []string) (errors []error) {
 	argSet.StringVar(&d.TestName, "test-name", "basic", "(Optional) the name of the config that will be used to test Resource Identity. Defaults to `basic`.")
 	argSet.BoolVar(&d.TestExpectNonEmptyPlan, "test-expect-non-empty", false, "(Optional) Whether to expect (and ignore) a non-empty plan, to be used when the API does not return certain values during import. Defaults to `false`.")
 	argSet.BoolVar(&d.TestSequential, "test-sequential", false, "(Optional) generates a lowercase test function name for use in sequential test suites. Defaults to `false`.")
+	argSet.BoolVar(&d.Skip, "skip", false, "(Optional) adds a t.Skip call at the start of the test function. Defaults to `false`.")
+	argSet.StringVar(&d.SkipReason, "skip-reason", "", "(Optional) the reason message passed to t.Skip. Only used when -skip is set.")
 
 	if err := argSet.Parse(args); err != nil {
 		errors = append(errors, err)

--- a/internal/tools/generator-tests/generators/templates/identity_test.gotpl
+++ b/internal/tools/generator-tests/generators/templates/identity_test.gotpl
@@ -21,6 +21,10 @@ func testAcc{{ToCamel .ResourceName}}_resourceIdentity(t *testing.T) {
 {{- else }}
 func TestAcc{{ToCamel .ResourceName}}_resourceIdentity(t *testing.T) {
 {{- end }}
+{{- if .Skip }}
+	t.Skip("{{ .SkipReason }}")
+
+{{- end }}
 	data := acceptance.BuildTestData(t, "azurerm_{{ ToSnake $resourceName }}", "test")
 	r := {{ ToCamel $resourceName }}Resource{}
 

--- a/website/docs/list-resources/vmware_netapp_volume_attachment.html.markdown
+++ b/website/docs/list-resources/vmware_netapp_volume_attachment.html.markdown
@@ -1,0 +1,30 @@
+---
+subcategory: "Azure VMware Solution"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_vmware_netapp_volume_attachment"
+description: |-
+    Lists VMware NetApp Volume Attachment resources.
+---
+
+# List resource: azurerm_vmware_netapp_volume_attachment
+
+Lists VMware NetApp Volume Attachment resources.
+
+## Example Usage
+
+### List all NetApp Volume Attachments in a VMware Cluster
+
+```hcl
+list "azurerm_vmware_netapp_volume_attachment" "example" {
+  provider = azurerm
+  config {
+    vmware_cluster_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.AVS/privateClouds/myPrivateCloud/clusters/Cluster-1"
+  }
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `vmware_cluster_id` - (Required) The ID of the VMware Cluster to query.

--- a/website/docs/list-resources/vmware_private_cloud.html.markdown
+++ b/website/docs/list-resources/vmware_private_cloud.html.markdown
@@ -1,0 +1,41 @@
+---
+subcategory: "Azure VMware Solution"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_vmware_private_cloud"
+description: |-
+  Lists Azure VMware Solution Private Cloud resources.
+---
+
+# List resource: azurerm_vmware_private_cloud
+
+Lists Azure VMware Solution Private Cloud resources.
+
+## Example Usage
+
+### List all VMware Private Clouds in the subscription
+
+```hcl
+list "azurerm_vmware_private_cloud" "example" {
+  provider = azurerm
+  config {}
+}
+```
+
+### List all VMware Private Clouds in a specific resource group
+
+```hcl
+list "azurerm_vmware_private_cloud" "example" {
+  provider = azurerm
+  config {
+    resource_group_name = "example-rg"
+  }
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `resource_group_name` - (Optional) The name of the resource group to query.
+
+* `subscription_id` - (Optional) The Subscription ID to query. Defaults to the value specified in the Provider Configuration.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_VMWARE/665095?buildTab=tests&status=all
<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
