### PR TITLE
consumption: convert budget resources to use typed models with Decode/Encode

### DIFF
--- a/internal/services/consumption/consumption_budget_base.go
+++ b/internal/services/consumption/consumption_budget_base.go
@@ -10,17 +10,49 @@ import (
 
 	"github.com/Azure/go-autorest/autorest/date"
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/consumption/2019-10-01/budgets"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/consumption/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type consumptionBudgetBaseResource struct{}
+
+// Shared nested model structs for consumption budget resources
+
+type ConsumptionBudgetFilterDimensionModel struct {
+	Name     string   `tfschema:"name"`
+	Operator string   `tfschema:"operator"`
+	Values   []string `tfschema:"values"`
+}
+
+type ConsumptionBudgetFilterTagModel struct {
+	Name     string   `tfschema:"name"`
+	Operator string   `tfschema:"operator"`
+	Values   []string `tfschema:"values"`
+}
+
+type ConsumptionBudgetFilterModel struct {
+	Dimension []ConsumptionBudgetFilterDimensionModel `tfschema:"dimension"`
+	Tag       []ConsumptionBudgetFilterTagModel       `tfschema:"tag"`
+}
+
+type ConsumptionBudgetTimePeriodModel struct {
+	StartDate string `tfschema:"start_date"`
+	EndDate   string `tfschema:"end_date"`
+}
+
+// Full notification model (subscription + resource group variants)
+type ConsumptionBudgetNotificationModel struct {
+	Enabled       bool     `tfschema:"enabled"`
+	Threshold     int64    `tfschema:"threshold"`
+	ThresholdType string   `tfschema:"threshold_type"`
+	Operator      string   `tfschema:"operator"`
+	ContactEmails []string `tfschema:"contact_emails"`
+	ContactGroups []string `tfschema:"contact_groups"`
+	ContactRoles  []string `tfschema:"contact_roles"`
+}
 
 func getDimensionNames() []string {
 	return []string{
@@ -252,81 +284,6 @@ func (br consumptionBudgetBaseResource) attributes() map[string]*pluginsdk.Schem
 	return map[string]*pluginsdk.Schema{}
 }
 
-func (br consumptionBudgetBaseResource) createFunc(resourceName, scopeFieldName string) sdk.ResourceFunc {
-	return sdk.ResourceFunc{
-		Timeout: 30 * time.Minute,
-		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
-			client := metadata.Client.Consumption.BudgetsClient
-
-			var err error
-			scope := metadata.ResourceData.Get(scopeFieldName).(string)
-
-			id := budgets.NewScopedBudgetID(scope, metadata.ResourceData.Get("name").(string))
-
-			existing, err := client.Get(ctx, id)
-			if err != nil {
-				if !response.WasNotFound(existing.HttpResponse) {
-					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
-				}
-			}
-
-			if !response.WasNotFound(existing.HttpResponse) {
-				return tf.ImportAsExistsError(resourceName, id.ID())
-			}
-
-			if err = createOrUpdateConsumptionBudget(ctx, client, metadata, id); err != nil {
-				return fmt.Errorf("creating %s: %+v", id, err)
-			}
-
-			metadata.SetID(id)
-			return nil
-		},
-	}
-}
-
-func (br consumptionBudgetBaseResource) readFunc(scopeFieldName string) sdk.ResourceFunc {
-	return sdk.ResourceFunc{
-		Timeout: 5 * time.Minute,
-		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
-			client := metadata.Client.Consumption.BudgetsClient
-			id, err := budgets.ParseScopedBudgetID(metadata.ResourceData.Id())
-			if err != nil {
-				return err
-			}
-
-			resp, err := client.Get(ctx, *id)
-			if err != nil {
-				if response.WasNotFound(resp.HttpResponse) {
-					return metadata.MarkAsGone(id)
-				}
-				return fmt.Errorf("reading %s, %+v", *id, err)
-			}
-
-			metadata.ResourceData.Set("name", id.BudgetName)
-			// lintignore:R001
-			metadata.ResourceData.Set(scopeFieldName, id.Scope)
-
-			if model := resp.Model; model != nil {
-				eTag := ""
-				if v := model.ETag; v != nil {
-					eTag = *v
-				}
-				metadata.ResourceData.Set("etag", eTag)
-
-				if props := model.Properties; props != nil {
-					metadata.ResourceData.Set("amount", props.Amount)
-					metadata.ResourceData.Set("time_grain", string(props.TimeGrain))
-					metadata.ResourceData.Set("time_period", flattenConsumptionBudgetTimePeriod(&props.TimePeriod))
-					metadata.ResourceData.Set("notification", flattenConsumptionBudgetNotifications(props.Notifications, scopeFieldName))
-					metadata.ResourceData.Set("filter", flattenConsumptionBudgetFilter(props.Filter))
-				}
-			}
-
-			return nil
-		},
-	}
-}
-
 func (br consumptionBudgetBaseResource) deleteFunc() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Timeout: 30 * time.Minute,
@@ -346,26 +303,6 @@ func (br consumptionBudgetBaseResource) deleteFunc() sdk.ResourceFunc {
 	}
 }
 
-func (br consumptionBudgetBaseResource) updateFunc() sdk.ResourceFunc {
-	return sdk.ResourceFunc{
-		Timeout: 30 * time.Minute,
-		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
-			client := metadata.Client.Consumption.BudgetsClient
-
-			id, err := budgets.ParseScopedBudgetID(metadata.ResourceData.Id())
-			if err != nil {
-				return err
-			}
-
-			if err = createOrUpdateConsumptionBudget(ctx, client, metadata, *id); err != nil {
-				return fmt.Errorf("updating %s: %+v", *id, err)
-			}
-
-			return nil
-		},
-	}
-}
-
 func (br consumptionBudgetBaseResource) importerFunc() sdk.ResourceRunFunc {
 	return func(ctx context.Context, metadata sdk.ResourceMetaData) error {
 		if _, err := budgets.ParseScopedBudgetID(metadata.ResourceData.Id()); err != nil {
@@ -376,250 +313,139 @@ func (br consumptionBudgetBaseResource) importerFunc() sdk.ResourceRunFunc {
 	}
 }
 
-func createOrUpdateConsumptionBudget(ctx context.Context, client *budgets.BudgetsClient, metadata sdk.ResourceMetaData, id budgets.ScopedBudgetId) error {
-	timePeriod, err := expandConsumptionBudgetTimePeriod(metadata.ResourceData.Get("time_period").([]interface{}))
-	if err != nil {
-		return fmt.Errorf("expanding `time_period`: %+v", err)
-	}
-
-	// The Consumption Budget API requires the category type field to be set in a budget's properties.
-	// 'Cost' is the only valid Budget type today according to the API spec.
-
-	parameters := budgets.Budget{
-		Name: pointer.To(id.BudgetName),
-		Properties: &budgets.BudgetProperties{
-			Amount:        metadata.ResourceData.Get("amount").(float64),
-			Category:      budgets.CategoryTypeCost,
-			Filter:        expandConsumptionBudgetFilter(metadata.ResourceData.Get("filter").([]interface{})),
-			Notifications: expandConsumptionBudgetNotifications(metadata.ResourceData.Get("notification").(*pluginsdk.Set).List()),
-			TimeGrain:     budgets.TimeGrainType(metadata.ResourceData.Get("time_grain").(string)),
-			TimePeriod:    *timePeriod,
-		},
-	}
-
-	if v, ok := metadata.ResourceData.GetOk("etag"); ok {
-		parameters.ETag = pointer.To(v.(string))
-	}
-
-	if _, err = client.CreateOrUpdate(ctx, id, parameters); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func expandConsumptionBudgetTimePeriod(i []interface{}) (*budgets.BudgetTimePeriod, error) {
-	if len(i) == 0 || i[0] == nil {
+func expandConsumptionBudgetTimePeriodFromModel(input []ConsumptionBudgetTimePeriodModel) (*budgets.BudgetTimePeriod, error) {
+	if len(input) == 0 {
 		return nil, nil
 	}
 
-	input := i[0].(map[string]interface{})
+	tp := input[0]
 	timePeriod := budgets.BudgetTimePeriod{}
 
-	if startDateInput, ok := input["start_date"].(string); ok {
-		if _, err := date.ParseTime(time.RFC3339, startDateInput); err != nil {
-			return nil, fmt.Errorf("start_date '%s' was not in the correct format: %+v", startDateInput, err)
-		}
-		timePeriod.StartDate = input["start_date"].(string)
+	if _, err := date.ParseTime(time.RFC3339, tp.StartDate); err != nil {
+		return nil, fmt.Errorf("start_date '%s' was not in the correct format: %+v", tp.StartDate, err)
 	}
+	timePeriod.StartDate = tp.StartDate
 
-	if endDateInput, ok := input["end_date"].(string); ok {
-		if endDateInput != "" {
-			if _, err := date.ParseTime(time.RFC3339, endDateInput); err != nil {
-				return nil, fmt.Errorf("end_date '%s' was not in the correct format: %+v", endDateInput, err)
-			}
-
-			timePeriod.EndDate = pointer.To(input["end_date"].(string))
+	if tp.EndDate != "" {
+		if _, err := date.ParseTime(time.RFC3339, tp.EndDate); err != nil {
+			return nil, fmt.Errorf("end_date '%s' was not in the correct format: %+v", tp.EndDate, err)
 		}
+		timePeriod.EndDate = pointer.To(tp.EndDate)
 	}
 
 	return &timePeriod, nil
 }
 
-func flattenConsumptionBudgetTimePeriod(input *budgets.BudgetTimePeriod) []interface{} {
-	timePeriod := make([]interface{}, 0)
-
+func flattenConsumptionBudgetTimePeriodToModel(input *budgets.BudgetTimePeriod) []ConsumptionBudgetTimePeriodModel {
 	if input == nil {
-		return timePeriod
+		return []ConsumptionBudgetTimePeriodModel{}
 	}
 
-	startDate := input.StartDate
-
-	endDate := ""
-	if v := input.EndDate; v != nil {
-		endDate = *v
+	return []ConsumptionBudgetTimePeriodModel{
+		{
+			StartDate: input.StartDate,
+			EndDate:   pointer.From(input.EndDate),
+		},
 	}
-
-	return append(timePeriod, map[string]interface{}{
-		"start_date": startDate,
-		"end_date":   endDate,
-	})
 }
 
-func expandConsumptionBudgetNotifications(input []interface{}) *map[string]budgets.Notification {
+func expandConsumptionBudgetNotificationsFromModel(input []ConsumptionBudgetNotificationModel) *map[string]budgets.Notification {
 	if len(input) == 0 {
 		return nil
 	}
 
 	notifications := make(map[string]budgets.Notification)
-
-	for _, v := range input {
-		if v != nil {
-			notificationRaw := v.(map[string]interface{})
-			notification := budgets.Notification{}
-
-			notification.Enabled = notificationRaw["enabled"].(bool)
-			notification.Operator = budgets.OperatorType(notificationRaw["operator"].(string))
-
-			notification.Threshold = float64(notificationRaw["threshold"].(int))
-
-			thresholdType := budgets.ThresholdType(notificationRaw["threshold_type"].(string))
-			notification.ThresholdType = &thresholdType
-
-			contactEmails := utils.ExpandStringSlice(notificationRaw["contact_emails"].([]interface{}))
-			notification.ContactEmails = *contactEmails
-
-			// contact_roles cannot be set on consumption budgets for management groups
-			if _, ok := notificationRaw["contact_roles"]; ok {
-				notification.ContactRoles = utils.ExpandStringSlice(notificationRaw["contact_roles"].([]interface{}))
-			}
-
-			// contact_groups cannot be set on consumption budgets for management groups
-			if _, ok := notificationRaw["contact_groups"]; ok {
-				notification.ContactGroups = utils.ExpandStringSlice(notificationRaw["contact_groups"].([]interface{}))
-			}
-
-			notificationKey := fmt.Sprintf("%s_%s_%f_Percent", string(thresholdType), string(notification.Operator), notification.Threshold)
-			notifications[notificationKey] = notification
+	for _, n := range input {
+		notification := budgets.Notification{
+			Enabled:  n.Enabled,
+			Operator: budgets.OperatorType(n.Operator),
+			// nolint: gosec
+			Threshold: float64(n.Threshold),
 		}
+
+		thresholdType := budgets.ThresholdType(n.ThresholdType)
+		notification.ThresholdType = &thresholdType
+
+		notification.ContactEmails = n.ContactEmails
+		if len(n.ContactRoles) > 0 {
+			notification.ContactRoles = &n.ContactRoles
+		}
+		if len(n.ContactGroups) > 0 {
+			notification.ContactGroups = &n.ContactGroups
+		}
+
+		notificationKey := fmt.Sprintf("%s_%s_%f_Percent", string(thresholdType), string(notification.Operator), notification.Threshold)
+		notifications[notificationKey] = notification
 	}
 
 	return &notifications
 }
 
-func flattenConsumptionBudgetNotifications(input *map[string]budgets.Notification, scope string) []interface{} {
+func flattenConsumptionBudgetNotificationsToModel(input *map[string]budgets.Notification) []ConsumptionBudgetNotificationModel {
 	if input == nil {
-		return []interface{}{}
+		return []ConsumptionBudgetNotificationModel{}
 	}
 
-	notifications := make([]interface{}, 0)
+	result := make([]ConsumptionBudgetNotificationModel, 0)
 	for _, n := range *input {
-		block := make(map[string]interface{})
-
-		block["enabled"] = n.Enabled
-
-		operator := ""
-		if v := n.Operator; v != "" {
-			operator = string(v)
-		}
-		block["operator"] = operator
-
-		block["threshold"] = n.Threshold
-
 		thresholdType := string(budgets.ThresholdTypeActual)
 		if v := n.ThresholdType; v != nil {
 			thresholdType = string(*v)
 		}
-		block["threshold_type"] = thresholdType
 
-		var emails []interface{}
-		if v := n.ContactEmails; v != nil {
-			emails = utils.FlattenStringSlice(&v)
-		}
-		block["contact_emails"] = emails
-
-		if scope != "management_group_id" {
-			var roles []interface{}
-			if v := n.ContactRoles; v != nil {
-				roles = utils.FlattenStringSlice(v)
-			}
-			block["contact_roles"] = roles
-
-			var groups []interface{}
-			if v := n.ContactGroups; v != nil {
-				groups = utils.FlattenStringSlice(v)
-			}
-			block["contact_groups"] = groups
+		model := ConsumptionBudgetNotificationModel{
+			Enabled:       n.Enabled,
+			Operator:      string(n.Operator),
+			Threshold:     int64(n.Threshold),
+			ThresholdType: thresholdType,
+			ContactEmails: n.ContactEmails,
 		}
 
-		notifications = append(notifications, block)
+		if v := n.ContactRoles; v != nil {
+			model.ContactRoles = *v
+		}
+		if v := n.ContactGroups; v != nil {
+			model.ContactGroups = *v
+		}
+
+		result = append(result, model)
 	}
 
-	return notifications
+	return result
 }
 
-func expandConsumptionBudgetComparisonExpression(input interface{}) *budgets.BudgetComparisonExpression {
-	if input == nil {
-		return nil
-	}
-
-	v := input.(map[string]interface{})
-
-	return &budgets.BudgetComparisonExpression{
-		Name:     v["name"].(string),
-		Operator: budgets.BudgetOperatorType(v["operator"].(string)),
-		Values:   *utils.ExpandStringSlice(v["values"].([]interface{})),
-	}
-}
-
-func flattenConsumptionBudgetComparisonExpression(input *budgets.BudgetComparisonExpression) *map[string]interface{} {
-	consumptionBudgetComparisonExpression := make(map[string]interface{})
-
-	consumptionBudgetComparisonExpression["name"] = input.Name
-	consumptionBudgetComparisonExpression["operator"] = input.Operator
-	consumptionBudgetComparisonExpression["values"] = utils.FlattenStringSlice(&input.Values)
-
-	return &consumptionBudgetComparisonExpression
-}
-
-func expandConsumptionBudgetFilterDimensions(input []interface{}) []budgets.BudgetFilterProperties {
+func expandConsumptionBudgetFilterFromModel(input []ConsumptionBudgetFilterModel) *budgets.BudgetFilter {
 	if len(input) == 0 {
 		return nil
 	}
+
+	f := input[0]
+	filter := budgets.BudgetFilter{}
 
 	dimensions := make([]budgets.BudgetFilterProperties, 0)
-
-	for _, v := range input {
-		dimension := budgets.BudgetFilterProperties{
-			Dimensions: expandConsumptionBudgetComparisonExpression(v),
-		}
-		dimensions = append(dimensions, dimension)
-	}
-
-	return dimensions
-}
-
-func expandConsumptionBudgetFilterTag(input []interface{}) []budgets.BudgetFilterProperties {
-	if len(input) == 0 {
-		return nil
+	for _, d := range f.Dimension {
+		dimensions = append(dimensions, budgets.BudgetFilterProperties{
+			Dimensions: &budgets.BudgetComparisonExpression{
+				Name:     d.Name,
+				Operator: budgets.BudgetOperatorType(d.Operator),
+				Values:   d.Values,
+			},
+		})
 	}
 
 	tags := make([]budgets.BudgetFilterProperties, 0)
-
-	for _, v := range input {
-		tag := budgets.BudgetFilterProperties{
-			Tags: expandConsumptionBudgetComparisonExpression(v),
-		}
-
-		tags = append(tags, tag)
+	for _, t := range f.Tag {
+		tags = append(tags, budgets.BudgetFilterProperties{
+			Tags: &budgets.BudgetComparisonExpression{
+				Name:     t.Name,
+				Operator: budgets.BudgetOperatorType(t.Operator),
+				Values:   t.Values,
+			},
+		})
 	}
 
-	return tags
-}
-
-func expandConsumptionBudgetFilter(i []interface{}) *budgets.BudgetFilter {
-	if len(i) == 0 || i[0] == nil {
-		return nil
-	}
-	input := i[0].(map[string]interface{})
-
-	filter := budgets.BudgetFilter{}
-
-	tags := expandConsumptionBudgetFilterTag(input["tag"].(*pluginsdk.Set).List())
-	dimensions := expandConsumptionBudgetFilterDimensions(input["dimension"].(*pluginsdk.Set).List())
-
-	tagsSet := len(tags) > 0
 	dimensionsSet := len(dimensions) > 0
+	tagsSet := len(tags) > 0
 
 	if dimensionsSet && tagsSet {
 		dimensions = append(dimensions, tags...)
@@ -643,47 +469,56 @@ func expandConsumptionBudgetFilter(i []interface{}) *budgets.BudgetFilter {
 	return &filter
 }
 
-func flattenConsumptionBudgetFilter(input *budgets.BudgetFilter) []interface{} {
-	filter := make([]interface{}, 0)
-
+func flattenConsumptionBudgetFilterToModel(input *budgets.BudgetFilter) []ConsumptionBudgetFilterModel {
 	if input == nil {
-		return filter
+		return []ConsumptionBudgetFilterModel{}
 	}
 
-	dimensions := make([]interface{}, 0)
-	tags := make([]interface{}, 0)
-
-	filterBlock := make(map[string]interface{})
+	dimensions := make([]ConsumptionBudgetFilterDimensionModel, 0)
+	tags := make([]ConsumptionBudgetFilterTagModel, 0)
 
 	if input.And != nil {
 		for _, v := range *input.And {
 			if v.Dimensions != nil {
-				dimensions = append(dimensions, flattenConsumptionBudgetComparisonExpression(v.Dimensions))
-			} else {
-				tags = append(tags, flattenConsumptionBudgetComparisonExpression(v.Tags))
+				dimensions = append(dimensions, ConsumptionBudgetFilterDimensionModel{
+					Name:     v.Dimensions.Name,
+					Operator: string(v.Dimensions.Operator),
+					Values:   v.Dimensions.Values,
+				})
+			}
+			if v.Tags != nil {
+				tags = append(tags, ConsumptionBudgetFilterTagModel{
+					Name:     v.Tags.Name,
+					Operator: string(v.Tags.Operator),
+					Values:   v.Tags.Values,
+				})
 			}
 		}
-
-		if len(dimensions) != 0 {
-			filterBlock["dimension"] = dimensions
-		}
-
-		if len(tags) != 0 {
-			filterBlock["tag"] = tags
-		}
 	} else {
-		if input.Tags != nil {
-			filterBlock["tag"] = append(tags, flattenConsumptionBudgetComparisonExpression(input.Tags))
-		}
-
 		if input.Dimensions != nil {
-			filterBlock["dimension"] = append(dimensions, flattenConsumptionBudgetComparisonExpression(input.Dimensions))
+			dimensions = append(dimensions, ConsumptionBudgetFilterDimensionModel{
+				Name:     input.Dimensions.Name,
+				Operator: string(input.Dimensions.Operator),
+				Values:   input.Dimensions.Values,
+			})
+		}
+		if input.Tags != nil {
+			tags = append(tags, ConsumptionBudgetFilterTagModel{
+				Name:     input.Tags.Name,
+				Operator: string(input.Tags.Operator),
+				Values:   input.Tags.Values,
+			})
 		}
 	}
 
-	if len(filterBlock) != 0 {
-		filter = append(filter, filterBlock)
+	if len(dimensions) == 0 && len(tags) == 0 {
+		return []ConsumptionBudgetFilterModel{}
 	}
 
-	return filter
+	return []ConsumptionBudgetFilterModel{
+		{
+			Dimension: dimensions,
+			Tag:       tags,
+		},
+	}
 }

--- a/internal/services/consumption/consumption_budget_data_source_helpers.go
+++ b/internal/services/consumption/consumption_budget_data_source_helpers.go
@@ -1,0 +1,135 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package consumption
+
+import (
+	"github.com/hashicorp/go-azure-sdk/resource-manager/consumption/2019-10-01/budgets"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+func flattenConsumptionBudgetTimePeriod(input *budgets.BudgetTimePeriod) []interface{} {
+	timePeriod := make([]interface{}, 0)
+
+	if input == nil {
+		return timePeriod
+	}
+
+	startDate := input.StartDate
+
+	endDate := ""
+	if v := input.EndDate; v != nil {
+		endDate = *v
+	}
+
+	return append(timePeriod, map[string]interface{}{
+		"start_date": startDate,
+		"end_date":   endDate,
+	})
+}
+
+func flattenConsumptionBudgetNotifications(input *map[string]budgets.Notification, scope string) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	notifications := make([]interface{}, 0)
+	for _, n := range *input {
+		block := make(map[string]interface{})
+
+		block["enabled"] = n.Enabled
+
+		operator := ""
+		if v := n.Operator; v != "" {
+			operator = string(v)
+		}
+		block["operator"] = operator
+
+		block["threshold"] = n.Threshold
+
+		thresholdType := string(budgets.ThresholdTypeActual)
+		if v := n.ThresholdType; v != nil {
+			thresholdType = string(*v)
+		}
+		block["threshold_type"] = thresholdType
+
+		var emails []interface{}
+		if v := n.ContactEmails; v != nil {
+			emails = utils.FlattenStringSlice(&v)
+		}
+		block["contact_emails"] = emails
+
+		if scope != "management_group_id" {
+			var roles []interface{}
+			if v := n.ContactRoles; v != nil {
+				roles = utils.FlattenStringSlice(v)
+			}
+			block["contact_roles"] = roles
+
+			var groups []interface{}
+			if v := n.ContactGroups; v != nil {
+				groups = utils.FlattenStringSlice(v)
+			}
+			block["contact_groups"] = groups
+		}
+
+		notifications = append(notifications, block)
+	}
+
+	return notifications
+}
+
+func flattenConsumptionBudgetComparisonExpression(input *budgets.BudgetComparisonExpression) *map[string]interface{} {
+	consumptionBudgetComparisonExpression := make(map[string]interface{})
+
+	consumptionBudgetComparisonExpression["name"] = input.Name
+	consumptionBudgetComparisonExpression["operator"] = input.Operator
+	consumptionBudgetComparisonExpression["values"] = utils.FlattenStringSlice(&input.Values)
+
+	return &consumptionBudgetComparisonExpression
+}
+
+func flattenConsumptionBudgetFilter(input *budgets.BudgetFilter) []interface{} {
+	filter := make([]interface{}, 0)
+
+	if input == nil {
+		return filter
+	}
+
+	dimensions := make([]interface{}, 0)
+	tags := make([]interface{}, 0)
+
+	filterBlock := make(map[string]interface{})
+
+	if input.And != nil {
+		for _, v := range *input.And {
+			if v.Dimensions != nil {
+				dimensions = append(dimensions, flattenConsumptionBudgetComparisonExpression(v.Dimensions))
+			} else {
+				tags = append(tags, flattenConsumptionBudgetComparisonExpression(v.Tags))
+			}
+		}
+
+		if len(dimensions) != 0 {
+			filterBlock["dimension"] = dimensions
+		}
+
+		if len(tags) != 0 {
+			filterBlock["tag"] = tags
+		}
+	} else {
+		if input.Tags != nil {
+			filterBlock["tag"] = append(tags, flattenConsumptionBudgetComparisonExpression(input.Tags))
+		}
+
+		if input.Dimensions != nil {
+			filterBlock["dimension"] = append(dimensions, flattenConsumptionBudgetComparisonExpression(input.Dimensions))
+		}
+	}
+
+	if len(filterBlock) != 0 {
+		filter = append(filter, filterBlock)
+	}
+
+	return filter
+}

--- a/internal/services/consumption/consumption_budget_management_group_resource.go
+++ b/internal/services/consumption/consumption_budget_management_group_resource.go
@@ -4,7 +4,14 @@
 package consumption
 
 import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/consumption/2019-10-01/budgets"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	validateManagementGroup "github.com/hashicorp/terraform-provider-azurerm/internal/services/managementgroup/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -13,6 +20,26 @@ import (
 
 type ManagementGroupConsumptionBudget struct {
 	base consumptionBudgetBaseResource
+}
+
+type ManagementGroupConsumptionBudgetModel struct {
+	Name              string                                   `tfschema:"name"`
+	ManagementGroupId string                                   `tfschema:"management_group_id"`
+	Etag              string                                   `tfschema:"etag"`
+	Amount            float64                                  `tfschema:"amount"`
+	TimeGrain         string                                   `tfschema:"time_grain"`
+	TimePeriod        []ConsumptionBudgetTimePeriodModel       `tfschema:"time_period"`
+	Notification      []ConsumptionBudgetMgmtNotificationModel `tfschema:"notification"`
+	Filter            []ConsumptionBudgetFilterModel           `tfschema:"filter"`
+}
+
+// Management group notification model (no contact_groups/contact_roles)
+type ConsumptionBudgetMgmtNotificationModel struct {
+	Enabled       bool     `tfschema:"enabled"`
+	Threshold     int64    `tfschema:"threshold"`
+	ThresholdType string   `tfschema:"threshold_type"`
+	Operator      string   `tfschema:"operator"`
+	ContactEmails []string `tfschema:"contact_emails"`
 }
 
 var (
@@ -93,7 +120,7 @@ func (r ManagementGroupConsumptionBudget) Attributes() map[string]*pluginsdk.Sch
 }
 
 func (r ManagementGroupConsumptionBudget) ModelObject() interface{} {
-	return nil
+	return &ManagementGroupConsumptionBudgetModel{}
 }
 
 func (r ManagementGroupConsumptionBudget) ResourceType() string {
@@ -105,11 +132,98 @@ func (r ManagementGroupConsumptionBudget) IDValidationFunc() pluginsdk.SchemaVal
 }
 
 func (r ManagementGroupConsumptionBudget) Create() sdk.ResourceFunc {
-	return r.base.createFunc(r.ResourceType(), "management_group_id")
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Consumption.BudgetsClient
+
+			var config ManagementGroupConsumptionBudgetModel
+			if err := metadata.Decode(&config); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			id := budgets.NewScopedBudgetID(config.ManagementGroupId, config.Name)
+
+			existing, err := client.Get(ctx, id)
+			if err != nil {
+				if !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+				}
+			}
+
+			if !response.WasNotFound(existing.HttpResponse) {
+				return tf.ImportAsExistsError(r.ResourceType(), id.ID())
+			}
+
+			timePeriod, err := expandConsumptionBudgetTimePeriodFromModel(config.TimePeriod)
+			if err != nil {
+				return fmt.Errorf("expanding `time_period`: %+v", err)
+			}
+
+			parameters := budgets.Budget{
+				Name: pointer.To(id.BudgetName),
+				Properties: &budgets.BudgetProperties{
+					Amount:        config.Amount,
+					Category:      budgets.CategoryTypeCost,
+					Filter:        expandConsumptionBudgetFilterFromModel(config.Filter),
+					Notifications: expandConsumptionBudgetMgmtNotificationsFromModel(config.Notification),
+					TimeGrain:     budgets.TimeGrainType(config.TimeGrain),
+					TimePeriod:    *timePeriod,
+				},
+			}
+
+			if config.Etag != "" {
+				parameters.ETag = pointer.To(config.Etag)
+			}
+
+			if _, err = client.CreateOrUpdate(ctx, id, parameters); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+	}
 }
 
 func (r ManagementGroupConsumptionBudget) Read() sdk.ResourceFunc {
-	return r.base.readFunc("management_group_id")
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Consumption.BudgetsClient
+			id, err := budgets.ParseScopedBudgetID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.Get(ctx, *id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return metadata.MarkAsGone(id)
+				}
+				return fmt.Errorf("reading %s, %+v", *id, err)
+			}
+
+			state := ManagementGroupConsumptionBudgetModel{
+				Name:              id.BudgetName,
+				ManagementGroupId: id.Scope,
+			}
+
+			if model := resp.Model; model != nil {
+				state.Etag = pointer.From(model.ETag)
+
+				if props := model.Properties; props != nil {
+					state.Amount = props.Amount
+					state.TimeGrain = string(props.TimeGrain)
+					state.TimePeriod = flattenConsumptionBudgetTimePeriodToModel(&props.TimePeriod)
+					state.Notification = flattenConsumptionBudgetMgmtNotificationsToModel(props.Notifications)
+					state.Filter = flattenConsumptionBudgetFilterToModel(props.Filter)
+				}
+			}
+
+			return metadata.Encode(&state)
+		},
+	}
 }
 
 func (r ManagementGroupConsumptionBudget) Delete() sdk.ResourceFunc {
@@ -117,9 +231,101 @@ func (r ManagementGroupConsumptionBudget) Delete() sdk.ResourceFunc {
 }
 
 func (r ManagementGroupConsumptionBudget) Update() sdk.ResourceFunc {
-	return r.base.updateFunc()
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Consumption.BudgetsClient
+
+			id, err := budgets.ParseScopedBudgetID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			var config ManagementGroupConsumptionBudgetModel
+			if err := metadata.Decode(&config); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			timePeriod, err := expandConsumptionBudgetTimePeriodFromModel(config.TimePeriod)
+			if err != nil {
+				return fmt.Errorf("expanding `time_period`: %+v", err)
+			}
+
+			parameters := budgets.Budget{
+				Name: pointer.To(id.BudgetName),
+				Properties: &budgets.BudgetProperties{
+					Amount:        config.Amount,
+					Category:      budgets.CategoryTypeCost,
+					Filter:        expandConsumptionBudgetFilterFromModel(config.Filter),
+					Notifications: expandConsumptionBudgetMgmtNotificationsFromModel(config.Notification),
+					TimeGrain:     budgets.TimeGrainType(config.TimeGrain),
+					TimePeriod:    *timePeriod,
+				},
+			}
+
+			if config.Etag != "" {
+				parameters.ETag = pointer.To(config.Etag)
+			}
+
+			if _, err = client.CreateOrUpdate(ctx, *id, parameters); err != nil {
+				return fmt.Errorf("updating %s: %+v", *id, err)
+			}
+
+			return nil
+		},
+	}
 }
 
 func (r ManagementGroupConsumptionBudget) CustomImporter() sdk.ResourceRunFunc {
 	return r.base.importerFunc()
+}
+
+func expandConsumptionBudgetMgmtNotificationsFromModel(input []ConsumptionBudgetMgmtNotificationModel) *map[string]budgets.Notification {
+	if len(input) == 0 {
+		return nil
+	}
+
+	notifications := make(map[string]budgets.Notification)
+	for _, n := range input {
+		notification := budgets.Notification{
+			Enabled:  n.Enabled,
+			Operator: budgets.OperatorType(n.Operator),
+			// nolint: gosec
+			Threshold: float64(n.Threshold),
+		}
+
+		thresholdType := budgets.ThresholdType(n.ThresholdType)
+		notification.ThresholdType = &thresholdType
+
+		notification.ContactEmails = n.ContactEmails
+
+		notificationKey := fmt.Sprintf("%s_%s_%f_Percent", string(thresholdType), string(notification.Operator), notification.Threshold)
+		notifications[notificationKey] = notification
+	}
+
+	return &notifications
+}
+
+func flattenConsumptionBudgetMgmtNotificationsToModel(input *map[string]budgets.Notification) []ConsumptionBudgetMgmtNotificationModel {
+	if input == nil {
+		return []ConsumptionBudgetMgmtNotificationModel{}
+	}
+
+	result := make([]ConsumptionBudgetMgmtNotificationModel, 0)
+	for _, n := range *input {
+		thresholdType := string(budgets.ThresholdTypeActual)
+		if v := n.ThresholdType; v != nil {
+			thresholdType = string(*v)
+		}
+
+		result = append(result, ConsumptionBudgetMgmtNotificationModel{
+			Enabled:       n.Enabled,
+			Operator:      string(n.Operator),
+			Threshold:     int64(n.Threshold),
+			ThresholdType: thresholdType,
+			ContactEmails: n.ContactEmails,
+		})
+	}
+
+	return result
 }

--- a/internal/services/consumption/consumption_budget_resource_group_resource.go
+++ b/internal/services/consumption/consumption_budget_resource_group_resource.go
@@ -4,7 +4,14 @@
 package consumption
 
 import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/consumption/2019-10-01/budgets"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	validateResourceGroup "github.com/hashicorp/terraform-provider-azurerm/internal/services/resource/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -13,6 +20,17 @@ import (
 
 type ResourceGroupConsumptionBudget struct {
 	base consumptionBudgetBaseResource
+}
+
+type ResourceGroupConsumptionBudgetModel struct {
+	Name            string                               `tfschema:"name"`
+	ResourceGroupId string                               `tfschema:"resource_group_id"`
+	Etag            string                               `tfschema:"etag"`
+	Amount          float64                              `tfschema:"amount"`
+	TimeGrain       string                               `tfschema:"time_grain"`
+	TimePeriod      []ConsumptionBudgetTimePeriodModel   `tfschema:"time_period"`
+	Notification    []ConsumptionBudgetNotificationModel `tfschema:"notification"`
+	Filter          []ConsumptionBudgetFilterModel       `tfschema:"filter"`
 }
 
 var (
@@ -43,7 +61,7 @@ func (r ResourceGroupConsumptionBudget) Attributes() map[string]*pluginsdk.Schem
 }
 
 func (r ResourceGroupConsumptionBudget) ModelObject() interface{} {
-	return nil
+	return &ResourceGroupConsumptionBudgetModel{}
 }
 
 func (r ResourceGroupConsumptionBudget) ResourceType() string {
@@ -55,11 +73,98 @@ func (r ResourceGroupConsumptionBudget) IDValidationFunc() pluginsdk.SchemaValid
 }
 
 func (r ResourceGroupConsumptionBudget) Create() sdk.ResourceFunc {
-	return r.base.createFunc(r.ResourceType(), "resource_group_id")
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Consumption.BudgetsClient
+
+			var config ResourceGroupConsumptionBudgetModel
+			if err := metadata.Decode(&config); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			id := budgets.NewScopedBudgetID(config.ResourceGroupId, config.Name)
+
+			existing, err := client.Get(ctx, id)
+			if err != nil {
+				if !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+				}
+			}
+
+			if !response.WasNotFound(existing.HttpResponse) {
+				return tf.ImportAsExistsError(r.ResourceType(), id.ID())
+			}
+
+			timePeriod, err := expandConsumptionBudgetTimePeriodFromModel(config.TimePeriod)
+			if err != nil {
+				return fmt.Errorf("expanding `time_period`: %+v", err)
+			}
+
+			parameters := budgets.Budget{
+				Name: pointer.To(id.BudgetName),
+				Properties: &budgets.BudgetProperties{
+					Amount:        config.Amount,
+					Category:      budgets.CategoryTypeCost,
+					Filter:        expandConsumptionBudgetFilterFromModel(config.Filter),
+					Notifications: expandConsumptionBudgetNotificationsFromModel(config.Notification),
+					TimeGrain:     budgets.TimeGrainType(config.TimeGrain),
+					TimePeriod:    *timePeriod,
+				},
+			}
+
+			if config.Etag != "" {
+				parameters.ETag = pointer.To(config.Etag)
+			}
+
+			if _, err = client.CreateOrUpdate(ctx, id, parameters); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+	}
 }
 
 func (r ResourceGroupConsumptionBudget) Read() sdk.ResourceFunc {
-	return r.base.readFunc("resource_group_id")
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Consumption.BudgetsClient
+			id, err := budgets.ParseScopedBudgetID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.Get(ctx, *id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return metadata.MarkAsGone(id)
+				}
+				return fmt.Errorf("reading %s, %+v", *id, err)
+			}
+
+			state := ResourceGroupConsumptionBudgetModel{
+				Name:            id.BudgetName,
+				ResourceGroupId: id.Scope,
+			}
+
+			if model := resp.Model; model != nil {
+				state.Etag = pointer.From(model.ETag)
+
+				if props := model.Properties; props != nil {
+					state.Amount = props.Amount
+					state.TimeGrain = string(props.TimeGrain)
+					state.TimePeriod = flattenConsumptionBudgetTimePeriodToModel(&props.TimePeriod)
+					state.Notification = flattenConsumptionBudgetNotificationsToModel(props.Notifications)
+					state.Filter = flattenConsumptionBudgetFilterToModel(props.Filter)
+				}
+			}
+
+			return metadata.Encode(&state)
+		},
+	}
 }
 
 func (r ResourceGroupConsumptionBudget) Delete() sdk.ResourceFunc {
@@ -67,7 +172,49 @@ func (r ResourceGroupConsumptionBudget) Delete() sdk.ResourceFunc {
 }
 
 func (r ResourceGroupConsumptionBudget) Update() sdk.ResourceFunc {
-	return r.base.updateFunc()
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Consumption.BudgetsClient
+
+			id, err := budgets.ParseScopedBudgetID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			var config ResourceGroupConsumptionBudgetModel
+			if err := metadata.Decode(&config); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			timePeriod, err := expandConsumptionBudgetTimePeriodFromModel(config.TimePeriod)
+			if err != nil {
+				return fmt.Errorf("expanding `time_period`: %+v", err)
+			}
+
+			parameters := budgets.Budget{
+				Name: pointer.To(id.BudgetName),
+				Properties: &budgets.BudgetProperties{
+					Amount:        config.Amount,
+					Category:      budgets.CategoryTypeCost,
+					Filter:        expandConsumptionBudgetFilterFromModel(config.Filter),
+					Notifications: expandConsumptionBudgetNotificationsFromModel(config.Notification),
+					TimeGrain:     budgets.TimeGrainType(config.TimeGrain),
+					TimePeriod:    *timePeriod,
+				},
+			}
+
+			if config.Etag != "" {
+				parameters.ETag = pointer.To(config.Etag)
+			}
+
+			if _, err = client.CreateOrUpdate(ctx, *id, parameters); err != nil {
+				return fmt.Errorf("updating %s: %+v", *id, err)
+			}
+
+			return nil
+		},
+	}
 }
 
 func (r ResourceGroupConsumptionBudget) CustomImporter() sdk.ResourceRunFunc {

--- a/internal/services/consumption/consumption_budget_subscription_resource.go
+++ b/internal/services/consumption/consumption_budget_subscription_resource.go
@@ -4,8 +4,15 @@
 package consumption
 
 import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/consumption/2019-10-01/budgets"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/consumption/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/consumption/validate"
@@ -14,6 +21,17 @@ import (
 
 type SubscriptionConsumptionBudget struct {
 	base consumptionBudgetBaseResource
+}
+
+type SubscriptionConsumptionBudgetModel struct {
+	Name           string                               `tfschema:"name"`
+	SubscriptionId string                               `tfschema:"subscription_id"`
+	Etag           string                               `tfschema:"etag"`
+	Amount         float64                              `tfschema:"amount"`
+	TimeGrain      string                               `tfschema:"time_grain"`
+	TimePeriod     []ConsumptionBudgetTimePeriodModel   `tfschema:"time_period"`
+	Notification   []ConsumptionBudgetNotificationModel `tfschema:"notification"`
+	Filter         []ConsumptionBudgetFilterModel       `tfschema:"filter"`
 }
 
 var (
@@ -45,7 +63,7 @@ func (r SubscriptionConsumptionBudget) Attributes() map[string]*pluginsdk.Schema
 }
 
 func (r SubscriptionConsumptionBudget) ModelObject() interface{} {
-	return nil
+	return &SubscriptionConsumptionBudgetModel{}
 }
 
 func (r SubscriptionConsumptionBudget) ResourceType() string {
@@ -57,11 +75,98 @@ func (r SubscriptionConsumptionBudget) IDValidationFunc() pluginsdk.SchemaValida
 }
 
 func (r SubscriptionConsumptionBudget) Create() sdk.ResourceFunc {
-	return r.base.createFunc(r.ResourceType(), "subscription_id")
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Consumption.BudgetsClient
+
+			var config SubscriptionConsumptionBudgetModel
+			if err := metadata.Decode(&config); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			id := budgets.NewScopedBudgetID(config.SubscriptionId, config.Name)
+
+			existing, err := client.Get(ctx, id)
+			if err != nil {
+				if !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+				}
+			}
+
+			if !response.WasNotFound(existing.HttpResponse) {
+				return tf.ImportAsExistsError(r.ResourceType(), id.ID())
+			}
+
+			timePeriod, err := expandConsumptionBudgetTimePeriodFromModel(config.TimePeriod)
+			if err != nil {
+				return fmt.Errorf("expanding `time_period`: %+v", err)
+			}
+
+			parameters := budgets.Budget{
+				Name: pointer.To(id.BudgetName),
+				Properties: &budgets.BudgetProperties{
+					Amount:        config.Amount,
+					Category:      budgets.CategoryTypeCost,
+					Filter:        expandConsumptionBudgetFilterFromModel(config.Filter),
+					Notifications: expandConsumptionBudgetNotificationsFromModel(config.Notification),
+					TimeGrain:     budgets.TimeGrainType(config.TimeGrain),
+					TimePeriod:    *timePeriod,
+				},
+			}
+
+			if config.Etag != "" {
+				parameters.ETag = pointer.To(config.Etag)
+			}
+
+			if _, err = client.CreateOrUpdate(ctx, id, parameters); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+	}
 }
 
 func (r SubscriptionConsumptionBudget) Read() sdk.ResourceFunc {
-	return r.base.readFunc("subscription_id")
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Consumption.BudgetsClient
+			id, err := budgets.ParseScopedBudgetID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.Get(ctx, *id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return metadata.MarkAsGone(id)
+				}
+				return fmt.Errorf("reading %s, %+v", *id, err)
+			}
+
+			state := SubscriptionConsumptionBudgetModel{
+				Name:           id.BudgetName,
+				SubscriptionId: id.Scope,
+			}
+
+			if model := resp.Model; model != nil {
+				state.Etag = pointer.From(model.ETag)
+
+				if props := model.Properties; props != nil {
+					state.Amount = props.Amount
+					state.TimeGrain = string(props.TimeGrain)
+					state.TimePeriod = flattenConsumptionBudgetTimePeriodToModel(&props.TimePeriod)
+					state.Notification = flattenConsumptionBudgetNotificationsToModel(props.Notifications)
+					state.Filter = flattenConsumptionBudgetFilterToModel(props.Filter)
+				}
+			}
+
+			return metadata.Encode(&state)
+		},
+	}
 }
 
 func (r SubscriptionConsumptionBudget) Delete() sdk.ResourceFunc {
@@ -69,7 +174,49 @@ func (r SubscriptionConsumptionBudget) Delete() sdk.ResourceFunc {
 }
 
 func (r SubscriptionConsumptionBudget) Update() sdk.ResourceFunc {
-	return r.base.updateFunc()
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Consumption.BudgetsClient
+
+			id, err := budgets.ParseScopedBudgetID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			var config SubscriptionConsumptionBudgetModel
+			if err := metadata.Decode(&config); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			timePeriod, err := expandConsumptionBudgetTimePeriodFromModel(config.TimePeriod)
+			if err != nil {
+				return fmt.Errorf("expanding `time_period`: %+v", err)
+			}
+
+			parameters := budgets.Budget{
+				Name: pointer.To(id.BudgetName),
+				Properties: &budgets.BudgetProperties{
+					Amount:        config.Amount,
+					Category:      budgets.CategoryTypeCost,
+					Filter:        expandConsumptionBudgetFilterFromModel(config.Filter),
+					Notifications: expandConsumptionBudgetNotificationsFromModel(config.Notification),
+					TimeGrain:     budgets.TimeGrainType(config.TimeGrain),
+					TimePeriod:    *timePeriod,
+				},
+			}
+
+			if config.Etag != "" {
+				parameters.ETag = pointer.To(config.Etag)
+			}
+
+			if _, err = client.CreateOrUpdate(ctx, *id, parameters); err != nil {
+				return fmt.Errorf("updating %s: %+v", *id, err)
+			}
+
+			return nil
+		},
+	}
 }
 
 func (r SubscriptionConsumptionBudget) CustomImporter() sdk.ResourceRunFunc {


### PR DESCRIPTION
## Community Note
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Convert the three consumption budget resources (`azurerm_consumption_budget_subscription`, `azurerm_consumption_budget_resource_group`, `azurerm_consumption_budget_management_group`) from returning `nil` in ModelObject() with raw `metadata.ResourceData.Get()`/`Set()` calls to using proper typed model structs with `metadata.Decode()`/`metadata.Encode()`.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing

- `go build ./internal/services/consumption/...` — passes
- `go vet ./internal/services/consumption/...` — passes
- `make static-analysis` — passes
- Test registration (`go test -short`) — all consumption budget tests discover and register without [ValidateModelObject](file:///Users/kt/hashi/tf/azure/azurerm-zoo/internal/sdk/wrapper_validate.go#12-35) panics

No behavioral changes were made; existing acceptance tests cover the Create/Read/Update/Delete flows and will validate correctness when run with `TF_ACC`.


## Change Log

* `azurerm_consumption_budget_subscription` - refactor to use typed model with `Decode`/`Encode`
* `azurerm_consumption_budget_resource_group` - refactor to use typed model with `Decode`/`Encode`
* `azurerm_consumption_budget_management_group` - refactor to use typed model with `Decode`/`Encode`


This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

N/A — internal tech debt cleanup


## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

AI was used for code generation of the typed model structs, expand/flatten helpers, and inlined CRUD methods. All changes were reviewed and validated manually.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

No changes to security controls.