### PR TITLE
workflows: grant pull-requests write for comment-failure

### DIFF
--- a/.github/workflows/comment-failure.yaml
+++ b/.github/workflows/comment-failure.yaml
@@ -4,6 +4,9 @@ on:
   # This file is reused, and called from other workflows
   workflow_call:
 
+permissions:
+  pull-requests: write
+
 jobs:
   comment-failure:
     runs-on: ubuntu-latest

--- a/.github/workflows/depscheck.yaml
+++ b/.github/workflows/depscheck.yaml
@@ -3,6 +3,7 @@ name: Vendor Dependencies Check
 
 permissions:
   contents: read
+  pull-requests: write
 
 on:
   pull_request:

--- a/.github/workflows/gencheck.yaml
+++ b/.github/workflows/gencheck.yaml
@@ -3,6 +3,7 @@ name: Generation Check
 
 permissions:
   contents: read
+  pull-requests: write
 
 on:
   pull_request:

--- a/.github/workflows/golint.yaml
+++ b/.github/workflows/golint.yaml
@@ -3,6 +3,7 @@ name: GoLang Linting
 
 permissions:
   contents: read
+  pull-requests: write
 
 on:
   pull_request:

--- a/.github/workflows/gradually-deprecated.yaml
+++ b/.github/workflows/gradually-deprecated.yaml
@@ -3,6 +3,7 @@ name: Check for new usages of deprecated functionality
 
 permissions:
   contents: read
+  pull-requests: write
 
 on:
   pull_request:

--- a/.github/workflows/provider-test.yaml
+++ b/.github/workflows/provider-test.yaml
@@ -12,7 +12,7 @@ on:
 permissions:
   contents: read
   id-token: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   secrets-check:

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -3,6 +3,7 @@ name: ShellCheck Scripts
 
 permissions:
   contents: read
+  pull-requests: write
 
 on:
   pull_request:

--- a/.github/workflows/tflint.yaml
+++ b/.github/workflows/tflint.yaml
@@ -3,6 +3,7 @@ name: Terraform Schema Linting
 
 permissions:
   contents: read
+  pull-requests: write
 
 on:
   pull_request:

--- a/.github/workflows/thirty-two-bit.yaml
+++ b/.github/workflows/thirty-two-bit.yaml
@@ -3,7 +3,7 @@ name: 32 Bit Build
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
 
 on:
   pull_request:

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -3,7 +3,7 @@ name: Unit Tests
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
 
 on:
   pull_request:

--- a/.github/workflows/validate-examples.yaml
+++ b/.github/workflows/validate-examples.yaml
@@ -3,7 +3,7 @@ name: Validate Examples
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
 
 on:
   pull_request:

--- a/.github/workflows/website-lint.yaml
+++ b/.github/workflows/website-lint.yaml
@@ -3,7 +3,7 @@ name: Website Linting
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
 
 on:
   pull_request:


### PR DESCRIPTION
## Community Note
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

The `comment-failure` reusable workflow uses `actions/github-script` to post a "Build failure" comment on PRs. This requires `pull-requests: write` on the `GITHUB_TOKEN`, but most calling workflows only granted `contents: read` (or `pull-requests: read`), causing the step to fail with:

```
HttpError: Resource not accessible by integration (403)
```

This PR adds or upgrades `pull-requests: write` in all 12 workflows that call `comment-failure.yaml`:

| Workflow | Change |
|---|---|
| shellcheck.yaml | added `pull-requests: write` |
| gradually-deprecated.yaml | added `pull-requests: write` |
| depscheck.yaml | added `pull-requests: write` |
| tflint.yaml | added `pull-requests: write` |
| gencheck.yaml | added `pull-requests: write` |
| golint.yaml | added `pull-requests: write` |
| comment-failure.yaml | added `pull-requests: write` |
| provider-test.yaml | `read` → `write` |
| thirty-two-bit.yaml | `read` → `write` |
| unit-test.yaml | `read` → `write` |
| website-lint.yaml | `read` → `write` |
| validate-examples.yaml | `read` → `write` |

`preview-api-version-linter.yaml` already had `pull-requests: write` and required no change.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.


## Change Log

* N/A - CI workflow permissions fix only, no provider changes.


This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

N/A


## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

AI was used to identify the root cause and apply the permission changes across all affected workflow files.


## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

This PR grants `pull-requests: write` to workflow tokens that previously only had `read` (or no PR permission). This is the minimum permission needed for `actions/github-script` to post comments on PRs. No other permissions are changed.
