### PR TITLE
`azurerm_orchestrated_virtual_machine_scale_set` - fix acceptance tests

### DIFF
--- a/internal/services/compute/orchestrated_virtual_machine_scale_set.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set.go
@@ -670,7 +670,6 @@ func OrchestratedVirtualMachineScaleSetOSDiskSchema() *pluginsdk.Schema {
 							"placement": {
 								Type:     pluginsdk.TypeString,
 								Optional: true,
-								ForceNew: true,
 								Default:  string(virtualmachinescalesets.DiffDiskPlacementCacheDisk),
 								ValidateFunc: validation.StringInSlice([]string{
 									string(virtualmachinescalesets.DiffDiskPlacementCacheDisk),
@@ -1428,6 +1427,13 @@ func ExpandOrchestratedVirtualMachineScaleSetOSDiskUpdate(input []interface{}) *
 
 	if osDiskSize := raw["disk_size_gb"].(int); osDiskSize > 0 {
 		disk.DiskSizeGB = pointer.To(int64(osDiskSize))
+	}
+
+	if rawDiffDiskSettings := raw["diff_disk_settings"].([]interface{}); len(rawDiffDiskSettings) > 0 && rawDiffDiskSettings[0] != nil {
+		diffDiskSettings := rawDiffDiskSettings[0].(map[string]interface{})
+		disk.DiffDiskSettings = &virtualmachinescalesets.DiffDiskSettings{
+			Placement: pointer.ToEnum[virtualmachinescalesets.DiffDiskPlacement](diffDiskSettings["placement"].(string)),
+		}
 	}
 
 	return &disk

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
@@ -397,6 +397,12 @@ func resourceOrchestratedVirtualMachineScaleSet() *pluginsdk.Resource {
 					}
 				}
 
+				if diff.HasChange("os_disk.0.diff_disk_settings.0.placement") {
+					if !diff.HasChange("sku_name") {
+						return fmt.Errorf("changing `os_disk.0.diff_disk_settings.0.placement` requires `sku_name` to be updated as well")
+					}
+				}
+
 				return nil
 			}),
 		),

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_disk_os_test.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_disk_os_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 )
@@ -15,7 +17,7 @@ func TestAccOrchestratedVirtualMachineScaleSet_disksOSDiskCaching(t *testing.T) 
 	data := acceptance.BuildTestData(t, "azurerm_orchestrated_virtual_machine_scale_set", "test")
 	r := OrchestratedVirtualMachineScaleSetResource{}
 
-	data.ResourceTest(t, r, []acceptance.TestStep{
+	data.ResourceTestIgnoreRecreate(t, r, []acceptance.TestStep{
 		{
 			Config: r.disksOSDiskEphemeral(data, "CacheDisk"),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -25,6 +27,11 @@ func TestAccOrchestratedVirtualMachineScaleSet_disksOSDiskCaching(t *testing.T) 
 		data.ImportStep("os_profile.0.linux_configuration.0.admin_password"),
 		{
 			Config: r.disksOSDiskEphemeral(data, "ResourceDisk"),
+			ConfigPlanChecks: resource.ConfigPlanChecks{
+				PreApply: []plancheck.PlanCheck{
+					plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionReplace),
+				},
+			},
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_disk_os_test.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_disk_os_test.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 )
@@ -17,21 +15,16 @@ func TestAccOrchestratedVirtualMachineScaleSet_disksOSDiskCaching(t *testing.T) 
 	data := acceptance.BuildTestData(t, "azurerm_orchestrated_virtual_machine_scale_set", "test")
 	r := OrchestratedVirtualMachineScaleSetResource{}
 
-	data.ResourceTestIgnoreRecreate(t, r, []acceptance.TestStep{
+	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.disksOSDiskEphemeral(data, "CacheDisk"),
+			Config: r.disksOSDiskEphemeral(data, "CacheDisk", "Standard_F4s_v2"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep("os_profile.0.linux_configuration.0.admin_password"),
 		{
-			Config: r.disksOSDiskEphemeral(data, "ResourceDisk"),
-			ConfigPlanChecks: resource.ConfigPlanChecks{
-				PreApply: []plancheck.PlanCheck{
-					plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionReplace),
-				},
-			},
+			Config: r.disksOSDiskEphemeral(data, "ResourceDisk", "Standard_F8s_v2"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -115,7 +108,7 @@ func TestAccOrchestratedVirtualMachineScaleSet_disksOSDiskStorageAccountTypeStan
 	})
 }
 
-func (r OrchestratedVirtualMachineScaleSetResource) disksOSDiskEphemeral(data acceptance.TestData, placement string) string {
+func (r OrchestratedVirtualMachineScaleSetResource) disksOSDiskEphemeral(data acceptance.TestData, placement string, skuName string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -133,7 +126,7 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
 
-  sku_name  = "Standard_F4s_v2"
+  sku_name  = "%[5]s"
   instances = 1
 
   platform_fault_domain_count = 2
@@ -182,7 +175,7 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
     version   = "latest"
   }
 }
-`, r.natgateway_template(data), data.Locations.Primary, data.RandomInteger, placement)
+`, r.natgateway_template(data), data.Locations.Primary, data.RandomInteger, placement, skuName)
 }
 
 func (r OrchestratedVirtualMachineScaleSetResource) disksOSDiskStorageAccountType(data acceptance.TestData, storageAccountType string) string {

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_extensions_test.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_extensions_test.go
@@ -375,7 +375,7 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
   }
 
   network_interface {
-    name    = "TestNetworkProfile"
+    name    = "TestNetworkProfile-%[1]d"
     primary = true
 
     ip_configuration {

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_other_test.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_other_test.go
@@ -1391,8 +1391,8 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
 
   source_image_reference {
     publisher = "Canonical"
-    offer     = "UbuntuServer"
-    sku       = "16.04-LTS"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts"
     version   = "latest"
   }
 

--- a/website/docs/r/orchestrated_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/orchestrated_virtual_machine_scale_set.html.markdown
@@ -329,7 +329,7 @@ A `diff_disk_settings` block supports the following:
 
 * `option` - (Required) Specifies the Ephemeral Disk Settings for the OS Disk. At this time the only possible value is `Local`. Changing this forces a new resource to be created.
 
-* `placement` - (Optional) Specifies where to store the Ephemeral Disk. Possible values are `CacheDisk` and `ResourceDisk`. Defaults to `CacheDisk`. Changing this forces a new resource to be created.
+* `placement` - (Optional) Specifies where to store the Ephemeral Disk. Possible values are `CacheDisk` and `ResourceDisk`. Defaults to `CacheDisk`.
 
 ---
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

`TestAccOrchestratedVirtualMachineScaleSet_disksOSDiskCaching` fails due to resource recreation because of the change in `os_disk.0.diff_disk_settings.0.placement` property with `ForceNew` behavior as shown in the error below. It is tested that `placement` can be updated when `sku_name` property is updated at the same time. Hence, `ForceNew` behavior is removed from `placement`. `ExpandOrchestratedVirtualMachineScaleSetOSDiskUpdate` method is updated to include `placement`. Plan-time catch is added to `CustomizeDiff` behavior to ensure that `sku_name` is updated together with `placement`.

```
    testcase.go:192: Step 4/6 error: Pre-apply plan check(s) failed:
        'azurerm_orchestrated_virtual_machine_scale_set.test' - expected action to not be Replace, path: [[os_disk 0 diff_disk_settings 0 placement]] tried to update a value that is ForceNew
```

`TestAccOrchestratedVirtualMachineScaleSet_extensionsMultiple_on_existing_OVMSS` fails due to resource recreation because of the change in `network_interface.0.name` property with `ForceNew` behavior. The change is due to typo and is fixed accordingly.

```
    testcase.go:192: Step 4/6 error: Pre-apply plan check(s) failed:
        'azurerm_orchestrated_virtual_machine_scale_set.test' - expected action to not be Replace, path: [[network_interface 0 name]] tried to update a value that is ForceNew
```

`TestAccOrchestratedVirtualMachineScaleSet_otherAutomaticRepairsPolicy` fails due to resource recreation because of the change in `source_image_reference.0.offer` property with `ForceNew` behavior. The change is due to incorrect `source_image_reference` configurations which is irrelevant to the test purpose and is fixed accordingly.

```
    testcase.go:192: Step 4/15 error: Pre-apply plan check(s) failed:
        'azurerm_orchestrated_virtual_machine_scale_set.test' - expected action to not be Replace, path: [[source_image_reference 0 offer]] tried to update a value that is ForceNew
```


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] ~I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.~
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] ~I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).~
- [ ] ~I have written new tests for my resource or datasource changes & updated any relevant documentation.~
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] ~(For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.~


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

Version 4.0
https://hashicorp.teamcity.com/viewQueued.html?itemId=687888

Version 5.0
https://hashicorp.teamcity.com/viewQueued.html?itemId=687889


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_orchestrated_virtual_machine_scale_set` - fix acceptance tests


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
