### PR TITLE
`azurerm_virtual_machine_power_action` - fix acceptance tests

### DIFF
--- a/internal/services/compute/proximity_placement_group_resource_test.go
+++ b/internal/services/compute/proximity_placement_group_resource_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-01/proximityplacementgroups"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -67,7 +69,7 @@ func TestAccProximityPlacementGroup_allowedVmSizes(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_proximity_placement_group", "test")
 	r := ProximityPlacementGroupResource{}
 
-	data.ResourceTest(t, r, []acceptance.TestStep{
+	data.ResourceTestIgnoreRecreate(t, r, []acceptance.TestStep{
 		{
 			Config: r.basicWithAllowedVmSizes(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -84,6 +86,11 @@ func TestAccProximityPlacementGroup_allowedVmSizes(t *testing.T) {
 		data.ImportStep(),
 		{
 			Config: r.basic(data),
+			ConfigPlanChecks: resource.ConfigPlanChecks{
+				PreApply: []plancheck.PlanCheck{
+					plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionReplace),
+				},
+			},
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),

--- a/internal/services/compute/proximity_placement_group_resource_test.go
+++ b/internal/services/compute/proximity_placement_group_resource_test.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-01/proximityplacementgroups"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -69,7 +67,7 @@ func TestAccProximityPlacementGroup_allowedVmSizes(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_proximity_placement_group", "test")
 	r := ProximityPlacementGroupResource{}
 
-	data.ResourceTestIgnoreRecreate(t, r, []acceptance.TestStep{
+	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basicWithAllowedVmSizes(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -86,11 +84,6 @@ func TestAccProximityPlacementGroup_allowedVmSizes(t *testing.T) {
 		data.ImportStep(),
 		{
 			Config: r.basic(data),
-			ConfigPlanChecks: resource.ConfigPlanChecks{
-				PreApply: []plancheck.PlanCheck{
-					plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionReplace),
-				},
-			},
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),

--- a/internal/services/compute/shared_image_resource_test.go
+++ b/internal/services/compute/shared_image_resource_test.go
@@ -92,7 +92,7 @@ func TestAccSharedImage_complete(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("os_type").HasValue("Linux"),
 				check.That(data.ResourceName).Key("hyper_v_generation").HasValue("V1"),
-				check.That(data.ResourceName).Key("description").HasValue("Wubba lubba dub dubs"),
+				check.That(data.ResourceName).Key("description").HasValue("Wubba lubba dub dub"),
 				check.That(data.ResourceName).Key("eula").HasValue("Do you agree there's infinite Rick's and Infinite Morty's?"),
 				check.That(data.ResourceName).Key("privacy_statement_uri").HasValue("https://council.of.ricks/privacy-statement"),
 				check.That(data.ResourceName).Key("release_note_uri").HasValue("https://council.of.ricks/changelog.md"),

--- a/internal/services/compute/shared_image_resource_test.go
+++ b/internal/services/compute/shared_image_resource_test.go
@@ -92,7 +92,7 @@ func TestAccSharedImage_complete(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("os_type").HasValue("Linux"),
 				check.That(data.ResourceName).Key("hyper_v_generation").HasValue("V1"),
-				check.That(data.ResourceName).Key("description").HasValue("Wubba lubba dub dub"),
+				check.That(data.ResourceName).Key("description").HasValue("Wubba lubba dub"),
 				check.That(data.ResourceName).Key("eula").HasValue("Do you agree there's infinite Rick's and Infinite Morty's?"),
 				check.That(data.ResourceName).Key("privacy_statement_uri").HasValue("https://council.of.ricks/privacy-statement"),
 				check.That(data.ResourceName).Key("release_note_uri").HasValue("https://council.of.ricks/changelog.md"),
@@ -554,7 +554,7 @@ resource "azurerm_shared_image" "test" {
   location              = azurerm_resource_group.test.location
   os_type               = "Linux"
   hyper_v_generation    = "%s"
-  description           = "Wubba lubba dub dub"
+  description           = "Wubba lubba dub"
   eula                  = "Do you agree there's infinite Rick's and Infinite Morty's?"
   privacy_statement_uri = "https://council.of.ricks/privacy-statement"
   release_note_uri      = "https://council.of.ricks/changelog.md"

--- a/internal/services/compute/virtual_machine_power_action_test.go
+++ b/internal/services/compute/virtual_machine_power_action_test.go
@@ -95,18 +95,13 @@ resource "azurerm_linux_virtual_machine" "test" {
   }
 }
 
-data "azurerm_virtual_machine" "test" {
-  name                = "acctestVM-%[2]d" // sidestep cyclic reference issue
-  resource_group_name = azurerm_resource_group.test.name
-}
-
 action "azurerm_virtual_machine_power" "test" {
   config {
-    virtual_machine_id = data.azurerm_virtual_machine.test.id
+    virtual_machine_id = "/subscriptions/%[3]s/resourceGroups/${azurerm_resource_group.test.name}/providers/Microsoft.Compute/virtualMachines/acctestVM-%[2]d" // sidestep cyclic reference issue
     power_action       = "restart"
   }
 }
-`, a.templateLinux(data), data.RandomInteger)
+`, a.templateLinux(data), data.RandomInteger, data.Subscriptions.Primary)
 }
 
 func (a *VirtualMachinePowerAction) techSupport(data acceptance.TestData, tagVal string) string {
@@ -139,29 +134,12 @@ resource "azurerm_windows_virtual_machine" "test" {
   }
 
   tags = {
-    triggerme = %[3]s
+    triggerme = "%[3]s"
   }
-
-  lifecycle {
-    action_trigger {
-      events  = [before_update]
-      actions = [action.azurerm_virtual_machine_power.power_off]
-    }
-
-    action_trigger {
-      events  = [after_update]
-      actions = [action.azurerm_virtual_machine_power.power_on]
-    }
-  }
-}
-
-data "azurerm_virtual_machine" "test" {
-  name                = local.vm_name
-  resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "terraform_data" "trigger" {
-  input = azurerm_linux_virtual_machine.test.tags
+  input = azurerm_windows_virtual_machine.test.tags
   lifecycle {
     action_trigger {
       events  = [before_update]
@@ -177,18 +155,18 @@ resource "terraform_data" "trigger" {
 
 action "azurerm_virtual_machine_power" "power_off" {
   config {
-    virtual_machine_id = azurerm_windows_virtual_machine.test.id
+    virtual_machine_id = "/subscriptions/%[4]s/resourceGroups/${azurerm_resource_group.test.name}/providers/Microsoft.Compute/virtualMachines/${local.vm_name}" // sidestep cyclic reference issue
     power_action       = "power_off"
   }
 }
 
 action "azurerm_virtual_machine_power" "power_on" {
   config {
-    virtual_machine_id = azurerm_windows_virtual_machine.test.id
+    virtual_machine_id = "/subscriptions/%[4]s/resourceGroups/${azurerm_resource_group.test.name}/providers/Microsoft.Compute/virtualMachines/${local.vm_name}" // sidestep cyclic reference issue
     power_action       = "power_on"
   }
 }
-`, a.templateWindows(data), data.RandomInteger, tagVal)
+`, a.templateWindows(data), data.RandomInteger, tagVal, data.Subscriptions.Primary)
 }
 
 func (a *VirtualMachinePowerAction) templateLinux(data acceptance.TestData) string {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

`TestAccVirtualMachinePowerAction_basic` and `TestAccVirtualMachinePowerAction_tryTurningItOffAndOnAgain` fails primarily due to incorrect configurations related to cyclic reference issues. The error logs below show the failure to get results of virtual machine with `azurerm_virtual_machine` data source due to inappropriate method to circumvent cyclic reference issues. The test configurations are fixed accordingly.

```
    virtual_machine_power_action_test.go:23: Step 1/1 error: Error running apply: exit status 1
        Error: Virtual Machine (Subscription: "*******"
        Resource Group Name: "REDACTED"
        Virtual Machine Name: "REDACTED") was not found
          with data.azurerm_virtual_machine.test,
          on terraform_plugin_test.tf line 95, in data "azurerm_virtual_machine" "test":
          95: data "azurerm_virtual_machine" "test" {
```


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] ~I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.~
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] ~I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).~
- [ ] ~I have written new tests for my resource or datasource changes & updated any relevant documentation.~
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] ~(For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.~


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

Version 4.0
https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_COMPUTE/687892?buildTab=overview
<img width="1471" height="493" alt="image" src="https://github.com/user-attachments/assets/c87b068d-077c-4cc9-844c-13a56877758e" />

Version 5.0
https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_COMPUTE/687900?buildTab=overview
<img width="1471" height="357" alt="image" src="https://github.com/user-attachments/assets/b50d119f-651c-4426-bfb4-15fd56305b59" />


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_virtual_machine_power_action` - fix acceptance tests


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
