### PR TITLE
Compute - fix `TestAccWindowsVirtualMachine_diskOSImportManagedDisk*` and `TestAccWindowsVirtualMachine_otherGalleryApplication`

### DIFF
--- a/internal/services/compute/windows_virtual_machine_resource.go
+++ b/internal/services/compute/windows_virtual_machine_resource.go
@@ -1065,6 +1065,9 @@ func resourceWindowsVirtualMachineRead(d *pluginsdk.ResourceData, meta interface
 			}
 			d.Set("platform_fault_domain", platformFaultDomain)
 
+			// defaulted to false to avoid missing attribute during import
+			d.Set("bypass_platform_safety_checks_on_user_schedule_enabled", false)
+
 			if profile := props.OsProfile; profile != nil {
 				d.Set("admin_username", profile.AdminUsername)
 				d.Set("allow_extension_operations", profile.AllowExtensionOperations)

--- a/internal/services/compute/windows_virtual_machine_resource.go
+++ b/internal/services/compute/windows_virtual_machine_resource.go
@@ -1066,11 +1066,12 @@ func resourceWindowsVirtualMachineRead(d *pluginsdk.ResourceData, meta interface
 			d.Set("platform_fault_domain", platformFaultDomain)
 
 			// defaulted to false to avoid missing attribute during import
-			d.Set("bypass_platform_safety_checks_on_user_schedule_enabled", false)
+			bypassPlatformSafetyChecksOnUserScheduleEnabled := false
 
 			if profile := props.OsProfile; profile != nil {
 				d.Set("admin_username", profile.AdminUsername)
 				d.Set("allow_extension_operations", profile.AllowExtensionOperations)
+				d.Set("bypass_platform_safety_checks_on_user_schedule_enabled", bypassPlatformSafetyChecksOnUserScheduleEnabled)
 				d.Set("computer_name", profile.ComputerName)
 
 				if config := profile.WindowsConfiguration; config != nil {
@@ -1086,7 +1087,6 @@ func resourceWindowsVirtualMachineRead(d *pluginsdk.ResourceData, meta interface
 					d.Set("vm_agent_platform_updates_enabled", config.EnableVMAgentPlatformUpdates)
 
 					assessmentMode := string(virtualmachines.WindowsPatchAssessmentModeImageDefault)
-					bypassPlatformSafetyChecksOnUserScheduleEnabled := false
 					rebootSetting := ""
 					if patchSettings := config.PatchSettings; patchSettings != nil {
 						d.Set("patch_mode", pointer.From(patchSettings.PatchMode))

--- a/internal/services/compute/windows_virtual_machine_resource_other_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_other_test.go
@@ -2013,7 +2013,7 @@ resource "azurerm_windows_virtual_machine" "test" {
 
   gallery_application {
     version_id                                  = azurerm_gallery_application_version.test2.id
-    automatic_upgrade_enabled                   = true
+    automatic_upgrade_enabled                   = false
     order                                       = 2
     configuration_blob_uri                      = azurerm_storage_blob.test2.id
     tag                                         = "app2"

--- a/internal/services/compute/windows_virtual_machine_resource_other_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_other_test.go
@@ -2013,7 +2013,6 @@ resource "azurerm_windows_virtual_machine" "test" {
 
   gallery_application {
     version_id                                  = azurerm_gallery_application_version.test2.id
-    automatic_upgrade_enabled                   = false
     order                                       = 2
     configuration_blob_uri                      = azurerm_storage_blob.test2.id
     tag                                         = "app2"


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

`TestAccWindowsVirtualMachine_diskOSImportManagedDisk` and `TestAccWindowsVirtualMachine_diskOSImportManagedDiskUpdateSize` fail due to the missing bypass_platform_safety_checks_on_user_schedule_enabled attribute during import as shown in the error log below. To fix the issue, the default value of bypass_platform_safety_checks_on_user_schedule_enabled is always set initially during Read operation.

```
    testcase.go:192: Step 7/10 error running import: ImportStateVerify attributes not equivalent. Difference is shown below. The - symbol indicates attributes missing after import.
          map[string]string{
        -   "bypass_platform_safety_checks_on_user_schedule_enabled": "false",
          }
```

`TestAccWindowsVirtualMachine_otherGalleryApplication` fail as `automatic_upgrade_enabled` cannot be set to `true` when `configuration_blob_uri` is specified as shown in the error log below. The issue is fixed by setting `automatic_upgrade_enabled` to `false`.

```
    testcase.go:192: Step 4/12 error: Error running apply: exit status 1
        Error: updating Windows Virtual Machine (Subscription: "*******"
        Resource Group Name: "REDACTED"
        Virtual Machine Name: "REDACTED"): performing Update: unexpected status 409 (409 Conflict) with error: OperationNotAllowed: EnableAutomaticUpgrade cannot be set to true for applications with configurationReference. Please remove configurationReference from application '/subscriptions/*******/resourceGroups/REDACTED/providers/Microsoft.Compute/galleries/REDACTED/applications/REDACTED/versions/0.0.1' to enable auto-upgrades for it.
          with azurerm_windows_virtual_machine.test,
          on terraform_plugin_test.tf line 170, in resource "azurerm_windows_virtual_machine" "test":
         170: resource "azurerm_windows_virtual_machine" "test" {
```


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] ~I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.~
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] ~I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).~
- [ ] ~I have written new tests for my resource or datasource changes & updated any relevant documentation.~
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] ~(For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.~


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

The failed tests are due intermittent or pre-existing errors from `main` branch which are unrelated to the changes in this PR.

Version 4.0
https://hashicorp.teamcity.com/viewQueued.html?itemId=687908
<img width="1476" height="839" alt="image" src="https://github.com/user-attachments/assets/0b44c577-bdbb-4754-9be0-a6c90d2f2359" />

Version 5.0
https://hashicorp.teamcity.com/viewQueued.html?itemId=687909
<img width="1480" height="864" alt="image" src="https://github.com/user-attachments/assets/a68bc9dc-3c87-420d-ae77-3e2e7b3ef983" />


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_windows_virtual_machine` - fix acceptance tests


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
