### PR TITLE
[New Data Source:] `azurerm_cdn_frontdoor_security_policy` 

### DIFF
--- a/internal/provider/services.go
+++ b/internal/provider/services.go
@@ -155,6 +155,7 @@ func SupportedTypedServices() []sdk.TypedServiceRegistration {
 		azurestackhci.Registration{},
 		batch.Registration{},
 		bot.Registration{},
+		cdn.Registration{},
 		codesigning.Registration{},
 		cognitive.Registration{},
 		communication.Registration{},

--- a/internal/services/cdn/cdn_frontdoor_security_policy_data_source.go
+++ b/internal/services/cdn/cdn_frontdoor_security_policy_data_source.go
@@ -4,6 +4,7 @@
 package cdn
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -13,86 +14,120 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2024-02-01/profiles"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2024-02-01/securitypolicies"
 	waf "github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2024-02-01/webapplicationfirewallpolicies"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cdn/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cdn/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-func dataSourceCdnFrontDoorSecurityPolicy() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
-		Read: dataSourceCdnFrontDoorSecurityPolicyRead,
+var _ sdk.DataSource = CdnFrontDoorSecurityPolicyDataSource{}
 
-		Timeouts: &pluginsdk.ResourceTimeout{
-			Read: pluginsdk.DefaultTimeout(5 * time.Minute),
+type CdnFrontDoorSecurityPolicyDataSource struct{}
+
+type CdnFrontDoorSecurityPolicyDataSourceModel struct {
+	Name                  string                                  `tfschema:"name"`
+	ProfileName           string                                  `tfschema:"profile_name"`
+	ResourceGroupName     string                                  `tfschema:"resource_group_name"`
+	CdnFrontDoorProfileId string                                  `tfschema:"cdn_frontdoor_profile_id"`
+	SecurityPolicies      []CdnFrontDoorSecurityPolicyPolicyModel `tfschema:"security_policies"`
+}
+
+type CdnFrontDoorSecurityPolicyPolicyModel struct {
+	Firewall []CdnFrontDoorSecurityPolicyFirewallModel `tfschema:"firewall"`
+}
+
+type CdnFrontDoorSecurityPolicyFirewallModel struct {
+	Association                  []CdnFrontDoorSecurityPolicyAssociationModel `tfschema:"association"`
+	CdnFrontDoorFirewallPolicyId string                                       `tfschema:"cdn_frontdoor_firewall_policy_id"`
+}
+
+type CdnFrontDoorSecurityPolicyAssociationModel struct {
+	Domain          []CdnFrontDoorSecurityPolicyDomainModel `tfschema:"domain"`
+	PatternsToMatch []string                                `tfschema:"patterns_to_match"`
+}
+
+type CdnFrontDoorSecurityPolicyDomainModel struct {
+	Active               bool   `tfschema:"active"`
+	CdnFrontDoorDomainId string `tfschema:"cdn_frontdoor_domain_id"`
+}
+
+func (CdnFrontDoorSecurityPolicyDataSource) ResourceType() string {
+	return "azurerm_cdn_frontdoor_security_policy"
+}
+
+func (CdnFrontDoorSecurityPolicyDataSource) ModelObject() interface{} {
+	return &CdnFrontDoorSecurityPolicyDataSourceModel{}
+}
+
+func (CdnFrontDoorSecurityPolicyDataSource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validate.FrontDoorSecurityPolicyName,
 		},
 
-		Schema: map[string]*pluginsdk.Schema{
-			"name": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ValidateFunc: validate.FrontDoorSecurityPolicyName,
-			},
+		"profile_name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validate.FrontDoorName,
+		},
 
-			"profile_name": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ValidateFunc: validate.FrontDoorName,
-			},
+		"resource_group_name": commonschema.ResourceGroupNameForDataSource(),
+	}
+}
 
-			"resource_group_name": commonschema.ResourceGroupNameForDataSource(),
+func (CdnFrontDoorSecurityPolicyDataSource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"cdn_frontdoor_profile_id": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
 
-			"cdn_frontdoor_profile_id": {
-				Type:     pluginsdk.TypeString,
-				Computed: true,
-			},
-
-			"security_policies": {
-				Type:     pluginsdk.TypeList,
-				Computed: true,
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-						"firewall": {
-							Type:     pluginsdk.TypeList,
-							Computed: true,
-							Elem: &pluginsdk.Resource{
-								Schema: map[string]*pluginsdk.Schema{
-									"association": {
-										Type:     pluginsdk.TypeList,
-										Computed: true,
-										Elem: &pluginsdk.Resource{
-											Schema: map[string]*pluginsdk.Schema{
-												"domain": {
-													Type:     pluginsdk.TypeList,
-													Computed: true,
-													Elem: &pluginsdk.Resource{
-														Schema: map[string]*pluginsdk.Schema{
-															"active": {
-																Type:     pluginsdk.TypeBool,
-																Computed: true,
-															},
-															"cdn_frontdoor_domain_id": {
-																Type:     pluginsdk.TypeString,
-																Computed: true,
-															},
+		"security_policies": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"firewall": {
+						Type:     pluginsdk.TypeList,
+						Computed: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"association": {
+									Type:     pluginsdk.TypeList,
+									Computed: true,
+									Elem: &pluginsdk.Resource{
+										Schema: map[string]*pluginsdk.Schema{
+											"domain": {
+												Type:     pluginsdk.TypeList,
+												Computed: true,
+												Elem: &pluginsdk.Resource{
+													Schema: map[string]*pluginsdk.Schema{
+														"active": {
+															Type:     pluginsdk.TypeBool,
+															Computed: true,
+														},
+														"cdn_frontdoor_domain_id": {
+															Type:     pluginsdk.TypeString,
+															Computed: true,
 														},
 													},
 												},
-												"patterns_to_match": {
-													Type:     pluginsdk.TypeList,
-													Computed: true,
-													Elem: &pluginsdk.Schema{
-														Type: pluginsdk.TypeString,
-													},
+											},
+											"patterns_to_match": {
+												Type:     pluginsdk.TypeList,
+												Computed: true,
+												Elem: &pluginsdk.Schema{
+													Type: pluginsdk.TypeString,
 												},
 											},
 										},
 									},
-									"cdn_frontdoor_firewall_policy_id": {
-										Type:     pluginsdk.TypeString,
-										Computed: true,
-									},
+								},
+								"cdn_frontdoor_firewall_policy_id": {
+									Type:     pluginsdk.TypeString,
+									Computed: true,
 								},
 							},
 						},
@@ -103,53 +138,60 @@ func dataSourceCdnFrontDoorSecurityPolicy() *pluginsdk.Resource {
 	}
 }
 
-func dataSourceCdnFrontDoorSecurityPolicyRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Cdn.FrontDoorSecurityPoliciesClient
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
-	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
-	defer cancel()
+func (CdnFrontDoorSecurityPolicyDataSource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Cdn.FrontDoorSecurityPoliciesClient
+			subscriptionId := metadata.Client.Account.SubscriptionId
 
-	id := securitypolicies.NewSecurityPolicyID(subscriptionId, d.Get("resource_group_name").(string), d.Get("profile_name").(string), d.Get("name").(string))
+			var state CdnFrontDoorSecurityPolicyDataSourceModel
+			if err := metadata.Decode(&state); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
 
-	resp, err := client.Get(ctx, id)
-	if err != nil {
-		if response.WasNotFound(resp.HttpResponse) {
-			return fmt.Errorf("%s was not found", id)
-		}
+			id := securitypolicies.NewSecurityPolicyID(subscriptionId, state.ResourceGroupName, state.ProfileName, state.Name)
 
-		return fmt.Errorf("retrieving %s: %+v", id, err)
-	}
-
-	d.SetId(id.ID())
-	d.Set("name", id.SecurityPolicyName)
-	d.Set("profile_name", id.ProfileName)
-	d.Set("resource_group_name", id.ResourceGroupName)
-	d.Set("cdn_frontdoor_profile_id", profiles.NewProfileID(id.SubscriptionId, id.ResourceGroupName, id.ProfileName).ID())
-
-	if model := resp.Model; model != nil {
-		if props := model.Properties; props != nil {
-			securityPolicies, err := flattenCdnFrontDoorSecurityPolicyDataSource(props.Parameters)
+			resp, err := client.Get(ctx, id)
 			if err != nil {
-				return fmt.Errorf("flattening `security_policies`: %+v", err)
+				if response.WasNotFound(resp.HttpResponse) {
+					return fmt.Errorf("%s was not found", id)
+				}
+
+				return fmt.Errorf("retrieving %s: %+v", id, err)
 			}
 
-			if err := d.Set("security_policies", securityPolicies); err != nil {
-				return fmt.Errorf("setting `security_policies`: %+v", err)
+			state.Name = id.SecurityPolicyName
+			state.ProfileName = id.ProfileName
+			state.ResourceGroupName = id.ResourceGroupName
+			state.CdnFrontDoorProfileId = profiles.NewProfileID(id.SubscriptionId, id.ResourceGroupName, id.ProfileName).ID()
+
+			if model := resp.Model; model != nil {
+				if props := model.Properties; props != nil {
+					securityPolicies, err := flattenCdnFrontDoorSecurityPolicyDataSource(props.Parameters)
+					if err != nil {
+						return fmt.Errorf("flattening `security_policies`: %+v", err)
+					}
+
+					state.SecurityPolicies = securityPolicies
+				}
 			}
-		}
+
+			metadata.SetID(id)
+
+			return metadata.Encode(&state)
+		},
 	}
-
-	return nil
 }
 
-func flattenCdnFrontDoorSecurityPolicyDataSource(input securitypolicies.SecurityPolicyPropertiesParameters) ([]interface{}, error) {
-	results := make([]interface{}, 0)
+func flattenCdnFrontDoorSecurityPolicyDataSource(input securitypolicies.SecurityPolicyPropertiesParameters) ([]CdnFrontDoorSecurityPolicyPolicyModel, error) {
+	results := make([]CdnFrontDoorSecurityPolicyPolicyModel, 0)
 	if input.SecurityPolicyPropertiesParameters().Type != securitypolicies.SecurityPolicyTypeWebApplicationFirewall {
 		return results, fmt.Errorf("unexpected security policy `Type` %q, expected `WebApplicationFirewall`", input.SecurityPolicyPropertiesParameters().Type)
 	}
 
 	wafParams := input.(securitypolicies.SecurityPolicyWebApplicationFirewallParameters)
-	associations := make([]interface{}, 0)
+	associations := make([]CdnFrontDoorSecurityPolicyAssociationModel, 0)
 	wafPolicyId := ""
 
 	if wafParams.WafPolicy != nil {
@@ -163,27 +205,54 @@ func flattenCdnFrontDoorSecurityPolicyDataSource(input securitypolicies.Security
 
 	if wafParams.Associations != nil {
 		for _, item := range *wafParams.Associations {
-			domain, err := flattenSecurityPoliciesActivatedResourceReference(item.Domains)
+			domain, err := flattenCdnFrontDoorSecurityPolicyActivatedResourceReference(item.Domains)
 			if err != nil {
 				return results, fmt.Errorf("flattening `domain`: %+v", err)
 			}
 
-			associations = append(associations, map[string]interface{}{
-				"domain":            domain,
-				"patterns_to_match": utils.FlattenStringSlice(item.PatternsToMatch),
+			associations = append(associations, CdnFrontDoorSecurityPolicyAssociationModel{
+				Domain:          domain,
+				PatternsToMatch: pointer.From(item.PatternsToMatch),
 			})
 		}
 	}
 
-	results = []interface{}{
-		map[string]interface{}{
-			"firewall": []interface{}{
-				map[string]interface{}{
-					"association":                      associations,
-					"cdn_frontdoor_firewall_policy_id": wafPolicyId,
+	results = []CdnFrontDoorSecurityPolicyPolicyModel{
+		{
+			Firewall: []CdnFrontDoorSecurityPolicyFirewallModel{
+				{
+					Association:                  associations,
+					CdnFrontDoorFirewallPolicyId: wafPolicyId,
 				},
 			},
 		},
+	}
+
+	return results, nil
+}
+
+func flattenCdnFrontDoorSecurityPolicyActivatedResourceReference(input *[]securitypolicies.ActivatedResourceReference) ([]CdnFrontDoorSecurityPolicyDomainModel, error) {
+	results := make([]CdnFrontDoorSecurityPolicyDomainModel, 0)
+	if input == nil {
+		return results, nil
+	}
+
+	for _, item := range *input {
+		frontDoorDomainId := ""
+		if item.Id != nil {
+			if parsedFrontDoorCustomDomainId, frontDoorCustomDomainIdErr := parse.FrontDoorCustomDomainIDInsensitively(*item.Id); frontDoorCustomDomainIdErr == nil {
+				frontDoorDomainId = parsedFrontDoorCustomDomainId.ID()
+			} else if parsedFrontDoorEndpointId, frontDoorEndpointIdErr := parse.FrontDoorEndpointIDInsensitively(*item.Id); frontDoorEndpointIdErr == nil {
+				frontDoorDomainId = parsedFrontDoorEndpointId.ID()
+			} else {
+				return results, fmt.Errorf("flattening `cdn_frontdoor_domain_id`: %+v; %+v", frontDoorCustomDomainIdErr, frontDoorEndpointIdErr)
+			}
+		}
+
+		results = append(results, CdnFrontDoorSecurityPolicyDomainModel{
+			Active:               pointer.From(item.IsActive),
+			CdnFrontDoorDomainId: frontDoorDomainId,
+		})
 	}
 
 	return results, nil

--- a/internal/services/cdn/cdn_frontdoor_security_policy_data_source.go
+++ b/internal/services/cdn/cdn_frontdoor_security_policy_data_source.go
@@ -1,0 +1,187 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package cdn
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2024-02-01/profiles"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2024-02-01/securitypolicies"
+	waf "github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2024-02-01/webapplicationfirewallpolicies"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cdn/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+func dataSourceCdnFrontDoorSecurityPolicy() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Read: dataSourceCdnFrontDoorSecurityPolicyRead,
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Read: pluginsdk.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*pluginsdk.Schema{
+			"name": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ValidateFunc: validate.FrontDoorSecurityPolicyName,
+			},
+
+			"profile_name": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ValidateFunc: validate.FrontDoorName,
+			},
+
+			"resource_group_name": commonschema.ResourceGroupNameForDataSource(),
+
+			"cdn_frontdoor_profile_id": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"security_policies": {
+				Type:     pluginsdk.TypeList,
+				Computed: true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"firewall": {
+							Type:     pluginsdk.TypeList,
+							Computed: true,
+							Elem: &pluginsdk.Resource{
+								Schema: map[string]*pluginsdk.Schema{
+									"association": {
+										Type:     pluginsdk.TypeList,
+										Computed: true,
+										Elem: &pluginsdk.Resource{
+											Schema: map[string]*pluginsdk.Schema{
+												"domain": {
+													Type:     pluginsdk.TypeList,
+													Computed: true,
+													Elem: &pluginsdk.Resource{
+														Schema: map[string]*pluginsdk.Schema{
+															"active": {
+																Type:     pluginsdk.TypeBool,
+																Computed: true,
+															},
+															"cdn_frontdoor_domain_id": {
+																Type:     pluginsdk.TypeString,
+																Computed: true,
+															},
+														},
+													},
+												},
+												"patterns_to_match": {
+													Type:     pluginsdk.TypeList,
+													Computed: true,
+													Elem: &pluginsdk.Schema{
+														Type: pluginsdk.TypeString,
+													},
+												},
+											},
+										},
+									},
+									"cdn_frontdoor_firewall_policy_id": {
+										Type:     pluginsdk.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceCdnFrontDoorSecurityPolicyRead(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Cdn.FrontDoorSecurityPoliciesClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id := securitypolicies.NewSecurityPolicyID(subscriptionId, d.Get("resource_group_name").(string), d.Get("profile_name").(string), d.Get("name").(string))
+
+	resp, err := client.Get(ctx, id)
+	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			return fmt.Errorf("%s was not found", id)
+		}
+
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	d.SetId(id.ID())
+	d.Set("name", id.SecurityPolicyName)
+	d.Set("profile_name", id.ProfileName)
+	d.Set("resource_group_name", id.ResourceGroupName)
+	d.Set("cdn_frontdoor_profile_id", profiles.NewProfileID(id.SubscriptionId, id.ResourceGroupName, id.ProfileName).ID())
+
+	if model := resp.Model; model != nil {
+		if props := model.Properties; props != nil {
+			securityPolicies, err := flattenCdnFrontDoorSecurityPolicyDataSource(props.Parameters)
+			if err != nil {
+				return fmt.Errorf("flattening `security_policies`: %+v", err)
+			}
+
+			if err := d.Set("security_policies", securityPolicies); err != nil {
+				return fmt.Errorf("setting `security_policies`: %+v", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func flattenCdnFrontDoorSecurityPolicyDataSource(input securitypolicies.SecurityPolicyPropertiesParameters) ([]interface{}, error) {
+	if input.SecurityPolicyPropertiesParameters().Type != securitypolicies.SecurityPolicyTypeWebApplicationFirewall {
+		return nil, fmt.Errorf("unexpected security policy `Type` %q, expected `WebApplicationFirewall`", input.SecurityPolicyPropertiesParameters().Type)
+	}
+
+	wafParams := input.(securitypolicies.SecurityPolicyWebApplicationFirewallParameters)
+	associations := make([]interface{}, 0)
+	wafPolicyId := ""
+
+	if wafParams.WafPolicy != nil {
+		parsedId, err := waf.ParseFrontDoorWebApplicationFirewallPolicyIDInsensitively(pointer.From(wafParams.WafPolicy.Id))
+		if err != nil {
+			return nil, fmt.Errorf("flattening `cdn_frontdoor_firewall_policy_id`: %+v", err)
+		}
+
+		wafPolicyId = parsedId.ID()
+	}
+
+	if wafParams.Associations != nil {
+		for _, item := range *wafParams.Associations {
+			domain, err := flattenSecurityPoliciesActivatedResourceReference(item.Domains)
+			if err != nil {
+				return nil, fmt.Errorf("flattening `domain`: %+v", err)
+			}
+
+			associations = append(associations, map[string]interface{}{
+				"domain":            domain,
+				"patterns_to_match": utils.FlattenStringSlice(item.PatternsToMatch),
+			})
+		}
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"firewall": []interface{}{
+				map[string]interface{}{
+					"association":                      associations,
+					"cdn_frontdoor_firewall_policy_id": wafPolicyId,
+				},
+			},
+		},
+	}, nil
+}

--- a/internal/services/cdn/cdn_frontdoor_security_policy_data_source.go
+++ b/internal/services/cdn/cdn_frontdoor_security_policy_data_source.go
@@ -143,8 +143,9 @@ func dataSourceCdnFrontDoorSecurityPolicyRead(d *pluginsdk.ResourceData, meta in
 }
 
 func flattenCdnFrontDoorSecurityPolicyDataSource(input securitypolicies.SecurityPolicyPropertiesParameters) ([]interface{}, error) {
+	results := make([]interface{}, 0)
 	if input.SecurityPolicyPropertiesParameters().Type != securitypolicies.SecurityPolicyTypeWebApplicationFirewall {
-		return nil, fmt.Errorf("unexpected security policy `Type` %q, expected `WebApplicationFirewall`", input.SecurityPolicyPropertiesParameters().Type)
+		return results, fmt.Errorf("unexpected security policy `Type` %q, expected `WebApplicationFirewall`", input.SecurityPolicyPropertiesParameters().Type)
 	}
 
 	wafParams := input.(securitypolicies.SecurityPolicyWebApplicationFirewallParameters)
@@ -154,7 +155,7 @@ func flattenCdnFrontDoorSecurityPolicyDataSource(input securitypolicies.Security
 	if wafParams.WafPolicy != nil {
 		parsedId, err := waf.ParseFrontDoorWebApplicationFirewallPolicyIDInsensitively(pointer.From(wafParams.WafPolicy.Id))
 		if err != nil {
-			return nil, fmt.Errorf("flattening `cdn_frontdoor_firewall_policy_id`: %+v", err)
+			return results, fmt.Errorf("flattening `cdn_frontdoor_firewall_policy_id`: %+v", err)
 		}
 
 		wafPolicyId = parsedId.ID()
@@ -164,7 +165,7 @@ func flattenCdnFrontDoorSecurityPolicyDataSource(input securitypolicies.Security
 		for _, item := range *wafParams.Associations {
 			domain, err := flattenSecurityPoliciesActivatedResourceReference(item.Domains)
 			if err != nil {
-				return nil, fmt.Errorf("flattening `domain`: %+v", err)
+				return results, fmt.Errorf("flattening `domain`: %+v", err)
 			}
 
 			associations = append(associations, map[string]interface{}{
@@ -174,7 +175,7 @@ func flattenCdnFrontDoorSecurityPolicyDataSource(input securitypolicies.Security
 		}
 	}
 
-	return []interface{}{
+	results = []interface{}{
 		map[string]interface{}{
 			"firewall": []interface{}{
 				map[string]interface{}{
@@ -183,5 +184,7 @@ func flattenCdnFrontDoorSecurityPolicyDataSource(input securitypolicies.Security
 				},
 			},
 		},
-	}, nil
+	}
+
+	return results, nil
 }

--- a/internal/services/cdn/cdn_frontdoor_security_policy_data_source.go
+++ b/internal/services/cdn/cdn_frontdoor_security_policy_data_source.go
@@ -197,7 +197,7 @@ func flattenCdnFrontDoorSecurityPolicyDataSource(input securitypolicies.Security
 	if wafParams.WafPolicy != nil {
 		parsedId, err := waf.ParseFrontDoorWebApplicationFirewallPolicyIDInsensitively(pointer.From(wafParams.WafPolicy.Id))
 		if err != nil {
-			return results, fmt.Errorf("flattening `cdn_frontdoor_firewall_policy_id`: %+v", err)
+			return results, err
 		}
 
 		wafPolicyId = parsedId.ID()

--- a/internal/services/cdn/cdn_frontdoor_security_policy_data_source_test.go
+++ b/internal/services/cdn/cdn_frontdoor_security_policy_data_source_test.go
@@ -1,0 +1,43 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package cdn_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+type CdnFrontDoorSecurityPolicyDataSource struct{}
+
+func TestAccCdnFrontDoorSecurityPolicyDataSource_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_cdn_frontdoor_security_policy", "test")
+	d := CdnFrontDoorSecurityPolicyDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: d.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("cdn_frontdoor_profile_id").MatchesOtherKey(check.That("azurerm_cdn_frontdoor_security_policy.test").Key("cdn_frontdoor_profile_id")),
+				check.That(data.ResourceName).Key("security_policies.0.firewall.0.cdn_frontdoor_firewall_policy_id").MatchesOtherKey(check.That("azurerm_cdn_frontdoor_security_policy.test").Key("security_policies.0.firewall.0.cdn_frontdoor_firewall_policy_id")),
+				check.That(data.ResourceName).Key("security_policies.0.firewall.0.association.0.domain.0.cdn_frontdoor_domain_id").MatchesOtherKey(check.That("azurerm_cdn_frontdoor_security_policy.test").Key("security_policies.0.firewall.0.association.0.domain.0.cdn_frontdoor_domain_id")),
+				check.That(data.ResourceName).Key("security_policies.0.firewall.0.association.0.patterns_to_match.0").HasValue("/*"),
+			),
+		},
+	})
+}
+
+func (CdnFrontDoorSecurityPolicyDataSource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_cdn_frontdoor_security_policy" "test" {
+	name                = azurerm_cdn_frontdoor_security_policy.test.name
+	profile_name        = azurerm_cdn_frontdoor_profile.test.name
+	resource_group_name = azurerm_resource_group.test.name
+}
+`, CdnFrontDoorSecurityPolicyResource{}.basic(data))
+}

--- a/internal/services/cdn/cdn_frontdoor_security_policy_data_source_test.go
+++ b/internal/services/cdn/cdn_frontdoor_security_policy_data_source_test.go
@@ -35,9 +35,9 @@ func (CdnFrontDoorSecurityPolicyDataSource) basic(data acceptance.TestData) stri
 %s
 
 data "azurerm_cdn_frontdoor_security_policy" "test" {
-	name                = azurerm_cdn_frontdoor_security_policy.test.name
-	profile_name        = azurerm_cdn_frontdoor_profile.test.name
-	resource_group_name = azurerm_resource_group.test.name
+  name                = azurerm_cdn_frontdoor_security_policy.test.name
+  profile_name        = azurerm_cdn_frontdoor_profile.test.name
+  resource_group_name = azurerm_resource_group.test.name
 }
 `, CdnFrontDoorSecurityPolicyResource{}.basic(data))
 }

--- a/internal/services/cdn/cdn_frontdoor_security_policy_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_security_policy_resource.go
@@ -405,8 +405,9 @@ func flattenSecurityPoliciesActivatedResourceReference(input *[]securitypolicies
 }
 
 func flattenCdnFrontDoorSecurityPolicyResource(input securitypolicies.SecurityPolicyPropertiesParameters) ([]interface{}, error) {
+	results := make([]interface{}, 0)
 	if input.SecurityPolicyPropertiesParameters().Type != securitypolicies.SecurityPolicyTypeWebApplicationFirewall {
-		return nil, fmt.Errorf("unexpected security policy `Type` %q, expected `WebApplicationFirewall`", input.SecurityPolicyPropertiesParameters().Type)
+		return results, fmt.Errorf("unexpected security policy `Type` %q, expected `WebApplicationFirewall`", input.SecurityPolicyPropertiesParameters().Type)
 	}
 
 	wafParams := input.(securitypolicies.SecurityPolicyWebApplicationFirewallParameters)
@@ -416,7 +417,7 @@ func flattenCdnFrontDoorSecurityPolicyResource(input securitypolicies.SecurityPo
 	if wafParams.WafPolicy != nil {
 		parsedId, err := waf.ParseFrontDoorWebApplicationFirewallPolicyIDInsensitively(pointer.From(wafParams.WafPolicy.Id))
 		if err != nil {
-			return nil, fmt.Errorf("flattening `cdn_frontdoor_firewall_policy_id`: %+v", err)
+			return results, fmt.Errorf("flattening `cdn_frontdoor_firewall_policy_id`: %+v", err)
 		}
 
 		wafPolicyId = parsedId.ID()
@@ -426,7 +427,7 @@ func flattenCdnFrontDoorSecurityPolicyResource(input securitypolicies.SecurityPo
 		for _, item := range *wafParams.Associations {
 			domain, err := flattenSecurityPoliciesActivatedResourceReference(item.Domains)
 			if err != nil {
-				return nil, fmt.Errorf("flattening `domain`: %+v", err)
+				return results, fmt.Errorf("flattening `domain`: %+v", err)
 			}
 
 			associations = append(associations, map[string]interface{}{
@@ -436,7 +437,7 @@ func flattenCdnFrontDoorSecurityPolicyResource(input securitypolicies.SecurityPo
 		}
 	}
 
-	return []interface{}{
+	results = []interface{}{
 		map[string]interface{}{
 			"firewall": []interface{}{
 				map[string]interface{}{
@@ -445,5 +446,7 @@ func flattenCdnFrontDoorSecurityPolicyResource(input securitypolicies.SecurityPo
 				},
 			},
 		},
-	}, nil
+	}
+
+	return results, nil
 }

--- a/internal/services/cdn/cdn_frontdoor_security_policy_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_security_policy_resource.go
@@ -172,12 +172,11 @@ func resourceCdnFrontdoorSecurityPolicyCreate(d *pluginsdk.ResourceData, meta in
 		return errors.New("profileModel is 'nil'")
 	}
 
-	isStandardSku := true
-	if skuName := pointer.FromEnum(profileModel.Sku.Name); skuName != "" {
-		isStandardSku = strings.HasPrefix(strings.ToLower(skuName), "standard")
+	if profileModel.Sku.Name == nil {
+		return errors.New("profileModel.Sku.Name is 'nil'")
 	}
 
-	params, err := expandCdnFrontdoorFirewallPolicyParameters(d.Get("security_policies").([]interface{}), isStandardSku)
+	params, err := expandCdnFrontdoorFirewallPolicyParameters(d.Get("security_policies").([]interface{}), strings.EqualFold(pointer.FromEnum(profileModel.Sku.Name), string(profiles.SkuNameStandardAzureFrontDoor)))
 	if err != nil {
 		return fmt.Errorf("expanding 'security_policies': %+v", err)
 	}
@@ -268,12 +267,11 @@ func resourceCdnFrontdoorSecurityPolicyUpdate(d *pluginsdk.ResourceData, meta in
 		return errors.New("profileModel is 'nil'")
 	}
 
-	isStandardSku := true
-	if skuName := pointer.FromEnum(profileModel.Sku.Name); skuName != "" {
-		isStandardSku = strings.HasPrefix(strings.ToLower(skuName), "standard")
+	if profileModel.Sku.Name == nil {
+		return errors.New("profileModel.Sku.Name is 'nil'")
 	}
 
-	params, err := expandCdnFrontdoorFirewallPolicyParameters(d.Get("security_policies").([]interface{}), isStandardSku)
+	params, err := expandCdnFrontdoorFirewallPolicyParameters(d.Get("security_policies").([]interface{}), strings.EqualFold(pointer.FromEnum(profileModel.Sku.Name), string(profiles.SkuNameStandardAzureFrontDoor)))
 	if err != nil {
 		return fmt.Errorf("expanding 'security_policies': %+v", err)
 	}
@@ -335,7 +333,7 @@ func expandCdnFrontdoorFirewallPolicyParameters(input []interface{}, isStandardS
 	for _, item := range configAssociations {
 		v := item.(map[string]interface{})
 		domains := expandSecurityPoliciesActivatedResourceReference(v["domain"].([]interface{}))
-		domainCount := len(pointer.From(domains))
+		domainCount := len(*domains)
 
 		if isStandardSku {
 			if domainCount > 100 {
@@ -388,9 +386,9 @@ func flattenSecurityPoliciesActivatedResourceReference(input *[]securitypolicies
 	for _, item := range *input {
 		frontDoorDomainId := ""
 		if item.Id != nil {
-			if parsedFrontDoorCustomDomainId, frontDoorCustomDomainIdErr := parse.FrontDoorCustomDomainIDInsensitively(pointer.From(item.Id)); frontDoorCustomDomainIdErr == nil {
+			if parsedFrontDoorCustomDomainId, frontDoorCustomDomainIdErr := parse.FrontDoorCustomDomainIDInsensitively(*item.Id); frontDoorCustomDomainIdErr == nil {
 				frontDoorDomainId = parsedFrontDoorCustomDomainId.ID()
-			} else if parsedFrontDoorEndpointId, frontDoorEndpointIdErr := parse.FrontDoorEndpointIDInsensitively(pointer.From(item.Id)); frontDoorEndpointIdErr == nil {
+			} else if parsedFrontDoorEndpointId, frontDoorEndpointIdErr := parse.FrontDoorEndpointIDInsensitively(*item.Id); frontDoorEndpointIdErr == nil {
 				frontDoorDomainId = parsedFrontDoorEndpointId.ID()
 			} else {
 				return nil, fmt.Errorf("flattening `cdn_frontdoor_domain_id`: %+v; %+v", frontDoorCustomDomainIdErr, frontDoorEndpointIdErr)

--- a/internal/services/cdn/cdn_frontdoor_security_policy_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_security_policy_resource.go
@@ -48,7 +48,7 @@ func resourceCdnFrontDoorSecurityPolicy() *pluginsdk.Resource {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
+				ValidateFunc: validate.FrontDoorSecurityPolicyName,
 			},
 
 			"cdn_frontdoor_profile_id": {
@@ -173,8 +173,8 @@ func resourceCdnFrontdoorSecurityPolicyCreate(d *pluginsdk.ResourceData, meta in
 	}
 
 	isStandardSku := true
-	if profileModel.Sku.Name != nil {
-		isStandardSku = strings.HasPrefix(strings.ToLower(pointer.FromEnum(profileModel.Sku.Name)), "standard")
+	if skuName := pointer.FromEnum(profileModel.Sku.Name); skuName != "" {
+		isStandardSku = strings.HasPrefix(strings.ToLower(skuName), "standard")
 	}
 
 	params, err := expandCdnFrontdoorFirewallPolicyParameters(d.Get("security_policies").([]interface{}), isStandardSku)
@@ -221,50 +221,14 @@ func resourceCdnFrontdoorSecurityPolicyRead(d *pluginsdk.ResourceData, meta inte
 
 	if model := resp.Model; model != nil {
 		if props := model.Properties; props != nil {
-			if props.Parameters.SecurityPolicyPropertiesParameters().Type != securitypolicies.SecurityPolicyTypeWebApplicationFirewall {
-				return fmt.Errorf("'model.Properties.Parameters.Type' of %q is unexpected, want security policy 'Type' of 'WebApplicationFirewall': %s", props.Parameters.SecurityPolicyPropertiesParameters().Type, id)
+			securityPolicies, err := flattenCdnFrontDoorSecurityPolicyResource(props.Parameters)
+			if err != nil {
+				return fmt.Errorf("flattening `security_policies`: %+v", err)
 			}
 
-			// we know it's a firewall policy at this point,
-			// create the objects to hold the policy data
-			wafParams := props.Parameters.(securitypolicies.SecurityPolicyWebApplicationFirewallParameters)
-			associations := make([]interface{}, 0)
-			wafPolicyId := ""
-
-			if wafParams.WafPolicy != nil && wafParams.WafPolicy.Id != nil {
-				parsedId, err := waf.ParseFrontDoorWebApplicationFirewallPolicyIDInsensitively(*wafParams.WafPolicy.Id)
-				if err != nil {
-					return fmt.Errorf("flattening `cdn_frontdoor_firewall_policy_id`: %+v", err)
-				}
-				wafPolicyId = parsedId.ID()
+			if err := d.Set("security_policies", securityPolicies); err != nil {
+				return fmt.Errorf("setting `security_policies`: %+v", err)
 			}
-
-			if wafParams.Associations != nil {
-				for _, item := range *wafParams.Associations {
-					domain, err := flattenSecurityPoliciesActivatedResourceReference(item.Domains)
-					if err != nil {
-						return fmt.Errorf("flattening `ActivatedResourceReference`: %+v", err)
-					}
-
-					associations = append(associations, map[string]interface{}{
-						"domain":            domain,
-						"patterns_to_match": utils.FlattenStringSlice(item.PatternsToMatch),
-					})
-				}
-			}
-
-			securityPolicy := []interface{}{
-				map[string]interface{}{
-					"firewall": []interface{}{
-						map[string]interface{}{
-							"association":                      associations,
-							"cdn_frontdoor_firewall_policy_id": wafPolicyId,
-						},
-					},
-				},
-			}
-
-			d.Set("security_policies", securityPolicy)
 		}
 	}
 
@@ -295,7 +259,7 @@ func resourceCdnFrontdoorSecurityPolicyUpdate(d *pluginsdk.ResourceData, meta in
 	profileClient := meta.(*clients.Client).Cdn.FrontDoorProfilesClient
 	resp, err := profileClient.Get(ctx, pointer.From(profileId))
 	if err != nil {
-		return fmt.Errorf("unable to retrieve the `sku_name` from %s: %+v", *profileId, err)
+		return fmt.Errorf("unable to retrieve the `sku_name` from %s: %+v", pointer.From(profileId), err)
 	}
 
 	profileModel := resp.Model
@@ -305,8 +269,8 @@ func resourceCdnFrontdoorSecurityPolicyUpdate(d *pluginsdk.ResourceData, meta in
 	}
 
 	isStandardSku := true
-	if profileModel.Sku.Name != nil {
-		isStandardSku = strings.HasPrefix(strings.ToLower(pointer.FromEnum(profileModel.Sku.Name)), "standard")
+	if skuName := pointer.FromEnum(profileModel.Sku.Name); skuName != "" {
+		isStandardSku = strings.HasPrefix(strings.ToLower(skuName), "standard")
 	}
 
 	params, err := expandCdnFrontdoorFirewallPolicyParameters(d.Get("security_policies").([]interface{}), isStandardSku)
@@ -341,7 +305,7 @@ func resourceCdnFrontdoorSecurityPolicyDelete(d *pluginsdk.ResourceData, meta in
 
 	err = client.DeleteThenPoll(ctx, pointer.From(id))
 	if err != nil {
-		return fmt.Errorf("deleting %s: %+v", *id, err)
+		return fmt.Errorf("deleting %s: %+v", pointer.From(id), err)
 	}
 
 	return nil
@@ -371,14 +335,15 @@ func expandCdnFrontdoorFirewallPolicyParameters(input []interface{}, isStandardS
 	for _, item := range configAssociations {
 		v := item.(map[string]interface{})
 		domains := expandSecurityPoliciesActivatedResourceReference(v["domain"].([]interface{}))
+		domainCount := len(pointer.From(domains))
 
 		if isStandardSku {
-			if len(*domains) > 100 {
-				return &results, fmt.Errorf("the 'Standard_AzureFrontDoor' sku is only allowed to have 100 or less domains associated with the firewall policy, got %d", len(*domains))
+			if domainCount > 100 {
+				return &results, fmt.Errorf("the 'Standard_AzureFrontDoor' sku is only allowed to have 100 or less domains associated with the firewall policy, got %d", domainCount)
 			}
 		} else {
-			if len(*domains) > 500 {
-				return &results, fmt.Errorf("the 'Premium_AzureFrontDoor' sku is only allowed to have 500 or less domains associated with the firewall policy, got %d", len(*domains))
+			if domainCount > 500 {
+				return &results, fmt.Errorf("the 'Premium_AzureFrontDoor' sku is only allowed to have 500 or less domains associated with the firewall policy, got %d", domainCount)
 			}
 		}
 
@@ -423,9 +388,9 @@ func flattenSecurityPoliciesActivatedResourceReference(input *[]securitypolicies
 	for _, item := range *input {
 		frontDoorDomainId := ""
 		if item.Id != nil {
-			if parsedFrontDoorCustomDomainId, frontDoorCustomDomainIdErr := parse.FrontDoorCustomDomainIDInsensitively(*item.Id); frontDoorCustomDomainIdErr == nil {
+			if parsedFrontDoorCustomDomainId, frontDoorCustomDomainIdErr := parse.FrontDoorCustomDomainIDInsensitively(pointer.From(item.Id)); frontDoorCustomDomainIdErr == nil {
 				frontDoorDomainId = parsedFrontDoorCustomDomainId.ID()
-			} else if parsedFrontDoorEndpointId, frontDoorEndpointIdErr := parse.FrontDoorEndpointIDInsensitively(*item.Id); frontDoorEndpointIdErr == nil {
+			} else if parsedFrontDoorEndpointId, frontDoorEndpointIdErr := parse.FrontDoorEndpointIDInsensitively(pointer.From(item.Id)); frontDoorEndpointIdErr == nil {
 				frontDoorDomainId = parsedFrontDoorEndpointId.ID()
 			} else {
 				return nil, fmt.Errorf("flattening `cdn_frontdoor_domain_id`: %+v; %+v", frontDoorCustomDomainIdErr, frontDoorEndpointIdErr)
@@ -439,4 +404,48 @@ func flattenSecurityPoliciesActivatedResourceReference(input *[]securitypolicies
 	}
 
 	return results, nil
+}
+
+func flattenCdnFrontDoorSecurityPolicyResource(input securitypolicies.SecurityPolicyPropertiesParameters) ([]interface{}, error) {
+	if input.SecurityPolicyPropertiesParameters().Type != securitypolicies.SecurityPolicyTypeWebApplicationFirewall {
+		return nil, fmt.Errorf("unexpected security policy `Type` %q, expected `WebApplicationFirewall`", input.SecurityPolicyPropertiesParameters().Type)
+	}
+
+	wafParams := input.(securitypolicies.SecurityPolicyWebApplicationFirewallParameters)
+	associations := make([]interface{}, 0)
+	wafPolicyId := ""
+
+	if wafParams.WafPolicy != nil {
+		parsedId, err := waf.ParseFrontDoorWebApplicationFirewallPolicyIDInsensitively(pointer.From(wafParams.WafPolicy.Id))
+		if err != nil {
+			return nil, fmt.Errorf("flattening `cdn_frontdoor_firewall_policy_id`: %+v", err)
+		}
+
+		wafPolicyId = parsedId.ID()
+	}
+
+	if wafParams.Associations != nil {
+		for _, item := range *wafParams.Associations {
+			domain, err := flattenSecurityPoliciesActivatedResourceReference(item.Domains)
+			if err != nil {
+				return nil, fmt.Errorf("flattening `domain`: %+v", err)
+			}
+
+			associations = append(associations, map[string]interface{}{
+				"domain":            domain,
+				"patterns_to_match": utils.FlattenStringSlice(item.PatternsToMatch),
+			})
+		}
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"firewall": []interface{}{
+				map[string]interface{}{
+					"association":                      associations,
+					"cdn_frontdoor_firewall_policy_id": wafPolicyId,
+				},
+			},
+		},
+	}, nil
 }

--- a/internal/services/cdn/cdn_frontdoor_security_policy_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_security_policy_resource.go
@@ -417,7 +417,7 @@ func flattenCdnFrontDoorSecurityPolicyResource(input securitypolicies.SecurityPo
 	if wafParams.WafPolicy != nil {
 		parsedId, err := waf.ParseFrontDoorWebApplicationFirewallPolicyIDInsensitively(pointer.From(wafParams.WafPolicy.Id))
 		if err != nil {
-			return results, fmt.Errorf("flattening `cdn_frontdoor_firewall_policy_id`: %+v", err)
+			return results, err
 		}
 
 		wafPolicyId = parsedId.ID()

--- a/internal/services/cdn/cdn_frontdoor_security_policy_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_security_policy_resource_test.go
@@ -6,7 +6,6 @@ package cdn_test
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -45,17 +44,6 @@ func TestAccCdnFrontDoorSecurityPolicy_basicEndpoint(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
-	})
-}
-
-func TestAccCdnFrontDoorSecurityPolicy_validate(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_security_policy", "test")
-	r := CdnFrontDoorSecurityPolicyResource{}
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config:      r.invalidName(data),
-			ExpectError: regexp.MustCompile(`must begin and end with an alphanumeric character, and may contain only alphanumeric characters and hyphens`),
-		},
 	})
 }
 
@@ -362,37 +350,6 @@ resource "azurerm_cdn_frontdoor_security_policy" "test" {
       association {
         domain {
           cdn_frontdoor_domain_id = azurerm_cdn_frontdoor_endpoint.test.id
-        }
-
-        patterns_to_match = ["/*"]
-      }
-    }
-  }
-}
-`, template, data.RandomInteger)
-}
-
-func (r CdnFrontDoorSecurityPolicyResource) invalidName(data acceptance.TestData) string {
-	template := r.template(data)
-	// lintignore:AZNR007
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-%s
-
-resource "azurerm_cdn_frontdoor_security_policy" "test" {
-  name                     = "-acctestsecpol%d"
-  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
-
-  security_policies {
-    firewall {
-      cdn_frontdoor_firewall_policy_id = azurerm_cdn_frontdoor_firewall_policy.test.id
-
-      association {
-        domain {
-          cdn_frontdoor_domain_id = azurerm_cdn_frontdoor_custom_domain.test.id
         }
 
         patterns_to_match = ["/*"]

--- a/internal/services/cdn/cdn_frontdoor_security_policy_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_security_policy_resource_test.go
@@ -374,6 +374,7 @@ resource "azurerm_cdn_frontdoor_security_policy" "test" {
 
 func (r CdnFrontDoorSecurityPolicyResource) invalidName(data acceptance.TestData) string {
 	template := r.template(data)
+	// lintignore:AZNR007
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/internal/services/cdn/cdn_frontdoor_security_policy_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_security_policy_resource_test.go
@@ -6,6 +6,7 @@ package cdn_test
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -44,6 +45,17 @@ func TestAccCdnFrontDoorSecurityPolicy_basicEndpoint(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
+	})
+}
+
+func TestAccCdnFrontDoorSecurityPolicy_validate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_security_policy", "test")
+	r := CdnFrontDoorSecurityPolicyResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:      r.invalidName(data),
+			ExpectError: regexp.MustCompile(`must begin and end with an alphanumeric character, and may contain only alphanumeric characters and hyphens`),
+		},
 	})
 }
 
@@ -350,6 +362,36 @@ resource "azurerm_cdn_frontdoor_security_policy" "test" {
       association {
         domain {
           cdn_frontdoor_domain_id = azurerm_cdn_frontdoor_endpoint.test.id
+        }
+
+        patterns_to_match = ["/*"]
+      }
+    }
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r CdnFrontDoorSecurityPolicyResource) invalidName(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_cdn_frontdoor_security_policy" "test" {
+  name                     = "-acctestsecpol%d"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+
+  security_policies {
+    firewall {
+      cdn_frontdoor_firewall_policy_id = azurerm_cdn_frontdoor_firewall_policy.test.id
+
+      association {
+        domain {
+          cdn_frontdoor_domain_id = azurerm_cdn_frontdoor_custom_domain.test.id
         }
 
         patterns_to_match = ["/*"]

--- a/internal/services/cdn/registration.go
+++ b/internal/services/cdn/registration.go
@@ -14,6 +14,8 @@ type Registration struct{}
 
 var _ sdk.UntypedServiceRegistrationWithAGitHubLabel = Registration{}
 
+var _ sdk.TypedServiceRegistrationWithAGitHubLabel = Registration{}
+
 var _ sdk.FrameworkServiceRegistration = Registration{}
 
 func (r Registration) AssociatedGitHubLabel() string {
@@ -47,8 +49,17 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 		"azurerm_cdn_frontdoor_profile":         dataSourceCdnFrontDoorProfile(),
 		"azurerm_cdn_frontdoor_rule_set":        dataSourceCdnFrontDoorRuleSet(),
 		"azurerm_cdn_frontdoor_secret":          dataSourceCdnFrontDoorSecret(),
-		"azurerm_cdn_frontdoor_security_policy": dataSourceCdnFrontDoorSecurityPolicy(),
 	}
+}
+
+func (r Registration) DataSources() []sdk.DataSource {
+	return []sdk.DataSource{
+		CdnFrontDoorSecurityPolicyDataSource{},
+	}
+}
+
+func (r Registration) Resources() []sdk.Resource {
+	return []sdk.Resource{}
 }
 
 // SupportedResources returns the supported Resources supported by this Service

--- a/internal/services/cdn/registration.go
+++ b/internal/services/cdn/registration.go
@@ -45,6 +45,7 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 		"azurerm_cdn_frontdoor_origin_group":    dataSourceCdnFrontDoorOriginGroup(),
 		"azurerm_cdn_frontdoor_profile":         dataSourceCdnFrontDoorProfile(),
 		"azurerm_cdn_frontdoor_rule_set":        dataSourceCdnFrontDoorRuleSet(),
+		"azurerm_cdn_frontdoor_security_policy": dataSourceCdnFrontDoorSecurityPolicy(),
 		"azurerm_cdn_frontdoor_secret":          dataSourceCdnFrontDoorSecret(),
 	}
 }

--- a/internal/services/cdn/registration.go
+++ b/internal/services/cdn/registration.go
@@ -33,7 +33,6 @@ func (r Registration) WebsiteCategories() []string {
 }
 
 // SupportedDataSources returns the supported Data Sources supported by this Service
-// lintignore:AZNR005
 func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 	return map[string]*pluginsdk.Resource{
 		// CDN
@@ -52,9 +51,8 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 }
 
 // SupportedResources returns the supported Resources supported by this Service
-// lintignore:AZNR005
 func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
-	resources := map[string]*pluginsdk.Resource{
+	return map[string]*pluginsdk.Resource{
 		// CDN
 		"azurerm_cdn_endpoint":               resourceCdnEndpoint(),
 		"azurerm_cdn_endpoint_custom_domain": resourceArmCdnEndpointCustomDomain(),
@@ -74,8 +72,6 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_cdn_frontdoor_secret":                    resourceCdnFrontDoorSecret(),
 		"azurerm_cdn_frontdoor_security_policy":           resourceCdnFrontDoorSecurityPolicy(),
 	}
-
-	return resources
 }
 
 func (r Registration) Actions() []func() action.Action {

--- a/internal/services/cdn/registration.go
+++ b/internal/services/cdn/registration.go
@@ -45,8 +45,8 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 		"azurerm_cdn_frontdoor_origin_group":    dataSourceCdnFrontDoorOriginGroup(),
 		"azurerm_cdn_frontdoor_profile":         dataSourceCdnFrontDoorProfile(),
 		"azurerm_cdn_frontdoor_rule_set":        dataSourceCdnFrontDoorRuleSet(),
-		"azurerm_cdn_frontdoor_security_policy": dataSourceCdnFrontDoorSecurityPolicy(),
 		"azurerm_cdn_frontdoor_secret":          dataSourceCdnFrontDoorSecret(),
+		"azurerm_cdn_frontdoor_security_policy": dataSourceCdnFrontDoorSecurityPolicy(),
 	}
 }
 

--- a/internal/services/cdn/registration.go
+++ b/internal/services/cdn/registration.go
@@ -33,8 +33,8 @@ func (r Registration) WebsiteCategories() []string {
 }
 
 // SupportedDataSources returns the supported Data Sources supported by this Service
+// lintignore:AZNR005
 func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
-	// lintignore:AZNR005
 	return map[string]*pluginsdk.Resource{
 		// CDN
 		"azurerm_cdn_profile": dataSourceCdnProfile(),
@@ -52,8 +52,8 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 }
 
 // SupportedResources returns the supported Resources supported by this Service
+// lintignore:AZNR005
 func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
-	// lintignore:AZNR005
 	resources := map[string]*pluginsdk.Resource{
 		// CDN
 		"azurerm_cdn_endpoint":               resourceCdnEndpoint(),

--- a/internal/services/cdn/registration.go
+++ b/internal/services/cdn/registration.go
@@ -33,6 +33,7 @@ func (r Registration) WebsiteCategories() []string {
 }
 
 // SupportedDataSources returns the supported Data Sources supported by this Service
+// lintignore:AZNR005
 func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 	return map[string]*pluginsdk.Resource{
 		// CDN
@@ -51,6 +52,7 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 }
 
 // SupportedResources returns the supported Resources supported by this Service
+// lintignore:AZNR005
 func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 	return map[string]*pluginsdk.Resource{
 		// CDN

--- a/internal/services/cdn/registration.go
+++ b/internal/services/cdn/registration.go
@@ -34,6 +34,7 @@ func (r Registration) WebsiteCategories() []string {
 
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
+	// lintignore:AZNR005
 	return map[string]*pluginsdk.Resource{
 		// CDN
 		"azurerm_cdn_profile": dataSourceCdnProfile(),
@@ -52,6 +53,7 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
+	// lintignore:AZNR005
 	resources := map[string]*pluginsdk.Resource{
 		// CDN
 		"azurerm_cdn_endpoint":               resourceCdnEndpoint(),

--- a/internal/services/cdn/validate/front_door_security_policy_name.go
+++ b/internal/services/cdn/validate/front_door_security_policy_name.go
@@ -1,0 +1,18 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package validate
+
+import (
+	"fmt"
+
+	validatehelper "github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
+)
+
+func FrontDoorSecurityPolicyName(i interface{}, k string) (_ []string, errors []error) {
+	if m, regexErrs := validatehelper.RegExHelper(i, k, `^[\da-zA-Z](?:[-\da-zA-Z]*[\da-zA-Z])?$`); !m {
+		return nil, append(regexErrs, fmt.Errorf("%q must begin and end with an alphanumeric character, and may contain only alphanumeric characters and hyphens", k))
+	}
+
+	return nil, nil
+}

--- a/internal/services/cdn/validate/front_door_security_policy_name_test.go
+++ b/internal/services/cdn/validate/front_door_security_policy_name_test.go
@@ -46,10 +46,6 @@ func TestFrontDoorSecurityPolicyName(t *testing.T) {
 			Input: "A!1",
 			Valid: false,
 		},
-		{
-			Input: "A🙂1",
-			Valid: false,
-		},
 	}
 
 	for _, tc := range cases {

--- a/internal/services/cdn/validate/front_door_security_policy_name_test.go
+++ b/internal/services/cdn/validate/front_door_security_policy_name_test.go
@@ -1,0 +1,64 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package validate
+
+import "testing"
+
+func TestFrontDoorSecurityPolicyName(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+		{
+			Input: "",
+			Valid: false,
+		},
+		{
+			Input: "A",
+			Valid: true,
+		},
+		{
+			Input: "1",
+			Valid: true,
+		},
+		{
+			Input: "A-1",
+			Valid: true,
+		},
+		{
+			Input: "-A1",
+			Valid: false,
+		},
+		{
+			Input: "A1-",
+			Valid: false,
+		},
+		{
+			Input: "A_1",
+			Valid: false,
+		},
+		{
+			Input: "A 1",
+			Valid: false,
+		},
+		{
+			Input: "A!1",
+			Valid: false,
+		},
+		{
+			Input: "A🙂1",
+			Valid: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := FrontDoorSecurityPolicyName(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Testing value %q, Expected %t but got %t", tc.Input, tc.Valid, valid)
+		}
+	}
+}

--- a/website/docs/d/cdn_frontdoor_security_policy.html.markdown
+++ b/website/docs/d/cdn_frontdoor_security_policy.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "CDN"
 layout: "azurerm"
-page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_security_policy"
+page_title: "Azure Resource Manager: Data Source: azurerm_cdn_frontdoor_security_policy"
 description: |-
   Gets information about an existing Front Door (standard/premium) Security Policy.
 ---
@@ -101,7 +101,7 @@ The following arguments are supported:
 
 * `profile_name` - (Required) The name of the Front Door Profile.
 
-* `resource_group_name` - (Required) The name of the resource group.
+* `resource_group_name` - (Required) The name of the Resource Group.
 
 ## Attributes Reference
 

--- a/website/docs/d/cdn_frontdoor_security_policy.html.markdown
+++ b/website/docs/d/cdn_frontdoor_security_policy.html.markdown
@@ -150,3 +150,9 @@ A `domain` block exports the following:
 The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/configure#define-operation-timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Front Door Security Policy.
+
+## API Providers
+<!-- This section is generated, changes will be overwritten -->
+This data source uses the following Azure API Providers:
+
+* `Microsoft.Cdn` - 2024-02-01

--- a/website/docs/d/cdn_frontdoor_security_policy.html.markdown
+++ b/website/docs/d/cdn_frontdoor_security_policy.html.markdown
@@ -1,0 +1,152 @@
+---
+subcategory: "CDN"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_security_policy"
+description: |-
+  Gets information about an existing Front Door (standard/premium) Security Policy.
+---
+
+# Data Source: azurerm_cdn_frontdoor_security_policy
+
+Gets information about an existing Front Door (standard/premium) Security Policy.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-cdn-frontdoor"
+  location = "West Europe"
+}
+
+resource "azurerm_cdn_frontdoor_profile" "example" {
+  name                = "example-frontdoor-profile"
+  resource_group_name = azurerm_resource_group.example.name
+  sku_name            = "Standard_AzureFrontDoor"
+}
+
+resource "azurerm_cdn_frontdoor_firewall_policy" "example" {
+  name                = "examplecdnfrontdoorfirewallpolicy"
+  resource_group_name = azurerm_resource_group.example.name
+  sku_name            = azurerm_cdn_frontdoor_profile.example.sku_name
+  enabled             = true
+  mode                = "Prevention"
+  redirect_url        = "https://www.example.com"
+
+  custom_rule {
+    name                           = "Rule1"
+    enabled                        = true
+    priority                       = 1
+    rate_limit_duration_in_minutes = 1
+    rate_limit_threshold           = 10
+    type                           = "MatchRule"
+    action                         = "Block"
+
+    match_condition {
+      match_variable     = "RemoteAddr"
+      operator           = "IPMatch"
+      negation_condition = false
+      match_values       = ["192.168.1.0/24"]
+    }
+  }
+}
+
+resource "azurerm_dns_zone" "example" {
+  name                = "example-frontdoor.com"
+  resource_group_name = azurerm_resource_group.example.name
+}
+
+resource "azurerm_cdn_frontdoor_custom_domain" "example" {
+  name                     = "example-custom-domain"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.example.id
+  dns_zone_id              = azurerm_dns_zone.example.id
+  host_name                = "www.example-frontdoor.com"
+
+  tls {
+    certificate_type    = "ManagedCertificate"
+    minimum_tls_version = "TLS12"
+  }
+}
+
+resource "azurerm_cdn_frontdoor_security_policy" "example" {
+  name                     = "example-security-policy"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.example.id
+
+  security_policies {
+    firewall {
+      cdn_frontdoor_firewall_policy_id = azurerm_cdn_frontdoor_firewall_policy.example.id
+
+      association {
+        domain {
+          cdn_frontdoor_domain_id = azurerm_cdn_frontdoor_custom_domain.example.id
+        }
+
+        patterns_to_match = ["/*"]
+      }
+    }
+  }
+}
+
+data "azurerm_cdn_frontdoor_security_policy" "example" {
+  name                = azurerm_cdn_frontdoor_security_policy.example.name
+  profile_name        = azurerm_cdn_frontdoor_profile.example.name
+  resource_group_name = azurerm_resource_group.example.name
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the Front Door Security Policy.
+
+-> **Note:** The `name` must begin and end with an alphanumeric character, and may contain only alphanumeric characters and hyphens.
+
+* `profile_name` - (Required) The name of the Front Door Profile.
+
+* `resource_group_name` - (Required) The name of the resource group.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Front Door Security Policy.
+
+* `cdn_frontdoor_profile_id` - The ID of the Front Door Profile associated with this Front Door Security Policy.
+
+* `security_policies` - A `security_policies` block as defined below.
+
+---
+
+A `security_policies` block exports the following:
+
+* `firewall` - A `firewall` block as defined below.
+
+---
+
+A `firewall` block exports the following:
+
+* `association` - An `association` block as defined below.
+
+* `cdn_frontdoor_firewall_policy_id` - The ID of the Front Door Firewall Policy associated with this Front Door Security Policy.
+
+---
+
+An `association` block exports the following:
+
+* `domain` - A `domain` block as defined below.
+
+* `patterns_to_match` - The paths associated with this firewall policy.
+
+---
+
+A `domain` block exports the following:
+
+* `active` - Is the Front Door Custom Domain or Front Door Endpoint active?
+
+* `cdn_frontdoor_domain_id` - The ID of the Front Door Custom Domain or Front Door Endpoint associated with this Front Door Security Policy.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/configure#define-operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Front Door Security Policy.

--- a/website/docs/d/cdn_frontdoor_security_policy.html.markdown
+++ b/website/docs/d/cdn_frontdoor_security_policy.html.markdown
@@ -99,8 +99,6 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the Front Door Security Policy.
 
--> **Note:** The `name` must begin and end with an alphanumeric character, and may contain only alphanumeric characters and hyphens.
-
 * `profile_name` - (Required) The name of the Front Door Profile.
 
 * `resource_group_name` - (Required) The name of the resource group.

--- a/website/docs/r/cdn_frontdoor_security_policy.html.markdown
+++ b/website/docs/r/cdn_frontdoor_security_policy.html.markdown
@@ -61,7 +61,7 @@ resource "azurerm_cdn_frontdoor_custom_domain" "example" {
   name                     = "example-customDomain"
   cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.example.id
   dns_zone_id              = azurerm_dns_zone.example.id
-  host_name                = "contoso.fabrikam.com"
+  host_name                = join(".", ["contoso", azurerm_dns_zone.example.name])
 
   tls {
     certificate_type    = "ManagedCertificate"
@@ -92,27 +92,25 @@ resource "azurerm_cdn_frontdoor_security_policy" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name which should be used for this Front Door Security Policy. Changing this forces a new Front Door Security Policy to be created.
+* `name` - (Required) The name which should be used for this Front Door Security Policy. Changing this forces a new resource to be created.
 
--> **Note:** The `name` must begin and end with an alphanumeric character, and may contain only alphanumeric characters and hyphens.
+* `cdn_frontdoor_profile_id` - (Required) The Front Door Profile Resource Id that is linked to this Front Door Security Policy. Changing this forces a new resource to be created.
 
-* `cdn_frontdoor_profile_id` - (Required) The Front Door Profile Resource Id that is linked to this Front Door Security Policy. Changing this forces a new Front Door Security Policy to be created.
-
-* `security_policies` - (Required) An `security_policies` block as defined below.
+* `security_policies` - (Required) A `security_policies` block as defined below.
 
 ---
 
 A `security_policies` block supports the following:
 
-* `firewall` - (Required) An `firewall` block as defined below.
+* `firewall` - (Required) A `firewall` block as defined below.
 
 ---
 
 A `firewall` block supports the following:
 
-* `cdn_frontdoor_firewall_policy_id` - (Required) The Resource Id of the Front Door Firewall Policy that should be linked to this Front Door Security Policy. Changing this forces a new Front Door Security Policy to be created.
-
 * `association` - (Required) An `association` block as defined below.
+
+* `cdn_frontdoor_firewall_policy_id` - (Required) The Resource Id of the Front Door Firewall Policy that should be linked to this Front Door Security Policy. Changing this forces a new resource to be created.
 
 ---
 
@@ -120,17 +118,15 @@ An `association` block supports the following:
 
 * `domain` - (Required) One or more `domain` blocks as defined below.
 
-* `patterns_to_match` - (Required) The list of paths to match for this firewall policy. Possible value includes `/*`. Changing this forces a new Front Door Security Policy to be created.
+~> **Note:** The number of `domain` blocks that may be included in the configuration varies depending on the `sku_name` field of the linked Front Door Profile. The `Standard_AzureFrontDoor` sku may contain up to 100 `domain` blocks and a `Premium_AzureFrontDoor` sku may contain up to 500 `domain` blocks.
+
+* `patterns_to_match` - (Required) The list of paths to match for this firewall policy. The only possible value is `/*`. Changing this forces a new resource to be created.
 
 ---
 
 A `domain` block supports the following:
 
-~> **Note:** The number of `domain` blocks that maybe included in the configuration file varies depending on the `sku_name` field of the linked Front Door Profile. The `Standard_AzureFrontDoor` sku may contain up to 100 `domain` blocks and a `Premium_AzureFrontDoor` sku may contain up to 500 `domain` blocks.
-
 * `cdn_frontdoor_domain_id` - (Required) The Resource Id of the **Front Door Custom Domain** or **Front Door Endpoint** that should be bound to this Front Door Security Policy.
-
-* `active` - (Computed) Is the Front Door Custom Domain/Endpoint activated?
 
 ---
 
@@ -139,6 +135,33 @@ A `domain` block supports the following:
 In addition to the Arguments listed above - the following Attributes are exported:
 
 * `id` - The ID of the Front Door Security Policy.
+
+* `security_policies` - A `security_policies` block as defined below.
+
+---
+
+A `security_policies` block exports the following:
+
+* `firewall` - A `firewall` block as defined below.
+
+---
+
+A `firewall` block exports the following:
+
+* `association` - An `association` block as defined below.
+
+---
+
+An `association` block exports the following:
+
+* `domain` - A `domain` block as defined below.
+
+---
+
+A `domain` block exports the following:
+
+* `active` - Whether the Front Door Custom Domain or Front Door Endpoint is active.
+
 
 ## Timeouts
 
@@ -151,7 +174,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Front Door Security Policies can be imported using the `resource id`, e.g.
+A Front Door Security Policy can be imported using the `resource id`, e.g.
 
 ```shell
 terraform import azurerm_cdn_frontdoor_security_policy.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.Cdn/profiles/profile1/securityPolicies/policy1

--- a/website/docs/r/cdn_frontdoor_security_policy.html.markdown
+++ b/website/docs/r/cdn_frontdoor_security_policy.html.markdown
@@ -92,7 +92,9 @@ resource "azurerm_cdn_frontdoor_security_policy" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name which should be used for this Front Door Security Policy. Possible values must not be an empty string. Changing this forces a new Front Door Security Policy to be created.
+* `name` - (Required) The name which should be used for this Front Door Security Policy. Changing this forces a new Front Door Security Policy to be created.
+
+-> **Note:** The `name` must begin and end with an alphanumeric character, and may contain only alphanumeric characters and hyphens.
 
 * `cdn_frontdoor_profile_id` - (Required) The Front Door Profile Resource Id that is linked to this Front Door Security Policy. Changing this forces a new Front Door Security Policy to be created.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR adds support for the `azurerm_cdn_frontdoor_security_policy` data source and aligns Front Door Security Policy name validation with the existing Azure service-side behavior.

### What Changed
* Added the new azurerm_cdn_frontdoor_security_policy data source
* Registered the data source in the CDN service registration
* Added dedicated flattening logic for the new data source to read nested firewall associations
* Added acceptance coverage for the new data source
* Tightened azurerm_cdn_frontdoor_security_policy name validation for both the resource and data source
* Updated the resource and data source documentation

### Validation Change Rationale
Previously, the provider only validated that the Front Door Security Policy name was non-empty.

During investigation, an intentionally invalid security policy name was sent to Azure and the backend returned the following error:

`BadRequest: Azure Front Door Security Policy name is invalid. More information: Azure Front Door Security Policy name must start and end with alphanumeric, and may contain only alphanumerics and hyphens.`

The new validator is derived directly from that Azure service response. This change is intended to align provider validation with the existing service contract and fail earlier during validation, rather than allowing the request to reach Azure and fail during `create`/`update` operations.

I did not add any length restriction because neither the public Microsoft.Cdn/profiles/securityPolicies documentation nor the Azure service error provided evidence for one. The validation is intentionally limited to the rules that could be proven from the backend response.

### Testing
* Added acceptance coverage for the new data source.
* Added an acceptance validation test for invalid Front Door Security Policy names.
* Verified the validation test passes with an invalid leading-hyphen name, confirming provider-side validation is enforced before the request reaches Azure.

<img width="1223" height="187" alt="image" src="https://github.com/user-attachments/assets/9438e850-5f3a-49c7-be8f-579f77c2440e" />


## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [X] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [X] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [X] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [X] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [X] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [X] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [X] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [X] New Feature (ie adding a service, resource, or data source)
- [X] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #31948


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [X] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
