### PR TITLE
`api_management_api_resource`: include displayName on import request

### DIFF
--- a/internal/services/apimanagement/api_management_api_resource.go
+++ b/internal/services/apimanagement/api_management_api_resource.go
@@ -400,7 +400,7 @@ func resourceApiManagementApiCreate(d *pluginsdk.ResourceData, meta interface{})
 	// First we execute import and then updated the other props.
 	if importVs, ok := d.GetOk("import"); ok {
 		if apiParams := expandApiManagementApiImport(importVs.([]interface{}), apiType, soapApiType,
-			path, d.Get("service_url").(string), version, versionSetId); apiParams != nil {
+			path, d.Get("service_url").(string), version, versionSetId, displayName); apiParams != nil {
 			result, err := client.CreateOrUpdate(ctx, id, *apiParams, api.CreateOrUpdateOperationOptions{})
 			if err != nil {
 				return fmt.Errorf("creating with import of %s: %+v", id, err)
@@ -527,7 +527,7 @@ func resourceApiManagementApiUpdate(d *pluginsdk.ResourceData, meta interface{})
 		if vs, hasImport := d.GetOk("import"); hasImport {
 			d.Partial(true)
 			if apiParams := expandApiManagementApiImport(vs.([]interface{}), apiType, soapApiType,
-				path, serviceUrl, version, versionSetId); apiParams != nil {
+				path, serviceUrl, version, versionSetId, displayName); apiParams != nil {
 				result, err := client.CreateOrUpdate(ctx, *id, *apiParams, api.CreateOrUpdateOperationOptions{})
 				if err != nil {
 					return fmt.Errorf("creating with import of %s: %+v", id, err)
@@ -799,7 +799,7 @@ func soapApiTypeFromApiType(apiType api.ApiType) api.SoapApiType {
 	}[apiType]
 }
 
-func expandApiManagementApiImport(importVs []interface{}, apiType api.ApiType, soapApiType api.SoapApiType, path, serviceUrl, version, versionSetId string) *api.ApiCreateOrUpdateParameter {
+func expandApiManagementApiImport(importVs []interface{}, apiType api.ApiType, soapApiType api.SoapApiType, path, serviceUrl, version, versionSetId string, displayName string) *api.ApiCreateOrUpdateParameter {
 	if len(importVs) == 0 || importVs[0] == nil {
 		return nil
 	}
@@ -814,11 +814,12 @@ func expandApiManagementApiImport(importVs []interface{}, apiType api.ApiType, s
 
 	apiParams := api.ApiCreateOrUpdateParameter{
 		Properties: &api.ApiCreateOrUpdateProperties{
-			Type:    pointer.To(apiType),
-			ApiType: pointer.To(soapApiType),
-			Format:  pointer.To(api.ContentFormat(contentFormat)),
-			Value:   pointer.To(contentValue),
-			Path:    path,
+			Type:        pointer.To(apiType),
+			ApiType:     pointer.To(soapApiType),
+			Format:      pointer.To(api.ContentFormat(contentFormat)),
+			Value:       pointer.To(contentValue),
+			Path:        path,
+			DisplayName: pointer.To(displayName),
 		},
 	}
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

When Terraform creates or updates an api ressource with an import the creation is split into two phases/requests:
- the first one imports the api spec with some basic meta information, the apim infers some properties (like the DisplayName, which has a unique constraint) fom the spec file here
- the second request updates the rest of the properties, overwriting the infered props if necessary 

These steps are apparently not done atomicly resulting in the failure mode we observed:
Given some (n>1) APIs with an identical inferrable Name (in our case it was `US4G`, since all S4/Hana APIs in this package share the same `service_name` in their WSDL)
Deploying them via `terraform apply` yields the following error:
```json
{
  "error": {
    "code":"ValidationError",
    "message":"One or more fields contain incorrect values:",
    "details": [
      {
         "code":"ValidationError",
         "target":"name",
         "message":"API with specified name 'US4G' already exists"
       }
]}}
```

Problem with the parallel execution can be simplified down to:
1. Initial Request/API A: Ressource gets created with the inferred name `US4G`
2. Initial Request/API B: Ressource gets created with the inferred name `US4G`
3. Second Request/API A: Validation Error

When using the flag `--paralellism=1` this behaviour cannot be observed.

Since I assume that we don't want to lock the apim for other requests during the creation of an API I fixed this behaviour by adding the `displayName` property to the initial request.

## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [X] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [X] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [X] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [X] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)
Since I'm unsure on how to work with the go test framework and this is a minor fix I did not create a new test.

Observed behaviour before patch:
```log
azurerm_api_management_api.utilities_test_base_api_v1_SmartMeterGatewayMeterCreateConfirmation_In: Creating...
azurerm_api_management_api.utilities_test_base_api_v1_SmartMeterGatewayMeterProfileCreateBulkConfirmation_In: Creating...
azurerm_api_management_api.utilities_test_base_api_v1_SmartMeterGatewayMeterProfileCreateBulkConfirmation_In: Still creating... [00m10s elapsed]
azurerm_api_management_api.utilities_test_base_api_v1_SmartMeterGatewayMeterProfileCreateBulkConfirmation_In: Creation complete after 12s [id=/subscriptions/<redacted>/resourceGroups/sap-utilities-api/providers/Microsoft.ApiManagement/service/sap-utilities-apim-test-new/apis/test_SMG_MeterProfileCreateBulkConfirmation_In_V1;rev=1]
azurerm_api_management_api_policy.utilities_test_base_policy_v1_SmartMeterGatewayMeterProfileCreateBulkConfirmation_In: Creating...
azurerm_api_management_product_api.utilities_test_base_product_api_v1_SmartMeterGatewayMeterProfileCreateBulkConfirmation_In: Creating...
azurerm_api_management_product_api.utilities_test_base_product_api_v1_SmartMeterGatewayMeterProfileCreateBulkConfirmation_In: Creation complete after 4s [id=/subscriptions/<redacted>/resourceGroups/sap-utilities-api/providers/Microsoft.ApiManagement/service/sap-utilities-apim-test-new/products/test_base_product/apis/test_SMG_MeterProfileCreateBulkConfirmation_In_V1]
azurerm_api_management_api_policy.utilities_test_base_policy_v1_SmartMeterGatewayMeterProfileCreateBulkConfirmation_In: Creation complete after 4s [id=/subscriptions/<redacted>/resourceGroups/sap-utilities-api/providers/Microsoft.ApiManagement/service/sap-utilities-apim-test-new/apis/test_SMG_MeterProfileCreateBulkConfirmation_In_V1]
╷
│ Error: polling import Api (Subscription: "<redacted>"
│ Resource Group Name: "sap-utilities-api"
│ Service Name: "sap-utilities-apim-test-new"
│ Api: "test_SMG_MeterCreateConfirmation_In_V1;rev=1"): retrieving Api (Subscription: "<redacted>"
│ Resource Group Name: "sap-utilities-api"
│ Service Name: "sap-utilities-apim-test-new"
│ Api: "test_SMG_MeterCreateConfirmation_In_V1;rev=1"): unexpected status 400 (400 Bad Request) with error: ValidationError: One or more fields contain incorrect values:
│ 
│   with azurerm_api_management_api.utilities_test_base_api_v1_SmartMeterGatewayMeterCreateConfirmation_In,
│   on utilities_test_base_api_SmartMeterGatewayMeterCreateConfirmation_In.tf line 2, in resource "azurerm_api_management_api" "utilities_test_base_api_v1_SmartMeterGatewayMeterCreateConfirmation_In":
│    2: resource "azurerm_api_management_api" "utilities_test_base_api_v1_SmartMeterGatewayMeterCreateConfirmation_In" {
│ 
```

Observed behaviour after patch:
```log
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - hashicorp/azurerm in /home/martin/go/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.

azurerm_api_management_api.utilities_test_base_api_v1_SmartMeterGatewayMeterProfileCreateBulkConfirmation_In: Creating...
azurerm_api_management_api.utilities_test_base_api_v1_SmartMeterGatewayMeterCreateConfirmation_In: Creating...
azurerm_api_management_api.utilities_test_base_api_v1_SmartMeterGatewayMeterProfileCreateBulkConfirmation_In: Still creating... [00m10s elapsed]
azurerm_api_management_api.utilities_test_base_api_v1_SmartMeterGatewayMeterCreateConfirmation_In: Still creating... [00m10s elapsed]
azurerm_api_management_api.utilities_test_base_api_v1_SmartMeterGatewayMeterCreateConfirmation_In: Creation complete after 10s [id=/subscriptions/<redacted>/resourceGroups/sap-utilities-api/providers/Microsoft.ApiManagement/service/sap-utilities-apim-test-new/apis/test_SMG_MeterCreateConfirmation_In_V1;rev=1]
azurerm_api_management_product_api.utilities_test_base_product_api_v1_SmartMeterGatewayMeterCreateConfirmation_In: Creating...
azurerm_api_management_api_policy.utilities_test_base_policy_v1_SmartMeterGatewayMeterCreateConfirmation_In: Creating...
azurerm_api_management_api.utilities_test_base_api_v1_SmartMeterGatewayMeterProfileCreateBulkConfirmation_In: Creation complete after 10s [id=/subscriptions/<redacted>/resourceGroups/sap-utilities-api/providers/Microsoft.ApiManagement/service/sap-utilities-apim-test-new/apis/test_SMG_MeterProfileCreateBulkConfirmation_In_V1;rev=1]
azurerm_api_management_product_api.utilities_test_base_product_api_v1_SmartMeterGatewayMeterProfileCreateBulkConfirmation_In: Creating...
azurerm_api_management_api_policy.utilities_test_base_policy_v1_SmartMeterGatewayMeterProfileCreateBulkConfirmation_In: Creating...
azurerm_api_management_product_api.utilities_test_base_product_api_v1_SmartMeterGatewayMeterProfileCreateBulkConfirmation_In: Creation complete after 3s [id=/subscriptions/<redacted>/resourceGroups/sap-utilities-api/providers/Microsoft.ApiManagement/service/sap-utilities-apim-test-new/products/test_base_product/apis/test_SMG_MeterProfileCreateBulkConfirmation_In_V1]
azurerm_api_management_api_policy.utilities_test_base_policy_v1_SmartMeterGatewayMeterProfileCreateBulkConfirmation_In: Creation complete after 3s [id=/subscriptions/<redacted>/resourceGroups/sap-utilities-api/providers/Microsoft.ApiManagement/service/sap-utilities-apim-test-new/apis/test_SMG_MeterProfileCreateBulkConfirmation_In_V1]
azurerm_api_management_product_api.utilities_test_base_product_api_v1_SmartMeterGatewayMeterCreateConfirmation_In: Creation complete after 3s [id=/subscriptions/<redacted>/resourceGroups/sap-utilities-api/providers/Microsoft.ApiManagement/service/sap-utilities-apim-test-new/products/test_base_product/apis/test_SMG_MeterCreateConfirmation_In_V1]
azurerm_api_management_api_policy.utilities_test_base_policy_v1_SmartMeterGatewayMeterCreateConfirmation_In: Creation complete after 4s [id=/subscriptions/<redacted>/resourceGroups/sap-utilities-api/providers/Microsoft.ApiManagement/service/sap-utilities-apim-test-new/apis/test_SMG_MeterCreateConfirmation_In_V1]

Apply complete! Resources: 6 added, 0 changed, 0 destroyed.
```
## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_api_management_api` - include displayName on import request


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [X] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

None open Issues were found with this problem. 
I figured to rather contribute a fix directly.


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

