### PR TITLE
`web` - Retire deprecated resources in 5.0

### DIFF
--- a/internal/services/appservice/app_service_environment_v3_resource_test.go
+++ b/internal/services/appservice/app_service_environment_v3_resource_test.go
@@ -9,12 +9,11 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/web/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 type AppServiceEnvironmentV3Resource struct{}
@@ -170,20 +169,17 @@ func TestAccAppServiceEnvironmentV3_dedicatedHosts(t *testing.T) {
 }
 
 func (AppServiceEnvironmentV3Resource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	id, err := parse.AppServiceEnvironmentID(state.ID)
+	id, err := commonids.ParseAppServiceEnvironmentID(state.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := client.Web.AppServiceEnvironmentsClientV1.Get(ctx, id.ResourceGroup, id.HostingEnvironmentName)
+	resp, err := client.AppService.AppServiceEnvironmentClient.Get(ctx, *id)
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
-			return pointer.To(false), nil
-		}
-		return nil, fmt.Errorf("retrieving App Service Environment V3 %q (Resource Group %q): %+v", id.HostingEnvironmentName, id.ResourceGroup, err)
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	return pointer.To(true), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r AppServiceEnvironmentV3Resource) basic(data acceptance.TestData) string {

--- a/internal/services/appservice/app_service_environment_v3_resource_test.go
+++ b/internal/services/appservice/app_service_environment_v3_resource_test.go
@@ -175,7 +175,7 @@ func (AppServiceEnvironmentV3Resource) Exists(ctx context.Context, client *clien
 		return nil, err
 	}
 
-	resp, err := client.Web.AppServiceEnvironmentsClient.Get(ctx, id.ResourceGroup, id.HostingEnvironmentName)
+	resp, err := client.Web.AppServiceEnvironmentsClientV1.Get(ctx, id.ResourceGroup, id.HostingEnvironmentName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			return pointer.To(false), nil

--- a/internal/services/logic/logic_app_standard_data_source.go
+++ b/internal/services/logic/logic_app_standard_data_source.go
@@ -206,7 +206,7 @@ func dataSourceLogicAppStandard() *pluginsdk.Resource {
 
 func dataSourceLogicAppStandardRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).AppService.WebAppsClient
-	subscriptionId := meta.(*clients.Client).Web.AppServicesClientV1.SubscriptionID
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 

--- a/internal/services/logic/logic_app_standard_data_source.go
+++ b/internal/services/logic/logic_app_standard_data_source.go
@@ -206,7 +206,7 @@ func dataSourceLogicAppStandard() *pluginsdk.Resource {
 
 func dataSourceLogicAppStandardRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).AppService.WebAppsClient
-	subscriptionId := meta.(*clients.Client).Web.AppServicesClient.SubscriptionID
+	subscriptionId := meta.(*clients.Client).Web.AppServicesClientV1.SubscriptionID
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 

--- a/internal/services/logic/logic_app_standard_resource_test.go
+++ b/internal/services/logic/logic_app_standard_resource_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/logic/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
@@ -1127,18 +1126,22 @@ func (r LogicAppStandardResource) Exists(ctx context.Context, clients *clients.C
 
 func (r LogicAppStandardResource) hasExtensionBundleAppSetting(shouldExist bool) func(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) error {
 	return func(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) error {
-		id, err := parse.LogicAppStandardID(state.ID)
+		id, err := commonids.ParseLogicAppId(state.ID)
 		if err != nil {
 			return err
 		}
 
-		appSettingsResp, err := clients.Web.AppServicesClientV1.ListApplicationSettings(ctx, id.ResourceGroup, id.SiteName)
+		appSettingsResp, err := clients.AppService.WebAppsClient.ListApplicationSettings(ctx, *id)
 		if err != nil {
 			return fmt.Errorf("listing AppSettings: %+v", err)
 		}
 
+		if appSettingsResp.Model == nil {
+			return fmt.Errorf("listing AppSettings for %s: `model` was nil", id)
+		}
+
 		exists := false
-		for k := range appSettingsResp.Properties {
+		for k := range pointer.From(appSettingsResp.Model.Properties) {
 			if strings.EqualFold("AzureFunctionsJobHost__extensionBundle__id", k) {
 				exists = true
 				break

--- a/internal/services/logic/logic_app_standard_resource_test.go
+++ b/internal/services/logic/logic_app_standard_resource_test.go
@@ -1132,7 +1132,7 @@ func (r LogicAppStandardResource) hasExtensionBundleAppSetting(shouldExist bool)
 			return err
 		}
 
-		appSettingsResp, err := clients.Web.AppServicesClient.ListApplicationSettings(ctx, id.ResourceGroup, id.SiteName)
+		appSettingsResp, err := clients.Web.AppServicesClientV1.ListApplicationSettings(ctx, id.ResourceGroup, id.SiteName)
 		if err != nil {
 			return fmt.Errorf("listing AppSettings: %+v", err)
 		}

--- a/internal/services/web/app_service_active_slot_resource.go
+++ b/internal/services/web/app_service_active_slot_resource.go
@@ -28,7 +28,7 @@ func resourceAppServiceActiveSlot() *pluginsdk.Resource {
 			return err
 		}),
 
-		DeprecationMessage: "The `azurerm_app_service_active_slot` resource has been superseded by the `azurerm_web_app_active_slot` and `azurerm_function_app_active_slot` resources. Whilst this resource will continue to be available in the 2.x and 3.x releases it is feature-frozen for compatibility purposes, will no longer receive any updates and will be removed in a future major release of the Azure Provider.",
+		DeprecationMessage: "The `azurerm_app_service_active_slot` resource has been superseded by the `azurerm_web_app_active_slot` and `azurerm_function_app_active_slot` resources. This resource will be removed in v5.0 of the AzureRM provider.",
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
@@ -55,7 +55,7 @@ func resourceAppServiceActiveSlot() *pluginsdk.Resource {
 }
 
 func resourceAppServiceActiveSlotCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.AppServicesClient
+	client := meta.(*clients.Client).Web.AppServicesClientV1
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -96,7 +96,7 @@ func resourceAppServiceActiveSlotCreateUpdate(d *pluginsdk.ResourceData, meta in
 }
 
 func resourceAppServiceActiveSlotRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.AppServicesClient
+	client := meta.(*clients.Client).Web.AppServicesClientV1
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 

--- a/internal/services/web/app_service_active_slot_resource_test.go
+++ b/internal/services/web/app_service_active_slot_resource_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/web/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -20,6 +21,9 @@ import (
 type AppServiceActiveSlotResource struct{}
 
 func TestAccAppServiceActiveSlot_basic(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_active_slot", "test")
 	r := AppServiceActiveSlotResource{}
 
@@ -35,6 +39,9 @@ func TestAccAppServiceActiveSlot_basic(t *testing.T) {
 }
 
 func TestAccAppServiceActiveSlot_update(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_active_slot", "test")
 	r := AppServiceActiveSlotResource{}
 
@@ -61,7 +68,7 @@ func (r AppServiceActiveSlotResource) Exists(ctx context.Context, clients *clien
 		return nil, err
 	}
 
-	resp, err := clients.Web.AppServicesClient.Get(ctx, id.ResourceGroup, id.SiteName)
+	resp, err := clients.Web.AppServicesClientV1.Get(ctx, id.ResourceGroup, id.SiteName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			return pointer.To(false), nil

--- a/internal/services/web/app_service_certificate_binding_resource.go
+++ b/internal/services/web/app_service_certificate_binding_resource.go
@@ -83,8 +83,8 @@ func resourceAppServiceCertificateBinding() *pluginsdk.Resource {
 }
 
 func resourceAppServiceCertificateBindingCreate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.AppServicesClient
-	certClient := meta.(*clients.Client).Web.CertificatesClient
+	client := meta.(*clients.Client).Web.AppServicesClientV1
+	certClient := meta.(*clients.Client).Web.CertificatesClientV1
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -146,7 +146,7 @@ func resourceAppServiceCertificateBindingCreate(d *pluginsdk.ResourceData, meta 
 }
 
 func resourceAppServiceCertificateBindingRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.AppServicesClient
+	client := meta.(*clients.Client).Web.AppServicesClientV1
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -183,7 +183,7 @@ func resourceAppServiceCertificateBindingRead(d *pluginsdk.ResourceData, meta in
 }
 
 func resourceAppServiceCertificateBindingDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.AppServicesClient
+	client := meta.(*clients.Client).Web.AppServicesClientV1
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 

--- a/internal/services/web/app_service_certificate_binding_resource_test.go
+++ b/internal/services/web/app_service_certificate_binding_resource_test.go
@@ -85,14 +85,14 @@ func (t AppServiceCertificateBindingResource) Exists(ctx context.Context, client
 		return nil, err
 	}
 
-	binding, err := clients.Web.AppServicesClient.GetHostNameBinding(ctx, id.HostnameBindingId.ResourceGroup, id.SiteName, id.HostnameBindingId.Name)
+	binding, err := clients.Web.AppServicesClientV1.GetHostNameBinding(ctx, id.HostnameBindingId.ResourceGroup, id.SiteName, id.HostnameBindingId.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(binding.Response) {
 			return pointer.To(false), nil
 		}
 		return nil, fmt.Errorf("retrieving App Service Hostname Binding %q (resource group %q) to check for Certificate Binding %q: %+v", id.HostnameBindingId.Name, id.HostnameBindingId.ResourceGroup, id.HostnameBindingId.Name, err)
 	}
-	certificate, err := clients.Web.CertificatesClient.Get(ctx, id.CertificateId.ResourceGroup, id.CertificateId.Name)
+	certificate, err := clients.Web.CertificatesClientV1.Get(ctx, id.CertificateId.ResourceGroup, id.CertificateId.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(certificate.Response) {
 			return pointer.To(false), nil

--- a/internal/services/web/app_service_certificate_data_source.go
+++ b/internal/services/web/app_service_certificate_data_source.go
@@ -81,7 +81,7 @@ func dataSourceAppServiceCertificate() *pluginsdk.Resource {
 }
 
 func dataSourceAppServiceCertificateRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.CertificatesClient
+	client := meta.(*clients.Client).Web.CertificatesClientV1
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()

--- a/internal/services/web/app_service_certificate_order_data_source.go
+++ b/internal/services/web/app_service_certificate_order_data_source.go
@@ -143,7 +143,7 @@ func dataSourceAppServiceCertificateOrder() *pluginsdk.Resource {
 }
 
 func dataSourceAppServiceCertificateOrderRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.CertificatesOrderClient
+	client := meta.(*clients.Client).Web.CertificatesOrderClientV1
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()

--- a/internal/services/web/app_service_certificate_order_resource.go
+++ b/internal/services/web/app_service_certificate_order_resource.go
@@ -179,7 +179,7 @@ func resourceAppServiceCertificateOrder() *pluginsdk.Resource {
 }
 
 func resourceAppServiceCertificateOrderCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.CertificatesOrderClient
+	client := meta.(*clients.Client).Web.CertificatesOrderClientV1
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -247,7 +247,7 @@ func resourceAppServiceCertificateOrderCreateUpdate(d *pluginsdk.ResourceData, m
 }
 
 func resourceAppServiceCertificateOrderRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.CertificatesOrderClient
+	client := meta.(*clients.Client).Web.CertificatesOrderClientV1
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -313,7 +313,7 @@ func resourceAppServiceCertificateOrderRead(d *pluginsdk.ResourceData, meta inte
 }
 
 func resourceAppServiceCertificateOrderDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.CertificatesOrderClient
+	client := meta.(*clients.Client).Web.CertificatesOrderClientV1
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 

--- a/internal/services/web/app_service_certificate_order_resource_test.go
+++ b/internal/services/web/app_service_certificate_order_resource_test.go
@@ -162,7 +162,7 @@ func (r AppServiceCertificateOrderResource) Exists(ctx context.Context, clients 
 		return nil, err
 	}
 
-	resp, err := clients.Web.CertificatesOrderClient.Get(ctx, id.ResourceGroup, id.Name)
+	resp, err := clients.Web.CertificatesOrderClientV1.Get(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			return pointer.To(false), nil

--- a/internal/services/web/app_service_certificate_resource.go
+++ b/internal/services/web/app_service_certificate_resource.go
@@ -51,7 +51,7 @@ func resourceAppServiceCertificate() *pluginsdk.Resource {
 
 func resourceAppServiceCertificateCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	keyVaultsClient := meta.(*clients.Client).KeyVault
-	client := meta.(*clients.Client).Web.CertificatesClient
+	client := meta.(*clients.Client).Web.CertificatesClientV1
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -136,7 +136,7 @@ func resourceAppServiceCertificateCreateUpdate(d *pluginsdk.ResourceData, meta i
 }
 
 func resourceAppServiceCertificateRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.CertificatesClient
+	client := meta.(*clients.Client).Web.CertificatesClientV1
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -191,7 +191,7 @@ func resourceAppServiceCertificateRead(d *pluginsdk.ResourceData, meta interface
 }
 
 func resourceAppServiceCertificateDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.CertificatesClient
+	client := meta.(*clients.Client).Web.CertificatesClientV1
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 

--- a/internal/services/web/app_service_certificate_resource_test.go
+++ b/internal/services/web/app_service_certificate_resource_test.go
@@ -101,7 +101,7 @@ func (r AppServiceCertificateResource) Exists(ctx context.Context, clients *clie
 		return nil, err
 	}
 
-	resp, err := clients.Web.CertificatesClient.Get(ctx, id.ResourceGroup, id.Name)
+	resp, err := clients.Web.CertificatesClientV1.Get(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			return pointer.To(false), nil

--- a/internal/services/web/app_service_custom_hostname_binding_resource.go
+++ b/internal/services/web/app_service_custom_hostname_binding_resource.go
@@ -82,7 +82,7 @@ func resourceAppServiceCustomHostnameBinding() *pluginsdk.Resource {
 }
 
 func resourceAppServiceCustomHostnameBindingCreate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.AppServicesClient
+	client := meta.(*clients.Client).Web.AppServicesClientV1
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -150,7 +150,7 @@ func resourceAppServiceCustomHostnameBindingCreate(d *pluginsdk.ResourceData, me
 }
 
 func resourceAppServiceCustomHostnameBindingRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.AppServicesClient
+	client := meta.(*clients.Client).Web.AppServicesClientV1
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -183,7 +183,7 @@ func resourceAppServiceCustomHostnameBindingRead(d *pluginsdk.ResourceData, meta
 }
 
 func resourceAppServiceCustomHostnameBindingDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.AppServicesClient
+	client := meta.(*clients.Client).Web.AppServicesClientV1
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 

--- a/internal/services/web/app_service_custom_hostname_binding_resource_test.go
+++ b/internal/services/web/app_service_custom_hostname_binding_resource_test.go
@@ -130,7 +130,7 @@ func (r ServiceCustomHostnameBindingResource) Exists(ctx context.Context, client
 		return nil, err
 	}
 
-	resp, err := clients.Web.AppServicesClient.GetHostNameBinding(ctx, id.ResourceGroup, id.AppServiceName, id.Name)
+	resp, err := clients.Web.AppServicesClientV1.GetHostNameBinding(ctx, id.ResourceGroup, id.AppServiceName, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			return pointer.To(false), nil

--- a/internal/services/web/app_service_data_source.go
+++ b/internal/services/web/app_service_data_source.go
@@ -28,7 +28,7 @@ func dataSourceAppService() *pluginsdk.Resource {
 			Read: pluginsdk.DefaultTimeout(5 * time.Minute),
 		},
 
-		DeprecationMessage: "The `azurerm_app_service` data source has been superseded by the `azurerm_linux_function_app` and `azurerm_windows_web_app` data sources. Whilst this resource will continue to be available in the 2.x and 3.x releases it is feature-frozen for compatibility purposes, will no longer receive any updates and will be removed in a future major release of the Azure Provider.",
+		DeprecationMessage: "The `azurerm_app_service` data source has been superseded by the `azurerm_linux_web_app` and `azurerm_windows_web_app` data sources. This data source will be removed in v5.0 of the AzureRM Provider.",
 
 		Schema: map[string]*pluginsdk.Schema{
 			"name": {
@@ -159,7 +159,7 @@ func dataSourceAppService() *pluginsdk.Resource {
 }
 
 func dataSourceAppServiceRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.AppServicesClient
+	client := meta.(*clients.Client).Web.AppServicesClientV1
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()

--- a/internal/services/web/app_service_data_source_test.go
+++ b/internal/services/web/app_service_data_source_test.go
@@ -9,11 +9,15 @@ import (
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 )
 
 type AppServiceDataSource struct{}
 
 func TestAccDataSourceAppService_basic(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this data source was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "data.azurerm_app_service", "test")
 
 	data.DataSourceTest(t, []acceptance.TestStep{
@@ -33,6 +37,9 @@ func TestAccDataSourceAppService_basic(t *testing.T) {
 }
 
 func TestAccDataSourceAppService_tags(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this data source was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "data.azurerm_app_service", "test")
 
 	data.DataSourceTest(t, []acceptance.TestStep{
@@ -47,6 +54,9 @@ func TestAccDataSourceAppService_tags(t *testing.T) {
 }
 
 func TestAccDataSourceAppService_clientAppAffinityDisabled(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this data source was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "data.azurerm_app_service", "test")
 
 	data.DataSourceTest(t, []acceptance.TestStep{
@@ -60,6 +70,9 @@ func TestAccDataSourceAppService_clientAppAffinityDisabled(t *testing.T) {
 }
 
 func TestAccDataSourceAppService_32Bit(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this data source was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "data.azurerm_app_service", "test")
 
 	data.DataSourceTest(t, []acceptance.TestStep{
@@ -73,6 +86,9 @@ func TestAccDataSourceAppService_32Bit(t *testing.T) {
 }
 
 func TestAccDataSourceAppService_appSettings(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this data source was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "data.azurerm_app_service", "test")
 
 	data.DataSourceTest(t, []acceptance.TestStep{
@@ -86,6 +102,9 @@ func TestAccDataSourceAppService_appSettings(t *testing.T) {
 }
 
 func TestAccDataSourceAppService_connectionString(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this data source was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "data.azurerm_app_service", "test")
 
 	data.DataSourceTest(t, []acceptance.TestStep{
@@ -99,6 +118,9 @@ func TestAccDataSourceAppService_connectionString(t *testing.T) {
 }
 
 func TestAccDataSourceAppService_ipRestriction(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this data source was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "data.azurerm_app_service", "test")
 
 	data.DataSourceTest(t, []acceptance.TestStep{
@@ -115,6 +137,9 @@ func TestAccDataSourceAppService_ipRestriction(t *testing.T) {
 }
 
 func TestAccDataSourceAppService_oneVNetSubnetIpRestriction(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this data source was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "data.azurerm_app_service", "test")
 
 	data.DataSourceTest(t, []acceptance.TestStep{
@@ -128,6 +153,9 @@ func TestAccDataSourceAppService_oneVNetSubnetIpRestriction(t *testing.T) {
 }
 
 func TestAccDataSourceAppService_scmUseMainIPRestriction(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this data source was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "data.azurerm_app_service", "test")
 
 	data.DataSourceTest(t, []acceptance.TestStep{
@@ -141,6 +169,9 @@ func TestAccDataSourceAppService_scmUseMainIPRestriction(t *testing.T) {
 }
 
 func TestAccDataSourceAppService_scmIPRestriction(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this data source was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "data.azurerm_app_service", "test")
 
 	data.DataSourceTest(t, []acceptance.TestStep{
@@ -157,6 +188,9 @@ func TestAccDataSourceAppService_scmIPRestriction(t *testing.T) {
 }
 
 func TestAccDataSourceAppService_withSourceControl(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this data source was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "data.azurerm_app_service", "test")
 
 	data.DataSourceTest(t, []acceptance.TestStep{
@@ -170,6 +204,9 @@ func TestAccDataSourceAppService_withSourceControl(t *testing.T) {
 }
 
 func TestAccDataSourceAppService_http2Enabled(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this data source was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "data.azurerm_app_service", "test")
 
 	data.DataSourceTest(t, []acceptance.TestStep{
@@ -183,6 +220,9 @@ func TestAccDataSourceAppService_http2Enabled(t *testing.T) {
 }
 
 func TestAccDataSourceAppService_minTls(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this data source was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "data.azurerm_app_service", "test")
 
 	data.DataSourceTest(t, []acceptance.TestStep{
@@ -196,6 +236,9 @@ func TestAccDataSourceAppService_minTls(t *testing.T) {
 }
 
 func TestAccDataSourceAppService_basicWindowsContainer(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this data source was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "data.azurerm_app_service", "test")
 
 	data.DataSourceTest(t, []acceptance.TestStep{

--- a/internal/services/web/app_service_hybrid_connection_resource.go
+++ b/internal/services/web/app_service_hybrid_connection_resource.go
@@ -39,7 +39,7 @@ func resourceAppServiceHybridConnection() *pluginsdk.Resource {
 			return err
 		}),
 
-		DeprecationMessage: "The `azurerm_app_service_hybrid_connection` resource has been superseded by the `azurerm_function_app_hybrid_connection` and `azurerm_web_app_hybrid_connection` resources. Whilst this resource will continue to be available in the 2.x and 3.x releases it is feature-frozen for compatibility purposes, will no longer receive any updates and will be removed in a future major release of the Azure Provider.",
+		DeprecationMessage: "The `azurerm_app_service_hybrid_connection` resource has been superseded by the `azurerm_function_app_hybrid_connection` and `azurerm_web_app_hybrid_connection` resources. This resource will be removed in v5.0 of the AzureRM Provider.",
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
@@ -114,7 +114,7 @@ func resourceAppServiceHybridConnection() *pluginsdk.Resource {
 }
 
 func resourceAppServiceHybridConnectionCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.AppServicesClient
+	client := meta.(*clients.Client).Web.AppServicesClientV1
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -161,7 +161,7 @@ func resourceAppServiceHybridConnectionCreateUpdate(d *pluginsdk.ResourceData, m
 }
 
 func resourceAppServiceHybridConnectionRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.AppServicesClient
+	client := meta.(*clients.Client).Web.AppServicesClientV1
 	relayClient := meta.(*clients.Client).Relay.HybridConnectionsClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -222,7 +222,7 @@ func resourceAppServiceHybridConnectionRead(d *pluginsdk.ResourceData, meta inte
 }
 
 func resourceAppServiceHybridConnectionDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.AppServicesClient
+	client := meta.(*clients.Client).Web.AppServicesClientV1
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 

--- a/internal/services/web/app_service_hybrid_connection_resource_test.go
+++ b/internal/services/web/app_service_hybrid_connection_resource_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/web/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -20,6 +21,9 @@ import (
 type AppServiceHybridConnectionResource struct{}
 
 func TestAccAppServiceHybridConnection_basic(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_hybrid_connection", "test")
 	r := AppServiceHybridConnectionResource{}
 
@@ -35,6 +39,9 @@ func TestAccAppServiceHybridConnection_basic(t *testing.T) {
 }
 
 func TestAccAppServiceHybridConnection_update(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_hybrid_connection", "test")
 	r := AppServiceHybridConnectionResource{}
 
@@ -57,6 +64,9 @@ func TestAccAppServiceHybridConnection_update(t *testing.T) {
 }
 
 func TestAccAppServiceHybridConnection_requiresImport(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_hybrid_connection", "test")
 	r := AppServiceHybridConnectionResource{}
 
@@ -72,6 +82,9 @@ func TestAccAppServiceHybridConnection_requiresImport(t *testing.T) {
 }
 
 func TestAccAppServiceHybridConnection_differentResourceGroup(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_hybrid_connection", "test")
 	r := AppServiceHybridConnectionResource{}
 
@@ -87,6 +100,9 @@ func TestAccAppServiceHybridConnection_differentResourceGroup(t *testing.T) {
 }
 
 func TestAccAppServiceHybridConnection_useSendKeyDeclaredOnHybridConnection(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_hybrid_connection", "test")
 	r := AppServiceHybridConnectionResource{}
 
@@ -107,7 +123,7 @@ func (r AppServiceHybridConnectionResource) Exists(ctx context.Context, clients 
 		return nil, err
 	}
 
-	resp, err := clients.Web.AppServicesClient.GetHybridConnection(ctx, id.ResourceGroup, id.SiteName, id.HybridConnectionNamespaceName, id.RelayName)
+	resp, err := clients.Web.AppServicesClientV1.GetHybridConnection(ctx, id.ResourceGroup, id.SiteName, id.HybridConnectionNamespaceName, id.RelayName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			return pointer.To(false), nil

--- a/internal/services/web/app_service_managed_certificate_resource.go
+++ b/internal/services/web/app_service_managed_certificate_resource.go
@@ -98,8 +98,8 @@ func resourceAppServiceManagedCertificate() *pluginsdk.Resource {
 }
 
 func resourceAppServiceManagedCertificateCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.CertificatesClient
-	appServiceClient := meta.(*clients.Client).Web.AppServicesClient
+	client := meta.(*clients.Client).Web.CertificatesClientV1
+	appServiceClient := meta.(*clients.Client).Web.AppServicesClientV1
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -199,7 +199,7 @@ func resourceAppServiceManagedCertificateCreateUpdate(d *pluginsdk.ResourceData,
 }
 
 func resourceAppServiceManagedCertificateRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.CertificatesClient
+	client := meta.(*clients.Client).Web.CertificatesClientV1
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -241,7 +241,7 @@ func resourceAppServiceManagedCertificateRead(d *pluginsdk.ResourceData, meta in
 }
 
 func resourceAppServiceManagedCertificateDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.CertificatesClient
+	client := meta.(*clients.Client).Web.CertificatesClientV1
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 

--- a/internal/services/web/app_service_managed_certificate_resource_test.go
+++ b/internal/services/web/app_service_managed_certificate_resource_test.go
@@ -84,7 +84,7 @@ func (t AppServiceManagedCertificateResource) Exists(ctx context.Context, client
 		return nil, err
 	}
 
-	resp, err := clients.Web.CertificatesClient.Get(ctx, id.ResourceGroup, id.CertificateName)
+	resp, err := clients.Web.CertificatesClientV1.Get(ctx, id.ResourceGroup, id.CertificateName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			return pointer.To(false), nil

--- a/internal/services/web/app_service_plan_data_source.go
+++ b/internal/services/web/app_service_plan_data_source.go
@@ -21,7 +21,7 @@ func dataSourceAppServicePlan() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
 		Read: AppServicePlanDataSourceRead,
 
-		DeprecationMessage: "The `azurerm_app_service_plan` data source has been superseded by the `azurerm_service_plan` data source. Whilst this resource will continue to be available in the 2.x and 3.x releases it is feature-frozen for compatibility purposes, will no longer receive any updates and will be removed in a future major release of the Azure Provider.",
+		DeprecationMessage: "The `azurerm_app_service_plan` data source has been superseded by the `azurerm_service_plan` data source. This data source will be removed in v5.0 of the AzureRM Provider.",
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Read: pluginsdk.DefaultTimeout(5 * time.Minute),
@@ -104,7 +104,7 @@ func dataSourceAppServicePlan() *pluginsdk.Resource {
 }
 
 func AppServicePlanDataSourceRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.AppServicePlansClient
+	client := meta.(*clients.Client).Web.AppServicePlansClientV1
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()

--- a/internal/services/web/app_service_plan_data_source_test.go
+++ b/internal/services/web/app_service_plan_data_source_test.go
@@ -8,11 +8,15 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 )
 
 type AppServicePlanDataSource struct{}
 
 func TestAccAppServicePlanDataSource_basic(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this data source was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "data.azurerm_app_service_plan", "test")
 
 	data.DataSourceTest(t, []acceptance.TestStep{
@@ -30,6 +34,9 @@ func TestAccAppServicePlanDataSource_basic(t *testing.T) {
 }
 
 func TestAccAppServicePlanDataSource_complete(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this data source was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "data.azurerm_app_service_plan", "test")
 
 	data.DataSourceTest(t, []acceptance.TestStep{
@@ -48,6 +55,9 @@ func TestAccAppServicePlanDataSource_complete(t *testing.T) {
 }
 
 func TestAccAppServicePlanDataSource_premiumSKU(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this data source was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "data.azurerm_app_service_plan", "test")
 
 	data.DataSourceTest(t, []acceptance.TestStep{
@@ -65,6 +75,9 @@ func TestAccAppServicePlanDataSource_premiumSKU(t *testing.T) {
 }
 
 func TestAccAppServicePlanDataSource_basicWindowsContainer(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this data source was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "data.azurerm_app_service_plan", "test")
 
 	data.DataSourceTest(t, []acceptance.TestStep{

--- a/internal/services/web/app_service_plan_resource.go
+++ b/internal/services/web/app_service_plan_resource.go
@@ -37,7 +37,7 @@ func resourceAppServicePlan() *pluginsdk.Resource {
 			return err
 		}),
 
-		DeprecationMessage: "The `azurerm_app_service_plan` resource has been superseded by the `azurerm_service_plan` resource. Whilst this resource will continue to be available in the 2.x and 3.x releases it is feature-frozen for compatibility purposes, will no longer receive any updates and will be removed in a future major release of the Azure Provider.",
+		DeprecationMessage: "The `azurerm_app_service_plan` resource has been superseded by the `azurerm_service_plan` resource. This resource will be removed in v5.0 of the AzureRM Provider.",
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(60 * time.Minute),
@@ -153,7 +153,7 @@ func resourceAppServicePlan() *pluginsdk.Resource {
 }
 
 func resourceAppServicePlanCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.AppServicePlansClient
+	client := meta.(*clients.Client).Web.AppServicePlansClientV1
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -243,7 +243,7 @@ func resourceAppServicePlanCreateUpdate(d *pluginsdk.ResourceData, meta interfac
 }
 
 func resourceAppServicePlanRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.AppServicePlansClient
+	client := meta.(*clients.Client).Web.AppServicePlansClientV1
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -311,7 +311,7 @@ func resourceAppServicePlanRead(d *pluginsdk.ResourceData, meta interface{}) err
 }
 
 func resourceAppServicePlanDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.AppServicePlansClient
+	client := meta.(*clients.Client).Web.AppServicePlansClientV1
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 

--- a/internal/services/web/app_service_plan_resource_test.go
+++ b/internal/services/web/app_service_plan_resource_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/web/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -20,6 +21,9 @@ import (
 type AppServicePlanResource struct{}
 
 func TestAccAppServicePlan_basicWindows(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_plan", "test")
 	r := AppServicePlanResource{}
 
@@ -37,6 +41,9 @@ func TestAccAppServicePlan_basicWindows(t *testing.T) {
 }
 
 func TestAccAppServicePlan_basicLinux(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_plan", "test")
 	r := AppServicePlanResource{}
 
@@ -60,6 +67,9 @@ func TestAccAppServicePlan_basicLinux(t *testing.T) {
 }
 
 func TestAccAppServicePlan_requiresImport(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_plan", "test")
 	r := AppServicePlanResource{}
 
@@ -75,6 +85,9 @@ func TestAccAppServicePlan_requiresImport(t *testing.T) {
 }
 
 func TestAccAppServicePlan_standardWindows(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_plan", "test")
 	r := AppServicePlanResource{}
 
@@ -90,6 +103,9 @@ func TestAccAppServicePlan_standardWindows(t *testing.T) {
 }
 
 func TestAccAppServicePlan_premiumWindows(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_plan", "test")
 	r := AppServicePlanResource{}
 
@@ -105,6 +121,9 @@ func TestAccAppServicePlan_premiumWindows(t *testing.T) {
 }
 
 func TestAccAppServicePlan_premiumWindowsUpdated(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_plan", "test")
 	r := AppServicePlanResource{}
 
@@ -128,6 +147,9 @@ func TestAccAppServicePlan_premiumWindowsUpdated(t *testing.T) {
 }
 
 func TestAccAppServicePlan_completeWindows(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_plan", "test")
 	r := AppServicePlanResource{}
 
@@ -153,6 +175,9 @@ func TestAccAppServicePlan_completeWindows(t *testing.T) {
 }
 
 func TestAccAppServicePlan_consumptionPlan(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_plan", "test")
 	r := AppServicePlanResource{}
 
@@ -169,6 +194,9 @@ func TestAccAppServicePlan_consumptionPlan(t *testing.T) {
 }
 
 func TestAccAppServicePlan_linuxConsumptionPlan(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_plan", "test")
 	r := AppServicePlanResource{}
 
@@ -184,6 +212,9 @@ func TestAccAppServicePlan_linuxConsumptionPlan(t *testing.T) {
 }
 
 func TestAccAppServicePlan_premiumConsumptionPlan(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_plan", "test")
 	r := AppServicePlanResource{}
 
@@ -201,6 +232,9 @@ func TestAccAppServicePlan_premiumConsumptionPlan(t *testing.T) {
 }
 
 func TestAccAppServicePlan_basicWindowsContainer(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_plan", "test")
 	r := AppServicePlanResource{}
 
@@ -220,6 +254,9 @@ func TestAccAppServicePlan_basicWindowsContainer(t *testing.T) {
 }
 
 func TestAccAppServicePlan_zoneRedundant(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_plan", "test")
 	r := AppServicePlanResource{}
 
@@ -244,7 +281,7 @@ func (r AppServicePlanResource) Exists(ctx context.Context, clients *clients.Cli
 		return nil, err
 	}
 
-	resp, err := clients.Web.AppServicePlansClient.Get(ctx, id.ResourceGroup, id.ServerFarmName)
+	resp, err := clients.Web.AppServicePlansClientV1.Get(ctx, id.ResourceGroup, id.ServerFarmName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			return pointer.To(false), nil

--- a/internal/services/web/app_service_resource.go
+++ b/internal/services/web/app_service_resource.go
@@ -33,7 +33,7 @@ func resourceAppService() *pluginsdk.Resource {
 		Update: resourceAppServiceUpdate,
 		Delete: resourceAppServiceDelete,
 
-		DeprecationMessage: "The `azurerm_app_service` resource has been superseded by the `azurerm_linux_web_app` and `azurerm_windows_web_app` resources. Whilst this resource will continue to be available in the 2.x and 3.x releases it is feature-frozen for compatibility purposes, will no longer receive any updates and will be removed in a future major release of the Azure Provider.",
+		DeprecationMessage: "The `azurerm_app_service` resource has been superseded by the `azurerm_linux_web_app` and `azurerm_windows_web_app` resources. This resource will be removed in v5.0 of the AzureRM Provider.",
 
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
 			_, err := parse.AppServiceID(id)
@@ -228,8 +228,8 @@ func resourceAppService() *pluginsdk.Resource {
 }
 
 func resourceAppServiceCreate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.AppServicesClient
-	aspClient := meta.(*clients.Client).Web.AppServicePlansClient
+	client := meta.(*clients.Client).Web.AppServicesClientV1
+	aspClient := meta.(*clients.Client).Web.AppServicePlansClientV1
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -385,7 +385,7 @@ func resourceAppServiceCreate(d *pluginsdk.ResourceData, meta interface{}) error
 }
 
 func resourceAppServiceUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.AppServicesClient
+	client := meta.(*clients.Client).Web.AppServicesClientV1
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -617,7 +617,7 @@ func resourceAppServiceUpdate(d *pluginsdk.ResourceData, meta interface{}) error
 }
 
 func resourceAppServiceRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.AppServicesClient
+	client := meta.(*clients.Client).Web.AppServicesClientV1
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -795,7 +795,7 @@ func resourceAppServiceRead(d *pluginsdk.ResourceData, meta interface{}) error {
 }
 
 func resourceAppServiceDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.AppServicesClient
+	client := meta.(*clients.Client).Web.AppServicesClientV1
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 

--- a/internal/services/web/app_service_resource_test.go
+++ b/internal/services/web/app_service_resource_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/web/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -22,6 +23,9 @@ import (
 type AppServiceResource struct{}
 
 func TestAccAppService_basic(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -42,6 +46,9 @@ func TestAccAppService_basic(t *testing.T) {
 }
 
 func TestAccAppService_requiresImport(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -57,6 +64,9 @@ func TestAccAppService_requiresImport(t *testing.T) {
 }
 
 func TestAccAppService_movingAppService(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -77,6 +87,9 @@ func TestAccAppService_movingAppService(t *testing.T) {
 }
 
 func TestAccAppService_freeTier(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -92,6 +105,9 @@ func TestAccAppService_freeTier(t *testing.T) {
 }
 
 func TestAccAppService_sharedTier(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -107,6 +123,9 @@ func TestAccAppService_sharedTier(t *testing.T) {
 }
 
 func TestAccAppService_32Bit(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -123,6 +142,9 @@ func TestAccAppService_32Bit(t *testing.T) {
 }
 
 func TestAccAppService_backup(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -167,6 +189,9 @@ func TestAccAppService_backup(t *testing.T) {
 }
 
 func TestAccAppService_http2Enabled(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -183,6 +208,9 @@ func TestAccAppService_http2Enabled(t *testing.T) {
 }
 
 func TestAccAppService_alwaysOn(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -199,6 +227,9 @@ func TestAccAppService_alwaysOn(t *testing.T) {
 }
 
 func TestAccAppService_appCommandLine(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -215,6 +246,9 @@ func TestAccAppService_appCommandLine(t *testing.T) {
 }
 
 func TestAccAppService_httpsOnly(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -231,6 +265,9 @@ func TestAccAppService_httpsOnly(t *testing.T) {
 }
 
 func TestAccAppService_clientCertEnabled(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -254,6 +291,9 @@ func TestAccAppService_clientCertEnabled(t *testing.T) {
 }
 
 func TestAccAppService_clientCertEnabledWithMode(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -271,6 +311,9 @@ func TestAccAppService_clientCertEnabledWithMode(t *testing.T) {
 }
 
 func TestAccAppService_appSettings(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -287,6 +330,9 @@ func TestAccAppService_appSettings(t *testing.T) {
 }
 
 func TestAccAppService_appSettingsVnetRouteAll(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -304,6 +350,9 @@ func TestAccAppService_appSettingsVnetRouteAll(t *testing.T) {
 }
 
 func TestAccAppService_siteConfigVnetRouteAll(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -320,6 +369,9 @@ func TestAccAppService_siteConfigVnetRouteAll(t *testing.T) {
 }
 
 func TestAccAppService_clientAffinityEnabled(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -336,6 +388,9 @@ func TestAccAppService_clientAffinityEnabled(t *testing.T) {
 }
 
 func TestAccAppService_clientAffinityDisabled(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -352,6 +407,9 @@ func TestAccAppService_clientAffinityDisabled(t *testing.T) {
 }
 
 func TestAccAppService_enableManageServiceIdentity(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -369,6 +427,9 @@ func TestAccAppService_enableManageServiceIdentity(t *testing.T) {
 }
 
 func TestAccAppService_updateResourceByEnablingManageServiceIdentity(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -393,6 +454,9 @@ func TestAccAppService_updateResourceByEnablingManageServiceIdentity(t *testing.
 }
 
 func TestAccAppService_userAssignedIdentity(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -411,6 +475,9 @@ func TestAccAppService_userAssignedIdentity(t *testing.T) {
 }
 
 func TestAccAppService_clientAffinityUpdate(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -435,6 +502,9 @@ func TestAccAppService_clientAffinityUpdate(t *testing.T) {
 }
 
 func TestAccAppService_connectionStrings(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -457,6 +527,9 @@ func TestAccAppService_connectionStrings(t *testing.T) {
 }
 
 func TestAccAppService_storageAccounts(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -480,6 +553,9 @@ func TestAccAppService_storageAccounts(t *testing.T) {
 }
 
 func TestAccAppService_oneIpv4Restriction(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -497,6 +573,9 @@ func TestAccAppService_oneIpv4Restriction(t *testing.T) {
 }
 
 func TestAccAppService_oneIpv6Restriction(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -514,6 +593,9 @@ func TestAccAppService_oneIpv6Restriction(t *testing.T) {
 }
 
 func TestAccAppService_completeIpRestriction(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -579,6 +661,9 @@ func TestAccAppService_completeIpRestriction(t *testing.T) {
 }
 
 func TestAccAppService_oneVNetSubnetIpRestriction(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -594,6 +679,9 @@ func TestAccAppService_oneVNetSubnetIpRestriction(t *testing.T) {
 }
 
 func TestAccAppService_multipleVNetSubnetIpRestrictionUpdate(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -626,6 +714,9 @@ func TestAccAppService_multipleVNetSubnetIpRestrictionUpdate(t *testing.T) {
 }
 
 func TestAccAppService_mixedIpRestrictionUpdate(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -658,6 +749,9 @@ func TestAccAppService_mixedIpRestrictionUpdate(t *testing.T) {
 }
 
 func TestAccAppService_zeroedIpRestriction(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -690,6 +784,9 @@ func TestAccAppService_zeroedIpRestriction(t *testing.T) {
 }
 
 func TestAccAppService_zeroedIpRestrictionHeaders(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -759,6 +856,9 @@ func TestAccAppService_zeroedIpRestrictionHeaders(t *testing.T) {
 }
 
 func TestAccAppService_manyIpRestrictions(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -778,6 +878,9 @@ func TestAccAppService_manyIpRestrictions(t *testing.T) {
 }
 
 func TestAccAppService_scmUseMainIPRestriction(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -793,6 +896,9 @@ func TestAccAppService_scmUseMainIPRestriction(t *testing.T) {
 }
 
 func TestAccAppService_scmOneIpRestriction(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -808,6 +914,9 @@ func TestAccAppService_scmOneIpRestriction(t *testing.T) {
 }
 
 func TestAccAppService_completeScmIpRestriction(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -837,6 +946,9 @@ func TestAccAppService_completeScmIpRestriction(t *testing.T) {
 }
 
 func TestAccAppService_oneVNetSubnetScmIpRestriction(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -852,6 +964,9 @@ func TestAccAppService_oneVNetSubnetScmIpRestriction(t *testing.T) {
 }
 
 func TestAccAppService_zeroedScmIpRestriction(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -884,6 +999,9 @@ func TestAccAppService_zeroedScmIpRestriction(t *testing.T) {
 }
 
 func TestAccAppService_manyScmIpRestrictions(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -899,6 +1017,9 @@ func TestAccAppService_manyScmIpRestrictions(t *testing.T) {
 }
 
 func TestAccAppService_defaultDocuments(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -917,6 +1038,9 @@ func TestAccAppService_defaultDocuments(t *testing.T) {
 }
 
 func TestAccAppService_enabled(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -933,6 +1057,9 @@ func TestAccAppService_enabled(t *testing.T) {
 }
 
 func TestAccAppService_localMySql(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -949,6 +1076,9 @@ func TestAccAppService_localMySql(t *testing.T) {
 }
 
 func TestAccAppService_applicationBlobStorageLogs(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -979,6 +1109,9 @@ func TestAccAppService_applicationBlobStorageLogs(t *testing.T) {
 }
 
 func TestAccAppService_httpFileSystemLogs(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -1001,6 +1134,9 @@ func TestAccAppService_httpFileSystemLogs(t *testing.T) {
 }
 
 func TestAccAppService_httpBlobStorageLogs(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -1023,6 +1159,9 @@ func TestAccAppService_httpBlobStorageLogs(t *testing.T) {
 }
 
 func TestAccAppService_httpFileSystemAndStorageBlobLogs(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -1038,6 +1177,9 @@ func TestAccAppService_httpFileSystemAndStorageBlobLogs(t *testing.T) {
 }
 
 func TestAccAppService_managedPipelineMode(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -1054,6 +1196,9 @@ func TestAccAppService_managedPipelineMode(t *testing.T) {
 }
 
 func TestAccAppService_detailedErrorMessagesLogs(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -1077,6 +1222,9 @@ func TestAccAppService_detailedErrorMessagesLogs(t *testing.T) {
 }
 
 func TestAccAzureRMAppService_failedRequestTracingLogs(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -1100,6 +1248,9 @@ func TestAccAzureRMAppService_failedRequestTracingLogs(t *testing.T) {
 }
 
 func TestAccAppService_tagsUpdate(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -1125,6 +1276,9 @@ func TestAccAppService_tagsUpdate(t *testing.T) {
 }
 
 func TestAccAppService_remoteDebugging(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -1142,6 +1296,9 @@ func TestAccAppService_remoteDebugging(t *testing.T) {
 }
 
 func TestAccAppService_windowsDotNet2(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -1158,6 +1315,9 @@ func TestAccAppService_windowsDotNet2(t *testing.T) {
 }
 
 func TestAccAppService_windowsDotNet4(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -1174,6 +1334,9 @@ func TestAccAppService_windowsDotNet4(t *testing.T) {
 }
 
 func TestAccAppService_windowsDotNet5(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -1190,6 +1353,9 @@ func TestAccAppService_windowsDotNet5(t *testing.T) {
 }
 
 func TestAccAppService_windowsDotNet6(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -1206,6 +1372,9 @@ func TestAccAppService_windowsDotNet6(t *testing.T) {
 }
 
 func TestAccAppService_windowsDotNetUpdate(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -1242,6 +1411,9 @@ func TestAccAppService_windowsDotNetUpdate(t *testing.T) {
 }
 
 func TestAccAppService_windowsJava7Java(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -1260,6 +1432,9 @@ func TestAccAppService_windowsJava7Java(t *testing.T) {
 }
 
 func TestAccAppService_windowsJava8Java(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -1278,6 +1453,9 @@ func TestAccAppService_windowsJava8Java(t *testing.T) {
 }
 
 func TestAccAppService_windowsJava11Java(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -1296,6 +1474,9 @@ func TestAccAppService_windowsJava11Java(t *testing.T) {
 }
 
 func TestAccAppService_windowsJava7Jetty(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -1314,6 +1495,9 @@ func TestAccAppService_windowsJava7Jetty(t *testing.T) {
 }
 
 func TestAccAppService_windowsJava8Jetty(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -1332,6 +1516,9 @@ func TestAccAppService_windowsJava8Jetty(t *testing.T) {
 }
 
 func TestAccAppService_windowsJava11Jetty(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -1350,6 +1537,9 @@ func TestAccAppService_windowsJava11Jetty(t *testing.T) {
 }
 
 func TestAccAppService_windowsJava7Tomcat(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -1368,6 +1558,9 @@ func TestAccAppService_windowsJava7Tomcat(t *testing.T) {
 }
 
 func TestAccAppService_windowsJava8Tomcat(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -1386,6 +1579,9 @@ func TestAccAppService_windowsJava8Tomcat(t *testing.T) {
 }
 
 func TestAccAppService_windowsJava11Tomcat(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -1404,6 +1600,9 @@ func TestAccAppService_windowsJava11Tomcat(t *testing.T) {
 }
 
 func TestAccAppService_windowsPHP7(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -1420,6 +1619,9 @@ func TestAccAppService_windowsPHP7(t *testing.T) {
 }
 
 func TestAccAppService_windowsPython(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -1436,6 +1638,9 @@ func TestAccAppService_windowsPython(t *testing.T) {
 }
 
 func TestAccAppService_webSockets(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -1452,6 +1657,9 @@ func TestAccAppService_webSockets(t *testing.T) {
 }
 
 func TestAccAppService_scmType(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -1470,6 +1678,9 @@ func TestAccAppService_scmType(t *testing.T) {
 }
 
 func TestAccAppService_withSourceControl(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -1485,6 +1696,9 @@ func TestAccAppService_withSourceControl(t *testing.T) {
 }
 
 func TestAccAppService_withSourceControlUpdate(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -1507,6 +1721,9 @@ func TestAccAppService_withSourceControlUpdate(t *testing.T) {
 }
 
 func TestAccAppService_ftpsState(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -1523,6 +1740,9 @@ func TestAccAppService_ftpsState(t *testing.T) {
 }
 
 func TestAccAppService_healthCheckPath(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -1539,6 +1759,9 @@ func TestAccAppService_healthCheckPath(t *testing.T) {
 }
 
 func TestAccAppService_numberOfWorkers(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -1556,6 +1779,9 @@ func TestAccAppService_numberOfWorkers(t *testing.T) {
 
 // Note: to specify `linux_fx_version` the App Service Plan must be of `kind = "Linux"`, and `reserved = true`
 func TestAccAppService_linuxFxVersion(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -1571,6 +1797,9 @@ func TestAccAppService_linuxFxVersion(t *testing.T) {
 }
 
 func TestAccAppService_minTls(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -1595,6 +1824,9 @@ func TestAccAppService_minTls(t *testing.T) {
 }
 
 func TestAccAppService_corsSettings(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -1613,6 +1845,9 @@ func TestAccAppService_corsSettings(t *testing.T) {
 }
 
 func TestAccAppService_authSettingsAdditionalLoginParams(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	tenantID := os.Getenv("ARM_TENANT_ID")
 
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
@@ -1636,6 +1871,9 @@ func TestAccAppService_authSettingsAdditionalLoginParams(t *testing.T) {
 }
 
 func TestAccAppService_authSettingsAdditionalAllowedExternalRedirectUrls(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	tenantID := os.Getenv("ARM_TENANT_ID")
 
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
@@ -1660,6 +1898,9 @@ func TestAccAppService_authSettingsAdditionalAllowedExternalRedirectUrls(t *test
 }
 
 func TestAccAppService_authSettingsRuntimeVersion(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	tenantID := os.Getenv("ARM_TENANT_ID")
 
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
@@ -1683,6 +1924,9 @@ func TestAccAppService_authSettingsRuntimeVersion(t *testing.T) {
 }
 
 func TestAccAppService_authSettingsTokenRefreshExtensionHours(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	tenantID := os.Getenv("ARM_TENANT_ID")
 
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
@@ -1706,6 +1950,9 @@ func TestAccAppService_authSettingsTokenRefreshExtensionHours(t *testing.T) {
 }
 
 func TestAccAppService_authSettingsUnauthenticatedClientAction(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	tenantID := os.Getenv("ARM_TENANT_ID")
 
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
@@ -1729,6 +1976,9 @@ func TestAccAppService_authSettingsUnauthenticatedClientAction(t *testing.T) {
 }
 
 func TestAccAppService_authSettingsTokenStoreEnabled(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	tenantID := os.Getenv("ARM_TENANT_ID")
 
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
@@ -1752,6 +2002,9 @@ func TestAccAppService_authSettingsTokenStoreEnabled(t *testing.T) {
 }
 
 func TestAccAppService_aadAuthSettings(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	tenantID := os.Getenv("ARM_TENANT_ID")
 
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
@@ -1774,6 +2027,9 @@ func TestAccAppService_aadAuthSettings(t *testing.T) {
 }
 
 func TestAccAppService_facebookAuthSettings(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -1793,6 +2049,9 @@ func TestAccAppService_facebookAuthSettings(t *testing.T) {
 }
 
 func TestAccAppService_googleAuthSettings(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -1812,6 +2071,9 @@ func TestAccAppService_googleAuthSettings(t *testing.T) {
 }
 
 func TestAccAppService_microsoftAuthSettings(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -1831,6 +2093,9 @@ func TestAccAppService_microsoftAuthSettings(t *testing.T) {
 }
 
 func TestAccAppService_twitterAuthSettings(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -1849,6 +2114,9 @@ func TestAccAppService_twitterAuthSettings(t *testing.T) {
 }
 
 func TestAccAppService_multiAuthSettings(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	tenantID := os.Getenv("ARM_TENANT_ID")
 
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
@@ -1886,6 +2154,9 @@ func TestAccAppService_multiAuthSettings(t *testing.T) {
 }
 
 func TestAccAppService_basicWindowsContainer(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -1903,6 +2174,9 @@ func TestAccAppService_basicWindowsContainer(t *testing.T) {
 }
 
 func TestAccAppService_AcrManageIdentityCredentials(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -1918,6 +2192,9 @@ func TestAccAppService_AcrManageIdentityCredentials(t *testing.T) {
 }
 
 func TestAccAppService_AcrUserAssignedIdentity(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -1933,6 +2210,9 @@ func TestAccAppService_AcrUserAssignedIdentity(t *testing.T) {
 }
 
 func TestAccAppService_keyVaultUserAssignedIdentity(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service", "test")
 	r := AppServiceResource{}
 
@@ -1953,7 +2233,7 @@ func (r AppServiceResource) Exists(ctx context.Context, clients *clients.Client,
 		return nil, err
 	}
 
-	resp, err := clients.Web.AppServicesClient.Get(ctx, id.ResourceGroup, id.SiteName)
+	resp, err := clients.Web.AppServicesClientV1.Get(ctx, id.ResourceGroup, id.SiteName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			return pointer.To(false), nil

--- a/internal/services/web/app_service_slot_custom_hostname_binding_resource.go
+++ b/internal/services/web/app_service_slot_custom_hostname_binding_resource.go
@@ -81,7 +81,7 @@ func resourceAppServiceSlotCustomHostnameBinding() *pluginsdk.Resource {
 }
 
 func resourceAppServiceSlotCustomHostnameBindingCreate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.AppServicesClient
+	client := meta.(*clients.Client).Web.AppServicesClientV1
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -136,7 +136,7 @@ func resourceAppServiceSlotCustomHostnameBindingCreate(d *pluginsdk.ResourceData
 }
 
 func resourceAppServiceSlotCustomHostnameBindingRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.AppServicesClient
+	client := meta.(*clients.Client).Web.AppServicesClientV1
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -169,7 +169,7 @@ func resourceAppServiceSlotCustomHostnameBindingRead(d *pluginsdk.ResourceData, 
 }
 
 func resourceAppServiceSlotCustomHostnameBindingDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.AppServicesClient
+	client := meta.(*clients.Client).Web.AppServicesClientV1
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 

--- a/internal/services/web/app_service_slot_custom_hostname_binding_resource_test.go
+++ b/internal/services/web/app_service_slot_custom_hostname_binding_resource_test.go
@@ -83,7 +83,7 @@ func (r AppServiceSlotCustomHostnameBindingResource) Exists(ctx context.Context,
 		return nil, err
 	}
 
-	resp, err := clients.Web.AppServicesClient.GetHostNameBindingSlot(ctx, id.ResourceGroup, id.SiteName, id.SlotName, id.HostNameBindingName)
+	resp, err := clients.Web.AppServicesClientV1.GetHostNameBindingSlot(ctx, id.ResourceGroup, id.SiteName, id.SlotName, id.HostNameBindingName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			return pointer.To(false), nil

--- a/internal/services/web/app_service_slot_resource.go
+++ b/internal/services/web/app_service_slot_resource.go
@@ -32,7 +32,7 @@ func resourceAppServiceSlot() *pluginsdk.Resource {
 		Update: resourceAppServiceSlotCreateUpdate,
 		Delete: resourceAppServiceSlotDelete,
 
-		DeprecationMessage: "The `azurerm_app_service_slot` resource has been superseded by the `azurerm_linux_web_app_slot` and `azurerm_windows_web_app_slot` resources. Whilst this resource will continue to be available in the 2.x and 3.x releases it is feature-frozen for compatibility purposes, will no longer receive any updates and will be removed in a future major release of the Azure Provider.",
+		DeprecationMessage: "The `azurerm_app_service_slot` resource has been superseded by the `azurerm_linux_web_app_slot` and `azurerm_windows_web_app_slot` resources. This resource will be removed in v5.0 of the AzureRM Provider.",
 
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
 			_, err := parse.AppServiceSlotID(id)
@@ -181,7 +181,7 @@ func resourceAppServiceSlot() *pluginsdk.Resource {
 }
 
 func resourceAppServiceSlotCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.AppServicesClient
+	client := meta.(*clients.Client).Web.AppServicesClientV1
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -252,7 +252,7 @@ func resourceAppServiceSlotCreateUpdate(d *pluginsdk.ResourceData, meta interfac
 }
 
 func resourceAppServiceSlotUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.AppServicesClient
+	client := meta.(*clients.Client).Web.AppServicesClientV1
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -399,7 +399,7 @@ func resourceAppServiceSlotUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 }
 
 func resourceAppServiceSlotRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.AppServicesClient
+	client := meta.(*clients.Client).Web.AppServicesClientV1
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -549,7 +549,7 @@ func resourceAppServiceSlotRead(d *pluginsdk.ResourceData, meta interface{}) err
 }
 
 func resourceAppServiceSlotDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.AppServicesClient
+	client := meta.(*clients.Client).Web.AppServicesClientV1
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 

--- a/internal/services/web/app_service_slot_resource_test.go
+++ b/internal/services/web/app_service_slot_resource_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/web/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -22,6 +23,9 @@ import (
 type AppServiceSlotResource struct{}
 
 func TestAccAppServiceSlot_basic(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -37,6 +41,9 @@ func TestAccAppServiceSlot_basic(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_requiresImport(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -52,6 +59,9 @@ func TestAccAppServiceSlot_requiresImport(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_32Bit(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -68,6 +78,9 @@ func TestAccAppServiceSlot_32Bit(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_alwaysOn(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -84,6 +97,9 @@ func TestAccAppServiceSlot_alwaysOn(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_appCommandLine(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -100,6 +116,9 @@ func TestAccAppServiceSlot_appCommandLine(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_appSettings(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -116,6 +135,9 @@ func TestAccAppServiceSlot_appSettings(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_clientAffinityEnabled(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -131,6 +153,9 @@ func TestAccAppServiceSlot_clientAffinityEnabled(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_clientAffinityEnabledUpdate(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -153,6 +178,9 @@ func TestAccAppServiceSlot_clientAffinityEnabledUpdate(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_connectionStrings(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -175,6 +203,9 @@ func TestAccAppServiceSlot_connectionStrings(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_storageAccounts(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -198,6 +229,9 @@ func TestAccAppServiceSlot_storageAccounts(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_ipRestrictionHeaders(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -213,6 +247,9 @@ func TestAccAppServiceSlot_ipRestrictionHeaders(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_corsSettings(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -228,6 +265,9 @@ func TestAccAppServiceSlot_corsSettings(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_authSettingsAdditionalLoginParams(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	tenantID := os.Getenv("ARM_TENANT_ID")
 	r := AppServiceSlotResource{}
@@ -250,6 +290,9 @@ func TestAccAppServiceSlot_authSettingsAdditionalLoginParams(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_authSettingsAdditionalAllowedExternalRedirectUrls(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	tenantID := os.Getenv("ARM_TENANT_ID")
 	r := AppServiceSlotResource{}
@@ -273,6 +316,9 @@ func TestAccAppServiceSlot_authSettingsAdditionalAllowedExternalRedirectUrls(t *
 }
 
 func TestAccAppServiceSlot_authSettingsRuntimeVersion(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	tenantID := os.Getenv("ARM_TENANT_ID")
 	r := AppServiceSlotResource{}
@@ -295,6 +341,9 @@ func TestAccAppServiceSlot_authSettingsRuntimeVersion(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_authSettingsTokenRefreshExtensionHours(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	tenantID := os.Getenv("ARM_TENANT_ID")
 	r := AppServiceSlotResource{}
@@ -317,6 +366,9 @@ func TestAccAppServiceSlot_authSettingsTokenRefreshExtensionHours(t *testing.T) 
 }
 
 func TestAccAppServiceSlot_authSettingsUnauthenticatedClientAction(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	tenantID := os.Getenv("ARM_TENANT_ID")
 	r := AppServiceSlotResource{}
@@ -339,6 +391,9 @@ func TestAccAppServiceSlot_authSettingsUnauthenticatedClientAction(t *testing.T)
 }
 
 func TestAccAppServiceSlot_authSettingsTokenStoreEnabled(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	tenantID := os.Getenv("ARM_TENANT_ID")
 	r := AppServiceSlotResource{}
@@ -361,6 +416,9 @@ func TestAccAppServiceSlot_authSettingsTokenStoreEnabled(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_aadAuthSettings(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	tenantID := os.Getenv("ARM_TENANT_ID")
 	r := AppServiceSlotResource{}
@@ -382,6 +440,9 @@ func TestAccAppServiceSlot_aadAuthSettings(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_facebookAuthSettings(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -401,6 +462,9 @@ func TestAccAppServiceSlot_facebookAuthSettings(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_googleAuthSettings(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -419,6 +483,9 @@ func TestAccAppServiceSlot_googleAuthSettings(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_microsoftAuthSettings(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -438,6 +505,9 @@ func TestAccAppServiceSlot_microsoftAuthSettings(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_twitterAuthSettings(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -456,6 +526,9 @@ func TestAccAppServiceSlot_twitterAuthSettings(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_multiAuthSettings(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	tenantID := os.Getenv("ARM_TENANT_ID")
 	r := AppServiceSlotResource{}
@@ -492,6 +565,9 @@ func TestAccAppServiceSlot_multiAuthSettings(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_defaultDocuments(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -509,6 +585,9 @@ func TestAccAppServiceSlot_defaultDocuments(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_enabled(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -524,6 +603,9 @@ func TestAccAppServiceSlot_enabled(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_enabledUpdate(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -546,6 +628,9 @@ func TestAccAppServiceSlot_enabledUpdate(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_httpsOnly(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -561,6 +646,9 @@ func TestAccAppServiceSlot_httpsOnly(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_httpsOnlyUpdate(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -583,6 +671,9 @@ func TestAccAppServiceSlot_httpsOnlyUpdate(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_http2Enabled(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -598,6 +689,9 @@ func TestAccAppServiceSlot_http2Enabled(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_oneIpRestriction(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -613,6 +707,9 @@ func TestAccAppServiceSlot_oneIpRestriction(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_oneVNetSubnetIpRestriction(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -628,6 +725,9 @@ func TestAccAppServiceSlot_oneVNetSubnetIpRestriction(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_zeroedIpRestriction(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -660,6 +760,9 @@ func TestAccAppServiceSlot_zeroedIpRestriction(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_manyIpRestrictions(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -675,6 +778,9 @@ func TestAccAppServiceSlot_manyIpRestrictions(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_scmUseMainIPRestriction(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -690,6 +796,9 @@ func TestAccAppServiceSlot_scmUseMainIPRestriction(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_scmOneIPRestriction(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -705,6 +814,9 @@ func TestAccAppServiceSlot_scmOneIPRestriction(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_localMySql(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -720,6 +832,9 @@ func TestAccAppServiceSlot_localMySql(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_managedPipelineMode(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -735,6 +850,9 @@ func TestAccAppServiceSlot_managedPipelineMode(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_tagsUpdate(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -760,6 +878,9 @@ func TestAccAppServiceSlot_tagsUpdate(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_remoteDebugging(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -776,6 +897,9 @@ func TestAccAppServiceSlot_remoteDebugging(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_windowsDotNet2(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -791,6 +915,9 @@ func TestAccAppServiceSlot_windowsDotNet2(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_updateManageServiceIdentity(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -814,6 +941,9 @@ func TestAccAppServiceSlot_updateManageServiceIdentity(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_windowsDotNet4(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -829,6 +959,9 @@ func TestAccAppServiceSlot_windowsDotNet4(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_windowsDotNet5(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -844,6 +977,9 @@ func TestAccAppServiceSlot_windowsDotNet5(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_windowsDotNet6(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -859,6 +995,9 @@ func TestAccAppServiceSlot_windowsDotNet6(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_keyVaultUserAssignedIdentity(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -873,6 +1012,9 @@ func TestAccAppServiceSlot_keyVaultUserAssignedIdentity(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_userAssignedIdentity(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -891,6 +1033,9 @@ func TestAccAppServiceSlot_userAssignedIdentity(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_windowsDotNetUpdate(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -927,6 +1072,9 @@ func TestAccAppServiceSlot_windowsDotNetUpdate(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_windowsJava7Jetty(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -944,6 +1092,9 @@ func TestAccAppServiceSlot_windowsJava7Jetty(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_windowsJava8Jetty(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -961,6 +1112,9 @@ func TestAccAppServiceSlot_windowsJava8Jetty(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_windowsJava11Jetty(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -978,6 +1132,9 @@ func TestAccAppServiceSlot_windowsJava11Jetty(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_windowsJava7Tomcat(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -995,6 +1152,9 @@ func TestAccAppServiceSlot_windowsJava7Tomcat(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_windowsJava8Tomcat(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -1012,6 +1172,9 @@ func TestAccAppServiceSlot_windowsJava8Tomcat(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_windowsJava11Tomcat(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -1029,6 +1192,9 @@ func TestAccAppServiceSlot_windowsJava11Tomcat(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_windowsPHP7(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -1044,6 +1210,9 @@ func TestAccAppServiceSlot_windowsPHP7(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_windowsPython(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -1059,6 +1228,9 @@ func TestAccAppServiceSlot_windowsPython(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_webSockets(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -1074,6 +1246,9 @@ func TestAccAppServiceSlot_webSockets(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_enableManageServiceIdentity(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -1091,6 +1266,9 @@ func TestAccAppServiceSlot_enableManageServiceIdentity(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_minTls(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -1114,6 +1292,9 @@ func TestAccAppServiceSlot_minTls(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_applicationBlobStorageLogs(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -1133,6 +1314,9 @@ func TestAccAppServiceSlot_applicationBlobStorageLogs(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_emptyApplicationLogs(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -1150,6 +1334,9 @@ func TestAccAppServiceSlot_emptyApplicationLogs(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_httpFileSystemLogs(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -1167,6 +1354,9 @@ func TestAccAppServiceSlot_httpFileSystemLogs(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_httpBlobStorageLogs(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -1184,6 +1374,9 @@ func TestAccAppServiceSlot_httpBlobStorageLogs(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_detailedErrorMessagesLogs(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -1205,6 +1398,9 @@ func TestAccAppServiceSlot_detailedErrorMessagesLogs(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_failedRequestTracingLogs(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -1227,6 +1423,9 @@ func TestAccAppServiceSlot_failedRequestTracingLogs(t *testing.T) {
 }
 
 func TestAccAppServiceSlot_autoSwap(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_app_service_slot", "test")
 	r := AppServiceSlotResource{}
 
@@ -1248,7 +1447,7 @@ func (r AppServiceSlotResource) Exists(ctx context.Context, clients *clients.Cli
 		return nil, err
 	}
 
-	resp, err := clients.Web.AppServicesClient.GetSlot(ctx, id.ResourceGroup, id.SiteName, id.SlotName)
+	resp, err := clients.Web.AppServicesClientV1.GetSlot(ctx, id.ResourceGroup, id.SiteName, id.SlotName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			return pointer.To(false), nil

--- a/internal/services/web/app_service_slot_virtual_network_swift_connection_resource.go
+++ b/internal/services/web/app_service_slot_virtual_network_swift_connection_resource.go
@@ -64,7 +64,7 @@ func resourceAppServiceSlotVirtualNetworkSwiftConnection() *pluginsdk.Resource {
 }
 
 func resourceAppServiceSlotVirtualNetworkSwiftConnectionCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.AppServicesClient
+	client := meta.(*clients.Client).Web.AppServicesClientV1
 	subnetClient := meta.(*clients.Client).Network.Subnets
 	vnetClient := meta.(*clients.Client).Network.VirtualNetworks
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
@@ -170,7 +170,7 @@ func resourceAppServiceSlotVirtualNetworkSwiftConnectionCreateUpdate(d *pluginsd
 }
 
 func resourceAppServiceSlotVirtualNetworkSwiftConnectionRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.AppServicesClient
+	client := meta.(*clients.Client).Web.AppServicesClientV1
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -220,7 +220,7 @@ func resourceAppServiceSlotVirtualNetworkSwiftConnectionRead(d *pluginsdk.Resour
 }
 
 func resourceAppServiceSlotVirtualNetworkSwiftConnectionDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.AppServicesClient
+	client := meta.(*clients.Client).Web.AppServicesClientV1
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 

--- a/internal/services/web/app_service_slot_virtual_network_swift_connection_resource_test.go
+++ b/internal/services/web/app_service_slot_virtual_network_swift_connection_resource_test.go
@@ -161,7 +161,7 @@ func (r AppServiceSlotVirtualNetworkSwiftConnectionResource) Exists(ctx context.
 		return nil, err
 	}
 
-	resp, err := clients.Web.AppServicesClient.GetSwiftVirtualNetworkConnectionSlot(ctx, id.ResourceGroup, id.SiteName, id.SlotName)
+	resp, err := clients.Web.AppServicesClientV1.GetSwiftVirtualNetworkConnectionSlot(ctx, id.ResourceGroup, id.SiteName, id.SlotName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			return pointer.To(false), nil
@@ -178,7 +178,7 @@ func (t AppServiceSlotVirtualNetworkSwiftConnectionResource) disappears(ctx cont
 		return err
 	}
 
-	resp, err := clients.Web.AppServicesClient.DeleteSwiftVirtualNetworkSlot(ctx, id.ResourceGroup, id.SiteName, id.SlotName)
+	resp, err := clients.Web.AppServicesClientV1.DeleteSwiftVirtualNetworkSlot(ctx, id.ResourceGroup, id.SiteName, id.SlotName)
 	if err != nil {
 		if !utils.ResponseWasNotFound(resp) {
 			return fmt.Errorf("deleting %s: %+v", id.String(), err)

--- a/internal/services/web/app_service_source_control_token_resource.go
+++ b/internal/services/web/app_service_source_control_token_resource.go
@@ -37,7 +37,7 @@ func resourceAppServiceSourceControlToken() *pluginsdk.Resource {
 			return nil
 		}),
 
-		DeprecationMessage: "The `azurerm_app_service_source_control_token` resource has been superseded by the `azurerm_source_control_token` resource. Whilst this resource will continue to be available in the 2.x and 3.x releases it is feature-frozen for compatibility purposes, will no longer receive any updates and will be removed in a future major release of the Azure Provider.",
+		DeprecationMessage: "The `azurerm_app_service_source_control_token` resource has been superseded by the `azurerm_source_control_token` resource. This resource will be removed in v5.0 of the AzureRM provider.",
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
@@ -71,7 +71,7 @@ func resourceAppServiceSourceControlToken() *pluginsdk.Resource {
 }
 
 func resourceAppServiceSourceControlTokenCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.BaseClient
+	client := meta.(*clients.Client).Web.BaseClientV1
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -101,7 +101,7 @@ func resourceAppServiceSourceControlTokenCreateUpdate(d *pluginsdk.ResourceData,
 }
 
 func resourceAppServiceSourceControlTokenRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.BaseClient
+	client := meta.(*clients.Client).Web.BaseClientV1
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 	scmType := d.Id()
@@ -127,7 +127,7 @@ func resourceAppServiceSourceControlTokenRead(d *pluginsdk.ResourceData, meta in
 }
 
 func resourceAppServiceSourceControlTokenDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.BaseClient
+	client := meta.(*clients.Client).Web.BaseClientV1
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 

--- a/internal/services/web/app_service_source_control_token_resource_test.go
+++ b/internal/services/web/app_service_source_control_token_resource_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -20,6 +21,10 @@ import (
 type AppServiceSourceControlTokenResource struct{}
 
 func TestAccAppServiceSourceControlToken(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_app_service_source_control_token", "test")
 	r := AppServiceSourceControlTokenResource{}
 	token := strings.ToLower(acceptance.RandString(41))
@@ -39,7 +44,7 @@ func TestAccAppServiceSourceControlToken(t *testing.T) {
 }
 
 func (r AppServiceSourceControlTokenResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	resp, err := client.Web.BaseClient.GetSourceControl(ctx, state.ID)
+	resp, err := client.Web.BaseClientV1.GetSourceControl(ctx, state.ID)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			return pointer.To(false), nil

--- a/internal/services/web/app_service_virtual_network_swift_connection_resource.go
+++ b/internal/services/web/app_service_virtual_network_swift_connection_resource.go
@@ -58,7 +58,7 @@ func resourceAppServiceVirtualNetworkSwiftConnection() *pluginsdk.Resource {
 }
 
 func resourceAppServiceVirtualNetworkSwiftConnectionCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.AppServicesClient
+	client := meta.(*clients.Client).Web.AppServicesClientV1
 	subnetClient := meta.(*clients.Client).Network.Subnets
 	vnetClient := meta.(*clients.Client).Network.VirtualNetworks
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
@@ -154,7 +154,7 @@ func resourceAppServiceVirtualNetworkSwiftConnectionCreateUpdate(d *pluginsdk.Re
 }
 
 func resourceAppServiceVirtualNetworkSwiftConnectionRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.AppServicesClient
+	client := meta.(*clients.Client).Web.AppServicesClientV1
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -195,7 +195,7 @@ func resourceAppServiceVirtualNetworkSwiftConnectionRead(d *pluginsdk.ResourceDa
 }
 
 func resourceAppServiceVirtualNetworkSwiftConnectionDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.AppServicesClient
+	client := meta.(*clients.Client).Web.AppServicesClientV1
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 

--- a/internal/services/web/app_service_virtual_network_swift_connection_resource_test.go
+++ b/internal/services/web/app_service_virtual_network_swift_connection_resource_test.go
@@ -95,7 +95,7 @@ func (r AppServiceVirtualNetworkSwiftConnectionResource) Exists(ctx context.Cont
 		return nil, err
 	}
 
-	resp, err := clients.Web.AppServicesClient.GetSwiftVirtualNetworkConnection(ctx, id.ResourceGroup, id.SiteName)
+	resp, err := clients.Web.AppServicesClientV1.GetSwiftVirtualNetworkConnection(ctx, id.ResourceGroup, id.SiteName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			return pointer.To(false), nil
@@ -112,7 +112,7 @@ func (t AppServiceVirtualNetworkSwiftConnectionResource) disappears(ctx context.
 		return err
 	}
 
-	resp, err := clients.Web.AppServicesClient.DeleteSwiftVirtualNetwork(ctx, id.ResourceGroup, id.SiteName)
+	resp, err := clients.Web.AppServicesClientV1.DeleteSwiftVirtualNetwork(ctx, id.ResourceGroup, id.SiteName)
 	if err != nil {
 		if !utils.ResponseWasNotFound(resp) {
 			return fmt.Errorf("deleting %s: %+v", id.String(), err)

--- a/internal/services/web/client/client.go
+++ b/internal/services/web/client/client.go
@@ -9,13 +9,13 @@ import (
 )
 
 type Client struct {
-	AppServiceEnvironmentsClient *web.AppServiceEnvironmentsClient
-	AppServicePlansClient        *web.AppServicePlansClient
-	AppServicesClient            *web.AppsClient
-	BaseClient                   *web.BaseClient
-	CertificatesClient           *web.CertificatesClient
-	CertificatesOrderClient      *web.AppServiceCertificateOrdersClient
-	StaticSitesClient            *web.StaticSitesClient
+	AppServiceEnvironmentsClientV1 *web.AppServiceEnvironmentsClient
+	AppServicePlansClientV1        *web.AppServicePlansClient
+	AppServicesClientV1            *web.AppsClient
+	BaseClientV1                   *web.BaseClient
+	CertificatesClientV1           *web.CertificatesClient
+	CertificatesOrderClientV1      *web.AppServiceCertificateOrdersClient
+	StaticSitesClientV1            *web.StaticSitesClient
 }
 
 func NewClient(o *common.ClientOptions) *Client {
@@ -41,12 +41,12 @@ func NewClient(o *common.ClientOptions) *Client {
 	o.ConfigureClient(&staticSitesClient.Client, o.ResourceManagerAuthorizer)
 
 	return &Client{
-		AppServiceEnvironmentsClient: &appServiceEnvironmentsClient,
-		AppServicePlansClient:        &appServicePlansClient,
-		AppServicesClient:            &appServicesClient,
-		BaseClient:                   &baseClient,
-		CertificatesClient:           &certificatesClient,
-		CertificatesOrderClient:      &certificatesOrderClient,
-		StaticSitesClient:            &staticSitesClient,
+		AppServiceEnvironmentsClientV1: &appServiceEnvironmentsClient,
+		AppServicePlansClientV1:        &appServicePlansClient,
+		AppServicesClientV1:            &appServicesClient,
+		BaseClientV1:                   &baseClient,
+		CertificatesClientV1:           &certificatesClient,
+		CertificatesOrderClientV1:      &certificatesOrderClient,
+		StaticSitesClientV1:            &staticSitesClient,
 	}
 }

--- a/internal/services/web/function_app.go
+++ b/internal/services/web/function_app.go
@@ -371,7 +371,7 @@ func getFunctionAppServiceTier(ctx context.Context, appServicePlanId string, met
 
 	log.Printf("[DEBUG] Retrieving App Service Plan %q (Resource Group %q)", id.ServerFarmName, id.ResourceGroup)
 
-	appServicePlansClient := meta.(*clients.Client).Web.AppServicePlansClient
+	appServicePlansClient := meta.(*clients.Client).Web.AppServicePlansClientV1
 	appServicePlan, err := appServicePlansClient.Get(ctx, id.ResourceGroup, id.ServerFarmName)
 	if err != nil {
 		return "", fmt.Errorf("[ERROR] Could not retrieve App Service Plan ID %q: %+v", appServicePlanId, err)

--- a/internal/services/web/function_app_data_source.go
+++ b/internal/services/web/function_app_data_source.go
@@ -27,7 +27,7 @@ func dataSourceFunctionApp() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
 		Read: dataSourceFunctionAppRead,
 
-		DeprecationMessage: "The `azurerm_function_app` data source has been superseded by the `azurerm_linux_function_app` and `azurerm_windows_function_app` data sources. Whilst this resource will continue to be available in the 2.x and 3.x releases it is feature-frozen for compatibility purposes, will no longer receive any updates and will be removed in a future major release of the Azure Provider.",
+		DeprecationMessage: "The `azurerm_function_app` data source has been superseded by the `azurerm_linux_function_app` and `azurerm_windows_function_app` data sources. This data source will be removed in v5.0 of the AzureRM Provider.",
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Read: pluginsdk.DefaultTimeout(5 * time.Minute),
@@ -144,7 +144,7 @@ func dataSourceFunctionApp() *pluginsdk.Resource {
 }
 
 func dataSourceFunctionAppRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.AppServicesClient
+	client := meta.(*clients.Client).Web.AppServicesClientV1
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()

--- a/internal/services/web/function_app_data_source_test.go
+++ b/internal/services/web/function_app_data_source_test.go
@@ -9,11 +9,15 @@ import (
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 )
 
 type FunctionAppDataSource struct{}
 
 func TestAccFunctionAppDataSource_basic(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this data source was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "data.azurerm_function_app", "test")
 
 	data.DataSourceTest(t, []acceptance.TestStep{
@@ -29,6 +33,9 @@ func TestAccFunctionAppDataSource_basic(t *testing.T) {
 }
 
 func TestAccFunctionAppDataSource_appSettings(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this data source was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "data.azurerm_function_app", "test")
 
 	data.DataSourceTest(t, []acceptance.TestStep{
@@ -42,6 +49,9 @@ func TestAccFunctionAppDataSource_appSettings(t *testing.T) {
 }
 
 func TestAccFunctionAppDataSource_connectionStrings(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this data source was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "data.azurerm_function_app", "test")
 
 	data.DataSourceTest(t, []acceptance.TestStep{
@@ -57,6 +67,9 @@ func TestAccFunctionAppDataSource_connectionStrings(t *testing.T) {
 }
 
 func TestAccFunctionAppDataSource_withSourceControl(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this data source was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "data.azurerm_function_app", "test")
 
 	data.DataSourceTest(t, []acceptance.TestStep{
@@ -70,6 +83,9 @@ func TestAccFunctionAppDataSource_withSourceControl(t *testing.T) {
 }
 
 func TestAccFunctionAppDataSource_siteConfig(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this data source was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 
 	data.DataSourceTest(t, []acceptance.TestStep{
@@ -86,6 +102,9 @@ func TestAccFunctionAppDataSource_siteConfig(t *testing.T) {
 }
 
 func TestAccFunctionAppDataSource_clientCertMode(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this data source was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "data.azurerm_function_app", "test")
 
 	data.DataSourceTest(t, []acceptance.TestStep{
@@ -111,6 +130,9 @@ func TestAccFunctionAppDataSource_clientCertMode(t *testing.T) {
 }
 
 func TestAccFunctionAppDataSource_siteConfigVnetRouteAllEnabled(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this data source was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "data.azurerm_function_app", "test")
 
 	data.DataSourceTest(t, []acceptance.TestStep{

--- a/internal/services/web/function_app_host_keys_data_source.go
+++ b/internal/services/web/function_app_host_keys_data_source.go
@@ -83,7 +83,7 @@ func dataSourceFunctionAppHostKeys() *pluginsdk.Resource {
 }
 
 func dataSourceFunctionAppHostKeysRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.AppServicesClient
+	client := meta.(*clients.Client).Web.AppServicesClientV1
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()

--- a/internal/services/web/function_app_resource.go
+++ b/internal/services/web/function_app_resource.go
@@ -41,7 +41,7 @@ func resourceFunctionApp() *pluginsdk.Resource {
 			return err
 		}),
 
-		DeprecationMessage: "The `azurerm_function_app` resource has been superseded by the `azurerm_linux_function_app` and `azurerm_windows_function_app` resources. Whilst this resource will continue to be available in the 2.x and 3.x releases it is feature-frozen for compatibility purposes, will no longer receive any updates and will be removed in a future major release of the Azure Provider.",
+		DeprecationMessage: "The `azurerm_function_app` resource has been superseded by the `azurerm_linux_function_app` and `azurerm_windows_function_app` resources. This resource will be removed in v5.0 of the AzureRM Provider.",
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
@@ -244,7 +244,7 @@ func resourceFunctionApp() *pluginsdk.Resource {
 }
 
 func resourceFunctionAppCreate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.AppServicesClient
+	client := meta.(*clients.Client).Web.AppServicesClientV1
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -392,7 +392,7 @@ func resourceFunctionAppCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 }
 
 func resourceFunctionAppUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.AppServicesClient
+	client := meta.(*clients.Client).Web.AppServicesClientV1
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -580,7 +580,7 @@ func resourceFunctionAppUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 }
 
 func resourceFunctionAppRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.AppServicesClient
+	client := meta.(*clients.Client).Web.AppServicesClientV1
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -768,7 +768,7 @@ func resourceFunctionAppRead(d *pluginsdk.ResourceData, meta interface{}) error 
 }
 
 func resourceFunctionAppDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.AppServicesClient
+	client := meta.(*clients.Client).Web.AppServicesClientV1
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 

--- a/internal/services/web/function_app_resource_test.go
+++ b/internal/services/web/function_app_resource_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/web/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -22,6 +23,9 @@ import (
 type FunctionAppResource struct{}
 
 func TestAccFunctionApp_basic(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -42,6 +46,9 @@ func TestAccFunctionApp_basic(t *testing.T) {
 }
 
 func TestAccFunctionApp_requiresImport(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -58,6 +65,9 @@ func TestAccFunctionApp_requiresImport(t *testing.T) {
 }
 
 func TestAccFunctionApp_tags(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -75,6 +85,9 @@ func TestAccFunctionApp_tags(t *testing.T) {
 }
 
 func TestAccFunctionApp_tagsUpdate(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -100,6 +113,9 @@ func TestAccFunctionApp_tagsUpdate(t *testing.T) {
 }
 
 func TestAccFunctionApp_appSettings(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -115,6 +131,9 @@ func TestAccFunctionApp_appSettings(t *testing.T) {
 }
 
 func TestAccFunctionApp_appSettingsUpdate(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -151,6 +170,9 @@ func TestAccFunctionApp_appSettingsUpdate(t *testing.T) {
 }
 
 func TestAccFunctionApp_siteConfig(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -167,6 +189,9 @@ func TestAccFunctionApp_siteConfig(t *testing.T) {
 }
 
 func TestAccFunctionApp_scmIPRestriction(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -182,6 +207,9 @@ func TestAccFunctionApp_scmIPRestriction(t *testing.T) {
 }
 
 func TestAccFunctionApp_scmIPRestrictionSubnet(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -197,6 +225,9 @@ func TestAccFunctionApp_scmIPRestrictionSubnet(t *testing.T) {
 }
 
 func TestAccFunctionApp_healthCheck(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -213,6 +244,9 @@ func TestAccFunctionApp_healthCheck(t *testing.T) {
 }
 
 func TestAccFunctionApp_linuxFxVersion(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -230,6 +264,9 @@ func TestAccFunctionApp_linuxFxVersion(t *testing.T) {
 }
 
 func TestAccFunctionApp_elasticPremiumPlanLinux(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -246,6 +283,9 @@ func TestAccFunctionApp_elasticPremiumPlanLinux(t *testing.T) {
 }
 
 func TestAccFunctionApp_siteConfigVnetRouteAllEnabled(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -262,6 +302,9 @@ func TestAccFunctionApp_siteConfigVnetRouteAllEnabled(t *testing.T) {
 }
 
 func TestAccFunctionApp_appSettingsVnetRouteAllEnabled(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -279,6 +322,9 @@ func TestAccFunctionApp_appSettingsVnetRouteAllEnabled(t *testing.T) {
 }
 
 func TestAccFunctionApp_connectionStrings(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -295,6 +341,9 @@ func TestAccFunctionApp_connectionStrings(t *testing.T) {
 }
 
 func TestAccFunctionApp_siteConfigMulti(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -354,6 +403,9 @@ func TestAccFunctionApp_siteConfigMulti(t *testing.T) {
 }
 
 func TestAccFunctionApp_updateVersion(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -376,6 +428,9 @@ func TestAccFunctionApp_updateVersion(t *testing.T) {
 }
 
 func TestAccFunctionApp_3264bit(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -398,6 +453,9 @@ func TestAccFunctionApp_3264bit(t *testing.T) {
 }
 
 func TestAccFunctionApp_httpsOnly(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -413,6 +471,9 @@ func TestAccFunctionApp_httpsOnly(t *testing.T) {
 }
 
 func TestAccFunctionApp_dailyMemoryTimeQuota(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -437,6 +498,9 @@ func TestAccFunctionApp_dailyMemoryTimeQuota(t *testing.T) {
 }
 
 func TestAccFunctionApp_consumptionPlan(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -453,6 +517,9 @@ func TestAccFunctionApp_consumptionPlan(t *testing.T) {
 }
 
 func TestAccFunctionApp_keyVaultUserAssignedIdentity(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -468,6 +535,9 @@ func TestAccFunctionApp_keyVaultUserAssignedIdentity(t *testing.T) {
 }
 
 func TestAccFunctionApp_consumptionPlanUppercaseName(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -485,6 +555,9 @@ func TestAccFunctionApp_consumptionPlanUppercaseName(t *testing.T) {
 }
 
 func TestAccFunctionApp_createIdentity(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -503,6 +576,9 @@ func TestAccFunctionApp_createIdentity(t *testing.T) {
 }
 
 func TestAccFunctionApp_updateIdentity(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -528,6 +604,9 @@ func TestAccFunctionApp_updateIdentity(t *testing.T) {
 }
 
 func TestAccFunctionApp_userAssignedIdentity(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -558,6 +637,9 @@ func TestAccFunctionApp_userAssignedIdentity(t *testing.T) {
 }
 
 func TestAccFunctionApp_loggingDisabled(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -575,6 +657,9 @@ func TestAccFunctionApp_loggingDisabled(t *testing.T) {
 }
 
 func TestAccFunctionApp_updateLogging(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -604,6 +689,9 @@ func TestAccFunctionApp_updateLogging(t *testing.T) {
 }
 
 func TestAccFunctionApp_authSettings(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	tenantID := os.Getenv("ARM_TENANT_ID")
 	r := FunctionAppResource{}
@@ -632,6 +720,9 @@ func TestAccFunctionApp_authSettings(t *testing.T) {
 }
 
 func TestAccFunctionApp_corsSettings(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -650,6 +741,9 @@ func TestAccFunctionApp_corsSettings(t *testing.T) {
 }
 
 func TestAccFunctionApp_enableHttp2(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -666,6 +760,9 @@ func TestAccFunctionApp_enableHttp2(t *testing.T) {
 }
 
 func TestAccFunctionApp_minTlsVersion(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -682,6 +779,9 @@ func TestAccFunctionApp_minTlsVersion(t *testing.T) {
 }
 
 func TestAccFunctionApp_ftpsState(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -698,6 +798,9 @@ func TestAccFunctionApp_ftpsState(t *testing.T) {
 }
 
 func TestAccFunctionApp_javaVersion(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -713,6 +816,9 @@ func TestAccFunctionApp_javaVersion(t *testing.T) {
 }
 
 func TestAccFunctionApp_preWarmedInstanceCount(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -729,6 +835,9 @@ func TestAccFunctionApp_preWarmedInstanceCount(t *testing.T) {
 }
 
 func TestAccAzureRMFunctionApp_computedPreWarmedInstanceCount(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -745,6 +854,9 @@ func TestAccAzureRMFunctionApp_computedPreWarmedInstanceCount(t *testing.T) {
 }
 
 func TestAccFunctionApp_oneIpRestriction(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -761,6 +873,9 @@ func TestAccFunctionApp_oneIpRestriction(t *testing.T) {
 }
 
 func TestAccFunctionApp_oneServiceTagIpRestriction(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -777,6 +892,9 @@ func TestAccFunctionApp_oneServiceTagIpRestriction(t *testing.T) {
 }
 
 func TestAccFunctionApp_changeIpToServiceTagIpRestriction(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -806,6 +924,9 @@ func TestAccFunctionApp_changeIpToServiceTagIpRestriction(t *testing.T) {
 }
 
 func TestAccFunctionApp_oneVNetSubnetIpRestriction(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -821,6 +942,9 @@ func TestAccFunctionApp_oneVNetSubnetIpRestriction(t *testing.T) {
 }
 
 func TestAccFunctionApp_ipRestrictionRemoved(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -853,6 +977,9 @@ func TestAccFunctionApp_ipRestrictionRemoved(t *testing.T) {
 }
 
 func TestAccFunctionApp_manyIpRestrictions(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -868,6 +995,9 @@ func TestAccFunctionApp_manyIpRestrictions(t *testing.T) {
 }
 
 func TestAccFunctionApp_scmUseMainIPRestriction(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -883,6 +1013,9 @@ func TestAccFunctionApp_scmUseMainIPRestriction(t *testing.T) {
 }
 
 func TestAccFunctionApp_scmOneIpRestriction(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -898,6 +1031,9 @@ func TestAccFunctionApp_scmOneIpRestriction(t *testing.T) {
 }
 
 func TestAccFunctionApp_updateStorageAccountKey(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -927,6 +1063,9 @@ func TestAccFunctionApp_updateStorageAccountKey(t *testing.T) {
 }
 
 func TestAccFunctionApp_withSourceControl(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -942,6 +1081,9 @@ func TestAccFunctionApp_withSourceControl(t *testing.T) {
 }
 
 func TestAccFunctionApp_sourceControlUpdate(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -964,6 +1106,9 @@ func TestAccFunctionApp_sourceControlUpdate(t *testing.T) {
 }
 
 func TestAccFunctionApp_scm(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -979,6 +1124,9 @@ func TestAccFunctionApp_scm(t *testing.T) {
 }
 
 func TestAccFunctionApp_clientCertMode(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -1016,6 +1164,9 @@ func TestAccFunctionApp_clientCertMode(t *testing.T) {
 }
 
 func TestAccFunctionApp_elasticInstanceMinimum(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -1032,6 +1183,9 @@ func TestAccFunctionApp_elasticInstanceMinimum(t *testing.T) {
 }
 
 func TestAccFunctionApp_appScaleLimit(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -1048,6 +1202,9 @@ func TestAccFunctionApp_appScaleLimit(t *testing.T) {
 }
 
 func TestAccFunctionApp_runtimeScaleMonitoringEnabled(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -1064,6 +1221,9 @@ func TestAccFunctionApp_runtimeScaleMonitoringEnabled(t *testing.T) {
 }
 
 func TestAccFunctionApp_dotnetVersion4(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -1080,6 +1240,9 @@ func TestAccFunctionApp_dotnetVersion4(t *testing.T) {
 }
 
 func TestAccFunctionApp_dotnetVersion5(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -1096,6 +1259,9 @@ func TestAccFunctionApp_dotnetVersion5(t *testing.T) {
 }
 
 func TestAccFunctionApp_dotnetVersion6(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app", "test")
 	r := FunctionAppResource{}
 
@@ -1117,7 +1283,7 @@ func (r FunctionAppResource) Exists(ctx context.Context, clients *clients.Client
 		return nil, err
 	}
 
-	resp, err := clients.Web.AppServicesClient.Get(ctx, id.ResourceGroup, id.SiteName)
+	resp, err := clients.Web.AppServicesClientV1.Get(ctx, id.ResourceGroup, id.SiteName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			return pointer.To(false), nil
@@ -1140,7 +1306,7 @@ func (r FunctionAppResource) hasContentShareAppSetting(shouldExist bool) func(ct
 			return err
 		}
 
-		appSettingsResp, err := clients.Web.AppServicesClient.ListApplicationSettings(ctx, id.ResourceGroup, id.SiteName)
+		appSettingsResp, err := clients.Web.AppServicesClientV1.ListApplicationSettings(ctx, id.ResourceGroup, id.SiteName)
 		if err != nil {
 			return fmt.Errorf("listing AppSettings: %+v", err)
 		}

--- a/internal/services/web/function_app_slot_resource.go
+++ b/internal/services/web/function_app_slot_resource.go
@@ -40,7 +40,7 @@ func resourceFunctionAppSlot() *pluginsdk.Resource {
 			return err
 		}),
 
-		DeprecationMessage: "The `azurerm_function_app_slot` resource has been superseded by the `azurerm_linux_function_app_slot` and `azurerm_windows_function_app_slot` resources. Whilst this resource will continue to be available in the 2.x and 3.x releases it is feature-frozen for compatibility purposes, will no longer receive any updates and will be removed in a future major release of the Azure Provider.",
+		DeprecationMessage: "The `azurerm_function_app_slot` resource has been superseded by the `azurerm_linux_function_app_slot` and `azurerm_windows_function_app_slot` resources. This resource will be removed in v5.0 of the AzureRM Provider.",
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
@@ -221,7 +221,7 @@ func resourceFunctionAppSlot() *pluginsdk.Resource {
 }
 
 func resourceFunctionAppSlotCreate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.AppServicesClient
+	client := meta.(*clients.Client).Web.AppServicesClientV1
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -325,7 +325,7 @@ func resourceFunctionAppSlotCreate(d *pluginsdk.ResourceData, meta interface{}) 
 }
 
 func resourceFunctionAppSlotUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.AppServicesClient
+	client := meta.(*clients.Client).Web.AppServicesClientV1
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -458,7 +458,7 @@ func resourceFunctionAppSlotUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 }
 
 func resourceFunctionAppSlotRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.AppServicesClient
+	client := meta.(*clients.Client).Web.AppServicesClientV1
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -608,7 +608,7 @@ func resourceFunctionAppSlotRead(d *pluginsdk.ResourceData, meta interface{}) er
 }
 
 func resourceFunctionAppSlotDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.AppServicesClient
+	client := meta.(*clients.Client).Web.AppServicesClientV1
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -696,7 +696,7 @@ func getFunctionAppSlotServiceTier(ctx context.Context, appServicePlanID string,
 
 	log.Printf("[DEBUG] Retrieving App Service Plan %q (Resource Group %q)", id.ServerFarmName, id.ResourceGroup)
 
-	appServicePlansClient := meta.(*clients.Client).Web.AppServicePlansClient
+	appServicePlansClient := meta.(*clients.Client).Web.AppServicePlansClientV1
 	appServicePlan, err := appServicePlansClient.Get(ctx, id.ResourceGroup, id.ServerFarmName)
 	if err != nil {
 		return "", fmt.Errorf("[ERROR] Could not retrieve App Service Plan ID %q: %+v", appServicePlanID, err)

--- a/internal/services/web/function_app_slot_resource_test.go
+++ b/internal/services/web/function_app_slot_resource_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/web/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -21,6 +22,9 @@ import (
 type FunctionAppSlotResource struct{}
 
 func TestAccFunctionAppSlot_basic(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app_slot", "test")
 	r := FunctionAppSlotResource{}
 
@@ -36,6 +40,9 @@ func TestAccFunctionAppSlot_basic(t *testing.T) {
 }
 
 func TestAccFunctionAppSlot_requiresImport(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app_slot", "test")
 	r := FunctionAppSlotResource{}
 
@@ -51,6 +58,9 @@ func TestAccFunctionAppSlot_requiresImport(t *testing.T) {
 }
 
 func TestAccFunctionAppSlot_32Bit(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app_slot", "test")
 	r := FunctionAppSlotResource{}
 
@@ -67,6 +77,9 @@ func TestAccFunctionAppSlot_32Bit(t *testing.T) {
 }
 
 func TestAccFunctionAppSlot_alwaysOn(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app_slot", "test")
 	r := FunctionAppSlotResource{}
 
@@ -83,6 +96,9 @@ func TestAccFunctionAppSlot_alwaysOn(t *testing.T) {
 }
 
 func TestAccFunctionAppSlot_appSettings(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app_slot", "test")
 	r := FunctionAppSlotResource{}
 
@@ -99,6 +115,9 @@ func TestAccFunctionAppSlot_appSettings(t *testing.T) {
 }
 
 func TestAccFunctionAppSlot_connectionStrings(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app_slot", "test")
 	r := FunctionAppSlotResource{}
 
@@ -120,6 +139,9 @@ func TestAccFunctionAppSlot_connectionStrings(t *testing.T) {
 }
 
 func TestAccFunctionAppSlot_corsSettings(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app_slot", "test")
 	r := FunctionAppSlotResource{}
 
@@ -135,6 +157,9 @@ func TestAccFunctionAppSlot_corsSettings(t *testing.T) {
 }
 
 func TestAccFunctionAppSlot_autoSwap(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app_slot", "test")
 	r := FunctionAppSlotResource{}
 
@@ -151,6 +176,9 @@ func TestAccFunctionAppSlot_autoSwap(t *testing.T) {
 }
 
 func TestAccFunctionAppSlot_authSettings(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app_slot", "test")
 	tenantID := os.Getenv("ARM_TENANT_ID")
 	r := FunctionAppSlotResource{}
@@ -179,6 +207,9 @@ func TestAccFunctionAppSlot_authSettings(t *testing.T) {
 }
 
 func TestAccFunctionAppSlot_enabled(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app_slot", "test")
 	r := FunctionAppSlotResource{}
 
@@ -194,6 +225,9 @@ func TestAccFunctionAppSlot_enabled(t *testing.T) {
 }
 
 func TestAccFunctionAppSlot_enabledUpdate(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app_slot", "test")
 	r := FunctionAppSlotResource{}
 
@@ -216,6 +250,9 @@ func TestAccFunctionAppSlot_enabledUpdate(t *testing.T) {
 }
 
 func TestAccFunctionAppSlot_httpsOnly(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app_slot", "test")
 	r := FunctionAppSlotResource{}
 
@@ -231,6 +268,9 @@ func TestAccFunctionAppSlot_httpsOnly(t *testing.T) {
 }
 
 func TestAccFunctionAppSlot_httpsOnlyUpdate(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app_slot", "test")
 	r := FunctionAppSlotResource{}
 
@@ -253,6 +293,9 @@ func TestAccFunctionAppSlot_httpsOnlyUpdate(t *testing.T) {
 }
 
 func TestAccFunctionAppSlot_http2Enabled(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app_slot", "test")
 	r := FunctionAppSlotResource{}
 
@@ -268,6 +311,9 @@ func TestAccFunctionAppSlot_http2Enabled(t *testing.T) {
 }
 
 func TestAccFunctionAppSlot_oneIpRestriction(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app_slot", "test")
 	r := FunctionAppSlotResource{}
 
@@ -283,6 +329,9 @@ func TestAccFunctionAppSlot_oneIpRestriction(t *testing.T) {
 }
 
 func TestAccFunctionAppSlot_oneVNetSubnetIpRestriction(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app_slot", "test")
 	r := FunctionAppSlotResource{}
 
@@ -298,6 +347,9 @@ func TestAccFunctionAppSlot_oneVNetSubnetIpRestriction(t *testing.T) {
 }
 
 func TestAccFunctionAppSlot_zeroedIpRestriction(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app_slot", "test")
 	r := FunctionAppSlotResource{}
 
@@ -330,6 +382,9 @@ func TestAccFunctionAppSlot_zeroedIpRestriction(t *testing.T) {
 }
 
 func TestAccFunctionAppSlot_manyIpRestrictions(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app_slot", "test")
 	r := FunctionAppSlotResource{}
 
@@ -345,6 +400,9 @@ func TestAccFunctionAppSlot_manyIpRestrictions(t *testing.T) {
 }
 
 func TestAccFunctionAppSlot_scmUseMainIPRestriction(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app_slot", "test")
 	r := FunctionAppSlotResource{}
 
@@ -360,6 +418,9 @@ func TestAccFunctionAppSlot_scmUseMainIPRestriction(t *testing.T) {
 }
 
 func TestAccFunctionAppSlot_scmIPRestrictionComplete(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app_slot", "test")
 	r := FunctionAppSlotResource{}
 
@@ -375,6 +436,9 @@ func TestAccFunctionAppSlot_scmIPRestrictionComplete(t *testing.T) {
 }
 
 func TestAccFunctionAppSlot_scmIPRestrictionServiceTag(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app_slot", "test")
 	r := FunctionAppSlotResource{}
 
@@ -390,6 +454,9 @@ func TestAccFunctionAppSlot_scmIPRestrictionServiceTag(t *testing.T) {
 }
 
 func TestAccFunctionAppSlot_scmIPRestrictionSubnet(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app_slot", "test")
 	r := FunctionAppSlotResource{}
 
@@ -405,6 +472,9 @@ func TestAccFunctionAppSlot_scmIPRestrictionSubnet(t *testing.T) {
 }
 
 func TestAccFunctionAppSlot_tagsUpdate(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app_slot", "test")
 	r := FunctionAppSlotResource{}
 
@@ -430,6 +500,9 @@ func TestAccFunctionAppSlot_tagsUpdate(t *testing.T) {
 }
 
 func TestAccFunctionAppSlot_updateManageServiceIdentity(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app_slot", "test")
 	r := FunctionAppSlotResource{}
 
@@ -453,6 +526,9 @@ func TestAccFunctionAppSlot_updateManageServiceIdentity(t *testing.T) {
 }
 
 func TestAccFunctionAppSlot_updateVersion(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app_slot", "test")
 	r := FunctionAppSlotResource{}
 
@@ -475,6 +551,9 @@ func TestAccFunctionAppSlot_updateVersion(t *testing.T) {
 }
 
 func TestAccFunctionAppSlot_userAssignedIdentity(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app_slot", "test")
 	r := FunctionAppSlotResource{}
 
@@ -493,6 +572,9 @@ func TestAccFunctionAppSlot_userAssignedIdentity(t *testing.T) {
 }
 
 func TestAccFunctionAppSlot_webSockets(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app_slot", "test")
 	r := FunctionAppSlotResource{}
 
@@ -508,6 +590,9 @@ func TestAccFunctionAppSlot_webSockets(t *testing.T) {
 }
 
 func TestAccFunctionAppSlot_enableManageServiceIdentity(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app_slot", "test")
 	r := FunctionAppSlotResource{}
 
@@ -525,6 +610,9 @@ func TestAccFunctionAppSlot_enableManageServiceIdentity(t *testing.T) {
 }
 
 func TestAccFunctionAppSlot_minTls(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app_slot", "test")
 	r := FunctionAppSlotResource{}
 
@@ -548,6 +636,9 @@ func TestAccFunctionAppSlot_minTls(t *testing.T) {
 }
 
 func TestAccFunctionAppSlot_preWarmedInstanceCount(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app_slot", "test")
 	r := FunctionAppSlotResource{}
 
@@ -564,6 +655,9 @@ func TestAccFunctionAppSlot_preWarmedInstanceCount(t *testing.T) {
 }
 
 func TestAccFunctionAppSlot_elasticInstanceMinimum(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app_slot", "test")
 	r := FunctionAppSlotResource{}
 
@@ -580,6 +674,9 @@ func TestAccFunctionAppSlot_elasticInstanceMinimum(t *testing.T) {
 }
 
 func TestAccFunctionAppSlot_appScaleLimit(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app_slot", "test")
 	r := FunctionAppSlotResource{}
 
@@ -596,6 +693,9 @@ func TestAccFunctionAppSlot_appScaleLimit(t *testing.T) {
 }
 
 func TestAccFunctionAppSlot_runtimeScaleMonitoringEnabled(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app_slot", "test")
 	r := FunctionAppSlotResource{}
 
@@ -612,6 +712,9 @@ func TestAccFunctionAppSlot_runtimeScaleMonitoringEnabled(t *testing.T) {
 }
 
 func TestAccFunctionAppSlot_dotnetVersion4(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app_slot", "test")
 	r := FunctionAppSlotResource{}
 
@@ -628,6 +731,9 @@ func TestAccFunctionAppSlot_dotnetVersion4(t *testing.T) {
 }
 
 func TestAccFunctionAppSlot_dotnetVersion5(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app_slot", "test")
 	r := FunctionAppSlotResource{}
 
@@ -644,6 +750,9 @@ func TestAccFunctionAppSlot_dotnetVersion5(t *testing.T) {
 }
 
 func TestAccFunctionAppSlot_dotnetVersion6(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
 	data := acceptance.BuildTestData(t, "azurerm_function_app_slot", "test")
 	r := FunctionAppSlotResource{}
 
@@ -665,7 +774,7 @@ func (r FunctionAppSlotResource) Exists(ctx context.Context, clients *clients.Cl
 		return nil, err
 	}
 
-	resp, err := clients.Web.AppServicesClient.GetSlot(ctx, id.ResourceGroup, id.SiteName, id.SlotName)
+	resp, err := clients.Web.AppServicesClientV1.GetSlot(ctx, id.ResourceGroup, id.SiteName, id.SlotName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			return pointer.To(false), nil

--- a/internal/services/web/registration.go
+++ b/internal/services/web/registration.go
@@ -6,6 +6,7 @@ package web
 import (
 	"github.com/hashicorp/terraform-plugin-framework/action"
 	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
@@ -33,38 +34,45 @@ func (r Registration) WebsiteCategories() []string {
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 	datasources := map[string]*pluginsdk.Resource{
-		"azurerm_app_service":                   dataSourceAppService(),
 		"azurerm_app_service_certificate_order": dataSourceAppServiceCertificateOrder(),
 		"azurerm_app_service_certificate":       dataSourceAppServiceCertificate(),
-		"azurerm_app_service_plan":              dataSourceAppServicePlan(),
-		"azurerm_function_app":                  dataSourceFunctionApp(),
 		"azurerm_function_app_host_keys":        dataSourceFunctionAppHostKeys(),
 	}
+
+	if !features.FivePointOh() {
+		datasources["azurerm_app_service"] = dataSourceAppService()
+		datasources["azurerm_app_service_plan"] = dataSourceAppServicePlan()
+		datasources["azurerm_function_app"] = dataSourceFunctionApp()
+	}
+
 	return datasources
 }
 
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 	resources := map[string]*pluginsdk.Resource{
-		"azurerm_app_service_active_slot":                           resourceAppServiceActiveSlot(),
 		"azurerm_app_service_certificate":                           resourceAppServiceCertificate(),
 		"azurerm_app_service_certificate_order":                     resourceAppServiceCertificateOrder(),
 		"azurerm_app_service_custom_hostname_binding":               resourceAppServiceCustomHostnameBinding(),
 		"azurerm_app_service_certificate_binding":                   resourceAppServiceCertificateBinding(),
-		"azurerm_app_service_hybrid_connection":                     resourceAppServiceHybridConnection(),
 		"azurerm_app_service_managed_certificate":                   resourceAppServiceManagedCertificate(),
-		"azurerm_app_service_plan":                                  resourceAppServicePlan(),
 		"azurerm_app_service_public_certificate":                    resourceAppServicePublicCertificate(),
-		"azurerm_app_service_slot":                                  resourceAppServiceSlot(),
 		"azurerm_app_service_slot_custom_hostname_binding":          resourceAppServiceSlotCustomHostnameBinding(),
 		"azurerm_app_service_slot_virtual_network_swift_connection": resourceAppServiceSlotVirtualNetworkSwiftConnection(),
-		"azurerm_app_service_source_control_token":                  resourceAppServiceSourceControlToken(),
 		"azurerm_app_service_virtual_network_swift_connection":      resourceAppServiceVirtualNetworkSwiftConnection(),
-		"azurerm_app_service":                                       resourceAppService(),
-		"azurerm_function_app":                                      resourceFunctionApp(),
-		"azurerm_function_app_slot":                                 resourceFunctionAppSlot(),
-		"azurerm_static_site":                                       resourceStaticSite(),
-		"azurerm_static_site_custom_domain":                         resourceStaticSiteCustomDomain(),
+	}
+
+	if !features.FivePointOh() {
+		resources["azurerm_app_service_active_slot"] = resourceAppServiceActiveSlot()
+		resources["azurerm_app_service_hybrid_connection"] = resourceAppServiceHybridConnection()
+		resources["azurerm_app_service_plan"] = resourceAppServicePlan()
+		resources["azurerm_app_service_slot"] = resourceAppServiceSlot()
+		resources["azurerm_app_service_source_control_token"] = resourceAppServiceSourceControlToken()
+		resources["azurerm_app_service"] = resourceAppService()
+		resources["azurerm_function_app"] = resourceFunctionApp()
+		resources["azurerm_function_app_slot"] = resourceFunctionAppSlot()
+		resources["azurerm_static_site"] = resourceStaticSite()
+		resources["azurerm_static_site_custom_domain"] = resourceStaticSiteCustomDomain()
 	}
 
 	return resources

--- a/internal/services/web/static_site_custom_domain_resource.go
+++ b/internal/services/web/static_site_custom_domain_resource.go
@@ -27,7 +27,7 @@ const (
 
 func resourceStaticSiteCustomDomain() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		DeprecationMessage: "This resource has been deprecated in favour of `azurerm_static_web_app_custom_domain` and will be removed in a future release.",
+		DeprecationMessage: "This resource has been deprecated in favour of `azurerm_static_web_app_custom_domain` and will be removed v5.0 of the AzureRM provider.",
 		Create:             resourceStaticSiteCustomDomainCreate,
 		Read:               resourceStaticSiteCustomDomainRead,
 		Delete:             resourceStaticSiteCustomDomainDelete,
@@ -77,7 +77,7 @@ func resourceStaticSiteCustomDomain() *pluginsdk.Resource {
 }
 
 func resourceStaticSiteCustomDomainCreate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.StaticSitesClient
+	client := meta.(*clients.Client).Web.StaticSitesClientV1
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -176,7 +176,7 @@ func resourceStaticSiteCustomDomainCreate(d *pluginsdk.ResourceData, meta interf
 }
 
 func resourceStaticSiteCustomDomainRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.StaticSitesClient
+	client := meta.(*clients.Client).Web.StaticSitesClientV1
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -201,7 +201,7 @@ func resourceStaticSiteCustomDomainRead(d *pluginsdk.ResourceData, meta interfac
 }
 
 func resourceStaticSiteCustomDomainDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.StaticSitesClient
+	client := meta.(*clients.Client).Web.StaticSitesClientV1
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 

--- a/internal/services/web/static_site_resource.go
+++ b/internal/services/web/static_site_resource.go
@@ -27,7 +27,7 @@ import (
 
 func resourceStaticSite() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		DeprecationMessage: "This resource has been deprecated in favour of `azurerm_static_web_app` and will be removed in a future release.",
+		DeprecationMessage: "This resource has been deprecated in favour of `azurerm_static_web_app` and will be removed in v5.0 of the AzureRM provider.",
 		Create:             resourceStaticSiteCreateOrUpdate,
 		Read:               resourceStaticSiteRead,
 		Update:             resourceStaticSiteCreateOrUpdate,
@@ -103,7 +103,7 @@ func resourceStaticSite() *pluginsdk.Resource {
 }
 
 func resourceStaticSiteCreateOrUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.StaticSitesClient
+	client := meta.(*clients.Client).Web.StaticSitesClientV1
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -174,7 +174,7 @@ func resourceStaticSiteCreateOrUpdate(d *pluginsdk.ResourceData, meta interface{
 }
 
 func resourceStaticSiteRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.StaticSitesClient
+	client := meta.(*clients.Client).Web.StaticSitesClientV1
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -249,7 +249,7 @@ func resourceStaticSiteRead(d *pluginsdk.ResourceData, meta interface{}) error {
 }
 
 func resourceStaticSiteDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Web.StaticSitesClient
+	client := meta.(*clients.Client).Web.StaticSitesClientV1
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 

--- a/internal/services/web/static_site_resource_custom_domain_test.go
+++ b/internal/services/web/static_site_resource_custom_domain_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/web/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -20,6 +21,10 @@ import (
 type StaticSiteCustomDomainResource struct{}
 
 func TestAccAzureStaticSiteCustomDomain_basic(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_static_site_custom_domain", "test")
 	r := StaticSiteCustomDomainResource{}
 
@@ -36,6 +41,10 @@ func TestAccAzureStaticSiteCustomDomain_basic(t *testing.T) {
 }
 
 func TestAccAzureStaticSiteCustomDomain_requiresImport(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_static_site_custom_domain", "test")
 	r := StaticSiteCustomDomainResource{}
 
@@ -56,7 +65,7 @@ func (r StaticSiteCustomDomainResource) Exists(ctx context.Context, clients *cli
 		return nil, err
 	}
 
-	resp, err := clients.Web.StaticSitesClient.GetStaticSiteCustomDomain(ctx, id.ResourceGroup, id.StaticSiteName, id.CustomDomainName)
+	resp, err := clients.Web.StaticSitesClientV1.GetStaticSiteCustomDomain(ctx, id.ResourceGroup, id.StaticSiteName, id.CustomDomainName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			return pointer.To(false), nil

--- a/internal/services/web/static_site_resource_test.go
+++ b/internal/services/web/static_site_resource_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/web/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -20,6 +21,10 @@ import (
 type StaticSiteResource struct{}
 
 func TestAccAzureStaticSite_basic(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_static_site", "test")
 	r := StaticSiteResource{}
 
@@ -38,6 +43,10 @@ func TestAccAzureStaticSite_basic(t *testing.T) {
 }
 
 func TestAccAzureStaticSite_withSystemAssignedIdentity(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_static_site", "test")
 	r := StaticSiteResource{}
 
@@ -56,6 +65,10 @@ func TestAccAzureStaticSite_withSystemAssignedIdentity(t *testing.T) {
 }
 
 func TestAccAzureStaticSite_identity(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_static_site", "test")
 	r := StaticSiteResource{}
 
@@ -93,6 +106,10 @@ func TestAccAzureStaticSite_identity(t *testing.T) {
 }
 
 func TestAccAzureStaticSite_withSystemAssignedUserAssignedIdentity(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_static_site", "test")
 	r := StaticSiteResource{}
 
@@ -111,6 +128,10 @@ func TestAccAzureStaticSite_withSystemAssignedUserAssignedIdentity(t *testing.T)
 }
 
 func TestAccAzureStaticSite_withUserAssignedIdentity(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_static_site", "test")
 	r := StaticSiteResource{}
 
@@ -128,6 +149,10 @@ func TestAccAzureStaticSite_withUserAssignedIdentity(t *testing.T) {
 }
 
 func TestAccAzureStaticSite_basicUpdate(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_static_site", "test")
 	r := StaticSiteResource{}
 
@@ -156,6 +181,10 @@ func TestAccAzureStaticSite_basicUpdate(t *testing.T) {
 }
 
 func TestAccAzureStaticSite_requiresImport(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_static_site", "test")
 	r := StaticSiteResource{}
 
@@ -171,6 +200,10 @@ func TestAccAzureStaticSite_requiresImport(t *testing.T) {
 }
 
 func TestAccAzureStaticSite_appSettings(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this resource was removed in 5.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_static_site", "test")
 	r := StaticSiteResource{}
 
@@ -207,7 +240,7 @@ func (r StaticSiteResource) Exists(ctx context.Context, clients *clients.Client,
 		return nil, err
 	}
 
-	resp, err := clients.Web.StaticSitesClient.GetStaticSite(ctx, id.ResourceGroup, id.Name)
+	resp, err := clients.Web.StaticSitesClientV1.GetStaticSite(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			return pointer.To(false), nil

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -121,6 +121,30 @@ Please follow the format in the example below for adding removed resources:
 This deprecated resource has been superseded/retired and has been removed from the Azure Provider.
 ```
 
+### `azurerm_app_service`
+
+* This deprecated resource has been superseded by `azurerm_linux_web_app` and `azurerm_windows_web_app` and has been removed from the AzureRM Provider.
+
+### `azurerm_app_service_active_slot`
+
+* This deprecated resource has been superseded by `azurerm_web_app_active_slot` and `azurerm_function_app_active_slot` and has been removed from the AzureRM Provider.
+
+### `azurerm_app_service_hybrid_connection`
+
+* This deprecated resource has been superseded by `azurerm_web_app_hybrid_connection` and `azurerm_function_app_hybrid_connection` and has been removed from the AzureRM Provider.
+
+### `azurerm_app_service_plan`
+
+* This deprecated resource has been superseded by `azurerm_service_plan` and has been removed from the AzureRM Provider.
+
+### `azurerm_app_service_slot`
+
+* This deprecated resource has been superseded by `azurerm_linux_web_app_slot` and `azurerm_windows_web_app_slot` and has been removed from the AzureRM Provider.
+
+### `azurerm_app_service_source_control_token`
+
+* This deprecated resource has been removed from the AzureRM Provider.
+
 ### `azurerm_automation_software_update_configuration`
 
 * This deprecated resource has been retired and has been removed from the Azure Provider.
@@ -136,6 +160,14 @@ This deprecated resource has been superseded/retired and has been removed from t
 ### `azurerm_data_protection_backup_policy_postgresql`
 
 * This deprecated resource has been retired and has been removed from the Azure Provider.
+
+### `azurerm_function_app`
+
+* This deprecated resource has been superseded by `azurerm_linux_function_app` and `azurerm_windows_function_app` and has been removed from the AzureRM Provider.
+ 
+### `azurerm_function_app_slot`
+
+* This deprecated resource has been superseded by `azurerm_linux_function_app_slot` and `azurerm_windows_function_app_slot` and has been removed from the AzureRM Provider.
 
 ### `azurerm_hpc_cache`
 
@@ -156,10 +188,6 @@ This deprecated resource has been superseded/retired and has been removed from t
 ### `azurerm_hpc_cache_nfs_target`
 
 * This deprecated resource has been retired and has been removed from the Azure Provider.
-
-### `azurerm_logic_app_standard`
-
-* The `client_certificate_mode` property now defaults to `Required` aligning with the service default for this value.
 
 ### `azurerm_maps_creator`
 
@@ -209,10 +237,6 @@ This deprecated resource has been superseded/retired and has been removed from t
 
 * This deprecated resource has been retired and has been removed from the Azure Provider.
 
-### `azurerm_redis_enterprise_cluster`
-
-* The property `minimum_tls_version` property no longer accepts `1.0` or `1.1` as a value. Please see the [documentation for more details](https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-remove-tls-10-11).
-
 ### `azurerm_security_center_auto_provisioning`
 
 * This deprecated resource has been removed from the Azure Provider. Please see the [documentation for more details](https://learn.microsoft.com/en-us/azure/defender-for-cloud/prepare-deprecation-log-analytics-mma-agent#log-analytics-agent-autoprovisioning-experience---deprecation-plan).
@@ -220,6 +244,14 @@ This deprecated resource has been superseded/retired and has been removed from t
 ### `azurerm_spatial_anchors_account`
 
 * This deprecated resource has been retired and has been removed from the Azure Provider.
+
+### `azurerm_static_site`
+
+* This deprecated resource has been superseded by `azurerm_static_web_app` and has been removed from the AzureRM Provider.
+
+### `azurerm_static_site_custom_domain`
+
+* This deprecated resource has been superseded by `azurerm_static_web_app_custom_domain` and has been removed from the AzureRM Provider.
 
 
 ## Removed Data Sources
@@ -231,6 +263,18 @@ Please follow the format in the example below for adding removed data sources:
 
 This deprecated data source has been superseded/retired and has been removed from the Azure Provider.
 ```
+
+### `azurerm_app_service`
+
+* This deprecated data source has been superseded by `azurerm_linux_web_app` and `azurerm_windows_web_app` and has been removed from the Azure Provider
+
+### `azurerm_app_service_plan`
+
+* This deprecated data source has been superseded by `azurerm_service_plan` and has been removed from the Azure Provider.
+
+### `azurerm_function_app`
+
+* This deprecated data source has been superseded by `azurerm_linux_function_app` and `azurerm_windows_function_app` and has been removed from the Azure Provider.
 
 ### `azurerm_batch_certificate`
 

--- a/website/docs/d/app_service.html.markdown
+++ b/website/docs/d/app_service.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Use this data source to access information about an existing App Service.
 
-!> **Note:** The `azurerm_app_service` data source is deprecated in version 3.0 of the AzureRM provider and will be removed in version 4.0. Please use the [`azurerm_linux_web_app`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/linux_web_app) and [`azurerm_windows_web_app`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/windows_web_app) data sources instead.
+!> **Note:** This data source has been deprecated and will be removed in version 5.0 of the AzureRM provider. Please use the [`azurerm_linux_web_app`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/linux_web_app) and [`azurerm_windows_web_app`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/windows_web_app) data sources instead.
 
 ## Example Usage
 

--- a/website/docs/d/app_service_plan.html.markdown
+++ b/website/docs/d/app_service_plan.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Use this data source to access information about an existing App Service Plan (formerly known as a `Server Farm`).
 
-!> **Note:** The `azurerm_app_service_plan` data source is deprecated in version 3.0 of the AzureRM provider and will be removed in version 4.0. Please use the [`azurerm_service_plan`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/service_plan) data source instead.
+!> **Note:** This data source has been deprecated and will be removed in version 5.0 of the AzureRM provider. Please use the [`azurerm_service_plan`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/service_plan) data source instead.
 
 ## Example Usage
 

--- a/website/docs/d/function_app.html.markdown
+++ b/website/docs/d/function_app.html.markdown
@@ -11,7 +11,7 @@ description: |-
 
 Use this data source to access information about a Function App.
 
-!> **Note:** The `azurerm_function_app` data source is deprecated in version 3.0 of the AzureRM provider and will be removed in version 4.0. Please use the [`azurerm_linux_function_app`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/linux_function_app) and [`azurerm_windows_function_app`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/windows_function_app) data sources instead.
+!> **Note:** This data source has been deprecated and will be removed in version 5.0 of the AzureRM provider. Please use the [`azurerm_linux_function_app`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/linux_function_app) and [`azurerm_windows_function_app`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/windows_function_app) data sources instead.
 
 ## Example Usage
 

--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -11,7 +11,7 @@ description: |-
 
 Manages an App Service (within an App Service Plan).
 
-!> **Note:** This resource has been deprecated in version 3.0 of the AzureRM provider and will be removed in version 4.0. Please use [`azurerm_linux_web_app`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_web_app) and [`azurerm_windows_web_app`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/windows_web_app) resources instead.
+!> **Note:** This resource has been deprecated and will be removed in version 5.0 of the AzureRM provider. Please use [`azurerm_linux_web_app`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_web_app) and [`azurerm_windows_web_app`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/windows_web_app) resources instead.
 
 -> **Note:** When using Slots - the `app_settings`, `connection_string` and `site_config` blocks on the `azurerm_app_service` resource will be overwritten when promoting a Slot using the `azurerm_app_service_active_slot` resource.
 

--- a/website/docs/r/app_service_active_slot.html.markdown
+++ b/website/docs/r/app_service_active_slot.html.markdown
@@ -11,7 +11,7 @@ description: |-
 
 Promotes an App Service Slot to Production within an App Service.
 
-!> **Note:** This resource has been deprecated in version 3.0 of the AzureRM provider and will be removed in version 4.0. Please use [`azurerm_web_app_active_slot`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/web_app_active_slot) resource instead.
+!> **Note:** This resource has been deprecated and will be removed in version 5.0 of the AzureRM provider. Please use [`azurerm_web_app_active_slot`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/web_app_active_slot) resource instead.
 
 -> **Note:** When using Slots - the `app_settings`, `connection_string` and `site_config` blocks on the `azurerm_app_service` resource will be overwritten when promoting a Slot using the `azurerm_app_service_active_slot` resource.
 

--- a/website/docs/r/app_service_hybrid_connection.html.markdown
+++ b/website/docs/r/app_service_hybrid_connection.html.markdown
@@ -11,7 +11,7 @@ description: |-
 
 Manages an App Service Hybrid Connection for an existing App Service, Relay and Service Bus.
 
-!> **Note:** This resource has been deprecated in version 3.0 of the AzureRM provider and will be removed in version 4.0. Please use [`azurerm_function_app_hybrid_connection`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/function_app_hybrid_connection) and [`azurerm_web_app_hybrid_connection`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/web_app_hybrid_connection) resources instead.
+!> **Note:** This resource has been deprecated and will be removed in version 5.0 of the AzureRM provider. Please use [`azurerm_function_app_hybrid_connection`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/function_app_hybrid_connection) and [`azurerm_web_app_hybrid_connection`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/web_app_hybrid_connection) resources instead.
 
 ## Example Usage
 

--- a/website/docs/r/app_service_plan.html.markdown
+++ b/website/docs/r/app_service_plan.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Manages an App Service Plan component.
 
-!> **Note:** This resource has been deprecated in version 3.0 of the AzureRM provider and will be removed in version 4.0. Please use [`azurerm_service_plan`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/service_plan) resource instead.
+!> **Note:** This resource has been deprecated and will be removed in version 5.0 of the AzureRM provider. Please use [`azurerm_service_plan`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/service_plan) resource instead.
 
 ## Example Usage (Dedicated)
 

--- a/website/docs/r/app_service_slot.html.markdown
+++ b/website/docs/r/app_service_slot.html.markdown
@@ -11,7 +11,7 @@ description: |-
 
 Manages an App Service Slot (within an App Service).
 
-!> **Note:** This resource has been deprecated in version 3.0 of the AzureRM provider and will be removed in version 4.0. Please use [`azurerm_linux_web_app_slot`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_web_app_slot) and [`azurerm_windows_web_app_slot`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/windows_web_app_slot) resources instead.
+!> **Note:** This resource has been deprecated and will be removed in version 5.0 of the AzureRM provider. Please use [`azurerm_linux_web_app_slot`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_web_app_slot) and [`azurerm_windows_web_app_slot`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/windows_web_app_slot) resources instead.
 
 -> **Note:** When using Slots - the `app_settings`, `connection_string` and `site_config` blocks on the `azurerm_app_service` resource will be overwritten when promoting a Slot using the `azurerm_app_service_active_slot` resource.
 

--- a/website/docs/r/app_service_source_control_token.html.markdown
+++ b/website/docs/r/app_service_source_control_token.html.markdown
@@ -11,7 +11,7 @@ description: |-
 
 Manages an App Service source control token.
 
-!> **Note:** This resource has been deprecated in version 3.0 of the AzureRM provider and will be removed in version 4.0. Please use [`azurerm_service_plan`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/service_plan) resource instead.
+!> **Note:** This resource has been deprecated and will be removed in version 5.0 of the AzureRM provider. Please use [`azurerm_service_plan`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/service_plan) resource instead.
 
 ~> **Note:** Source Control Tokens are configured at the subscription level, not on each App Service - as such this can only be configured Subscription-wide
 

--- a/website/docs/r/function_app.html.markdown
+++ b/website/docs/r/function_app.html.markdown
@@ -11,7 +11,7 @@ description: |-
 
 Manages a Function App.
 
-!> **Note:** This resource has been deprecated in version 3.0 of the AzureRM provider and will be removed in version 4.0. Please use [`azurerm_linux_function_app`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_function_app) and [`azurerm_windows_function_app`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/windows_function_app) resources instead.
+!> **Note:** This resource has been deprecated and will be removed in version 5.0 of the AzureRM provider. Please use [`azurerm_linux_function_app`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_function_app) and [`azurerm_windows_function_app`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/windows_function_app) resources instead.
 
 ~> **Note:** To connect an Azure Function App and a subnet within the same region `azurerm_app_service_virtual_network_swift_connection` can be used.
 For an example, check the `azurerm_app_service_virtual_network_swift_connection` documentation.

--- a/website/docs/r/function_app_slot.html.markdown
+++ b/website/docs/r/function_app_slot.html.markdown
@@ -11,7 +11,7 @@ description: |-
 
 Manages a Function App deployment Slot.
 
-!> **Note:** This resource has been deprecated in version 3.0 of the AzureRM provider and will be removed in version 4.0. Please use [`azurerm_linux_function_app_slot`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_function_app_slot) and [`azurerm_windows_function_app_slot`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/windows_function_app_slot) resources instead.
+!> **Note:** This resource has been deprecated and will be removed in version 5.0 of the AzureRM provider. Please use [`azurerm_linux_function_app_slot`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_function_app_slot) and [`azurerm_windows_function_app_slot`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/windows_function_app_slot) resources instead.
 
 ## Example Usage (with App Service Plan)
 

--- a/website/docs/r/static_site.html.markdown
+++ b/website/docs/r/static_site.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Manages an App Service Static Site.
 
--> **Note:** The `azurerm_static_site` resource is deprecated in favour of `azurerm_static_web_app` and will be removed in a future major release.
+!> **Note:** This resource has been superseded by `azurerm_static_web_app` and will be removed in version 5.0 of the AzureRM provider.
 
 -> **Note:** After the Static Site is provisioned, you'll need to associate your target repository, which contains your web app, to the Static Site, by following the [Azure Static Site document](https://docs.microsoft.com/azure/static-web-apps/github-actions-workflow).
 

--- a/website/docs/r/static_site_custom_domain.html.markdown
+++ b/website/docs/r/static_site_custom_domain.html.markdown
@@ -10,9 +10,9 @@ description: |-
 
 Manages a Static Site Custom Domain.
 
-!> **Note:** DNS validation polling is only done for CNAME records, terraform will not validate TXT validation records are complete.
+!> **Note:** This resource has been superseded by `azurerm_static_web_app_custom_domain` and will be removed in version 5.0 of the AzureRM provider.
 
--> **Note:** The `azurerm_static_site_custom_domain` resource is deprecated in favour of `azurerm_static_web_app_custom_domain` and will be removed in a future major release.
+!> **Note:** DNS validation polling is only done for CNAME records, terraform will not validate TXT validation records are complete.
 
 ## Example Usage
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

- Updates deprecation messages to indicate removal in 5.0
- Conditionally registers for 4.0
- Renames `azure-sdk-for-go` clients (appended with `V1`) to prepare for remaining resources' migration to `go-azure-sdk`


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->

## Testing

- [ ] My submission includes Test coverage as described in the [Contribution Guide](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

AppService:
<img width="385" height="215" alt="image" src="https://github.com/user-attachments/assets/84afd147-d49a-4ee9-a4e3-011baaa6c241" />

Logic:
<img width="464" height="196" alt="image" src="https://github.com/user-attachments/assets/4b6de341-ba3e-48c8-a9b7-fec188553a73" />

4 transient errors, passed on rerun:
<img width="343" height="201" alt="image" src="https://github.com/user-attachments/assets/34557555-d332-46e7-8203-8ae27da147fe" />

Web:
<img width="391" height="203" alt="image" src="https://github.com/user-attachments/assets/438eee7a-8ba3-433e-a5ba-78d3c33148cb" />

rerunning 2 new failures...

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
