### PR TITLE
`azurerm_backup_policy_vm` - use just a timestamp vs. a datetimestamp for RetentionTime

### DIFF
--- a/internal/services/recoveryservices/backup_policy_vm_resource.go
+++ b/internal/services/recoveryservices/backup_policy_vm_resource.go
@@ -114,12 +114,13 @@ func resourceBackupProtectionPolicyVMCreate(d *pluginsdk.ResourceData, meta inte
 	log.Printf("[DEBUG] Creating %s", id)
 
 	// getting this ready now because its shared between *everything*, time is... complicated for this resource
-	timeOfDay := d.Get("backup.0.time").(string)
-	dateOfDay, err := time.Parse(time.RFC3339, fmt.Sprintf("%sT%s:00Z", time.Now().Format("2006-01-02"), timeOfDay))
+	timeOfDay := fmt.Sprintf("%s:00Z", d.Get("backup.0.time").(string))
+	dateOfDay, err := time.Parse(time.RFC3339, fmt.Sprintf("%sT%s", time.Now().Format("2006-01-02"), timeOfDay))
 	if err != nil {
 		return fmt.Errorf("generating time from %q for %s: %+v", timeOfDay, id, err)
 	}
 	times := append(make([]string, 0), date.Time{Time: dateOfDay}.String())
+	formattedTimeOfDay := append(make([]string, 0), timeOfDay)
 
 	existing, err := client.Get(ctx, id)
 	if err != nil {
@@ -150,10 +151,10 @@ func resourceBackupProtectionPolicyVMCreate(d *pluginsdk.ResourceData, meta inte
 		TieringPolicy:    expandBackupProtectionPolicyVMTieringPolicy(d.Get("tiering_policy").([]interface{})),
 		InstantRPDetails: expandBackupProtectionPolicyVMResourceGroup(d),
 		RetentionPolicy: &protectionpolicies.LongTermRetentionPolicy{ // SimpleRetentionPolicy only has duration property ¯\_(ツ)_/¯
-			DailySchedule:   expandBackupProtectionPolicyVMRetentionDaily(d, times),
-			WeeklySchedule:  expandBackupProtectionPolicyVMRetentionWeekly(d, times),
-			MonthlySchedule: expandBackupProtectionPolicyVMRetentionMonthly(d, times),
-			YearlySchedule:  expandBackupProtectionPolicyVMRetentionYearly(d, times),
+			DailySchedule:   expandBackupProtectionPolicyVMRetentionDaily(d, formattedTimeOfDay),
+			WeeklySchedule:  expandBackupProtectionPolicyVMRetentionWeekly(d, formattedTimeOfDay),
+			MonthlySchedule: expandBackupProtectionPolicyVMRetentionMonthly(d, formattedTimeOfDay),
+			YearlySchedule:  expandBackupProtectionPolicyVMRetentionYearly(d, formattedTimeOfDay),
 		},
 	}
 
@@ -289,12 +290,13 @@ func resourceBackupProtectionPolicyVMUpdate(d *pluginsdk.ResourceData, meta inte
 	log.Printf("[DEBUG] Updating %s", id)
 
 	// getting this ready now because its shared between *everything*, time is... complicated for this resource
-	timeOfDay := d.Get("backup.0.time").(string)
-	dateOfDay, err := time.Parse(time.RFC3339, fmt.Sprintf("%sT%s:00Z", time.Now().Format("2006-01-02"), timeOfDay))
+	timeOfDay := fmt.Sprintf("%s:00Z", d.Get("backup.0.time").(string))
+	dateOfDay, err := time.Parse(time.RFC3339, fmt.Sprintf("%sT%s", time.Now().Format("2006-01-02"), timeOfDay))
 	if err != nil {
 		return fmt.Errorf("generating time from %q for %s: %+v", timeOfDay, id, err)
 	}
 	times := append(make([]string, 0), date.Time{Time: dateOfDay}.String())
+	formattedTimeOfDay := append(make([]string, 0), timeOfDay)
 
 	// Less than 7 daily backups is no longer supported for create/update
 	if d.HasChange("retention_daily.0.count") && (d.Get("retention_daily.0.count").(int) > 1 && d.Get("retention_daily.0.count").(int) < 7) {
@@ -360,7 +362,7 @@ func resourceBackupProtectionPolicyVMUpdate(d *pluginsdk.ResourceData, meta inte
 			properties.RetentionPolicy = &protectionpolicies.LongTermRetentionPolicy{}
 		}
 
-		retentionPolicy.DailySchedule = expandBackupProtectionPolicyVMRetentionDaily(d, times)
+		retentionPolicy.DailySchedule = expandBackupProtectionPolicyVMRetentionDaily(d, formattedTimeOfDay)
 		properties.RetentionPolicy = retentionPolicy
 	}
 
@@ -373,7 +375,7 @@ func resourceBackupProtectionPolicyVMUpdate(d *pluginsdk.ResourceData, meta inte
 			properties.RetentionPolicy = &protectionpolicies.LongTermRetentionPolicy{}
 		}
 
-		retentionPolicy.WeeklySchedule = expandBackupProtectionPolicyVMRetentionWeekly(d, times)
+		retentionPolicy.WeeklySchedule = expandBackupProtectionPolicyVMRetentionWeekly(d, formattedTimeOfDay)
 		properties.RetentionPolicy = retentionPolicy
 	}
 
@@ -386,7 +388,7 @@ func resourceBackupProtectionPolicyVMUpdate(d *pluginsdk.ResourceData, meta inte
 			properties.RetentionPolicy = &protectionpolicies.LongTermRetentionPolicy{}
 		}
 
-		retentionPolicy.MonthlySchedule = expandBackupProtectionPolicyVMRetentionMonthly(d, times)
+		retentionPolicy.MonthlySchedule = expandBackupProtectionPolicyVMRetentionMonthly(d, formattedTimeOfDay)
 		properties.RetentionPolicy = retentionPolicy
 	}
 
@@ -399,7 +401,7 @@ func resourceBackupProtectionPolicyVMUpdate(d *pluginsdk.ResourceData, meta inte
 			properties.RetentionPolicy = &protectionpolicies.LongTermRetentionPolicy{}
 		}
 
-		retentionPolicy.YearlySchedule = expandBackupProtectionPolicyVMRetentionYearly(d, times)
+		retentionPolicy.YearlySchedule = expandBackupProtectionPolicyVMRetentionYearly(d, formattedTimeOfDay)
 		properties.RetentionPolicy = retentionPolicy
 	}
 

--- a/internal/services/recoveryservices/backup_policy_vm_resource.go
+++ b/internal/services/recoveryservices/backup_policy_vm_resource.go
@@ -334,7 +334,8 @@ func resourceBackupProtectionPolicyVMUpdate(d *pluginsdk.ResourceData, meta inte
 		properties.InstantRPDetails = expandBackupProtectionPolicyVMResourceGroup(d)
 	}
 
-	if d.HasChange("backup") {
+	// If anything changes inside any of the `retention_*` fields, update the `schedulePolicy` object as the API requires all timestamps match
+	if d.HasChanges("backup", "retention_daily", "retention_weekly", "retention_monthly", "retention_yearly") {
 		schedulePolicy, err := expandBackupProtectionPolicyVMSchedule(d, times)
 		if err != nil {
 			return err
@@ -342,7 +343,7 @@ func resourceBackupProtectionPolicyVMUpdate(d *pluginsdk.ResourceData, meta inte
 		properties.SchedulePolicy = schedulePolicy
 	}
 
-	if d.HasChange("retention_daily") || d.HasChange("backup.0.time") {
+	if d.HasChanges("retention_daily", "backup.0.time") {
 		if properties.RetentionPolicy == nil {
 			properties.RetentionPolicy = &protectionpolicies.LongTermRetentionPolicy{}
 		}
@@ -355,7 +356,7 @@ func resourceBackupProtectionPolicyVMUpdate(d *pluginsdk.ResourceData, meta inte
 		properties.RetentionPolicy = retentionPolicy
 	}
 
-	if d.HasChange("retention_weekly") {
+	if d.HasChanges("retention_weekly", "backup.0.time") {
 		if properties.RetentionPolicy == nil {
 			properties.RetentionPolicy = &protectionpolicies.LongTermRetentionPolicy{}
 		}
@@ -368,7 +369,7 @@ func resourceBackupProtectionPolicyVMUpdate(d *pluginsdk.ResourceData, meta inte
 		properties.RetentionPolicy = retentionPolicy
 	}
 
-	if d.HasChange("retention_monthly") {
+	if d.HasChanges("retention_monthly", "backup.0.time") {
 		if properties.RetentionPolicy == nil {
 			properties.RetentionPolicy = &protectionpolicies.LongTermRetentionPolicy{}
 		}
@@ -381,7 +382,7 @@ func resourceBackupProtectionPolicyVMUpdate(d *pluginsdk.ResourceData, meta inte
 		properties.RetentionPolicy = retentionPolicy
 	}
 
-	if d.HasChange("retention_yearly") {
+	if d.HasChanges("retention_yearly", "backup.0.time") {
 		if properties.RetentionPolicy == nil {
 			properties.RetentionPolicy = &protectionpolicies.LongTermRetentionPolicy{}
 		}

--- a/internal/services/recoveryservices/backup_policy_vm_resource.go
+++ b/internal/services/recoveryservices/backup_policy_vm_resource.go
@@ -11,7 +11,6 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/Azure/go-autorest/autorest/date"
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
@@ -115,12 +114,7 @@ func resourceBackupProtectionPolicyVMCreate(d *pluginsdk.ResourceData, meta inte
 
 	// getting this ready now because its shared between *everything*, time is... complicated for this resource
 	timeOfDay := fmt.Sprintf("%s:00Z", d.Get("backup.0.time").(string))
-	dateOfDay, err := time.Parse(time.RFC3339, fmt.Sprintf("%sT%s", time.Now().Format("2006-01-02"), timeOfDay))
-	if err != nil {
-		return fmt.Errorf("generating time from %q for %s: %+v", timeOfDay, id, err)
-	}
-	times := append(make([]string, 0), date.Time{Time: dateOfDay}.String())
-	formattedTimeOfDay := append(make([]string, 0), timeOfDay)
+	times := append(make([]string, 0), timeOfDay)
 
 	existing, err := client.Get(ctx, id)
 	if err != nil {
@@ -151,10 +145,10 @@ func resourceBackupProtectionPolicyVMCreate(d *pluginsdk.ResourceData, meta inte
 		TieringPolicy:    expandBackupProtectionPolicyVMTieringPolicy(d.Get("tiering_policy").([]interface{})),
 		InstantRPDetails: expandBackupProtectionPolicyVMResourceGroup(d),
 		RetentionPolicy: &protectionpolicies.LongTermRetentionPolicy{ // SimpleRetentionPolicy only has duration property ¯\_(ツ)_/¯
-			DailySchedule:   expandBackupProtectionPolicyVMRetentionDaily(d, formattedTimeOfDay),
-			WeeklySchedule:  expandBackupProtectionPolicyVMRetentionWeekly(d, formattedTimeOfDay),
-			MonthlySchedule: expandBackupProtectionPolicyVMRetentionMonthly(d, formattedTimeOfDay),
-			YearlySchedule:  expandBackupProtectionPolicyVMRetentionYearly(d, formattedTimeOfDay),
+			DailySchedule:   expandBackupProtectionPolicyVMRetentionDaily(d, times),
+			WeeklySchedule:  expandBackupProtectionPolicyVMRetentionWeekly(d, times),
+			MonthlySchedule: expandBackupProtectionPolicyVMRetentionMonthly(d, times),
+			YearlySchedule:  expandBackupProtectionPolicyVMRetentionYearly(d, times),
 		},
 	}
 
@@ -291,12 +285,7 @@ func resourceBackupProtectionPolicyVMUpdate(d *pluginsdk.ResourceData, meta inte
 
 	// getting this ready now because its shared between *everything*, time is... complicated for this resource
 	timeOfDay := fmt.Sprintf("%s:00Z", d.Get("backup.0.time").(string))
-	dateOfDay, err := time.Parse(time.RFC3339, fmt.Sprintf("%sT%s", time.Now().Format("2006-01-02"), timeOfDay))
-	if err != nil {
-		return fmt.Errorf("generating time from %q for %s: %+v", timeOfDay, id, err)
-	}
-	times := append(make([]string, 0), date.Time{Time: dateOfDay}.String())
-	formattedTimeOfDay := append(make([]string, 0), timeOfDay)
+	times := append(make([]string, 0), timeOfDay)
 
 	// Less than 7 daily backups is no longer supported for create/update
 	if d.HasChange("retention_daily.0.count") && (d.Get("retention_daily.0.count").(int) > 1 && d.Get("retention_daily.0.count").(int) < 7) {
@@ -362,7 +351,7 @@ func resourceBackupProtectionPolicyVMUpdate(d *pluginsdk.ResourceData, meta inte
 			properties.RetentionPolicy = &protectionpolicies.LongTermRetentionPolicy{}
 		}
 
-		retentionPolicy.DailySchedule = expandBackupProtectionPolicyVMRetentionDaily(d, formattedTimeOfDay)
+		retentionPolicy.DailySchedule = expandBackupProtectionPolicyVMRetentionDaily(d, times)
 		properties.RetentionPolicy = retentionPolicy
 	}
 
@@ -375,7 +364,7 @@ func resourceBackupProtectionPolicyVMUpdate(d *pluginsdk.ResourceData, meta inte
 			properties.RetentionPolicy = &protectionpolicies.LongTermRetentionPolicy{}
 		}
 
-		retentionPolicy.WeeklySchedule = expandBackupProtectionPolicyVMRetentionWeekly(d, formattedTimeOfDay)
+		retentionPolicy.WeeklySchedule = expandBackupProtectionPolicyVMRetentionWeekly(d, times)
 		properties.RetentionPolicy = retentionPolicy
 	}
 
@@ -388,7 +377,7 @@ func resourceBackupProtectionPolicyVMUpdate(d *pluginsdk.ResourceData, meta inte
 			properties.RetentionPolicy = &protectionpolicies.LongTermRetentionPolicy{}
 		}
 
-		retentionPolicy.MonthlySchedule = expandBackupProtectionPolicyVMRetentionMonthly(d, formattedTimeOfDay)
+		retentionPolicy.MonthlySchedule = expandBackupProtectionPolicyVMRetentionMonthly(d, times)
 		properties.RetentionPolicy = retentionPolicy
 	}
 
@@ -401,7 +390,7 @@ func resourceBackupProtectionPolicyVMUpdate(d *pluginsdk.ResourceData, meta inte
 			properties.RetentionPolicy = &protectionpolicies.LongTermRetentionPolicy{}
 		}
 
-		retentionPolicy.YearlySchedule = expandBackupProtectionPolicyVMRetentionYearly(d, formattedTimeOfDay)
+		retentionPolicy.YearlySchedule = expandBackupProtectionPolicyVMRetentionYearly(d, times)
 		properties.RetentionPolicy = retentionPolicy
 	}
 

--- a/internal/services/recoveryservices/backup_policy_vm_resource_test.go
+++ b/internal/services/recoveryservices/backup_policy_vm_resource_test.go
@@ -43,9 +43,20 @@ func TestAccBackupProtectionPolicyVM_basicDaily(t *testing.T) {
 			Config: r.basicDaily(data, "V1"),
 			Check: acceptance.ComposeAggregateTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("backup.0.frequency").HasValue("Daily"),
-				check.That(data.ResourceName).Key("backup.0.time").HasValue("23:00"),
-				check.That(data.ResourceName).Key("retention_daily.0.count").HasValue("10"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basicDailyWithTime(data, "V1", "22:00"),
+			Check: acceptance.ComposeAggregateTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basicDaily(data, "V1"),
+			Check: acceptance.ComposeAggregateTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
@@ -94,6 +105,20 @@ func TestAccBackupProtectionPolicyVM_basicWeekly(t *testing.T) {
 	r := BackupProtectionPolicyVMResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicWeekly(data, "V1"),
+			Check: acceptance.ComposeAggregateTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basicWeeklyWithTime(data, "V1", "22:00"),
+			Check: acceptance.ComposeAggregateTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
 		{
 			Config: r.basicWeekly(data, "V1"),
 			Check: acceptance.ComposeAggregateTestCheckFunc(
@@ -615,7 +640,7 @@ func TestAccBackupProtectionPolicyVM_updateBackupTime(t *testing.T) {
 	})
 }
 
-func (t BackupProtectionPolicyVMResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (r BackupProtectionPolicyVMResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := protectionpolicies.ParseBackupPolicyID(state.ID)
 	if err != nil {
 		return nil, err
@@ -623,7 +648,7 @@ func (t BackupProtectionPolicyVMResource) Exists(ctx context.Context, clients *c
 
 	resp, err := clients.RecoveryServices.ProtectionPoliciesClient.Get(ctx, *id)
 	if err != nil {
-		return nil, fmt.Errorf("reading Recovery Service Protection Policy (%s): %+v", id.String(), err)
+		return nil, fmt.Errorf("retrieving %s: %+v", id.String(), err)
 	}
 
 	return pointer.To(resp.Model != nil), nil
@@ -699,26 +724,30 @@ resource "azurerm_backup_policy_vm" "test" {
 }
 
 func (r BackupProtectionPolicyVMResource) basicDaily(data acceptance.TestData, policyType string) string {
+	return r.basicDailyWithTime(data, policyType, "23:00")
+}
+
+func (r BackupProtectionPolicyVMResource) basicDailyWithTime(data acceptance.TestData, policyType, time string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "azurerm_backup_policy_vm" "test" {
-  name                = "acctest-%d"
+  name                = "acctest-%[2]d"
   resource_group_name = azurerm_resource_group.test.name
   recovery_vault_name = azurerm_recovery_services_vault.test.name
 
   backup {
     frequency = "Daily"
-    time      = "23:00"
+    time      = "%[4]s"
   }
 
   retention_daily {
     count = 10
   }
 
-  policy_type = "%s"
+  policy_type = "%[3]s"
 }
-`, r.template(data), data.RandomInteger, policyType)
+`, r.template(data), data.RandomInteger, policyType, time)
 }
 
 func (r BackupProtectionPolicyVMResource) requiresImport(data acceptance.TestData) string {
@@ -743,17 +772,21 @@ resource "azurerm_backup_policy_vm" "import" {
 }
 
 func (r BackupProtectionPolicyVMResource) basicWeekly(data acceptance.TestData, policyType string) string {
+	return r.basicWeeklyWithTime(data, policyType, "23:00")
+}
+
+func (r BackupProtectionPolicyVMResource) basicWeeklyWithTime(data acceptance.TestData, policyType, time string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "azurerm_backup_policy_vm" "test" {
-  name                = "acctest-%d"
+  name                = "acctest-%[2]d"
   resource_group_name = azurerm_resource_group.test.name
   recovery_vault_name = azurerm_recovery_services_vault.test.name
 
   backup {
     frequency = "Weekly"
-    time      = "23:00"
+    time      = "%[4]s"
     weekdays  = ["Sunday", "Wednesday"]
   }
 
@@ -762,9 +795,9 @@ resource "azurerm_backup_policy_vm" "test" {
     weekdays = ["Sunday", "Wednesday"]
   }
 
-  policy_type = "%s"
+  policy_type = "%[3]s"
 }
-`, r.template(data), data.RandomInteger, policyType)
+`, r.template(data), data.RandomInteger, policyType, time)
 }
 
 func (r BackupProtectionPolicyVMResource) completeHourly(data acceptance.TestData, policyType string) string {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Currently there is a bug where if you attempt to change the retention count after the resource has been configured you'll get a 400 response for `BMSUserErrorInvalidPolicyInput`.  This is because the provider is currently setting the timestamp used for the "RetentionTime" to a date + timestamp using the current date.  So, if you were to set the hour to say 23:00, the update will try and set the value to the current day and 23:00.  Assuming you're running this change _before_ this time in the day, you're getting the 400 because you're trying to set the date in the future. This was sort of difficult to test/recreate and because of the root cause wouldn't have been caught in any automated tests. I actually had to deploy and wait a day to replicate to find the root cause.  If you wanted to recreate more easily though the API will take any date+time that's in the past (which based on commit history this bug was introduced in an attempt to squash bugs that might occur from hardcoding a past date...)

The API itself doesn't require a date (and the portal reflects only the hour to the user view) even though if you run a "show" or GET you'll see the full date in the return.  

This PR modifies the value sent for the retentions to use only the time vs. date+time to avoid such scenarios.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_backup_policy_vm` - fix the ability to update retention settings property


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #26917 
Fixes #27619 


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
