### PR TITLE
`appservice` - fix panic in `auth_settings` DiffSuppressFunc when block is not configured

### DIFF
--- a/internal/services/appservice/helpers/shared_schema.go
+++ b/internal/services/appservice/helpers/shared_schema.go
@@ -548,7 +548,7 @@ func AuthSettingsSchema() *pluginsdk.Schema {
 						// Azure returns nothing for `tokenRefreshExtensionHours`, and the zero-value is set into state.
 						// This then causes a diff on subsequent plans where Terraform wants to change from `0` to the default of `72`. So we'll suppress it.
 						authSettingsVal, authSettingsDiags := d.GetRawConfigAt(sdk.ConstructCtyPath("auth_settings"))
-						if !authSettingsDiags.HasError() && authSettingsVal.IsKnown() {
+						if !authSettingsDiags.HasError() && authSettingsVal.IsKnown() && authSettingsVal.CanIterateElements() {
 							return authSettingsVal.LengthInt() == 0 && o == "0" && n == "72"
 						}
 


### PR DESCRIPTION
## Community Note
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

The `DiffSuppressFunc` for `auth_settings.token_refresh_extension_hours` in `shared_schema.go` calls `LengthInt()` on the `cty.Value` returned by `GetRawConfigAt("auth_settings")` without first checking whether the value supports the `Length` operation.

When `auth_settings` is not configured (the common default for most App Service deployments), the returned value passes both `!HasError()` and `IsKnown()` checks but is not a collection type. Calling `LengthInt()` on it panics:

```
cty.Value.LengthInt (value_ops.go:997)
  ← AuthSettingsSchema.func2 (shared_schema.go:552)
  ← schemaMap.diff (schema.go:1314)
  ← schemaMap.diffList (schema.go:1435)
  ← schemaMapWithIdentity.Diff (schema.go:736)
```

The fix adds a `CanIterateElements()` guard before `LengthInt()`.

**Context:** This was discovered while using `azurerm_linux_web_app` through the [Crossplane upjet Azure provider](https://github.com/crossplane-contrib/provider-upjet-azure), which calls the Terraform provider's `Diff()` function as part of its reconciliation loop. In this context, `GetRawConfigAt` returns a `cty.Value` that differs from what standard Terraform CLI produces from HCL parsing, exposing this unguarded `LengthInt()` call. The bug causes managed resources to remain stuck indefinitely with no error logged — the panic is unrecovered and silent.

**Workaround:** Explicitly setting `auth_settings { enabled = false }` prevents the panic since any explicit value produces a collection type that supports `LengthInt()`.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them.
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.

**Testing note:** The panic occurs in a `DiffSuppressFunc` code path that requires a specific `cty.Value` type from `GetRawConfigAt` — one that is `Known` but not iterable. Standard Terraform CLI acceptance tests do not reproduce this because the CLI always populates `RawConfig` from HCL parsing with a proper list type. The panic was verified by building a custom provider binary with debug instrumentation and deploying it to a live cluster.


## Testing

Verified by building a patched provider binary and testing against a live Azure environment:

- **Before fix:** `schemaMap.Diff()` panics on every reconciliation for `azurerm_linux_web_app` when `auth_settings` is not configured. The resource is created in Azure but the provider cannot observe it.
- **After fix:** `Diff()` completes in ~6ms. The resource reaches Ready state and `atProvider` is fully populated.


## Change Log

* `azurerm_linux_web_app` - fix panic in `auth_settings` `DiffSuppressFunc` when `auth_settings` block is not configured [GH-0000]


This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

None — newly discovered.


## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

Claude Code (Anthropic) assisted with root cause analysis through iterative debugging (building custom provider binaries with instrumentation, analysing goroutine stacks, tracing the code path). The one-line fix was identified through manual source code analysis.


## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

No changes to security controls.