### PR TITLE
add list-resource and documentation for the list resource to scaff

### DIFF
--- a/contributing/topics/scaff.md
+++ b/contributing/topics/scaff.md
@@ -1,0 +1,198 @@
+<!-- Copyright IBM Corp. 2014, 2026 -->
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+
+# Provider Scaffolding (scaff)
+
+`scaff` is a Terraform AzureRM Provider scaffolding command line tool.
+It generates resource, data source, list resource, and documentation files along with test files which adhere to the latest best practices.
+These files are heavily commented with instructions, serving as the best way to get started with provider development.
+
+## Overview workflow steps
+
+1. Install `scaff`.
+1. Use `scaff` to generate provider code.
+1. Go through the generated code, customizing as necessary.
+1. Run, test, refine.
+1. Remove "TIP" comments.
+1. Submit a pull request.
+
+## Running `scaff`
+
+1. Clone the [Terraform AzureRM Provider](https://github.com/hashicorp/terraform-provider-azurerm) repository.
+1. Install `scaff`.
+
+    ```sh
+    make scaff
+    ```
+
+1. Change into the appropriate directory.
+    * For resources and list resources, this is the service directory where the new entity will reside, e.g. `internal/services/privatedns`.
+    * For functions, this is `internal/functions`.
+1. Generate the resource, list resource, data source or function. For example,
+    * `scaff resource -name="fw_mssql_database" -service_package_name="MSSQL" ...`.
+    * `scaff list-resource -service="PrivateDns" -resource="CNameRecord" ...`.
+    * `scaff list-documentation -path=internal/services/network`.
+
+To get help, enter `scaff` without arguments.
+
+## Usage
+
+### Help
+
+```console
+scaff --help
+```
+
+```
+Usage:
+  scaff [command]
+
+Available Commands:
+  list-documentation Generate documentation for list resources
+  list-resource      Generate list resource boilerplate code
+  resource           Create scaffolding for a resource
+
+Flags:
+  -h, --help   help for scaff
+```
+
+### List Resource
+
+Generate list resource boilerplate code from JSON file or CLI arguments.
+
+```console
+scaff list-resource --help
+```
+
+```
+Usage: scaff list-resource [options]
+
+  Generates list resource boilerplate code. Can accept either a JSON file
+  with multiple resource definitions or individual CLI arguments for a single resource.
+
+Options:
+  -json=<path>                    Path to JSON file containing resource definitions (use instead of full cli)
+  -service=<name>                 (Required) Service name (e.g., "PrivateDns")
+  -resource=<name>                (Required) Resource name (e.g., "CNameRecord")
+  -include_service_in_name=<bool> (Optional) Include service name in generated identifiers, defaults to false
+  -full_parent=<name>             (Optional) Full parent resource name
+  -parent=<name>                  (Optional) Parent resource name (e.g., "PrivateDnsZone"), defaults to resource_group
+  -parent_terraform_name=<name>   (Optional) Parent Terraform resource name (e.g., "private_dns_zone")
+  -terraform_name=<name>          (Optional) Terraform resource name (e.g., "private_dns_cname_record")
+  -id_structure=<type>            (Required) ID structure type (e.g., "privatedns.RecordType")
+  -path=<path>                    (Optional) Output path for generated files
+
+
+Examples:
+  # Using JSON file
+  scaff list-resource -json=internal/tools/scaff/commands/input_example/listResources.json
+
+  # Using CLI arguments
+  scaff list-resource -service="PrivateDns" -resource="CNameRecord" -parent="PrivateDnsZone" \
+    -terraform_name="private_dns_cname_record" -id_structure="privatedns.RecordType" \
+    -path="internal/services/privatedns/"
+```
+
+### List Documentation
+
+Generate documentation for list resources by scanning Go source files.
+> [!NOTE]
+      This command can only be used when the *_resource_list.go files already exist.
+
+```console
+scaff list-documentation --help
+```
+
+```
+Usage: scaff list-documentation [options]
+
+  Generates documentation for list resources by scanning Go source files
+  for files ending with '_resource_list.go'.
+
+Options:
+  -path=<path>              (Required) Path to file or directory to scan (required)
+  -subcategory=<name>       (Optional) Override the subcategory/section (e.g., "Network", "Database")
+  -addsectiontoname         (Optional) Prepend section name to attribute names (boolean flag)
+
+Examples:
+  # Basic usage
+  scaff list-documentation -path=internal/services/network
+
+  # With subcategory override
+  scaff list-documentation -path=internal/services/mssql -subcategory=Database
+
+  # With section name prefixing enabled
+  scaff list-documentation -path=internal/services/mssql -addsectiontoname
+```
+
+### Resource
+
+Create scaffolding for a resource using the Terraform Plugin Framework.
+
+```console
+scaff resource --help
+```
+
+```
+Usage: scaff resource -name "some_resource_name" -service_package_name="someservice" \
+  -rp_name="sql" -client_name="SomeClient" [-updatable=true] [-no_resource_group=true] \
+  -api_version="2023-08-01-preview" -id_type="commonids.SqlDatabaseId" [-sdk_name="databases"] \
+  -id_segments="SubscriptionId,ResourceGroupName,ServerName,DatabaseName" \
+  [-uses_lro_crud=true] [-use_create_options=true] [-use_read_options=true] \
+  [-use_update_options=true] [-use_delete_options=true]
+
+Parameters:
+  -name (Required)                 The name of the resource to scaffold
+  -service_package_name (Required) The name of the service package to scaffold the resource into
+  -rp_name (Required)              The name of the resource provider of the new resource
+  -client_name (Required)          The name of the client used to manage the new resource
+  -api_version (Required)          The API version of the resource to scaffold (e.g., 2025-01-01)
+  -id_type (Required)              The type of resource to scaffold (e.g., 'commonids.AppServiceId',
+                                   or 'virtualmachines.VirtualMachineId')
+  -id_segments (Required)          The User-Specified Segment names for the ID, order matters
+
+  -updatable (Optional)            Whether the new resource can be updated (i.e., any schema property
+                                   is not going to be 'ForceNew')
+  -uses_lro_crud (Optional)        The new resource uses LROs for Create, Update, and Delete
+  -use_create_options (Optional)   The new resource uses OperationOptions for Create
+  -use_read_options (Optional)     The new resource uses OperationOptions for Read
+  -use_update_options (Optional)   The new resource uses OperationOptions for Update
+  -use_delete_options (Optional)   The new resource uses OperationOptions for Delete
+  -config_validators (Optional)    Does the resource have configuration validators
+  -no_resource_group (Optional)    Set to true if the resource is not created in a resource group,
+                                   or if the RG is inferred from a parent resource ID
+  -sdk_name (Optional)             The name of the SDK used to manage the new resource. If omitted,
+                                   the first slug of the id_type value will be used
+
+Example:
+  scaff resource -name="fw_mssql_database" -service_package_name="MSSQL" -rp_name="sql" \
+    -client_name="DatabasesClient" -updatable=true -no_resource_group=true \
+    -api_version="2023-08-01-preview" -id_type="commonids.SqlDatabaseId" -sdk_name="databases" \
+    -id_segments="SubscriptionId,ResourceGroupName,ServerName,DatabaseName" \
+    -uses_lro_crud=true -use_read_options=true
+```
+
+### JSON Configuration
+
+For batch generation of multiple list resources, you can use a JSON configuration file:
+
+```json
+[
+  {
+    "service": "PrivateDns",
+    "resource": "AaaaRecord",
+    "include_service_in_name": true,
+    "full_parent": "",
+    "parent": "PrivateDnsZone",
+    "terraform_name": "private_dns_aaaa_record",
+    "id_structure": "privatedns.RecordType",
+    "path": "internal/services/privatedns/"
+  }
+]
+```
+
+Then run:
+
+```sh
+scaff list-resource -json=path/to/config.json
+```

--- a/internal/tools/scaff/commands/input_example/listResources.json
+++ b/internal/tools/scaff/commands/input_example/listResources.json
@@ -1,0 +1,12 @@
+[
+  {
+    "service": "PrivateDns",
+    "resource": "CNameRecord",
+    "include_service_in_name": true,
+    "full_parent": "",
+    "parent": "PrivateDnsZone",
+    "terraform_name": "private_dns_cname_record",
+    "id_structure": "privatedns.RecordType",
+    "path": "{tf-repository}/internal/services/privatedns/"
+  }
+]

--- a/internal/tools/scaff/commands/input_example/listResources.json
+++ b/internal/tools/scaff/commands/input_example/listResources.json
@@ -1,12 +1,12 @@
 [
   {
     "service": "PrivateDns",
-    "resource": "CNameRecord",
+    "resource": "AaaaRecord",
     "include_service_in_name": true,
     "full_parent": "",
     "parent": "PrivateDnsZone",
-    "terraform_name": "private_dns_cname_record",
+    "terraform_name": "private_dns_aaaa_record",
     "id_structure": "privatedns.RecordType",
-    "path": "{tf-repository}/internal/services/privatedns/"
+    "path": "/Users/mark/gitRepos/azureProviders/refactor1/internal/services/privatedns/"
   }
 ]

--- a/internal/tools/scaff/commands/list_documentation.go
+++ b/internal/tools/scaff/commands/list_documentation.go
@@ -1,0 +1,533 @@
+package commands
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"text/template"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tools/templatehelpers"
+	"github.com/mitchellh/cli"
+)
+
+type ListDocumentationCommand struct {
+	Ui cli.Ui
+}
+
+var _ cli.Command = &ListDocumentationCommand{}
+
+type ListDocumentationData struct {
+	Resource      string
+	Section       string
+	FriendlyTitle string
+	Examples      []Example
+	Arguments     []Argument
+}
+
+type Example struct {
+	Heading               string
+	AttributeName         string
+	AttributeExampleValue string
+}
+
+type Argument struct {
+	Name        string
+	Requirement string
+	Description string
+}
+
+type Attribute struct {
+	Name     string
+	Optional bool
+}
+
+var defaultListAttributes = []Attribute{
+	{
+		Name:     "subscription_id",
+		Optional: true,
+	},
+	{
+		Name:     "resource_group_name",
+		Optional: true,
+	},
+}
+
+func (c ListDocumentationCommand) Run(args []string) int {
+	if len(args) < 1 {
+		c.Ui.Error("usage: scaff list-documentation <directory>")
+		return 1
+	}
+
+	root := args[0]
+
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		if strings.HasSuffix(d.Name(), "_resource_list.go") {
+			if err := c.processFile(path); err != nil {
+				c.Ui.Error(fmt.Sprintf("❌ %s: %v", path, err))
+			} else {
+				c.Ui.Info(fmt.Sprintf("✅ processed %s", path))
+			}
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		c.Ui.Error(err.Error())
+		return 1
+	}
+
+	return 0
+}
+
+func (c ListDocumentationCommand) Synopsis() string {
+	return "Generate list resource documentation from Go source files"
+}
+
+func (c ListDocumentationCommand) Help() string {
+	return `
+Usage: scaff list-documentation <file>
+
+  Generates documentation for list resources by scanning Go source files
+  in the specified directory for files ending with '_resource_list.go'.
+
+Parameters:
+  <directory> (Required) The file or directory to scan for list resource files.
+
+Example:
+  scaff list-documentation internal/services/network
+`
+}
+
+func (c ListDocumentationCommand) processFile(filename string) error {
+	fset := token.NewFileSet()
+	node, err := parser.ParseFile(fset, filename, nil, 0)
+	if err != nil {
+		return err
+	}
+	var hasListSchema bool
+	var (
+		resourceName    string
+		attributes      []Attribute
+		varDeclarations = make(map[string]string) // Map variable names to their string values
+	)
+
+	// First pass: collect variable declarations from current file
+	ast.Inspect(node, func(n ast.Node) bool {
+		if decl, ok := n.(*ast.GenDecl); ok && decl.Tok == token.VAR {
+			for _, spec := range decl.Specs {
+				if vspec, ok := spec.(*ast.ValueSpec); ok {
+					for i, name := range vspec.Names {
+						if i < len(vspec.Values) {
+							if lit, ok := vspec.Values[i].(*ast.BasicLit); ok && lit.Kind == token.STRING {
+								val := strings.Trim(lit.Value, "`\"")
+								varDeclarations[name.Name] = val
+							}
+						}
+					}
+				}
+			}
+		}
+		return true
+	})
+
+	// Also check the corresponding resource file (without _list suffix) for variable declarations
+	if strings.HasSuffix(filename, "_resource_list.go") {
+		resourceFilename := strings.Replace(filename, "_resource_list.go", "_resource.go", 1)
+		if resourceNode, err := parser.ParseFile(fset, resourceFilename, nil, 0); err == nil {
+			ast.Inspect(resourceNode, func(n ast.Node) bool {
+				if decl, ok := n.(*ast.GenDecl); ok && decl.Tok == token.VAR {
+					for _, spec := range decl.Specs {
+						if vspec, ok := spec.(*ast.ValueSpec); ok {
+							for i, name := range vspec.Names {
+								if i < len(vspec.Values) {
+									if lit, ok := vspec.Values[i].(*ast.BasicLit); ok && lit.Kind == token.STRING {
+										val := strings.Trim(lit.Value, "`\"")
+										varDeclarations[name.Name] = val
+									}
+								}
+							}
+						}
+					}
+				}
+				return true
+			})
+		}
+	}
+
+	// Second pass: find resource name and attributes
+	ast.Inspect(node, func(n ast.Node) bool {
+		// Detect ListResourceConfigSchema method
+		if fn, ok := n.(*ast.FuncDecl); ok && fn.Name.Name == "ListResourceConfigSchema" {
+			hasListSchema = true
+		}
+
+		// Metadata → TypeName - handle both string literals and variable references
+		if fn, ok := n.(*ast.FuncDecl); ok && fn.Name.Name == "Metadata" {
+			ast.Inspect(fn.Body, func(n ast.Node) bool {
+				// Handle direct string literal: response.TypeName = "azurerm_..."
+				if lit, ok := n.(*ast.BasicLit); ok && lit.Kind == token.STRING {
+					val := strings.Trim(lit.Value, "`\"")
+					if strings.HasPrefix(val, "azurerm_") {
+						resourceName = val
+					}
+				}
+				// Handle variable reference: response.TypeName = variableName
+				if ident, ok := n.(*ast.Ident); ok {
+					if val, exists := varDeclarations[ident.Name]; exists && strings.HasPrefix(val, "azurerm_") {
+						resourceName = val
+					}
+				}
+				return true
+			})
+		}
+
+		// Schema attributes
+		cl, ok := n.(*ast.CompositeLit)
+		if !ok {
+			return true
+		}
+
+		for _, elt := range cl.Elts {
+			kv, ok := elt.(*ast.KeyValueExpr)
+			if !ok {
+				continue
+			}
+
+			key, ok := kv.Key.(*ast.BasicLit)
+			if !ok || key.Kind != token.STRING {
+				continue
+			}
+
+			attr := Attribute{
+				Name: strings.Trim(key.Value, "`\""),
+			}
+
+			if lit, ok := kv.Value.(*ast.CompositeLit); ok {
+				for _, e := range lit.Elts {
+					if kv, ok := e.(*ast.KeyValueExpr); ok {
+						if id, ok := kv.Key.(*ast.Ident); ok && id.Name == "Optional" {
+							if v, ok := kv.Value.(*ast.Ident); ok && v.Name == "true" {
+								attr.Optional = true
+							}
+						}
+					}
+				}
+			}
+
+			attributes = append(attributes, attr)
+		}
+
+		return true
+	})
+
+	if resourceName == "" {
+		return fmt.Errorf("resource type name not found")
+	}
+
+	if !hasListSchema || len(attributes) == 0 {
+		attributes = defaultListAttributes
+	}
+
+	md, err := renderMarkdown(resourceName, attributes, filename)
+	if err != nil {
+		return err
+	}
+
+	base := strings.TrimSuffix(filepath.Base(filename), "_resource_list.go")
+
+	out, err := markdownPathFromGo(filename, "", true)
+	if err != nil {
+		return err
+	}
+	out = filepath.Join(out, base+".html.markdown")
+
+	if err := os.WriteFile("/"+out, []byte(md), 0644); err != nil {
+		return err
+	}
+
+	c.Ui.Info(fmt.Sprintf("✅ generated %s", out))
+	return nil
+}
+
+func renderMarkdown(resource string, attrs []Attribute, filename string) (string, error) {
+	tmpl := template.Must(template.New("list_document.html.markdown.gotpl").Funcs(templatehelpers.TplFuncMap).ParseFS(Templatedir, "templates/list_document.html.markdown.gotpl"))
+
+	data, err := buildTemplateData(resource, attrs, filename)
+	if err != nil {
+		return "", err
+	}
+
+	var b bytes.Buffer
+	if err := tmpl.Execute(&b, data); err != nil {
+		return "", err
+	}
+	return b.String(), nil
+}
+
+func buildExampleForAttribute(a Attribute, friendlyTitleValue, sectionFromName, filename string) (Example, error) {
+	exampleNameBit := ""
+	if a.Name == "resource_group_name" {
+		exampleNameBit = "-rg"
+	}
+
+	switch {
+	case a.Name == "subscription_id":
+		return Example{
+			Heading: fmt.Sprintf("List all %ss in the subscription", friendlyTitleValue),
+		}, nil
+
+	case isNameAttribute(a.Name):
+		return Example{
+			Heading:               fmt.Sprintf("List all %ss in a %s", friendlyTitleValue, nameFriendlyName(a.Name)),
+			AttributeName:         a.Name,
+			AttributeExampleValue: fmt.Sprintf(`"example%s"`, exampleNameBit),
+		}, nil
+
+	default:
+		idExamplePath, err := markdownPathFromGo(filename, idRemoveID(checkAddSectionToName(sectionFromName, a.Name)), false)
+		if err != nil {
+			return Example{}, fmt.Errorf("failed to derive markdown path for example value for attribute `%s`: %w", a.Name, err)
+		}
+		idExample := getExampleValueForIDAttribute(idExamplePath)
+
+		return Example{
+			Heading:               fmt.Sprintf("List %ss in a %s", friendlyTitleValue, idFriendlyName(checkAddSectionToName(sectionFromName, a.Name))),
+			AttributeName:         a.Name,
+			AttributeExampleValue: idExample,
+		}, nil
+	}
+}
+
+func buildArgumentForAttribute(a Attribute, sectionFromName string) (Argument, bool) {
+	req := "Required"
+	if a.Optional {
+		req = "Optional"
+	}
+
+	extraBit := ""
+	if a.Name == "subscription_id" {
+		extraBit = " Defaults to the value specified in the Provider Configuration."
+	}
+
+	if isIDAttribute(a.Name) {
+		return Argument{
+			Name:        a.Name,
+			Requirement: req,
+			Description: fmt.Sprintf("The ID of the %s to query.%s", idFriendlyName(checkAddSectionToName(sectionFromName, a.Name)), extraBit),
+		}, true
+	}
+
+	if isNameAttribute(a.Name) {
+		return Argument{
+			Name:        a.Name,
+			Requirement: req,
+			Description: fmt.Sprintf("The name of the %s to query.", nameFriendlyName(a.Name)),
+		}, true
+	}
+
+	return Argument{}, false
+}
+
+func buildTemplateData(resource string, attrs []Attribute, filename string) (ListDocumentationData, error) {
+	friendlyTitleValue := friendlyTitle(resource)
+	sectionFromTitle := getSectionFromResourceTitle(friendlyTitleValue)
+	mappedSection := mapSectionToActualSection(sectionFromTitle)
+	sectionFromName := getSectionFromResourceName(resource)
+
+	data := ListDocumentationData{
+		Resource:      resource,
+		Section:       mappedSection,
+		FriendlyTitle: friendlyTitleValue,
+	}
+
+	for _, a := range attrs {
+		example, err := buildExampleForAttribute(a, friendlyTitleValue, sectionFromName, filename)
+		if err != nil {
+			return ListDocumentationData{}, fmt.Errorf("failed to build example for attribute %s: %w", a.Name, err)
+		}
+		data.Examples = append(data.Examples, example)
+
+		if arg, shouldAdd := buildArgumentForAttribute(a, sectionFromName); shouldAdd {
+			data.Arguments = append(data.Arguments, arg)
+		}
+	}
+
+	return data, nil
+}
+
+func isNameAttribute(name string) bool {
+	return strings.HasSuffix(name, "_name")
+}
+
+func isIDAttribute(name string) bool {
+	return strings.HasSuffix(name, "_id")
+}
+
+func idRemoveID(name string) string {
+	return strings.TrimSuffix(name, "_id")
+}
+
+// toFriendlyName converts snake_case to Title Case, removing the specified suffix
+func toFriendlyName(name, suffix string) string {
+	base := strings.TrimSuffix(name, suffix)
+	parts := strings.Split(base, "_")
+
+	for i, p := range parts {
+		if len(p) == 0 {
+			continue
+		}
+		parts[i] = strings.ToUpper(p[:1]) + strings.ToLower(p[1:])
+	}
+
+	return strings.Join(parts, " ")
+}
+
+func nameFriendlyName(name string) string {
+	return toFriendlyName(name, "_name")
+}
+
+func idFriendlyName(name string) string {
+	return toFriendlyName(name, "_id")
+}
+
+func friendlyTitle(name string) string {
+
+	parts := strings.Split(strings.TrimPrefix(name, "azurerm_"), "_")
+
+	for i, p := range parts {
+		if len(p) == 0 {
+			continue
+		}
+		parts[i] = strings.ToUpper(p[:1]) + strings.ToLower(p[1:])
+	}
+	return strings.Join(parts, " ")
+}
+
+func checkAddSectionToName(section string, name string) string {
+	if name == "subscription_id" || name == "resource_group_name" {
+		return name
+	}
+
+	sectionsCheck := []string{"mysql"}
+	for _, s := range sectionsCheck {
+		if s == section {
+			return s + "_" + name
+		}
+	}
+
+	return name
+}
+
+func removeSectionFromResourceName(section string, resource string) string {
+	if strings.HasPrefix(resource, "azurerm_"+section+"_") {
+		resource = strings.TrimPrefix(resource, "azurerm_"+section+"_")
+	}
+	resource = strings.TrimPrefix(resource, "azurerm_")
+	return resource
+}
+
+func getSectionFromResourceTitle(title string) string {
+	parts := strings.Split(title, " ")
+
+	return parts[0]
+}
+
+func getSectionFromResourceName(name string) string {
+	parts := strings.Split(name, "_")
+
+	return parts[1]
+}
+
+func mapSectionToActualSection(section string) string {
+
+	var sectionCategoryMap = map[string]string{
+		"Firewall":    "Network",
+		"Mssql":       "Database",
+		"Mysql":       "Database",
+		"Application": "Network",
+		"Ip":          "Network",
+		"Web":         "Network",
+		"Route":       "Network",
+		"Public":      "Network",
+		"Private":     "Network",
+		"Nat":         "Network",
+		"Virtual":     "Network",
+	}
+
+	if category, ok := sectionCategoryMap[section]; ok {
+		return category
+	}
+	return section
+}
+
+func markdownPathFromGo(goPath string, attributeName string, isOutput bool) (string, error) {
+	// Normalize path
+	goPath = filepath.Clean(goPath)
+
+	parts := strings.Split(goPath, string(filepath.Separator))
+
+	// Find "internal/services"
+	var moduleRoot string
+	var service string
+
+	for i := 0; i < len(parts)-2; i++ {
+		if parts[i] == "internal" && parts[i+1] == "services" {
+			service = parts[i+2]
+			moduleRoot = filepath.Join(parts[:i]...)
+			break
+		}
+	}
+
+	if service == "" {
+		return "", fmt.Errorf("could not determine service from path")
+	}
+
+	if isOutput {
+		outputPath := filepath.Join(moduleRoot, "website", "docs", "list-resources")
+		return outputPath, nil
+	} else {
+		mdPath := filepath.Join(moduleRoot, "website", "docs", "r", attributeName+".html.markdown")
+		return mdPath, nil
+	}
+}
+
+func getExampleValueForIDAttribute(filepath string) string {
+	file, err := os.Open("/" + filepath)
+	if err != nil {
+		return "failed to open"
+	}
+	defer file.Close()
+
+	re := regexp.MustCompile(`^\s*terraform import\s+[^\s]+\s+(.+)$`)
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if matches := re.FindStringSubmatch(line); matches != nil {
+			return fmt.Sprintf("%q", matches[1])
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return ""
+	}
+
+	return ""
+}

--- a/internal/tools/scaff/commands/list_documentation.go
+++ b/internal/tools/scaff/commands/list_documentation.go
@@ -94,7 +94,6 @@ func (c ListDocumentationCommand) Run(args []string) int {
 
 		return nil
 	})
-
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1
@@ -295,7 +294,7 @@ func (c ListDocumentationCommand) processFile(filename string, config *ListDocum
 	baseFileName := strings.TrimSuffix(filepath.Base(filename), "_resource_list.go")
 	outputPath := filepath.Join(docsDirectory, baseFileName+".html.markdown")
 
-	if err := os.WriteFile("/"+outputPath, []byte(md), 0644); err != nil {
+	if err := os.WriteFile("/"+outputPath, []byte(md), 0o644); err != nil {
 		return err
 	}
 

--- a/internal/tools/scaff/commands/list_documentation.go
+++ b/internal/tools/scaff/commands/list_documentation.go
@@ -133,9 +133,9 @@ Usage: scaff list-documentation [options]
   for files ending with '_resource_list.go'.
 
 Options:
-  -path=<path>              Path to file or directory to scan (required)
-  -subcategory=<name>       Override the subcategory/section (e.g., "Network", "Database")
-  -addsectiontoname         Prepend section name to attribute names (boolean flag)
+  -path=<path>              (Required) Path to file or directory to scan (required)
+  -subcategory=<name>       (Optional) Override the subcategory/section (e.g., "Network", "Database")
+  -addsectiontoname         (Optional) Prepend section name to attribute names (boolean flag)
 
 Examples:
   # Basic usage (backward compatible)

--- a/internal/tools/scaff/commands/list_documentation.go
+++ b/internal/tools/scaff/commands/list_documentation.go
@@ -3,6 +3,8 @@ package commands
 import (
 	"bufio"
 	"bytes"
+	"errors"
+	"flag"
 	"fmt"
 	"go/ast"
 	"go/parser"
@@ -21,11 +23,17 @@ type ListDocumentationCommand struct {
 	Ui cli.Ui
 }
 
+type ListDocumentationConfig struct {
+	Path             string
+	SubCategory      string
+	AddSectionToName bool
+}
+
 var _ cli.Command = &ListDocumentationCommand{}
 
 type ListDocumentationData struct {
 	Resource      string
-	Section       string
+	SubCategory   string
 	FriendlyTitle string
 	Examples      []Example
 	Arguments     []Argument
@@ -60,14 +68,14 @@ var defaultListAttributes = []Attribute{
 }
 
 func (c ListDocumentationCommand) Run(args []string) int {
-	if len(args) < 1 {
-		c.Ui.Error("usage: scaff list-documentation <directory>")
+	config := &ListDocumentationConfig{}
+
+	if err := config.parseArgs(args); err != nil {
+		c.Ui.Error(err.Error())
 		return 1
 	}
 
-	root := args[0]
-
-	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+	err := filepath.WalkDir(config.Path, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -77,7 +85,7 @@ func (c ListDocumentationCommand) Run(args []string) int {
 		}
 
 		if strings.HasSuffix(d.Name(), "_resource_list.go") {
-			if err := c.processFile(path); err != nil {
+			if err := c.processFile(path, config); err != nil {
 				c.Ui.Error(fmt.Sprintf("❌ %s: %v", path, err))
 			} else {
 				c.Ui.Info(fmt.Sprintf("✅ processed %s", path))
@@ -95,26 +103,56 @@ func (c ListDocumentationCommand) Run(args []string) int {
 	return 0
 }
 
+func (config *ListDocumentationConfig) parseArgs(args []string) error {
+	argSet := flag.NewFlagSet("list-documentation", flag.ContinueOnError)
+
+	argSet.StringVar(&config.Path, "path", "", "(Required) Path to file or directory to scan")
+	argSet.StringVar(&config.SubCategory, "subcategory", "", "(Optional) Subcategory to override section mapping")
+	argSet.BoolVar(&config.AddSectionToName, "addsectiontoname", false, "(Optional) Prepend section name to attribute names")
+
+	if err := argSet.Parse(args); err != nil {
+		return err
+	}
+
+	if config.Path == "" {
+		return errors.New("path is required")
+	}
+
+	return nil
+}
+
 func (c ListDocumentationCommand) Synopsis() string {
 	return "Generate list resource documentation from Go source files"
 }
 
 func (c ListDocumentationCommand) Help() string {
 	return `
-Usage: scaff list-documentation <file>
+Usage: scaff list-documentation [options]
 
   Generates documentation for list resources by scanning Go source files
-  in the specified directory for files ending with '_resource_list.go'.
+  for files ending with '_resource_list.go'.
 
-Parameters:
-  <directory> (Required) The file or directory to scan for list resource files.
+Options:
+  -path=<path>              Path to file or directory to scan (required)
+  -subcategory=<name>       Override the subcategory/section (e.g., "Network", "Database")
+  -addsectiontoname         Prepend section name to attribute names (boolean flag)
 
-Example:
+Examples:
+  # Basic usage (backward compatible)
   scaff list-documentation internal/services/network
+
+  # Using flags
+  scaff list-documentation -path=internal/services/network
+
+  # With subcategory override
+  scaff list-documentation -path=internal/services/mssql -subcategory=Database
+
+  # With section name prefixing enabled
+  scaff list-documentation -path=internal/services/mssql -addsectiontoname
 `
 }
 
-func (c ListDocumentationCommand) processFile(filename string) error {
+func (c ListDocumentationCommand) processFile(filename string, config *ListDocumentationConfig) error {
 	fset := token.NewFileSet()
 	node, err := parser.ParseFile(fset, filename, nil, 0)
 	if err != nil {
@@ -244,31 +282,31 @@ func (c ListDocumentationCommand) processFile(filename string) error {
 		attributes = defaultListAttributes
 	}
 
-	md, err := renderMarkdown(resourceName, attributes, filename)
+	md, err := config.renderMarkdown(resourceName, attributes, filename)
 	if err != nil {
 		return err
 	}
 
-	base := strings.TrimSuffix(filepath.Base(filename), "_resource_list.go")
-
-	out, err := markdownPathFromGo(filename, "", true)
+	docsDirectory, err := markdownPathFromGo(filename, "", true)
 	if err != nil {
 		return err
 	}
-	out = filepath.Join(out, base+".html.markdown")
 
-	if err := os.WriteFile("/"+out, []byte(md), 0644); err != nil {
+	baseFileName := strings.TrimSuffix(filepath.Base(filename), "_resource_list.go")
+	outputPath := filepath.Join(docsDirectory, baseFileName+".html.markdown")
+
+	if err := os.WriteFile("/"+outputPath, []byte(md), 0644); err != nil {
 		return err
 	}
 
-	c.Ui.Info(fmt.Sprintf("✅ generated %s", out))
+	c.Ui.Info(fmt.Sprintf("✅ generated %s", outputPath))
 	return nil
 }
 
-func renderMarkdown(resource string, attrs []Attribute, filename string) (string, error) {
+func (config *ListDocumentationConfig) renderMarkdown(resource string, attrs []Attribute, filename string) (string, error) {
 	tmpl := template.Must(template.New("list_document.html.markdown.gotpl").Funcs(templatehelpers.TplFuncMap).ParseFS(Templatedir, "templates/list_document.html.markdown.gotpl"))
 
-	data, err := buildTemplateData(resource, attrs, filename)
+	data, err := config.buildTemplateData(resource, attrs, filename)
 	if err != nil {
 		return "", err
 	}
@@ -280,92 +318,100 @@ func renderMarkdown(resource string, attrs []Attribute, filename string) (string
 	return b.String(), nil
 }
 
-func buildExampleForAttribute(a Attribute, friendlyTitleValue, sectionFromName, filename string) (Example, error) {
-	exampleNameBit := ""
+func (config *ListDocumentationConfig) buildExampleForAttribute(a Attribute, resourceTitle string, section string, filename string) (Example, error) {
+	exampleNameSuffix := ""
 	if a.Name == "resource_group_name" {
-		exampleNameBit = "-rg"
+		exampleNameSuffix = "-rg"
 	}
+	attributeName := config.checkAddSectionToName(section, a.Name)
 
 	switch {
 	case a.Name == "subscription_id":
 		return Example{
-			Heading: fmt.Sprintf("List all %ss in the subscription", friendlyTitleValue),
+			Heading: fmt.Sprintf("List all %ss in the subscription", resourceTitle),
 		}, nil
 
 	case isNameAttribute(a.Name):
 		return Example{
-			Heading:               fmt.Sprintf("List all %ss in a %s", friendlyTitleValue, nameFriendlyName(a.Name)),
+			Heading:               fmt.Sprintf("List all %ss in a %s", resourceTitle, nameTitle(a.Name)),
 			AttributeName:         a.Name,
-			AttributeExampleValue: fmt.Sprintf(`"example%s"`, exampleNameBit),
+			AttributeExampleValue: fmt.Sprintf(`"example%s"`, exampleNameSuffix),
 		}, nil
 
 	default:
-		idExamplePath, err := markdownPathFromGo(filename, idRemoveID(checkAddSectionToName(sectionFromName, a.Name)), false)
+		idExamplePath, err := markdownPathFromGo(filename, idRemoveID(attributeName), false)
 		if err != nil {
 			return Example{}, fmt.Errorf("failed to derive markdown path for example value for attribute `%s`: %w", a.Name, err)
 		}
 		idExample := getExampleValueForIDAttribute(idExamplePath)
 
 		return Example{
-			Heading:               fmt.Sprintf("List %ss in a %s", friendlyTitleValue, idFriendlyName(checkAddSectionToName(sectionFromName, a.Name))),
+			Heading:               fmt.Sprintf("List %ss in a %s", resourceTitle, idTitle(attributeName)),
 			AttributeName:         a.Name,
 			AttributeExampleValue: idExample,
 		}, nil
 	}
 }
 
-func buildArgumentForAttribute(a Attribute, sectionFromName string) (Argument, bool) {
+func (config *ListDocumentationConfig) buildArgumentForAttribute(a Attribute, sectionFromName string) (Argument, error) {
 	req := "Required"
 	if a.Optional {
 		req = "Optional"
 	}
 
-	extraBit := ""
+	extraDescription := ""
 	if a.Name == "subscription_id" {
-		extraBit = " Defaults to the value specified in the Provider Configuration."
+		extraDescription = " Defaults to the value specified in the Provider Configuration."
 	}
+
+	friendlyName := config.checkAddSectionToName(sectionFromName, a.Name)
 
 	if isIDAttribute(a.Name) {
 		return Argument{
 			Name:        a.Name,
 			Requirement: req,
-			Description: fmt.Sprintf("The ID of the %s to query.%s", idFriendlyName(checkAddSectionToName(sectionFromName, a.Name)), extraBit),
-		}, true
+			Description: fmt.Sprintf("The ID of the %s to query.%s", idTitle(friendlyName), extraDescription),
+		}, nil
 	}
 
 	if isNameAttribute(a.Name) {
 		return Argument{
 			Name:        a.Name,
 			Requirement: req,
-			Description: fmt.Sprintf("The name of the %s to query.", nameFriendlyName(a.Name)),
-		}, true
+			Description: fmt.Sprintf("The name of the %s to query.", nameTitle(friendlyName)),
+		}, nil
 	}
 
-	return Argument{}, false
+	return Argument{}, fmt.Errorf("%s is not an ID or name attribute", a.Name)
 }
 
-func buildTemplateData(resource string, attrs []Attribute, filename string) (ListDocumentationData, error) {
-	friendlyTitleValue := friendlyTitle(resource)
-	sectionFromTitle := getSectionFromResourceTitle(friendlyTitleValue)
-	mappedSection := mapSectionToActualSection(sectionFromTitle)
-	sectionFromName := getSectionFromResourceName(resource)
+func (config *ListDocumentationConfig) buildTemplateData(resource string, attrs []Attribute, filename string) (ListDocumentationData, error) {
+	resourceTitle := resourceTitle(resource)
+	section := getSection(resource)
+
+	subCategory := section
+	if config.SubCategory != "" {
+		subCategory = config.SubCategory
+	}
 
 	data := ListDocumentationData{
 		Resource:      resource,
-		Section:       mappedSection,
-		FriendlyTitle: friendlyTitleValue,
+		SubCategory:   subCategory,
+		FriendlyTitle: resourceTitle,
 	}
 
 	for _, a := range attrs {
-		example, err := buildExampleForAttribute(a, friendlyTitleValue, sectionFromName, filename)
+		example, err := config.buildExampleForAttribute(a, resourceTitle, section, filename)
 		if err != nil {
-			return ListDocumentationData{}, fmt.Errorf("failed to build example for attribute %s: %w", a.Name, err)
+			return ListDocumentationData{}, err
 		}
 		data.Examples = append(data.Examples, example)
 
-		if arg, shouldAdd := buildArgumentForAttribute(a, sectionFromName); shouldAdd {
-			data.Arguments = append(data.Arguments, arg)
+		arg, err := config.buildArgumentForAttribute(a, section)
+		if err != nil {
+			return ListDocumentationData{}, err
 		}
+		data.Arguments = append(data.Arguments, arg)
 	}
 
 	return data, nil
@@ -383,9 +429,8 @@ func idRemoveID(name string) string {
 	return strings.TrimSuffix(name, "_id")
 }
 
-// toFriendlyName converts snake_case to Title Case, removing the specified suffix
-func toFriendlyName(name, suffix string) string {
-	base := strings.TrimSuffix(name, suffix)
+func toTitle(name, suffix string) string {
+	base := strings.TrimSuffix(strings.TrimPrefix(name, "azurerm_"), suffix)
 	parts := strings.Split(base, "_")
 
 	for i, p := range parts {
@@ -398,82 +443,34 @@ func toFriendlyName(name, suffix string) string {
 	return strings.Join(parts, " ")
 }
 
-func nameFriendlyName(name string) string {
-	return toFriendlyName(name, "_name")
+func nameTitle(name string) string {
+	return toTitle(name, "_name")
 }
 
-func idFriendlyName(name string) string {
-	return toFriendlyName(name, "_id")
+func idTitle(name string) string {
+	return toTitle(name, "_id")
 }
 
-func friendlyTitle(name string) string {
-
-	parts := strings.Split(strings.TrimPrefix(name, "azurerm_"), "_")
-
-	for i, p := range parts {
-		if len(p) == 0 {
-			continue
-		}
-		parts[i] = strings.ToUpper(p[:1]) + strings.ToLower(p[1:])
-	}
-	return strings.Join(parts, " ")
+func resourceTitle(name string) string {
+	return toTitle(name, "")
 }
 
-func checkAddSectionToName(section string, name string) string {
+func (config *ListDocumentationConfig) checkAddSectionToName(section string, name string) string {
 	if name == "subscription_id" || name == "resource_group_name" {
 		return name
 	}
 
-	sectionsCheck := []string{"mysql"}
-	for _, s := range sectionsCheck {
-		if s == section {
-			return s + "_" + name
-		}
+	if config.AddSectionToName {
+		return section + "_" + name
 	}
 
 	return name
 }
 
-func removeSectionFromResourceName(section string, resource string) string {
-	if strings.HasPrefix(resource, "azurerm_"+section+"_") {
-		resource = strings.TrimPrefix(resource, "azurerm_"+section+"_")
-	}
-	resource = strings.TrimPrefix(resource, "azurerm_")
-	return resource
-}
-
-func getSectionFromResourceTitle(title string) string {
-	parts := strings.Split(title, " ")
-
-	return parts[0]
-}
-
-func getSectionFromResourceName(name string) string {
+func getSection(name string) string {
 	parts := strings.Split(name, "_")
 
 	return parts[1]
-}
-
-func mapSectionToActualSection(section string) string {
-
-	var sectionCategoryMap = map[string]string{
-		"Firewall":    "Network",
-		"Mssql":       "Database",
-		"Mysql":       "Database",
-		"Application": "Network",
-		"Ip":          "Network",
-		"Web":         "Network",
-		"Route":       "Network",
-		"Public":      "Network",
-		"Private":     "Network",
-		"Nat":         "Network",
-		"Virtual":     "Network",
-	}
-
-	if category, ok := sectionCategoryMap[section]; ok {
-		return category
-	}
-	return section
 }
 
 func markdownPathFromGo(goPath string, attributeName string, isOutput bool) (string, error) {
@@ -510,7 +507,7 @@ func markdownPathFromGo(goPath string, attributeName string, isOutput bool) (str
 func getExampleValueForIDAttribute(filepath string) string {
 	file, err := os.Open("/" + filepath)
 	if err != nil {
-		return "failed to open"
+		return fmt.Sprintf("failed to open %s", filepath)
 	}
 	defer file.Close()
 

--- a/internal/tools/scaff/commands/list_resource.go
+++ b/internal/tools/scaff/commands/list_resource.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tools/templatehelpers"
 	"github.com/mitchellh/cli"
 )
 
@@ -26,6 +27,7 @@ type ResourceInput struct {
 	IncludeServiceInName bool   `json:"include_service_in_name"`
 	FullParent           string `json:"full_parent"`
 	Parent               string `json:"parent"`
+	ParentTerraformName  string `json:"parent_terraform_name"`
 	TerraformName        string `json:"terraform_name"`
 	IDStructure          string `json:"id_structure"`
 	Path                 string `json:"path"`
@@ -47,7 +49,8 @@ type ListResourceData struct {
 
 	UseResourceGroup bool
 	// Terraform
-	TerraformResourceName string
+	TerraformResourceName       string
+	ParentTerraformResourceName string
 
 	// Go identifiers
 	ResourceStruct     string
@@ -109,15 +112,16 @@ Usage: scaff list-resource [options]
   with multiple resource definitions or individual CLI arguments for a single resource.
 
 Options:
-  -json=<path>                    Path to JSON file containing resource definitions
-  -service=<name>                 Service name (e.g., "PrivateDns")
-  -resource=<name>                Resource name (e.g., "CNameRecord")
-  -include_service_in_name=<bool> Include service name in generated identifiers
-  -full_parent=<name>             Full parent resource name
-  -parent=<name>                  Parent resource name (e.g., "PrivateDnsZone")
-  -terraform_name=<name>          Terraform resource name (e.g., "private_dns_cname_record")
-  -id_structure=<type>            ID structure type (e.g., "privatedns.RecordType")
-  -path=<path>                    Output path for generated files
+  -json=<path>                    Path to JSON file containing resource definitions (use instead of full cli)
+  -service=<name>                 (Required) Service name (e.g., "PrivateDns")
+  -resource=<name>                (Required) Resource name (e.g., "CNameRecord")
+  -include_service_in_name=<bool> (Optional) Include service name in generated identifiers, defaults to false
+  -full_parent=<name>             (Optional) Full parent resource name
+  -parent=<name>                  (Optional) Parent resource name (e.g., "PrivateDnsZone"), defaults to resource_group
+  -parent_terraform_name=<name>   (Optional) Parent Terraform resource name (e.g., "private_dns_zone")
+  -terraform_name=<name>          (Optional) Terraform resource name (e.g., "private_dns_cname_record")
+  -id_structure=<type>            (Required) ID structure type (e.g., "privatedns.RecordType")
+  -path=<path>                    (Optional) Output path for generated files
 
 Examples:
   # Using JSON file
@@ -135,10 +139,11 @@ func (input *ResourceInput) parseArgs(args []string) (errs []error) {
 	argSet.StringVar(&jsonFile, "json", "", "Path to JSON file containing resource definitions")
 	argSet.StringVar(&input.Service, "service", "", "Service name")
 	argSet.StringVar(&input.Resource, "resource", "", "Resource name")
-	argSet.BoolVar(&input.IncludeServiceInName, "include_service_in_name", false, "Include service name in generated identifiers")
-	argSet.StringVar(&input.FullParent, "full_parent", "", "Full parent resource name")
-	argSet.StringVar(&input.Parent, "parent", "", "Parent resource name")
-	argSet.StringVar(&input.TerraformName, "terraform_name", "", "Terraform resource name")
+	argSet.BoolVar(&input.IncludeServiceInName, "include_service_in_name", false, "(Optional) Include service name in generated identifiers")
+	argSet.StringVar(&input.FullParent, "full_parent", "", "(Optional) Full parent resource name, if different than parent")
+	argSet.StringVar(&input.Parent, "parent", "", "(Optional) Parent resource name, will default to resource group if not specified")
+	argSet.StringVar(&input.ParentTerraformName, "parent_terraform_name", "", "(Optional) Terraform resource name of the parent, will attempt to derive it if not provided")
+	argSet.StringVar(&input.TerraformName, "terraform_name", "", "(Optional) Terraform resource name, will attempt to derive it if not provided")
 	argSet.StringVar(&input.IDStructure, "id_structure", "", "ID structure type")
 	argSet.StringVar(&input.Path, "path", "", "Output path for generated files")
 
@@ -158,7 +163,6 @@ func (input *ResourceInput) parseArgs(args []string) (errs []error) {
 			errs = append(errs, errors.New("JSON file contains no resources"))
 			return
 		}
-		// Use first resource from JSON (or we could process all)
 		*input = resources[0]
 		return
 	}
@@ -169,14 +173,10 @@ func (input *ResourceInput) parseArgs(args []string) (errs []error) {
 		errs = append(errs, errors.New("service is required"))
 	case input.Resource == "":
 		errs = append(errs, errors.New("resource is required"))
-	case input.Parent == "":
-		errs = append(errs, errors.New("parent is required"))
-	case input.TerraformName == "":
-		errs = append(errs, errors.New("terraform_name is required"))
 	case input.IDStructure == "":
 		errs = append(errs, errors.New("id_structure is required"))
 	case input.Path == "":
-		errs = append(errs, errors.New("path is required"))
+		input.Path = fmt.Sprintf(".")
 	}
 
 	return
@@ -185,16 +185,17 @@ func (input *ResourceInput) parseArgs(args []string) (errs []error) {
 func (c ListResourceCommand) processResource(input ResourceInput) error {
 	data := derive(input)
 
-	templatePath := "templates/list.go.tmpl"
+	templateName := "list.go.gotpl"
+	templatePath := "templates"
 	outputPath := input.Path + data.OutputFile
-	if err := c.renderTemplate(templatePath, outputPath, data); err != nil {
+	if err := data.renderTemplate(templatePath, templateName, outputPath); err != nil {
 		return fmt.Errorf("failed to render %s: %w", outputPath, err)
 	}
 	c.Ui.Info(fmt.Sprintf("✅ generated %s", outputPath))
 
-	testTemplatePath := "templates/list_test.go.tmpl"
+	templateName = "list_test.go.gotpl"
 	testOutputPath := input.Path + data.OutputTestFile
-	if err := c.renderTemplate(testTemplatePath, testOutputPath, data); err != nil {
+	if err := data.renderTemplate(templatePath, templateName, testOutputPath); err != nil {
 		return fmt.Errorf("failed to render %s: %w", testOutputPath, err)
 	}
 	c.Ui.Info(fmt.Sprintf("✅ generated %s", testOutputPath))
@@ -202,14 +203,8 @@ func (c ListResourceCommand) processResource(input ResourceInput) error {
 	return nil
 }
 
-func (c ListResourceCommand) renderTemplate(templatePath, outputPath string, data any) error {
-	tmpl, err := template.
-		New(filepath.Base(templatePath)).
-		Option("missingkey=error").
-		ParseFiles(templatePath)
-	if err != nil {
-		return err
-	}
+func (data *ListResourceData) renderTemplate(templatePath, templateName, outputPath string) error {
+	tmpl := template.Must(template.New(templateName).Funcs(templatehelpers.TplFuncMap).ParseFS(Templatedir, fmt.Sprintf("%s/%s", templatePath, templateName)))
 
 	if err := os.MkdirAll(filepath.Dir(outputPath), 0o755); err != nil {
 		return err
@@ -224,10 +219,11 @@ func (c ListResourceCommand) renderTemplate(templatePath, outputPath string, dat
 	return tmpl.Execute(out, data)
 }
 
-func derive(input ResourceInput) ListResourceData {
+func derive(input ResourceInput) *ListResourceData {
 	service := input.Service   // Mssql
 	resource := input.Resource // ElasticPool
 	parent := input.Parent     // Server
+
 	fullParent := input.Parent
 	if input.FullParent != "" {
 		fullParent = input.FullParent
@@ -239,10 +235,8 @@ func derive(input ResourceInput) ListResourceData {
 	serviceLower := strings.ToLower(service)
 	resourceLower := strings.ToLower(resource)
 	useResourceGroup := false
-	if parentLower == "resourcegroup" {
+	if parentLower == "resourcegroup" || parentLower == "" {
 		useResourceGroup = true
-		fmt.Printf("derived that this resource uses resource group scoping based on parent `%s` \n", useResourceGroup)
-		fmt.Printf("derived that this resource uses resource group scoping based on parent `%s` \n", parentLower)
 	}
 	terraformName := fmt.Sprintf(
 		"azurerm_%s_%s",
@@ -262,7 +256,12 @@ func derive(input ResourceInput) ListResourceData {
 		)
 	}
 
-	// Go identifiers
+	parentTerraformName := parent
+
+	if input.ParentTerraformName != "" {
+		parentTerraformName = input.ParentTerraformName
+	}
+
 	listResourceStruct := fmt.Sprintf("%sListResource", resource)
 	resourceStruct := fmt.Sprintf("%sResource", resource)
 	modelStruct := fmt.Sprintf("%sListModel", resource)
@@ -270,18 +269,16 @@ func derive(input ResourceInput) ListResourceData {
 	childDisplayName := resource
 
 	if input.IncludeServiceInName {
-		// Go identifiers
 		resourceStruct = fmt.Sprintf("%s%sResource", service, resource)
 		listResourceStruct = fmt.Sprintf("%s%sListResource", service, resource)
 		modelStruct = fmt.Sprintf("%s%sListModel", service, resource)
 
-		// Display
 		childDisplayName = fmt.Sprintf("%s %s", service, resource)
 	}
 
-	fmt.Printf("return resource%s%sFlatten(d, id, resp.Model) \n}\n\nfunc resource%s%sFlatten(d *pluginsdk.ResourceData, id *%s.%sId, model *%s.%s) error {", service, resource, service, resource, idPackage, idType, idPackage, idType)
+	fmt.Printf("return resource%s%sFlatten(d, id, resp.Model) \n}\n\nfunc resource%s%sFlatten(d *pluginsdk.ResourceData, id *%s.%sId, model *%s.%s) error {\n\n", service, resource, service, resource, idPackage, idType, idPackage, idType)
 
-	return ListResourceData{
+	return &ListResourceData{
 		// Core
 		ServiceName:  service,
 		ResourceName: resource,
@@ -297,7 +294,8 @@ func derive(input ResourceInput) ListResourceData {
 		IdType:    idType,
 		IdName:    idName,
 		// Terraform
-		TerraformResourceName: terraformName,
+		TerraformResourceName:       terraformName,
+		ParentTerraformResourceName: parentTerraformName,
 
 		// Go identifiers
 		ResourceStruct:     resourceStruct,
@@ -308,9 +306,8 @@ func derive(input ResourceInput) ListResourceData {
 		ChildDisplayName: childDisplayName,
 
 		// Files
-		OutputFile:     fmt.Sprintf("%s_resource_list.go", resourceName),
-		OutputTestFile: fmt.Sprintf("%s_resource_list_test.go", resourceName),
-		AzureSDKImport: fmt.Sprintf(`"github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-08-01-preview/%s"`, resourceLower),
+		OutputFile:     fmt.Sprintf("/%s_resource_list.go", resourceName),
+		OutputTestFile: fmt.Sprintf("/%s_resource_list_test.go", resourceName),
 	}
 }
 

--- a/internal/tools/scaff/commands/list_resource.go
+++ b/internal/tools/scaff/commands/list_resource.go
@@ -1,0 +1,321 @@
+package commands
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"github.com/mitchellh/cli"
+)
+
+type ListResourceCommand struct {
+	Ui cli.Ui
+}
+
+var _ cli.Command = &ListResourceCommand{}
+
+type ResourceInput struct {
+	Service              string `json:"service"`
+	Resource             string `json:"resource"`
+	IncludeServiceInName bool   `json:"include_service_in_name"`
+	FullParent           string `json:"full_parent"`
+	Parent               string `json:"parent"`
+	TerraformName        string `json:"terraform_name"`
+	IDStructure          string `json:"id_structure"`
+	Path                 string `json:"path"`
+}
+
+type ListResourceData struct {
+	// Core
+	ServiceName   string
+	ResourceName  string
+	PackageName   string
+	ResourceLower string
+	FullParent    string
+	Parent        string
+	ParentLower   string
+
+	IdPackage string
+	IdType    string
+	IdName    string
+
+	UseResourceGroup bool
+	// Terraform
+	TerraformResourceName string
+
+	// Go identifiers
+	ResourceStruct     string
+	ListResourceStruct string
+	ModelStruct        string
+
+	// Display
+	ChildDisplayName string
+
+	// Files
+	OutputFile     string
+	OutputTestFile string
+	AzureSDKImport string
+}
+
+func loadResources(filePath string) ([]ResourceInput, error) {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	var resources []ResourceInput
+
+	err = json.Unmarshal(data, &resources)
+	if err != nil {
+		return nil, err
+	}
+
+	return resources, nil
+}
+
+func (c ListResourceCommand) Run(args []string) int {
+	input := &ResourceInput{}
+
+	if err := input.parseArgs(args); err != nil {
+		for _, e := range err {
+			c.Ui.Error(e.Error())
+		}
+		return 1
+	}
+
+	if err := c.processResource(*input); err != nil {
+		c.Ui.Error(err.Error())
+		return 1
+	}
+
+	return 0
+}
+
+func (c ListResourceCommand) Synopsis() string {
+	return "Generate list resource boilerplate code from JSON file or CLI arguments"
+}
+
+func (c ListResourceCommand) Help() string {
+	return `
+Usage: scaff list-resource [options]
+
+  Generates list resource boilerplate code. Can accept either a JSON file
+  with multiple resource definitions or individual CLI arguments for a single resource.
+
+Options:
+  -json=<path>                    Path to JSON file containing resource definitions
+  -service=<name>                 Service name (e.g., "PrivateDns")
+  -resource=<name>                Resource name (e.g., "CNameRecord")
+  -include_service_in_name=<bool> Include service name in generated identifiers
+  -full_parent=<name>             Full parent resource name
+  -parent=<name>                  Parent resource name (e.g., "PrivateDnsZone")
+  -terraform_name=<name>          Terraform resource name (e.g., "private_dns_cname_record")
+  -id_structure=<type>            ID structure type (e.g., "privatedns.RecordType")
+  -path=<path>                    Output path for generated files
+
+Examples:
+  # Using JSON file
+  scaff list-resource -json=internal/tools/scaff/commands/input_example/listResources.json
+
+  # Using CLI arguments
+  scaff list-resource -service="PrivateDns" -resource="CNameRecord" -parent="PrivateDnsZone" -terraform_name="private_dns_cname_record" -id_structure="privatedns.RecordType" -path="internal/services/privatedns/"
+`
+}
+
+func (input *ResourceInput) parseArgs(args []string) (errs []error) {
+	argSet := flag.NewFlagSet("list-resource", flag.ContinueOnError)
+
+	var jsonFile string
+	argSet.StringVar(&jsonFile, "json", "", "Path to JSON file containing resource definitions")
+	argSet.StringVar(&input.Service, "service", "", "Service name")
+	argSet.StringVar(&input.Resource, "resource", "", "Resource name")
+	argSet.BoolVar(&input.IncludeServiceInName, "include_service_in_name", false, "Include service name in generated identifiers")
+	argSet.StringVar(&input.FullParent, "full_parent", "", "Full parent resource name")
+	argSet.StringVar(&input.Parent, "parent", "", "Parent resource name")
+	argSet.StringVar(&input.TerraformName, "terraform_name", "", "Terraform resource name")
+	argSet.StringVar(&input.IDStructure, "id_structure", "", "ID structure type")
+	argSet.StringVar(&input.Path, "path", "", "Output path for generated files")
+
+	if err := argSet.Parse(args); err != nil {
+		errs = append(errs, err)
+		return
+	}
+
+	// If JSON file is provided, load from it
+	if jsonFile != "" {
+		resources, err := loadResources(jsonFile)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to load JSON file: %w", err))
+			return
+		}
+		if len(resources) == 0 {
+			errs = append(errs, errors.New("JSON file contains no resources"))
+			return
+		}
+		// Use first resource from JSON (or we could process all)
+		*input = resources[0]
+		return
+	}
+
+	// Validate required fields when using CLI arguments
+	switch {
+	case input.Service == "":
+		errs = append(errs, errors.New("service is required"))
+	case input.Resource == "":
+		errs = append(errs, errors.New("resource is required"))
+	case input.Parent == "":
+		errs = append(errs, errors.New("parent is required"))
+	case input.TerraformName == "":
+		errs = append(errs, errors.New("terraform_name is required"))
+	case input.IDStructure == "":
+		errs = append(errs, errors.New("id_structure is required"))
+	case input.Path == "":
+		errs = append(errs, errors.New("path is required"))
+	}
+
+	return
+}
+
+func (c ListResourceCommand) processResource(input ResourceInput) error {
+	data := derive(input)
+
+	templatePath := "templates/list.go.tmpl"
+	outputPath := input.Path + data.OutputFile
+	if err := c.renderTemplate(templatePath, outputPath, data); err != nil {
+		return fmt.Errorf("failed to render %s: %w", outputPath, err)
+	}
+	c.Ui.Info(fmt.Sprintf("✅ generated %s", outputPath))
+
+	testTemplatePath := "templates/list_test.go.tmpl"
+	testOutputPath := input.Path + data.OutputTestFile
+	if err := c.renderTemplate(testTemplatePath, testOutputPath, data); err != nil {
+		return fmt.Errorf("failed to render %s: %w", testOutputPath, err)
+	}
+	c.Ui.Info(fmt.Sprintf("✅ generated %s", testOutputPath))
+
+	return nil
+}
+
+func (c ListResourceCommand) renderTemplate(templatePath, outputPath string, data any) error {
+	tmpl, err := template.
+		New(filepath.Base(templatePath)).
+		Option("missingkey=error").
+		ParseFiles(templatePath)
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(outputPath), 0o755); err != nil {
+		return err
+	}
+
+	out, err := os.Create(outputPath)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	return tmpl.Execute(out, data)
+}
+
+func derive(input ResourceInput) ListResourceData {
+	service := input.Service   // Mssql
+	resource := input.Resource // ElasticPool
+	parent := input.Parent     // Server
+	fullParent := input.Parent
+	if input.FullParent != "" {
+		fullParent = input.FullParent
+	}
+
+	idPackage, idType, idName := parseIDStructure(input.IDStructure)
+
+	parentLower := strings.ToLower(parent)
+	serviceLower := strings.ToLower(service)
+	resourceLower := strings.ToLower(resource)
+	useResourceGroup := false
+	if parentLower == "resourcegroup" {
+		useResourceGroup = true
+		fmt.Printf("derived that this resource uses resource group scoping based on parent `%s` \n", useResourceGroup)
+		fmt.Printf("derived that this resource uses resource group scoping based on parent `%s` \n", parentLower)
+	}
+	terraformName := fmt.Sprintf(
+		"azurerm_%s_%s",
+		serviceLower,
+		resourceLower,
+	)
+	resourceName := fmt.Sprintf(
+		"%s_%s",
+		serviceLower,
+		resourceLower,
+	)
+	if input.TerraformName != "" {
+		resourceName = input.TerraformName
+		terraformName = fmt.Sprintf(
+			"azurerm_%s",
+			input.TerraformName,
+		)
+	}
+
+	// Go identifiers
+	listResourceStruct := fmt.Sprintf("%sListResource", resource)
+	resourceStruct := fmt.Sprintf("%sResource", resource)
+	modelStruct := fmt.Sprintf("%sListModel", resource)
+
+	childDisplayName := resource
+
+	if input.IncludeServiceInName {
+		// Go identifiers
+		resourceStruct = fmt.Sprintf("%s%sResource", service, resource)
+		listResourceStruct = fmt.Sprintf("%s%sListResource", service, resource)
+		modelStruct = fmt.Sprintf("%s%sListModel", service, resource)
+
+		// Display
+		childDisplayName = fmt.Sprintf("%s %s", service, resource)
+	}
+
+	fmt.Printf("return resource%s%sFlatten(d, id, resp.Model) \n}\n\nfunc resource%s%sFlatten(d *pluginsdk.ResourceData, id *%s.%sId, model *%s.%s) error {", service, resource, service, resource, idPackage, idType, idPackage, idType)
+
+	return ListResourceData{
+		// Core
+		ServiceName:  service,
+		ResourceName: resource,
+		PackageName:  serviceLower,
+
+		ResourceLower:    resourceLower,
+		FullParent:       fullParent,
+		Parent:           parent,
+		ParentLower:      parentLower,
+		UseResourceGroup: useResourceGroup,
+
+		IdPackage: idPackage,
+		IdType:    idType,
+		IdName:    idName,
+		// Terraform
+		TerraformResourceName: terraformName,
+
+		// Go identifiers
+		ResourceStruct:     resourceStruct,
+		ListResourceStruct: listResourceStruct,
+		ModelStruct:        modelStruct,
+
+		// Display
+		ChildDisplayName: childDisplayName,
+
+		// Files
+		OutputFile:     fmt.Sprintf("%s_resource_list.go", resourceName),
+		OutputTestFile: fmt.Sprintf("%s_resource_list_test.go", resourceName),
+		AzureSDKImport: fmt.Sprintf(`"github.com/hashicorp/go-azure-sdk/resource-manager/sql/2023-08-01-preview/%s"`, resourceLower),
+	}
+}
+
+func parseIDStructure(idStructure string) (string, string, string) {
+	parts := strings.Split(idStructure, ".")
+	name := strings.TrimSuffix(parts[1], "Id") // Remove "Id" suffix for type name
+	return parts[0], parts[1], name
+}

--- a/internal/tools/scaff/commands/list_resource.go
+++ b/internal/tools/scaff/commands/list_resource.go
@@ -175,7 +175,7 @@ func (input *ResourceInput) parseArgs(args []string) (errs []error) {
 	case input.IDStructure == "":
 		errs = append(errs, errors.New("id_structure is required"))
 	case input.Path == "":
-		input.Path = fmt.Sprintf(".")
+		input.Path = fmt.Sprint(".")
 	}
 
 	return
@@ -233,10 +233,8 @@ func derive(input ResourceInput) *ListResourceData {
 	parentLower := strings.ToLower(parent)
 	serviceLower := strings.ToLower(service)
 	resourceLower := strings.ToLower(resource)
-	useResourceGroup := false
-	if parentLower == "resourcegroup" || parentLower == "" {
-		useResourceGroup = true
-	}
+	useResourceGroup := parentLower == "resourcegroup" || parentLower == ""
+
 	terraformName := fmt.Sprintf(
 		"azurerm_%s_%s",
 		serviceLower,

--- a/internal/tools/scaff/commands/list_resource.go
+++ b/internal/tools/scaff/commands/list_resource.go
@@ -175,7 +175,7 @@ func (input *ResourceInput) parseArgs(args []string) (errs []error) {
 	case input.IDStructure == "":
 		errs = append(errs, errors.New("id_structure is required"))
 	case input.Path == "":
-		input.Path = fmt.Sprint(".")
+		input.Path = "."
 	}
 
 	return

--- a/internal/tools/scaff/commands/list_resource.go
+++ b/internal/tools/scaff/commands/list_resource.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-
 	"os"
 	"path/filepath"
 	"strings"

--- a/internal/tools/scaff/commands/templates/list.go.gotpl
+++ b/internal/tools/scaff/commands/templates/list.go.gotpl
@@ -1,0 +1,152 @@
+// Copyright IBM Corp.
+// SPDX-License-Identifier: MPL-2.0
+
+package {{ .PackageName }}
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-azure-helpers/framework/typehelpers"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+
+	{{ .AzureSDKImport }}
+)
+
+type {{ .ListResourceStruct }} struct{}
+{{- if .UseResourceGroup }}
+{{- else }}
+type {{ .ModelStruct }} struct {
+	{{.Parent}}Id types.String `tfsdk:"{{.ParentLower}}_id"`
+}
+{{- end }}
+
+var _ sdk.FrameworkListWrappedResource = new({{ .ListResourceStruct }})
+
+func (r {{ .ListResourceStruct }}) ResourceFunc() *pluginsdk.Resource {
+	return resource{{.ServiceName }}{{.ResourceName}}()
+}
+
+func (r {{ .ListResourceStruct }}) Metadata( _ context.Context, _ resource.MetadataRequest, response *resource.MetadataResponse) {
+	response.TypeName = "{{ .TerraformResourceName }}"
+}
+
+
+{{- if .UseResourceGroup }}
+{{- else }}
+func (r {{ .ListResourceStruct }}) ListResourceConfigSchema(_ context.Context,_ list.ListResourceSchemaRequest,response *list.ListResourceSchemaResponse) {
+	response.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"{{.ParentLower}}_id": schema.StringAttribute{
+				Required: true,
+				Validators: []validator.String{
+					typehelpers.WrappedStringValidator{
+						Func: {{ .IdPackage }}.Validate{{ .IdType }},
+					},
+				},
+			},
+		},
+	}
+}
+{{- end }}
+
+func (r {{ .ListResourceStruct }}) List( ctx context.Context, request list.ListRequest, stream *list.ListResultsStream, metadata sdk.ResourceMetadata) {
+	client := metadata.Client.{{ .PackageName }}.{{.ResourceName}}sClient
+
+{{- if .UseResourceGroup }}
+	var data sdk.DefaultListModel
+{{- else }}
+	var data {{ .ModelStruct }}
+{{- end }}
+	diags := request.Config.Get(ctx, &data)
+	if diags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	results := make([]{{ .ResourceLower }}s.{{.ResourceName}}, 0)
+
+{{- if .UseResourceGroup }}
+	subscriptionID := metadata.SubscriptionId
+	if !data.SubscriptionId.IsNull() {
+		subscriptionID = data.SubscriptionId.ValueString()
+	}
+
+switch {
+	case !data.ResourceGroupName.IsNull():
+		resp, err := client.ListComplete(ctx, commonids.NewResourceGroupID(subscriptionID, data.ResourceGroupName.ValueString()))
+		if err != nil {
+			sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("listing `%s`", `{{ .TerraformResourceName }}`), err)
+			return
+		}
+
+		results = resp.Items
+	default:
+		resp, err := client.ListAllComplete(ctx, commonids.NewSubscriptionID(subscriptionID))
+		if err != nil {
+			sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("listing `%s`", `{{ .TerraformResourceName }}`), err)
+			return
+		}
+
+		results = resp.Items
+	}
+{{- else }}
+
+	if !data.{{.Parent}}Id.IsNull() {
+		{{.ParentLower}}Id, err := {{ .IdPackage }}.Parse{{ .IdType }}(data.{{.Parent}}Id.ValueString())
+		if err != nil {
+			sdk.SetResponseErrorDiagnostic( stream, fmt.Sprintf("parsing {{.PackageName}} {{ .Parent }} ID for `%s`", "{{ .TerraformResourceName }}"), err)
+			return
+		}
+
+		resp, err := client.ListBy{{.Parent}}Complete(ctx, *{{.ParentLower}}Id, {{.ResourceLower }}s.DefaultListBy{{.Parent}}OperationOptions())
+		if err != nil {
+			sdk.SetResponseErrorDiagnostic( stream, fmt.Sprintf("listing `%s`", "{{ .TerraformResourceName }}"), err)
+			return
+		}
+
+		results = resp.Items
+	}
+{{- end }}
+
+	stream.Results = func(push func(list.ListResult) bool) {
+		for _, {{ .ResourceLower}} := range results {
+			result := request.NewListResult(ctx)
+
+			result.DisplayName = pointer.From({{ .ResourceLower}}.Name)
+
+			rd := resource{{.ServiceName}}{{ .ResourceName }}().Data(&terraform.InstanceState{})
+
+			id, err := {{ .IdPackage }}.Parse{{ .IdType }}(pointer.From({{ .ResourceLower}}.Id))
+			if err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult( result, push, "parsing {{ .ChildDisplayName }} ID", err)
+				return
+			}
+
+			rd.SetId(id.ID())
+
+			if err := resource{{.ServiceName}}{{ .ResourceName }}Flatten(rd, id, &{{ .ResourceLower}}); err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult( result, push, fmt.Sprintf( 	"encoding `%s` resource data", 	"{{ .TerraformResourceName }}", ), err)
+				return
+			}
+
+						sdk.EncodeListResult(ctx, rd, &result)
+			if result.Diagnostics.HasError() {
+				push(result)
+				return
+			}
+			if !push(result) {
+				return
+			}
+		}
+	}
+}

--- a/internal/tools/scaff/commands/templates/list.go.gotpl
+++ b/internal/tools/scaff/commands/templates/list.go.gotpl
@@ -19,14 +19,13 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 
-	{{ .AzureSDKImport }}
 )
 
 type {{ .ListResourceStruct }} struct{}
 {{- if .UseResourceGroup }}
 {{- else }}
 type {{ .ModelStruct }} struct {
-	{{.Parent}}Id types.String `tfsdk:"{{.ParentLower}}_id"`
+	{{.Parent}}Id types.String `tfsdk:"{{ToSnake .Parent}}_id"`
 }
 {{- end }}
 
@@ -43,10 +42,10 @@ func (r {{ .ListResourceStruct }}) Metadata( _ context.Context, _ resource.Metad
 
 {{- if .UseResourceGroup }}
 {{- else }}
-func (r {{ .ListResourceStruct }}) ListResourceConfigSchema(_ context.Context,_ list.ListResourceSchemaRequest,response *list.ListResourceSchemaResponse) {
+func (r {{ .ListResourceStruct }}) ListResourceConfigSchema( _ context.Context,_ list.ListResourceSchemaRequest,response *list.ListResourceSchemaResponse) {
 	response.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
-			"{{.ParentLower}}_id": schema.StringAttribute{
+			"{{ToSnake .Parent}}_id": schema.StringAttribute{
 				Required: true,
 				Validators: []validator.String{
 					typehelpers.WrappedStringValidator{
@@ -139,7 +138,7 @@ switch {
 				return
 			}
 
-						sdk.EncodeListResult(ctx, rd, &result)
+			sdk.EncodeListResult(ctx, rd, &result)
 			if result.Diagnostics.HasError() {
 				push(result)
 				return

--- a/internal/tools/scaff/commands/templates/list_document.html.markdown.gotpl
+++ b/internal/tools/scaff/commands/templates/list_document.html.markdown.gotpl
@@ -1,0 +1,39 @@
+---
+subcategory: "{{ .Section }}"
+layout: "azurerm"
+page_title: "Azure Resource Manager: {{ .Resource }}"
+description: |-
+    Lists {{ .FriendlyTitle }} resources.
+---
+
+# List resource: {{ .Resource }}
+
+Lists {{ .FriendlyTitle }} resources.
+
+## Example Usage
+
+{{- range .Examples }}
+
+### {{ .Heading }}
+
+```hcl
+list "{{ $.Resource }}" "example" {
+  provider = azurerm
+  config {
+  {{- if .AttributeName }}
+    {{ .AttributeName }} = {{ .AttributeExampleValue }}
+  {{- end }}
+  }
+}
+```
+{{- end }}
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+{{- range .Arguments }}
+
+* `{{ .Name }}` - ({{ .Requirement }}) {{ .Description }}
+
+{{- end }}

--- a/internal/tools/scaff/commands/templates/list_document.html.markdown.gotpl
+++ b/internal/tools/scaff/commands/templates/list_document.html.markdown.gotpl
@@ -1,5 +1,5 @@
 ---
-subcategory: "{{ .Section }}"
+subcategory: "{{ .SubCategory }}"
 layout: "azurerm"
 page_title: "Azure Resource Manager: {{ .Resource }}"
 description: |-

--- a/internal/tools/scaff/commands/templates/list_test.go.gotpl
+++ b/internal/tools/scaff/commands/templates/list_test.go.gotpl
@@ -1,0 +1,116 @@
+package {{ .PackageName }}_test
+
+import (
+	"context"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAcc{{ .ServiceName }}{{ .ResourceName }}_listBy{{ if .UseResourceGroup }}SubscriptionAndRG{{ else}}{{ .Parent }}ID{{ end}}(t *testing.T) {
+	data := acceptance.BuildTestData( t, "{{ .TerraformResourceName }}", "testlist1")
+	r := {{ .ResourceStruct }}{}
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit( context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basic(data),
+			},
+{{- if .UseResourceGroup }}
+			{
+				Query:  true,
+				Config: r.basicQuery(),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLengthAtLeast("{{ .TerraformResourceName }}.list", 1), // expect at least the 1 we created
+					querycheck.ExpectIdentity(
+						"{{ .TerraformResourceName }}.list",
+						map[string]knownvalue.Check{
+							"name":                knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"resource_group_name": knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"subscription_id":     knownvalue.StringExact(data.Subscriptions.Primary),
+						},
+					),
+				},
+			},
+			{
+				Query:  true,
+				Config: r.basicQueryByResourceGroupName(),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLength("{{ .TerraformResourceName }}.list", 1), // expect at least the 1 we created
+					querycheck.ExpectIdentity(
+						"{{ .TerraformResourceName }}.list",
+						map[string]knownvalue.Check{
+							"name":                knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"resource_group_name": knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"subscription_id":     knownvalue.StringExact(data.Subscriptions.Primary),
+						},
+					),
+				},
+			},
+{{- else }}
+			{
+				Query:  true,
+				Config: r.basicQuery(data),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLengthAtLeast("{{ .TerraformResourceName }}.list",1),
+					querycheck.ExpectIdentity(
+						"{{ .TerraformResourceName }}.list",
+						map[string]knownvalue.Check{
+							"name": knownvalue.StringRegexp( regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"resource_group_name": knownvalue.StringRegexp( regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"{{ .Parent }}_name": knownvalue.StringRegexp( regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"subscription_id": knownvalue.StringExact( data.Subscriptions.Primary),
+						},
+					),
+				},
+			},
+{{- end }}
+		},
+	})
+}
+
+{{- if .UseResourceGroup }}
+func (r {{ .ResourceStruct }}) basicQuery() string {
+	return `
+list "{{ .TerraformResourceName }}" "list" {
+  provider = azurerm
+  config {
+  }
+}
+`
+}
+
+func (r {{ .ResourceStruct }}) basicQueryByResourceGroupName() string {
+	return `
+list "{{ .TerraformResourceName }}" "list" {
+  provider = azurerm
+  config {
+    resource_group_name = azurerm_resource_group.test.name
+  }
+}
+`
+}
+{{- else }}
+
+func (r {{ .ResourceStruct }}) basicQuery(data acceptance.TestData) string {
+	return `
+list "{{ .TerraformResourceName }}" "list" {
+  provider = azurerm
+  config {
+    {{ .Parent }}_id = azurerm_{{ .PackageName }}_{{ .Parent }}.test.id
+  }
+}
+`
+}
+{{- end }}

--- a/internal/tools/scaff/commands/templates/list_test.go.gotpl
+++ b/internal/tools/scaff/commands/templates/list_test.go.gotpl
@@ -15,14 +15,14 @@ import (
 )
 
 func TestAcc{{ .ServiceName }}{{ .ResourceName }}_listBy{{ if .UseResourceGroup }}SubscriptionAndRG{{ else}}{{ .Parent }}ID{{ end}}(t *testing.T) {
-	data := acceptance.BuildTestData( t, "{{ .TerraformResourceName }}", "testlist1")
+	data := acceptance.BuildTestData(t, "{{ .TerraformResourceName }}", "testlist1")
 	r := {{ .ResourceStruct }}{}
 
 	resource.Test(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_14_0),
 		},
-		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit( context.Background(), "azurerm"),
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
 		Steps: []resource.TestStep{
 			{
 				Config: r.basic(data),
@@ -63,14 +63,14 @@ func TestAcc{{ .ServiceName }}{{ .ResourceName }}_listBy{{ if .UseResourceGroup 
 				Query:  true,
 				Config: r.basicQuery(data),
 				QueryResultChecks: []querycheck.QueryResultCheck{
-					querycheck.ExpectLengthAtLeast("{{ .TerraformResourceName }}.list",1),
+					querycheck.ExpectLengthAtLeast("{{ .TerraformResourceName }}.list", 1),
 					querycheck.ExpectIdentity(
 						"{{ .TerraformResourceName }}.list",
 						map[string]knownvalue.Check{
-							"name": knownvalue.StringRegexp( regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
-							"resource_group_name": knownvalue.StringRegexp( regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
-							"{{ .Parent }}_name": knownvalue.StringRegexp( regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
-							"subscription_id": knownvalue.StringExact( data.Subscriptions.Primary),
+							"name": knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"resource_group_name": knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"{{ToSnake .ParentTerraformResourceName }}_name": knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"subscription_id": knownvalue.StringExact(data.Subscriptions.Primary),
 						},
 					),
 				},
@@ -85,8 +85,7 @@ func (r {{ .ResourceStruct }}) basicQuery() string {
 	return `
 list "{{ .TerraformResourceName }}" "list" {
   provider = azurerm
-  config {
-  }
+  config {}
 }
 `
 }
@@ -108,7 +107,7 @@ func (r {{ .ResourceStruct }}) basicQuery(data acceptance.TestData) string {
 list "{{ .TerraformResourceName }}" "list" {
   provider = azurerm
   config {
-    {{ .Parent }}_id = azurerm_{{ .PackageName }}_{{ .Parent }}.test.id
+    {{ToSnake .ParentTerraformResourceName }}_id = azurerm_{{ToSnake .ParentTerraformResourceName }}.test.id
   }
 }
 `

--- a/internal/tools/scaff/main.go
+++ b/internal/tools/scaff/main.go
@@ -34,6 +34,16 @@ func realMain(args []string) int {
 				Ui: ui,
 			}, nil
 		},
+		"list-documentation": func() (cli.Command, error) {
+			return &commands.ListDocumentationCommand{
+				Ui: ui,
+			}, nil
+		},
+		"list-resource": func() (cli.Command, error) {
+			return &commands.ListResourceCommand{
+				Ui: ui,
+			}, nil
+		},
 	}
 
 	gen := cli.CLI{


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


adds to scaff the ability to generate list-resource and documentation for the list resource

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
