### PR TITLE
Storagesync identity list

### DIFF
--- a/internal/services/storage/registration.go
+++ b/internal/services/storage/registration.go
@@ -115,5 +115,6 @@ func (r Registration) ListResources() []sdk.FrameworkListWrappedResource {
 	return []sdk.FrameworkListWrappedResource{
 		StorageAccountCustomerManagedKeyListResource{},
 		StorageAccountListResource{},
+		StorageSyncListResource{},
 	}
 }

--- a/internal/services/storage/storage_sync_resource.go
+++ b/internal/services/storage/storage_sync_resource.go
@@ -4,6 +4,7 @@
 package storage
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
@@ -15,6 +16,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/registeredserverresource"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/storagesyncservicesresource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
@@ -23,6 +25,8 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name storage_sync -service-package-name storage -properties "name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
+
 func resourceStorageSync() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
 		Create: resourceStorageSyncCreate,
@@ -30,10 +34,11 @@ func resourceStorageSync() *pluginsdk.Resource {
 		Update: resourceStorageSyncUpdate,
 		Delete: resourceStorageSyncDelete,
 
-		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := storagesyncservicesresource.ParseStorageSyncServiceID(id)
-			return err
-		}),
+		Importer: pluginsdk.ImporterValidatingIdentity(&storagesyncservicesresource.StorageSyncServiceId{}),
+
+		Identity: &schema.ResourceIdentity{
+			SchemaFunc: pluginsdk.GenerateIdentitySchema(&storagesyncservicesresource.StorageSyncServiceId{}),
+		},
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
@@ -107,6 +112,10 @@ func resourceStorageSyncCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 	}
 
 	d.SetId(id.ID())
+	if err = pluginsdk.SetResourceIdentityData(d, &id); err != nil {
+		return err
+	}
+
 	return resourceStorageSyncRead(d, meta)
 }
 
@@ -130,16 +139,22 @@ func resourceStorageSyncRead(d *pluginsdk.ResourceData, meta interface{}) error 
 		}
 		return fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
+
+	return resourceStorageSyncFlatten(ctx, d, id, resp.Model, registeredServerClient)
+}
+
+func resourceStorageSyncFlatten(ctx context.Context, d *pluginsdk.ResourceData, id *storagesyncservicesresource.StorageSyncServiceId, model *storagesyncservicesresource.StorageSyncService, registeredServerClient *registeredserverresource.RegisteredServerResourceClient) error {
 	d.Set("name", id.StorageSyncServiceName)
 	d.Set("resource_group_name", id.ResourceGroupName)
-	if model := resp.Model; model != nil {
+
+	if model != nil {
 		d.Set("location", location.Normalize(model.Location))
 
 		if props := model.Properties; props != nil {
 			d.Set("incoming_traffic_policy", string(pointer.From(props.IncomingTrafficPolicy)))
 		}
 
-		if err = tags.FlattenAndSet(d, model.Tags); err != nil {
+		if err := tags.FlattenAndSet(d, model.Tags); err != nil {
 			return fmt.Errorf("setting `tags`: %+v", err)
 		}
 	}
@@ -152,19 +167,19 @@ func resourceStorageSyncRead(d *pluginsdk.ResourceData, meta interface{}) error 
 		}
 	}
 
-	if model := registeredServersResp.Model; model != nil && model.Value != nil {
-		registeredServers := make([]interface{}, 0)
-		for _, registeredServer := range *model.Value {
+	if serverModel := registeredServersResp.Model; serverModel != nil && serverModel.Value != nil {
+		registeredServers := make([]interface{}, 0, len(*serverModel.Value))
+		for _, registeredServer := range *serverModel.Value {
 			if registeredServer.Id != nil {
 				registeredServers = append(registeredServers, *registeredServer.Id)
 			}
 		}
-		if err = d.Set("registered_servers", registeredServers); err != nil {
+		if err := d.Set("registered_servers", registeredServers); err != nil {
 			return fmt.Errorf("setting `registered_servers`: %+v", err)
 		}
 	}
 
-	return nil
+	return pluginsdk.SetResourceIdentityData(d, id)
 }
 
 func resourceStorageSyncUpdate(d *pluginsdk.ResourceData, meta interface{}) error {

--- a/internal/services/storage/storage_sync_resource.go
+++ b/internal/services/storage/storage_sync_resource.go
@@ -25,6 +25,8 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
+const storageSyncResourceName = "azurerm_storage_sync"
+
 //go:generate go run ../../tools/generator-tests resourceidentity -resource-name storage_sync -service-package-name storage -properties "name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
 
 func resourceStorageSync() *pluginsdk.Resource {
@@ -96,7 +98,7 @@ func resourceStorageSyncCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 		}
 	}
 	if !response.WasNotFound(existing.HttpResponse) {
-		return tf.ImportAsExistsError("azurerm_storage_sync", id.ID())
+		return tf.ImportAsExistsError(storageSyncResourceName, id.ID())
 	}
 
 	parameters := storagesyncservicesresource.StorageSyncServiceCreateParameters{

--- a/internal/services/storage/storage_sync_resource.go
+++ b/internal/services/storage/storage_sync_resource.go
@@ -140,10 +140,10 @@ func resourceStorageSyncRead(d *pluginsdk.ResourceData, meta interface{}) error 
 		return fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return resourceStorageSyncFlatten(ctx, d, id, resp.Model, registeredServerClient)
+	return resourceStorageSyncFlatten(ctx, d, id, resp.Model, registeredServerClient, true)
 }
 
-func resourceStorageSyncFlatten(ctx context.Context, d *pluginsdk.ResourceData, id *storagesyncservicesresource.StorageSyncServiceId, model *storagesyncservicesresource.StorageSyncService, registeredServerClient *registeredserverresource.RegisteredServerResourceClient) error {
+func resourceStorageSyncFlatten(ctx context.Context, d *pluginsdk.ResourceData, id *storagesyncservicesresource.StorageSyncServiceId, model *storagesyncservicesresource.StorageSyncService, registeredServerClient *registeredserverresource.RegisteredServerResourceClient, includeRegisteredServers bool) error {
 	d.Set("name", id.StorageSyncServiceName)
 	d.Set("resource_group_name", id.ResourceGroupName)
 
@@ -159,23 +159,25 @@ func resourceStorageSyncFlatten(ctx context.Context, d *pluginsdk.ResourceData, 
 		}
 	}
 
-	storageSyncId := registeredserverresource.NewStorageSyncServiceID(id.SubscriptionId, id.ResourceGroupName, id.StorageSyncServiceName)
-	registeredServersResp, err := registeredServerClient.RegisteredServersListByStorageSyncService(ctx, storageSyncId)
-	if err != nil {
-		if !response.WasNotFound(registeredServersResp.HttpResponse) {
-			return fmt.Errorf("retrieving registered servers for %s: %+v", id, err)
-		}
-	}
-
-	if serverModel := registeredServersResp.Model; serverModel != nil && serverModel.Value != nil {
-		registeredServers := make([]interface{}, 0, len(*serverModel.Value))
-		for _, registeredServer := range *serverModel.Value {
-			if registeredServer.Id != nil {
-				registeredServers = append(registeredServers, *registeredServer.Id)
+	if includeRegisteredServers {
+		storageSyncId := registeredserverresource.NewStorageSyncServiceID(id.SubscriptionId, id.ResourceGroupName, id.StorageSyncServiceName)
+		registeredServersResp, err := registeredServerClient.RegisteredServersListByStorageSyncService(ctx, storageSyncId)
+		if err != nil {
+			if !response.WasNotFound(registeredServersResp.HttpResponse) {
+				return fmt.Errorf("retrieving registered servers for %s: %+v", id, err)
 			}
 		}
-		if err := d.Set("registered_servers", registeredServers); err != nil {
-			return fmt.Errorf("setting `registered_servers`: %+v", err)
+
+		if serverModel := registeredServersResp.Model; serverModel != nil && serverModel.Value != nil {
+			registeredServers := make([]interface{}, 0, len(*serverModel.Value))
+			for _, registeredServer := range *serverModel.Value {
+				if registeredServer.Id != nil {
+					registeredServers = append(registeredServers, *registeredServer.Id)
+				}
+			}
+			if err := d.Set("registered_servers", registeredServers); err != nil {
+				return fmt.Errorf("setting `registered_servers`: %+v", err)
+			}
 		}
 	}
 

--- a/internal/services/storage/storage_sync_resource_identity_gen_test.go
+++ b/internal/services/storage/storage_sync_resource_identity_gen_test.go
@@ -1,0 +1,39 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package storage_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
+)
+
+func TestAccStorageSync_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_sync", "test")
+	r := StorageSyncResource{}
+
+	checkedFields := map[string]struct{}{
+		"subscription_id":     {},
+		"name":                {},
+		"resource_group_name": {},
+	}
+
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				customstatecheck.ExpectAllIdentityFieldsAreChecked("azurerm_storage_sync.test", checkedFields),
+				statecheck.ExpectIdentityValue("azurerm_storage_sync.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_storage_sync.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_storage_sync.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
+			},
+		},
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
+}

--- a/internal/services/storage/storage_sync_resource_list.go
+++ b/internal/services/storage/storage_sync_resource_list.go
@@ -26,7 +26,7 @@ func (r StorageSyncListResource) ResourceFunc() *pluginsdk.Resource {
 }
 
 func (r StorageSyncListResource) Metadata(_ context.Context, _ resource.MetadataRequest, response *resource.MetadataResponse) {
-	response.TypeName = "azurerm_storage_sync"
+	response.TypeName = storageSyncResourceName
 }
 
 func (r StorageSyncListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream, metadata sdk.ResourceMetadata) {
@@ -49,7 +49,7 @@ func (r StorageSyncListResource) List(ctx context.Context, request list.ListRequ
 	case !data.ResourceGroupName.IsNull():
 		resp, err := client.StorageSyncServicesListByResourceGroup(ctx, commonids.NewResourceGroupID(subscriptionID, data.ResourceGroupName.ValueString()))
 		if err != nil {
-			sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("listing `%s`", "azurerm_storage_sync"), err)
+			sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("listing `%s`", storageSyncResourceName), err)
 			return
 		}
 
@@ -59,7 +59,7 @@ func (r StorageSyncListResource) List(ctx context.Context, request list.ListRequ
 	default:
 		resp, err := client.StorageSyncServicesListBySubscription(ctx, commonids.NewSubscriptionID(subscriptionID))
 		if err != nil {
-			sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("listing `%s`", "azurerm_storage_sync"), err)
+			sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("listing `%s`", storageSyncResourceName), err)
 			return
 		}
 
@@ -83,7 +83,7 @@ func (r StorageSyncListResource) List(ctx context.Context, request list.ListRequ
 			rd.SetId(id.ID())
 
 			if err := resourceStorageSyncFlatten(ctx, rd, id, &item, metadata.Client.Storage.SyncRegisteredServerClient, request.IncludeResource); err != nil {
-				sdk.SetErrorDiagnosticAndPushListResult(result, push, fmt.Sprintf("encoding `%s` resource data", "azurerm_storage_sync"), err)
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, fmt.Sprintf("encoding `%s` resource data", storageSyncResourceName), err)
 				return
 			}
 

--- a/internal/services/storage/storage_sync_resource_list.go
+++ b/internal/services/storage/storage_sync_resource_list.go
@@ -1,0 +1,101 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package storage
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/storagesyncservicesresource"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type StorageSyncListResource struct{}
+
+var _ sdk.FrameworkListWrappedResource = new(StorageSyncListResource)
+
+func (r StorageSyncListResource) ResourceFunc() *pluginsdk.Resource {
+	return resourceStorageSync()
+}
+
+func (r StorageSyncListResource) Metadata(_ context.Context, _ resource.MetadataRequest, response *resource.MetadataResponse) {
+	response.TypeName = "azurerm_storage_sync"
+}
+
+func (r StorageSyncListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream, metadata sdk.ResourceMetadata) {
+	client := metadata.Client.Storage.SyncServiceClient
+
+	var data sdk.DefaultListModel
+	if diags := request.Config.Get(ctx, &data); diags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	subscriptionID := metadata.SubscriptionId
+	if !data.SubscriptionId.IsNull() {
+		subscriptionID = data.SubscriptionId.ValueString()
+	}
+
+	results := make([]storagesyncservicesresource.StorageSyncService, 0)
+
+	switch {
+	case !data.ResourceGroupName.IsNull():
+		resp, err := client.StorageSyncServicesListByResourceGroup(ctx, commonids.NewResourceGroupID(subscriptionID, data.ResourceGroupName.ValueString()))
+		if err != nil {
+			sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("listing `%s`", "azurerm_storage_sync"), err)
+			return
+		}
+
+		if resp.Model != nil && resp.Model.Value != nil {
+			results = *resp.Model.Value
+		}
+	default:
+		resp, err := client.StorageSyncServicesListBySubscription(ctx, commonids.NewSubscriptionID(subscriptionID))
+		if err != nil {
+			sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("listing `%s`", "azurerm_storage_sync"), err)
+			return
+		}
+
+		if resp.Model != nil && resp.Model.Value != nil {
+			results = *resp.Model.Value
+		}
+	}
+
+	stream.Results = func(push func(list.ListResult) bool) {
+		for _, item := range results {
+			result := request.NewListResult(ctx)
+			result.DisplayName = pointer.From(item.Name)
+
+			id, err := storagesyncservicesresource.ParseStorageSyncServiceIDInsensitively(pointer.From(item.Id))
+			if err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, "parsing Storage Sync Service ID", err)
+				return
+			}
+
+			rd := resourceStorageSync().Data(&terraform.InstanceState{})
+			rd.SetId(id.ID())
+
+			if err := resourceStorageSyncFlatten(ctx, rd, id, &item, metadata.Client.Storage.SyncRegisteredServerClient); err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, fmt.Sprintf("encoding `%s` resource data", "azurerm_storage_sync"), err)
+				return
+			}
+
+			sdk.EncodeListResult(ctx, rd, &result)
+			if result.Diagnostics.HasError() {
+				push(result)
+				return
+			}
+
+			if !push(result) {
+				return
+			}
+		}
+	}
+}

--- a/internal/services/storage/storage_sync_resource_list.go
+++ b/internal/services/storage/storage_sync_resource_list.go
@@ -82,7 +82,7 @@ func (r StorageSyncListResource) List(ctx context.Context, request list.ListRequ
 			rd := resourceStorageSync().Data(&terraform.InstanceState{})
 			rd.SetId(id.ID())
 
-			if err := resourceStorageSyncFlatten(ctx, rd, id, &item, metadata.Client.Storage.SyncRegisteredServerClient); err != nil {
+			if err := resourceStorageSyncFlatten(ctx, rd, id, &item, metadata.Client.Storage.SyncRegisteredServerClient, request.IncludeResource); err != nil {
 				sdk.SetErrorDiagnosticAndPushListResult(result, push, fmt.Sprintf("encoding `%s` resource data", "azurerm_storage_sync"), err)
 				return
 			}

--- a/internal/services/storage/storage_sync_resource_list_test.go
+++ b/internal/services/storage/storage_sync_resource_list_test.go
@@ -1,0 +1,86 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package storage_test
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccStorageSync_list(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_sync", "test")
+	r := StorageSyncResource{}
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basic(data),
+			},
+			{
+				Query:  true,
+				Config: r.basicListQuery(),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLengthAtLeast("azurerm_storage_sync.list", 1),
+					querycheck.ExpectIdentity(
+						"azurerm_storage_sync.list",
+						map[string]knownvalue.Check{
+							"name":                knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"resource_group_name": knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"subscription_id":     knownvalue.StringExact(data.Subscriptions.Primary),
+						},
+					),
+				},
+			},
+			{
+				Query:  true,
+				Config: r.basicListQueryByResourceGroupName(data),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLength("azurerm_storage_sync.list", 1),
+					querycheck.ExpectIdentity(
+						"azurerm_storage_sync.list",
+						map[string]knownvalue.Check{
+							"name":                knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"resource_group_name": knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"subscription_id":     knownvalue.StringExact(data.Subscriptions.Primary),
+						},
+					),
+				},
+			},
+		},
+	})
+}
+
+func (StorageSyncResource) basicListQuery() string {
+	return `
+list "azurerm_storage_sync" "list" {
+  provider = azurerm
+  config {}
+}
+`
+}
+
+func (StorageSyncResource) basicListQueryByResourceGroupName(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+list "azurerm_storage_sync" "list" {
+  provider = azurerm
+  config {
+    resource_group_name = "acctestRG-ss-%d"
+  }
+}
+`, data.RandomInteger)
+}

--- a/website/docs/list-resources/storage_sync.html.markdown
+++ b/website/docs/list-resources/storage_sync.html.markdown
@@ -1,0 +1,41 @@
+---
+subcategory: "Storage"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_storage_sync"
+description: |-
+  Lists Storage Sync resources.
+---
+
+# List resource: azurerm_storage_sync
+
+Lists Storage Sync resources.
+
+## Example Usage
+
+### List all Storage Sync resources in the subscription
+
+```hcl
+list "azurerm_storage_sync" "example" {
+  provider = azurerm
+  config {}
+}
+```
+
+### List all Storage Sync resources in a specific resource group
+
+```hcl
+list "azurerm_storage_sync" "example" {
+  provider = azurerm
+  config {
+    resource_group_name = "example-rg"
+  }
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `resource_group_name` - (Optional) The name of the resource group to query.
+
+* `subscription_id` - (Optional) The Subscription ID to query. Defaults to the value specified in the Provider Configuration.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
List and identity implementation for azurerm_storage_sync
Teamcity run: https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_STORAGE/632009?buildTab=overview


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
