### PR TITLE
`azurerm_kubernetes_cluster_node_pool`: fix subnet lock to use resource ID instead of name

### DIFF
--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -649,20 +649,20 @@ func resourceKubernetesClusterNodePoolCreate(d *pluginsdk.ResourceData, meta int
 		profile.OsDiskType = pointer.To(agentpools.OSDiskType(osDiskType))
 	}
 
-	subnetsToLock := make([]string, 0)
+	subnetIDsToLock := make([]string, 0)
 	if podSubnetID != nil {
 		// Lock pod subnet to avoid race condition with AKS
 		profile.PodSubnetID = pointer.To(podSubnetID.ID())
-		subnetsToLock = append(subnetsToLock, podSubnetID.SubnetName)
+		subnetIDsToLock = append(subnetIDsToLock, podSubnetID.ID())
 	}
 
 	if nodeSubnetID != nil {
 		// Lock node subnet to avoid race condition with AKS
 		profile.VnetSubnetID = pointer.To(nodeSubnetID.ID())
-		subnetsToLock = append(subnetsToLock, nodeSubnetID.SubnetName)
+		subnetIDsToLock = append(subnetIDsToLock, nodeSubnetID.ID())
 	}
-	locks.MultipleByName(&subnetsToLock, network.SubnetResourceName)
-	defer locks.UnlockMultipleByName(&subnetsToLock, network.SubnetResourceName)
+	locks.MultipleByID(&subnetIDsToLock)
+	defer locks.UnlockMultipleByID(&subnetIDsToLock)
 
 	if hostGroupID := d.Get("host_group_id").(string); hostGroupID != "" {
 		profile.HostGroupID = pointer.To(hostGroupID)

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -3857,3 +3857,129 @@ resource "azurerm_kubernetes_cluster_node_pool" "pool2" {
 		data.RandomInteger,     // kubernetes_cluster dns_prefix
 	)
 }
+
+func TestAccKubernetesClusterNodePool_parallelCrossVNetSameSubnetName(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster_node_pool", "test")
+	r := KubernetesClusterNodePoolResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.parallelCrossVNetSameSubnetNameConfig(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That("azurerm_kubernetes_cluster_node_pool.pool1").ExistsInAzure(r),
+				check.That("azurerm_kubernetes_cluster_node_pool.pool2").ExistsInAzure(r),
+			),
+		},
+		data.ImportStepFor("azurerm_kubernetes_cluster_node_pool.pool1"),
+		data.ImportStepFor("azurerm_kubernetes_cluster_node_pool.pool2"),
+	})
+}
+
+func (KubernetesClusterNodePoolResource) parallelCrossVNetSameSubnetNameConfig(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_virtual_network" "test1" {
+  name                = "acctestnw1-%[1]d"
+  address_space       = ["10.0.0.0/8"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "nodesubnet1" {
+  name                 = "nodesubnet"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test1.name
+  address_prefixes     = ["10.240.0.0/16"]
+}
+
+resource "azurerm_virtual_network" "test2" {
+  name                = "acctestnw2-%[1]d"
+  address_space       = ["172.16.0.0/12"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "nodesubnet2" {
+  name                 = "nodesubnet"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test2.name
+  address_prefixes     = ["172.16.0.0/16"]
+}
+
+resource "azurerm_kubernetes_cluster" "test1" {
+  name                = "acctestaks1%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks1%[1]d"
+  sku_tier            = "Standard"
+  default_node_pool {
+    name           = "default"
+    node_count     = 1
+    vm_size        = "Standard_DS2_v2"
+    vnet_subnet_id = azurerm_subnet.nodesubnet1.id
+    upgrade_settings {
+      max_surge = "10%%"
+    }
+  }
+  network_profile {
+    network_plugin = "azure"
+  }
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_kubernetes_cluster" "test2" {
+  name                = "acctestaks2%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks2%[1]d"
+  sku_tier            = "Standard"
+  default_node_pool {
+    name           = "default"
+    node_count     = 1
+    vm_size        = "Standard_DS2_v2"
+    vnet_subnet_id = azurerm_subnet.nodesubnet2.id
+    upgrade_settings {
+      max_surge = "10%%"
+    }
+  }
+  network_profile {
+    network_plugin = "azure"
+  }
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_kubernetes_cluster_node_pool" "pool1" {
+  name                  = "pool1"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.test1.id
+  vm_size               = "Standard_DS2_v2"
+  node_count            = 1
+  vnet_subnet_id        = azurerm_subnet.nodesubnet1.id
+  upgrade_settings {
+    max_surge = "10%%"
+  }
+}
+
+resource "azurerm_kubernetes_cluster_node_pool" "pool2" {
+  name                  = "pool2"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.test2.id
+  vm_size               = "Standard_DS2_v2"
+  node_count            = 1
+  vnet_subnet_id        = azurerm_subnet.nodesubnet2.id
+  upgrade_settings {
+    max_surge = "10%%"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
+}


### PR DESCRIPTION
## Community Note

* Please vote on this PR by adding a :thumbsup: reaction to the original PR to help the community and maintainers prioritize this request.
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR reviewers.

## Description

The subnet mutex in `azurerm_kubernetes_cluster_node_pool` during nodepool creation uses `locks.MultipleByName` with just the subnet **name** (e.g., `"nodesubnet"`) as the lock key. This causes false-positive lock contention when two nodepools in different VNets or clusters use subnets with the same name, serializing operations that could safely run in parallel.

### Root Cause

In `kubernetes_cluster_node_pool_resource.go` (lines 652-665), the lock key is constructed from the subnet name only:

```go
subnetsToLock = append(subnetsToLock, podSubnetID.SubnetName)
subnetsToLock = append(subnetsToLock, nodeSubnetID.SubnetName)
locks.MultipleByName(&subnetsToLock, network.SubnetResourceName)
```

Since `locks.MultipleByName` creates a global mutex key of `"azurerm_subnet." + subnetName`, two completely independent subnets in different VNets with the same name (e.g., `"nodesubnet"`) will contend on the same mutex. The lock is held for the entire duration of the nodepool creation API call + polling (5-20 minutes), causing the second operation to wait unnecessarily.

### Fix

Replace `locks.MultipleByName` with `locks.MultipleByID`, which uses the full Azure resource ID as the lock key. This ensures:
- Operations on the **same actual subnet** are still serialized (protecting against the original race condition)
- Operations on **different subnets** with the same name proceed in parallel

This approach is consistent with the existing pattern in `container_group_resource.go` (line 758), which already uses `locks.ByID(subnet.ID())`.

## Related Issues / PRs

- Fixes #32002 
- Related to #26939 — Previously proposed the same fix (ByName → ByID), closed without merge
- Related to #29537 — Reintroduced subnet name locks (including pod subnet), reintroducing the regression
- Related to #25888 — Original PR that added VNet + subnet name-based locks

## Changes

- **`internal/services/containers/kubernetes_cluster_node_pool_resource.go`**: Changed `locks.MultipleByName(&subnetsToLock, network.SubnetResourceName)` to `locks.MultipleByID(&subnetIDsToLock)`, using full subnet resource IDs as lock keys
- **`internal/services/containers/kubernetes_cluster_node_pool_resource_test.go`**: Added `TestAccKubernetesClusterNodePool_parallelCrossVNetSameSubnetName` acceptance test that creates two AKS clusters with nodepools in different VNets using identically-named subnets

## Testing

- [x] `go build ./internal/services/containers/...` passes
- [x] `go vet ./internal/services/containers/...` passes
- [ ] New acceptance test `TestAccKubernetesClusterNodePool_parallelCrossVNetSameSubnetName` (requires Azure environment)
- [ ] Existing acceptance test `TestAccKubernetesClusterNodePool_parallelPodSubnet` still passes

### New Test: `TestAccKubernetesClusterNodePool_parallelCrossVNetSameSubnetName`

Creates:
- 1 resource group
- 2 virtual networks with non-overlapping address spaces
- 2 subnets with the **same name** (`"nodesubnet"`) in different VNets
- 2 AKS clusters, each in a different VNet
- 2 nodepools (one per cluster), which should create **in parallel** with the fix applied