### PR TITLE
[DRAFT] New Resource: `azurerm_machine_learning_online_endpoint`

### DIFF
--- a/internal/services/machinelearning/client/client.go
+++ b/internal/services/machinelearning/client/client.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/datastore"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/machinelearningcomputes"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/managednetwork"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/workspaces"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
 )
@@ -16,8 +17,9 @@ import (
 type Client struct {
 	Datastore               *datastore.DatastoreClient
 	MachineLearningComputes *machinelearningcomputes.MachineLearningComputesClient
-	Workspaces              *workspaces.WorkspacesClient
 	ManagedNetwork          *managednetwork.ManagedNetworkClient
+	OnlineEndpoints         *onlineendpoint.OnlineEndpointClient
+	Workspaces              *workspaces.WorkspacesClient
 }
 
 func NewClient(o *common.ClientOptions) (*Client, error) {
@@ -45,10 +47,17 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 	}
 	o.Configure(managedNetworkClient.Client, o.Authorizers.ResourceManager)
 
+	onlineEndpointClient, err := onlineendpoint.NewOnlineEndpointClientWithBaseURI(o.Environment.ResourceManager)
+	if err != nil {
+		return nil, fmt.Errorf("building OnlineEndpoint client: %+v", err)
+	}
+	o.Configure(onlineEndpointClient.Client, o.Authorizers.ResourceManager)
+
 	return &Client{
-		MachineLearningComputes: computesClient,
 		Datastore:               datastoreClient,
-		Workspaces:              workspacesClient,
+		MachineLearningComputes: computesClient,
 		ManagedNetwork:          managedNetworkClient,
+		OnlineEndpoints:         onlineEndpointClient,
+		Workspaces:              workspacesClient,
 	}, nil
 }

--- a/internal/services/machinelearning/machine_learning_online_endpoint_resource.go
+++ b/internal/services/machinelearning/machine_learning_online_endpoint_resource.go
@@ -1,0 +1,366 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package machinelearning
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/workspaces"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type MachineLearningOnlineEndpoint struct{}
+
+type MachineLearningOnlineEndpointModel struct {
+	Name                       string                                     `tfschema:"name"`
+	MachineLearningWorkspaceId string                                     `tfschema:"machine_learning_workspace_id"`
+	Location                   string                                     `tfschema:"location"`
+	AuthenticationMode         string                                     `tfschema:"authentication_mode"`
+	Description                string                                     `tfschema:"description"`
+	Identity                   []identity.ModelSystemAssignedUserAssigned `tfschema:"identity"`
+	PublicNetworkAccessEnabled bool                                       `tfschema:"public_network_access_enabled"`
+	Properties                 map[string]interface{}                     `tfschema:"properties"`
+	RestEndpoint               string                                     `tfschema:"rest_endpoint"`
+	SwaggerUri                 string                                     `tfschema:"swagger_uri"`
+	Tags                       map[string]interface{}                     `tfschema:"tags"`
+}
+
+func (r MachineLearningOnlineEndpoint) ModelObject() interface{} {
+	return &MachineLearningOnlineEndpointModel{}
+}
+
+func (r MachineLearningOnlineEndpoint) ResourceType() string {
+	return "azurerm_machine_learning_online_endpoint"
+}
+
+func (r MachineLearningOnlineEndpoint) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return onlineendpoint.ValidateOnlineEndpointID
+}
+
+var _ sdk.ResourceWithUpdate = MachineLearningOnlineEndpoint{}
+var _ sdk.ResourceWithCustomizeDiff = MachineLearningOnlineEndpoint{}
+
+func (r MachineLearningOnlineEndpoint) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+			ValidateFunc: validation.StringMatch(
+				regexp.MustCompile(`^[A-Za-z][A-Za-z0-9-]{1,30}[A-Za-z0-9]$`),
+				"`name` must start with a letter, contain only letters, digits, or dashes, end with a letter or digit, and be between 3 and 32 characters"),
+		},
+
+		"machine_learning_workspace_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: workspaces.ValidateWorkspaceID,
+		},
+
+		"location": commonschema.Location(),
+
+		"authentication_mode": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			Default:      string(onlineendpoint.EndpointAuthModeKey),
+			ValidateFunc: validation.StringInSlice(onlineendpoint.PossibleValuesForEndpointAuthMode(), false),
+		},
+
+		"description": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"identity": commonschema.SystemOrUserAssignedIdentityRequiredForceNew(),
+
+		"public_network_access_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
+
+		"properties": {
+			Type:     pluginsdk.TypeMap,
+			Optional: true,
+			ForceNew: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+
+		"tags": commonschema.Tags(),
+	}
+}
+
+func (r MachineLearningOnlineEndpoint) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"rest_endpoint": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"swagger_uri": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+	}
+}
+
+func (r MachineLearningOnlineEndpoint) CustomizeDiff() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			if metadata.ResourceDiff.Id() != "" && metadata.ResourceDiff.HasChange("description") {
+				return fmt.Errorf("the `description` of a Machine Learning Online Endpoint cannot be changed after creation")
+			}
+
+			return nil
+		},
+	}
+}
+
+func (r MachineLearningOnlineEndpoint) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.MachineLearning.OnlineEndpoints
+			subscriptionId := metadata.Client.Account.SubscriptionId
+
+			var model MachineLearningOnlineEndpointModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			workspaceId, err := workspaces.ParseWorkspaceID(model.MachineLearningWorkspaceId)
+			if err != nil {
+				return fmt.Errorf("parsing `machine_learning_workspace_id`: %+v", err)
+			}
+
+			id := onlineendpoint.NewOnlineEndpointID(subscriptionId, workspaceId.ResourceGroupName, workspaceId.WorkspaceName, model.Name)
+
+			existing, err := client.Get(ctx, id)
+			if err != nil {
+				if !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+				}
+			}
+			if !response.WasNotFound(existing.HttpResponse) {
+				return tf.ImportAsExistsError("azurerm_machine_learning_online_endpoint", id.ID())
+			}
+
+			expandedIdentity, err := identity.ExpandLegacySystemAndUserAssignedMapFromModel(model.Identity)
+			if err != nil {
+				return fmt.Errorf("expanding `identity`: %+v", err)
+			}
+
+			publicNetworkAccess := onlineendpoint.PublicNetworkAccessTypeEnabled
+			if !model.PublicNetworkAccessEnabled {
+				publicNetworkAccess = onlineendpoint.PublicNetworkAccessTypeDisabled
+			}
+
+			properties := onlineendpoint.OnlineEndpoint{
+				AuthMode:            onlineendpoint.EndpointAuthMode(model.AuthenticationMode),
+				Properties:          expandMachineLearningOnlineEndpointProperties(model.Properties),
+				PublicNetworkAccess: pointer.To(publicNetworkAccess),
+				Description:         pointer.To(model.Description),
+			}
+
+			payload := onlineendpoint.OnlineEndpointTrackedResource{
+				Identity:   expandedIdentity,
+				Location:   location.Normalize(model.Location),
+				Properties: properties,
+				Tags:       tags.Expand(model.Tags),
+			}
+
+			if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+	}
+}
+
+func (r MachineLearningOnlineEndpoint) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.MachineLearning.OnlineEndpoints
+
+			id, err := onlineendpoint.ParseOnlineEndpointID(metadata.ResourceData.Id())
+			if err != nil {
+				return fmt.Errorf("parsing online endpoint ID `%s`: %+v", metadata.ResourceData.Id(), err)
+			}
+
+			resp, err := client.Get(ctx, *id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return metadata.MarkAsGone(id)
+				}
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+
+			state := MachineLearningOnlineEndpointModel{
+				Name:                       id.OnlineEndpointName,
+				MachineLearningWorkspaceId: workspaces.NewWorkspaceID(id.SubscriptionId, id.ResourceGroupName, id.WorkspaceName).ID(),
+			}
+
+			model := resp.Model
+			if model == nil {
+				return fmt.Errorf("retrieving %s: model was nil", *id)
+			}
+
+			state.Location = location.Normalize(model.Location)
+
+			flattenedIdentity, err := identity.FlattenLegacySystemAndUserAssignedMapToModel(model.Identity)
+			if err != nil {
+				return fmt.Errorf("flattening `identity`: %+v", err)
+			}
+			state.Identity = flattenedIdentity
+
+			props := model.Properties
+			state.AuthenticationMode = string(props.AuthMode)
+			state.Description = pointer.From(props.Description)
+			state.Properties = flattenMachineLearningOnlineEndpointProperties(props.Properties)
+			state.PublicNetworkAccessEnabled = pointer.From(props.PublicNetworkAccess) == onlineendpoint.PublicNetworkAccessTypeEnabled
+			state.RestEndpoint = pointer.From(props.ScoringUri)
+			state.SwaggerUri = pointer.From(props.SwaggerUri)
+			state.Tags = tags.Flatten(model.Tags)
+
+			return metadata.Encode(&state)
+		},
+	}
+}
+
+func (r MachineLearningOnlineEndpoint) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.MachineLearning.OnlineEndpoints
+
+			id, err := onlineendpoint.ParseOnlineEndpointID(metadata.ResourceData.Id())
+			if err != nil {
+				return fmt.Errorf("parsing online endpoint ID `%s`: %+v", metadata.ResourceData.Id(), err)
+			}
+
+			var model MachineLearningOnlineEndpointModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			expandedIdentity, err := identity.ExpandLegacySystemAndUserAssignedMapFromModel(model.Identity)
+			if err != nil {
+				return fmt.Errorf("expanding `identity`: %+v", err)
+			}
+
+			publicNetworkAccess := onlineendpoint.PublicNetworkAccessTypeEnabled
+			if !model.PublicNetworkAccessEnabled {
+				publicNetworkAccess = onlineendpoint.PublicNetworkAccessTypeDisabled
+			}
+
+			properties := onlineendpoint.OnlineEndpoint{
+				AuthMode:            onlineendpoint.EndpointAuthMode(model.AuthenticationMode),
+				Properties:          expandMachineLearningOnlineEndpointProperties(model.Properties),
+				PublicNetworkAccess: pointer.To(publicNetworkAccess),
+				Description:         pointer.To(model.Description),
+			}
+
+			payload := onlineendpoint.OnlineEndpointTrackedResource{
+				Identity:   expandedIdentity,
+				Location:   location.Normalize(model.Location),
+				Properties: properties,
+				Tags:       tags.Expand(model.Tags),
+			}
+
+			if err := client.CreateOrUpdateThenPoll(ctx, *id, payload); err != nil {
+				return fmt.Errorf("updating %s: %+v", *id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func (r MachineLearningOnlineEndpoint) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.MachineLearning.OnlineEndpoints
+
+			id, err := onlineendpoint.ParseOnlineEndpointID(metadata.ResourceData.Id())
+			if err != nil {
+				return fmt.Errorf("parsing online endpoint ID `%s`: %+v", metadata.ResourceData.Id(), err)
+			}
+
+			if err := client.DeleteThenPoll(ctx, *id); err != nil {
+				return fmt.Errorf("deleting %s: %+v", *id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+var machineLearningOnlineEndpointSystemProperties = map[string]struct{}{
+	"azureasyncoperationuri":   {},
+	"azureml.onlineendpointid": {},
+}
+
+func isMachineLearningOnlineEndpointSystemProperty(key string) bool {
+	_, ok := machineLearningOnlineEndpointSystemProperties[strings.ToLower(key)]
+	return ok
+}
+
+func expandMachineLearningOnlineEndpointProperties(input map[string]interface{}) *map[string]string {
+	if len(input) == 0 {
+		return nil
+	}
+
+	result := make(map[string]string, len(input))
+	for k, v := range input {
+		if isMachineLearningOnlineEndpointSystemProperty(k) {
+			continue
+		}
+		result[k] = v.(string)
+	}
+
+	if len(result) == 0 {
+		return nil
+	}
+
+	return &result
+}
+
+func flattenMachineLearningOnlineEndpointProperties(input *map[string]string) map[string]interface{} {
+	if input == nil {
+		return map[string]interface{}{}
+	}
+
+	result := make(map[string]interface{}, len(*input))
+	for k, v := range *input {
+		if isMachineLearningOnlineEndpointSystemProperty(k) {
+			continue
+		}
+		result[k] = v
+	}
+
+	return result
+}

--- a/internal/services/machinelearning/machine_learning_online_endpoint_resource.go
+++ b/internal/services/machinelearning/machine_learning_online_endpoint_resource.go
@@ -52,8 +52,10 @@ func (r MachineLearningOnlineEndpoint) IDValidationFunc() pluginsdk.SchemaValida
 	return onlineendpoint.ValidateOnlineEndpointID
 }
 
-var _ sdk.ResourceWithUpdate = MachineLearningOnlineEndpoint{}
-var _ sdk.ResourceWithCustomizeDiff = MachineLearningOnlineEndpoint{}
+var (
+	_ sdk.ResourceWithUpdate        = MachineLearningOnlineEndpoint{}
+	_ sdk.ResourceWithCustomizeDiff = MachineLearningOnlineEndpoint{}
+)
 
 func (r MachineLearningOnlineEndpoint) Arguments() map[string]*pluginsdk.Schema {
 	return map[string]*pluginsdk.Schema{

--- a/internal/services/machinelearning/machine_learning_online_endpoint_resource_test.go
+++ b/internal/services/machinelearning/machine_learning_online_endpoint_resource_test.go
@@ -186,7 +186,7 @@ func (r OnlineEndpointResource) basic(data acceptance.TestData) string {
 %s
 
 resource "azurerm_machine_learning_online_endpoint" "test" {
-  name                          = "acctest-mle-%[2]d"
+  name                          = "acctest-mloe-%[2]d"
   machine_learning_workspace_id = azurerm_machine_learning_workspace.test.id
   location                      = azurerm_resource_group.test.location
 
@@ -220,7 +220,7 @@ func (r OnlineEndpointResource) complete(data acceptance.TestData) string {
 %s
 
 resource "azurerm_machine_learning_online_endpoint" "test" {
-  name                          = "acctest-mle-%[2]d"
+  name                          = "acctest-mloe-%[2]d"
   machine_learning_workspace_id = azurerm_machine_learning_workspace.test.id
   location                      = azurerm_resource_group.test.location
   authentication_mode           = "AMLToken"
@@ -248,7 +248,7 @@ func (r OnlineEndpointResource) authMode(data acceptance.TestData, mode string) 
 %s
 
 resource "azurerm_machine_learning_online_endpoint" "test" {
-  name                          = "acctest-mle-%[2]d"
+  name                          = "acctest-mloe-%[2]d"
   machine_learning_workspace_id = azurerm_machine_learning_workspace.test.id
   location                      = azurerm_resource_group.test.location
   authentication_mode           = "%[3]s"
@@ -266,7 +266,7 @@ func (r OnlineEndpointResource) publicNetworkAccessDisabled(data acceptance.Test
 %s
 
 resource "azurerm_machine_learning_online_endpoint" "test" {
-  name                          = "acctest-mle-%[2]d"
+  name                          = "acctest-mloe-%[2]d"
   machine_learning_workspace_id = azurerm_machine_learning_workspace.test.id
   location                      = azurerm_resource_group.test.location
   public_network_access_enabled = false
@@ -290,7 +290,7 @@ resource "azurerm_user_assigned_identity" "test" {
 }
 
 resource "azurerm_machine_learning_online_endpoint" "test" {
-  name                          = "acctest-mle-%[2]d"
+  name                          = "acctest-mloe-%[2]d"
   machine_learning_workspace_id = azurerm_machine_learning_workspace.test.id
   location                      = azurerm_resource_group.test.location
 
@@ -308,7 +308,7 @@ func (r OnlineEndpointResource) update(data acceptance.TestData) string {
 %s
 
 resource "azurerm_machine_learning_online_endpoint" "test" {
-  name                          = "acctest-mle-%[2]d"
+  name                          = "acctest-mloe-%[2]d"
   machine_learning_workspace_id = azurerm_machine_learning_workspace.test.id
   location                      = azurerm_resource_group.test.location
   public_network_access_enabled = false

--- a/internal/services/machinelearning/machine_learning_online_endpoint_resource_test.go
+++ b/internal/services/machinelearning/machine_learning_online_endpoint_resource_test.go
@@ -1,0 +1,388 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package machinelearning_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type OnlineEndpointResource struct{}
+
+func TestAccMachineLearningOnlineEndpoint_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_machine_learning_online_endpoint", "test")
+	r := OnlineEndpointResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccMachineLearningOnlineEndpoint_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_machine_learning_online_endpoint", "test")
+	r := OnlineEndpointResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func TestAccMachineLearningOnlineEndpoint_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_machine_learning_online_endpoint", "test")
+	r := OnlineEndpointResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccMachineLearningOnlineEndpoint_authModeAADToken(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_machine_learning_online_endpoint", "test")
+	r := OnlineEndpointResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authMode(data, "AADToken"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccMachineLearningOnlineEndpoint_authModeAMLToken(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_machine_learning_online_endpoint", "test")
+	r := OnlineEndpointResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authMode(data, "AMLToken"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccMachineLearningOnlineEndpoint_authModeKey(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_machine_learning_online_endpoint", "test")
+	r := OnlineEndpointResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authMode(data, "Key"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccMachineLearningOnlineEndpoint_publicNetworkAccessDisabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_machine_learning_online_endpoint", "test")
+	r := OnlineEndpointResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.publicNetworkAccessDisabled(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccMachineLearningOnlineEndpoint_identityUserAssigned(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_machine_learning_online_endpoint", "test")
+	r := OnlineEndpointResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.identityUserAssigned(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccMachineLearningOnlineEndpoint_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_machine_learning_online_endpoint", "test")
+	r := OnlineEndpointResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.update(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (r OnlineEndpointResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	onlineEndpointClient := client.MachineLearning.OnlineEndpoints
+
+	id, err := onlineendpoint.ParseOnlineEndpointID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := onlineEndpointClient.Get(ctx, *id)
+	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			return pointer.To(false), nil
+		}
+		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
+	}
+
+	return pointer.To(resp.Model != nil && resp.Model.Properties.AuthMode != ""), nil
+}
+
+func (r OnlineEndpointResource) basic(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_machine_learning_online_endpoint" "test" {
+  name                          = "acctest-mle-%[2]d"
+  machine_learning_workspace_id = azurerm_machine_learning_workspace.test.id
+  location                      = azurerm_resource_group.test.location
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, template, data.RandomIntOfLength(8))
+}
+
+func (r OnlineEndpointResource) requiresImport(data acceptance.TestData) string {
+	config := r.basic(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_machine_learning_online_endpoint" "import" {
+  name                          = azurerm_machine_learning_online_endpoint.test.name
+  machine_learning_workspace_id = azurerm_machine_learning_online_endpoint.test.machine_learning_workspace_id
+  location                      = azurerm_machine_learning_online_endpoint.test.location
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, config)
+}
+
+func (r OnlineEndpointResource) complete(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_machine_learning_online_endpoint" "test" {
+  name                          = "acctest-mle-%[2]d"
+  machine_learning_workspace_id = azurerm_machine_learning_workspace.test.id
+  location                      = azurerm_resource_group.test.location
+  authentication_mode           = "AMLToken"
+  description                   = "Test Online Endpoint"
+  public_network_access_enabled = false
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  properties = {
+    "test-key" = "test-value"
+  }
+
+  tags = {
+    environment = "test"
+  }
+}
+`, template, data.RandomIntOfLength(8))
+}
+
+func (r OnlineEndpointResource) authMode(data acceptance.TestData, mode string) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_machine_learning_online_endpoint" "test" {
+  name                          = "acctest-mle-%[2]d"
+  machine_learning_workspace_id = azurerm_machine_learning_workspace.test.id
+  location                      = azurerm_resource_group.test.location
+  authentication_mode           = "%[3]s"
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, template, data.RandomIntOfLength(8), mode)
+}
+
+func (r OnlineEndpointResource) publicNetworkAccessDisabled(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_machine_learning_online_endpoint" "test" {
+  name                          = "acctest-mle-%[2]d"
+  machine_learning_workspace_id = azurerm_machine_learning_workspace.test.id
+  location                      = azurerm_resource_group.test.location
+  public_network_access_enabled = false
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, template, data.RandomIntOfLength(8))
+}
+
+func (r OnlineEndpointResource) identityUserAssigned(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctestuai-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_machine_learning_online_endpoint" "test" {
+  name                          = "acctest-mle-%[2]d"
+  machine_learning_workspace_id = azurerm_machine_learning_workspace.test.id
+  location                      = azurerm_resource_group.test.location
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+}
+`, template, data.RandomIntOfLength(8))
+}
+
+func (r OnlineEndpointResource) update(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_machine_learning_online_endpoint" "test" {
+  name                          = "acctest-mle-%[2]d"
+  machine_learning_workspace_id = azurerm_machine_learning_workspace.test.id
+  location                      = azurerm_resource_group.test.location
+  public_network_access_enabled = false
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  tags = {
+    environment = "staging"
+    purpose     = "testing"
+  }
+}
+`, template, data.RandomIntOfLength(8))
+}
+
+func (r OnlineEndpointResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-ml-%[1]d"
+  location = "%[2]s"
+  tags = {
+    "stage" = "test"
+  }
+}
+
+resource "azurerm_application_insights" "test" {
+  name                = "acctestai-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  application_type    = "web"
+}
+
+resource "azurerm_key_vault" "test" {
+  name                = "acctest%[3]s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+
+  sku_name = "standard"
+
+  purge_protection_enabled   = true
+  soft_delete_retention_days = 7
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestsa%[3]s"
+  location                 = azurerm_resource_group.test.location
+  resource_group_name      = azurerm_resource_group.test.name
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_machine_learning_workspace" "test" {
+  name                    = "acctest-MLW%[4]d"
+  location                = azurerm_resource_group.test.location
+  resource_group_name     = azurerm_resource_group.test.name
+  application_insights_id = azurerm_application_insights.test.id
+  key_vault_id            = azurerm_key_vault.test.id
+  storage_account_id      = azurerm_storage_account.test.id
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomIntOfLength(16))
+}

--- a/internal/services/machinelearning/registration.go
+++ b/internal/services/machinelearning/registration.go
@@ -64,6 +64,7 @@ func (r Registration) Resources() []sdk.Resource {
 		MachineLearningDataStoreBlobStorage{},
 		MachineLearningDataStoreDataLakeGen2{},
 		MachineLearningDataStoreFileShare{},
+		MachineLearningOnlineEndpoint{},
 		WorkspaceNetworkOutboundRuleFqdn{},
 		WorkspaceNetworkOutboundRulePrivateEndpoint{},
 		WorkspaceNetworkOutboundRuleServiceTag{},

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/README.md
@@ -1,0 +1,148 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint` Documentation
+
+The `onlineendpoint` SDK allows for interaction with Azure Resource Manager `machinelearningservices` (API Version `2025-06-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint"
+```
+
+
+### Client Initialization
+
+```go
+client := onlineendpoint.NewOnlineEndpointClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `OnlineEndpointClient.CreateOrUpdate`
+
+```go
+ctx := context.TODO()
+id := onlineendpoint.NewOnlineEndpointID("12345678-1234-9876-4563-123456789012", "example-resource-group", "workspaceName", "onlineEndpointName")
+
+payload := onlineendpoint.OnlineEndpointTrackedResource{
+	// ...
+}
+
+
+if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `OnlineEndpointClient.Delete`
+
+```go
+ctx := context.TODO()
+id := onlineendpoint.NewOnlineEndpointID("12345678-1234-9876-4563-123456789012", "example-resource-group", "workspaceName", "onlineEndpointName")
+
+if err := client.DeleteThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `OnlineEndpointClient.Get`
+
+```go
+ctx := context.TODO()
+id := onlineendpoint.NewOnlineEndpointID("12345678-1234-9876-4563-123456789012", "example-resource-group", "workspaceName", "onlineEndpointName")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `OnlineEndpointClient.GetToken`
+
+```go
+ctx := context.TODO()
+id := onlineendpoint.NewOnlineEndpointID("12345678-1234-9876-4563-123456789012", "example-resource-group", "workspaceName", "onlineEndpointName")
+
+read, err := client.GetToken(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `OnlineEndpointClient.List`
+
+```go
+ctx := context.TODO()
+id := onlineendpoint.NewWorkspaceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "workspaceName")
+
+// alternatively `client.List(ctx, id, onlineendpoint.DefaultListOperationOptions())` can be used to do batched pagination
+items, err := client.ListComplete(ctx, id, onlineendpoint.DefaultListOperationOptions())
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `OnlineEndpointClient.ListKeys`
+
+```go
+ctx := context.TODO()
+id := onlineendpoint.NewOnlineEndpointID("12345678-1234-9876-4563-123456789012", "example-resource-group", "workspaceName", "onlineEndpointName")
+
+read, err := client.ListKeys(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `OnlineEndpointClient.RegenerateKeys`
+
+```go
+ctx := context.TODO()
+id := onlineendpoint.NewOnlineEndpointID("12345678-1234-9876-4563-123456789012", "example-resource-group", "workspaceName", "onlineEndpointName")
+
+payload := onlineendpoint.RegenerateEndpointKeysRequest{
+	// ...
+}
+
+
+if err := client.RegenerateKeysThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `OnlineEndpointClient.Update`
+
+```go
+ctx := context.TODO()
+id := onlineendpoint.NewOnlineEndpointID("12345678-1234-9876-4563-123456789012", "example-resource-group", "workspaceName", "onlineEndpointName")
+
+payload := onlineendpoint.PartialMinimalTrackedResourceWithIdentity{
+	// ...
+}
+
+
+if err := client.UpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/client.go
@@ -1,0 +1,26 @@
+package onlineendpoint
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OnlineEndpointClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewOnlineEndpointClientWithBaseURI(sdkApi sdkEnv.Api) (*OnlineEndpointClient, error) {
+	client, err := resourcemanager.NewClient(sdkApi, "onlineendpoint", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating OnlineEndpointClient: %+v", err)
+	}
+
+	return &OnlineEndpointClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/constants.go
@@ -1,0 +1,374 @@
+package onlineendpoint
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type EndpointAuthMode string
+
+const (
+	EndpointAuthModeAADToken EndpointAuthMode = "AADToken"
+	EndpointAuthModeAMLToken EndpointAuthMode = "AMLToken"
+	EndpointAuthModeKey      EndpointAuthMode = "Key"
+)
+
+func PossibleValuesForEndpointAuthMode() []string {
+	return []string{
+		string(EndpointAuthModeAADToken),
+		string(EndpointAuthModeAMLToken),
+		string(EndpointAuthModeKey),
+	}
+}
+
+func (s *EndpointAuthMode) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseEndpointAuthMode(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseEndpointAuthMode(input string) (*EndpointAuthMode, error) {
+	vals := map[string]EndpointAuthMode{
+		"aadtoken": EndpointAuthModeAADToken,
+		"amltoken": EndpointAuthModeAMLToken,
+		"key":      EndpointAuthModeKey,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := EndpointAuthMode(input)
+	return &out, nil
+}
+
+type EndpointComputeType string
+
+const (
+	EndpointComputeTypeAzureMLCompute EndpointComputeType = "AzureMLCompute"
+	EndpointComputeTypeKubernetes     EndpointComputeType = "Kubernetes"
+	EndpointComputeTypeManaged        EndpointComputeType = "Managed"
+)
+
+func PossibleValuesForEndpointComputeType() []string {
+	return []string{
+		string(EndpointComputeTypeAzureMLCompute),
+		string(EndpointComputeTypeKubernetes),
+		string(EndpointComputeTypeManaged),
+	}
+}
+
+func (s *EndpointComputeType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseEndpointComputeType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseEndpointComputeType(input string) (*EndpointComputeType, error) {
+	vals := map[string]EndpointComputeType{
+		"azuremlcompute": EndpointComputeTypeAzureMLCompute,
+		"kubernetes":     EndpointComputeTypeKubernetes,
+		"managed":        EndpointComputeTypeManaged,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := EndpointComputeType(input)
+	return &out, nil
+}
+
+type EndpointProvisioningState string
+
+const (
+	EndpointProvisioningStateCanceled  EndpointProvisioningState = "Canceled"
+	EndpointProvisioningStateCreating  EndpointProvisioningState = "Creating"
+	EndpointProvisioningStateDeleting  EndpointProvisioningState = "Deleting"
+	EndpointProvisioningStateFailed    EndpointProvisioningState = "Failed"
+	EndpointProvisioningStateSucceeded EndpointProvisioningState = "Succeeded"
+	EndpointProvisioningStateUpdating  EndpointProvisioningState = "Updating"
+)
+
+func PossibleValuesForEndpointProvisioningState() []string {
+	return []string{
+		string(EndpointProvisioningStateCanceled),
+		string(EndpointProvisioningStateCreating),
+		string(EndpointProvisioningStateDeleting),
+		string(EndpointProvisioningStateFailed),
+		string(EndpointProvisioningStateSucceeded),
+		string(EndpointProvisioningStateUpdating),
+	}
+}
+
+func (s *EndpointProvisioningState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseEndpointProvisioningState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseEndpointProvisioningState(input string) (*EndpointProvisioningState, error) {
+	vals := map[string]EndpointProvisioningState{
+		"canceled":  EndpointProvisioningStateCanceled,
+		"creating":  EndpointProvisioningStateCreating,
+		"deleting":  EndpointProvisioningStateDeleting,
+		"failed":    EndpointProvisioningStateFailed,
+		"succeeded": EndpointProvisioningStateSucceeded,
+		"updating":  EndpointProvisioningStateUpdating,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := EndpointProvisioningState(input)
+	return &out, nil
+}
+
+type KeyType string
+
+const (
+	KeyTypePrimary   KeyType = "Primary"
+	KeyTypeSecondary KeyType = "Secondary"
+)
+
+func PossibleValuesForKeyType() []string {
+	return []string{
+		string(KeyTypePrimary),
+		string(KeyTypeSecondary),
+	}
+}
+
+func (s *KeyType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseKeyType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseKeyType(input string) (*KeyType, error) {
+	vals := map[string]KeyType{
+		"primary":   KeyTypePrimary,
+		"secondary": KeyTypeSecondary,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := KeyType(input)
+	return &out, nil
+}
+
+type ManagedServiceIdentityType string
+
+const (
+	ManagedServiceIdentityTypeNone                       ManagedServiceIdentityType = "None"
+	ManagedServiceIdentityTypeSystemAssigned             ManagedServiceIdentityType = "SystemAssigned"
+	ManagedServiceIdentityTypeSystemAssignedUserAssigned ManagedServiceIdentityType = "SystemAssigned,UserAssigned"
+	ManagedServiceIdentityTypeUserAssigned               ManagedServiceIdentityType = "UserAssigned"
+)
+
+func PossibleValuesForManagedServiceIdentityType() []string {
+	return []string{
+		string(ManagedServiceIdentityTypeNone),
+		string(ManagedServiceIdentityTypeSystemAssigned),
+		string(ManagedServiceIdentityTypeSystemAssignedUserAssigned),
+		string(ManagedServiceIdentityTypeUserAssigned),
+	}
+}
+
+func (s *ManagedServiceIdentityType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseManagedServiceIdentityType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseManagedServiceIdentityType(input string) (*ManagedServiceIdentityType, error) {
+	vals := map[string]ManagedServiceIdentityType{
+		"none":                        ManagedServiceIdentityTypeNone,
+		"systemassigned":              ManagedServiceIdentityTypeSystemAssigned,
+		"systemassigned,userassigned": ManagedServiceIdentityTypeSystemAssignedUserAssigned,
+		"userassigned":                ManagedServiceIdentityTypeUserAssigned,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ManagedServiceIdentityType(input)
+	return &out, nil
+}
+
+type OrderString string
+
+const (
+	OrderStringCreatedAtAsc  OrderString = "CreatedAtAsc"
+	OrderStringCreatedAtDesc OrderString = "CreatedAtDesc"
+	OrderStringUpdatedAtAsc  OrderString = "UpdatedAtAsc"
+	OrderStringUpdatedAtDesc OrderString = "UpdatedAtDesc"
+)
+
+func PossibleValuesForOrderString() []string {
+	return []string{
+		string(OrderStringCreatedAtAsc),
+		string(OrderStringCreatedAtDesc),
+		string(OrderStringUpdatedAtAsc),
+		string(OrderStringUpdatedAtDesc),
+	}
+}
+
+func (s *OrderString) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseOrderString(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseOrderString(input string) (*OrderString, error) {
+	vals := map[string]OrderString{
+		"createdatasc":  OrderStringCreatedAtAsc,
+		"createdatdesc": OrderStringCreatedAtDesc,
+		"updatedatasc":  OrderStringUpdatedAtAsc,
+		"updatedatdesc": OrderStringUpdatedAtDesc,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := OrderString(input)
+	return &out, nil
+}
+
+type PublicNetworkAccessType string
+
+const (
+	PublicNetworkAccessTypeDisabled PublicNetworkAccessType = "Disabled"
+	PublicNetworkAccessTypeEnabled  PublicNetworkAccessType = "Enabled"
+)
+
+func PossibleValuesForPublicNetworkAccessType() []string {
+	return []string{
+		string(PublicNetworkAccessTypeDisabled),
+		string(PublicNetworkAccessTypeEnabled),
+	}
+}
+
+func (s *PublicNetworkAccessType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parsePublicNetworkAccessType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parsePublicNetworkAccessType(input string) (*PublicNetworkAccessType, error) {
+	vals := map[string]PublicNetworkAccessType{
+		"disabled": PublicNetworkAccessTypeDisabled,
+		"enabled":  PublicNetworkAccessTypeEnabled,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PublicNetworkAccessType(input)
+	return &out, nil
+}
+
+type SkuTier string
+
+const (
+	SkuTierBasic    SkuTier = "Basic"
+	SkuTierFree     SkuTier = "Free"
+	SkuTierPremium  SkuTier = "Premium"
+	SkuTierStandard SkuTier = "Standard"
+)
+
+func PossibleValuesForSkuTier() []string {
+	return []string{
+		string(SkuTierBasic),
+		string(SkuTierFree),
+		string(SkuTierPremium),
+		string(SkuTierStandard),
+	}
+}
+
+func (s *SkuTier) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseSkuTier(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseSkuTier(input string) (*SkuTier, error) {
+	vals := map[string]SkuTier{
+		"basic":    SkuTierBasic,
+		"free":     SkuTierFree,
+		"premium":  SkuTierPremium,
+		"standard": SkuTierStandard,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SkuTier(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/id_onlineendpoint.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/id_onlineendpoint.go
@@ -1,0 +1,139 @@
+package onlineendpoint
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&OnlineEndpointId{})
+}
+
+var _ resourceids.ResourceId = &OnlineEndpointId{}
+
+// OnlineEndpointId is a struct representing the Resource ID for a Online Endpoint
+type OnlineEndpointId struct {
+	SubscriptionId     string
+	ResourceGroupName  string
+	WorkspaceName      string
+	OnlineEndpointName string
+}
+
+// NewOnlineEndpointID returns a new OnlineEndpointId struct
+func NewOnlineEndpointID(subscriptionId string, resourceGroupName string, workspaceName string, onlineEndpointName string) OnlineEndpointId {
+	return OnlineEndpointId{
+		SubscriptionId:     subscriptionId,
+		ResourceGroupName:  resourceGroupName,
+		WorkspaceName:      workspaceName,
+		OnlineEndpointName: onlineEndpointName,
+	}
+}
+
+// ParseOnlineEndpointID parses 'input' into a OnlineEndpointId
+func ParseOnlineEndpointID(input string) (*OnlineEndpointId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&OnlineEndpointId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := OnlineEndpointId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseOnlineEndpointIDInsensitively parses 'input' case-insensitively into a OnlineEndpointId
+// note: this method should only be used for API response data and not user input
+func ParseOnlineEndpointIDInsensitively(input string) (*OnlineEndpointId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&OnlineEndpointId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := OnlineEndpointId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *OnlineEndpointId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.WorkspaceName, ok = input.Parsed["workspaceName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", input)
+	}
+
+	if id.OnlineEndpointName, ok = input.Parsed["onlineEndpointName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "onlineEndpointName", input)
+	}
+
+	return nil
+}
+
+// ValidateOnlineEndpointID checks that 'input' can be parsed as a Online Endpoint ID
+func ValidateOnlineEndpointID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseOnlineEndpointID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Online Endpoint ID
+func (id OnlineEndpointId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.MachineLearningServices/workspaces/%s/onlineEndpoints/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.WorkspaceName, id.OnlineEndpointName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Online Endpoint ID
+func (id OnlineEndpointId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftMachineLearningServices", "Microsoft.MachineLearningServices", "Microsoft.MachineLearningServices"),
+		resourceids.StaticSegment("staticWorkspaces", "workspaces", "workspaces"),
+		resourceids.UserSpecifiedSegment("workspaceName", "workspaceName"),
+		resourceids.StaticSegment("staticOnlineEndpoints", "onlineEndpoints", "onlineEndpoints"),
+		resourceids.UserSpecifiedSegment("onlineEndpointName", "onlineEndpointName"),
+	}
+}
+
+// String returns a human-readable description of this Online Endpoint ID
+func (id OnlineEndpointId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Workspace Name: %q", id.WorkspaceName),
+		fmt.Sprintf("Online Endpoint Name: %q", id.OnlineEndpointName),
+	}
+	return fmt.Sprintf("Online Endpoint (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/id_workspace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/id_workspace.go
@@ -1,0 +1,130 @@
+package onlineendpoint
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&WorkspaceId{})
+}
+
+var _ resourceids.ResourceId = &WorkspaceId{}
+
+// WorkspaceId is a struct representing the Resource ID for a Workspace
+type WorkspaceId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	WorkspaceName     string
+}
+
+// NewWorkspaceID returns a new WorkspaceId struct
+func NewWorkspaceID(subscriptionId string, resourceGroupName string, workspaceName string) WorkspaceId {
+	return WorkspaceId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		WorkspaceName:     workspaceName,
+	}
+}
+
+// ParseWorkspaceID parses 'input' into a WorkspaceId
+func ParseWorkspaceID(input string) (*WorkspaceId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&WorkspaceId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := WorkspaceId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseWorkspaceIDInsensitively parses 'input' case-insensitively into a WorkspaceId
+// note: this method should only be used for API response data and not user input
+func ParseWorkspaceIDInsensitively(input string) (*WorkspaceId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&WorkspaceId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := WorkspaceId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *WorkspaceId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.WorkspaceName, ok = input.Parsed["workspaceName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", input)
+	}
+
+	return nil
+}
+
+// ValidateWorkspaceID checks that 'input' can be parsed as a Workspace ID
+func ValidateWorkspaceID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseWorkspaceID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Workspace ID
+func (id WorkspaceId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.MachineLearningServices/workspaces/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.WorkspaceName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Workspace ID
+func (id WorkspaceId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftMachineLearningServices", "Microsoft.MachineLearningServices", "Microsoft.MachineLearningServices"),
+		resourceids.StaticSegment("staticWorkspaces", "workspaces", "workspaces"),
+		resourceids.UserSpecifiedSegment("workspaceName", "workspaceName"),
+	}
+}
+
+// String returns a human-readable description of this Workspace ID
+func (id WorkspaceId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Workspace Name: %q", id.WorkspaceName),
+	}
+	return fmt.Sprintf("Workspace (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/method_createorupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/method_createorupdate.go
@@ -1,0 +1,75 @@
+package onlineendpoint
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOrUpdateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *OnlineEndpointTrackedResource
+}
+
+// CreateOrUpdate ...
+func (c OnlineEndpointClient) CreateOrUpdate(ctx context.Context, id OnlineEndpointId, input OnlineEndpointTrackedResource) (result CreateOrUpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// CreateOrUpdateThenPoll performs CreateOrUpdate then polls until it's completed
+func (c OnlineEndpointClient) CreateOrUpdateThenPoll(ctx context.Context, id OnlineEndpointId, input OnlineEndpointTrackedResource) error {
+	result, err := c.CreateOrUpdate(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing CreateOrUpdate: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after CreateOrUpdate: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/method_delete.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/method_delete.go
@@ -1,0 +1,71 @@
+package onlineendpoint
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// Delete ...
+func (c OnlineEndpointClient) Delete(ctx context.Context, id OnlineEndpointId) (result DeleteOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusNoContent,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodDelete,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// DeleteThenPoll performs Delete then polls until it's completed
+func (c OnlineEndpointClient) DeleteThenPoll(ctx context.Context, id OnlineEndpointId) error {
+	result, err := c.Delete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Delete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Delete: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/method_get.go
@@ -1,0 +1,53 @@
+package onlineendpoint
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *OnlineEndpointTrackedResource
+}
+
+// Get ...
+func (c OnlineEndpointClient) Get(ctx context.Context, id OnlineEndpointId) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model OnlineEndpointTrackedResource
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/method_gettoken.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/method_gettoken.go
@@ -1,0 +1,54 @@
+package onlineendpoint
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetTokenOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *EndpointAuthToken
+}
+
+// GetToken ...
+func (c OnlineEndpointClient) GetToken(ctx context.Context, id OnlineEndpointId) (result GetTokenOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/token", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model EndpointAuthToken
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/method_list.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/method_list.go
@@ -1,0 +1,158 @@
+package onlineendpoint
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]OnlineEndpointTrackedResource
+}
+
+type ListCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []OnlineEndpointTrackedResource
+}
+
+type ListOperationOptions struct {
+	ComputeType *EndpointComputeType
+	Count       *int64
+	Name        *string
+	OrderBy     *OrderString
+	Properties  *string
+	Skip        *string
+	Tags        *string
+}
+
+func DefaultListOperationOptions() ListOperationOptions {
+	return ListOperationOptions{}
+}
+
+func (o ListOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o ListOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+
+	return &out
+}
+
+func (o ListOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.ComputeType != nil {
+		out.Append("computeType", fmt.Sprintf("%v", *o.ComputeType))
+	}
+	if o.Count != nil {
+		out.Append("count", fmt.Sprintf("%v", *o.Count))
+	}
+	if o.Name != nil {
+		out.Append("name", fmt.Sprintf("%v", *o.Name))
+	}
+	if o.OrderBy != nil {
+		out.Append("orderBy", fmt.Sprintf("%v", *o.OrderBy))
+	}
+	if o.Properties != nil {
+		out.Append("properties", fmt.Sprintf("%v", *o.Properties))
+	}
+	if o.Skip != nil {
+		out.Append("$skip", fmt.Sprintf("%v", *o.Skip))
+	}
+	if o.Tags != nil {
+		out.Append("tags", fmt.Sprintf("%v", *o.Tags))
+	}
+	return &out
+}
+
+type ListCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// List ...
+func (c OnlineEndpointClient) List(ctx context.Context, id WorkspaceId, options ListOperationOptions) (result ListOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		OptionsObject: options,
+		Pager:         &ListCustomPager{},
+		Path:          fmt.Sprintf("%s/onlineEndpoints", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]OnlineEndpointTrackedResource `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListComplete retrieves all the results into a single object
+func (c OnlineEndpointClient) ListComplete(ctx context.Context, id WorkspaceId, options ListOperationOptions) (ListCompleteResult, error) {
+	return c.ListCompleteMatchingPredicate(ctx, id, options, OnlineEndpointTrackedResourceOperationPredicate{})
+}
+
+// ListCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c OnlineEndpointClient) ListCompleteMatchingPredicate(ctx context.Context, id WorkspaceId, options ListOperationOptions, predicate OnlineEndpointTrackedResourceOperationPredicate) (result ListCompleteResult, err error) {
+	items := make([]OnlineEndpointTrackedResource, 0)
+
+	resp, err := c.List(ctx, id, options)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/method_listkeys.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/method_listkeys.go
@@ -1,0 +1,54 @@
+package onlineendpoint
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListKeysOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *EndpointAuthKeys
+}
+
+// ListKeys ...
+func (c OnlineEndpointClient) ListKeys(ctx context.Context, id OnlineEndpointId) (result ListKeysOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/listKeys", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model EndpointAuthKeys
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/method_regeneratekeys.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/method_regeneratekeys.go
@@ -1,0 +1,74 @@
+package onlineendpoint
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RegenerateKeysOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// RegenerateKeys ...
+func (c OnlineEndpointClient) RegenerateKeys(ctx context.Context, id OnlineEndpointId, input RegenerateEndpointKeysRequest) (result RegenerateKeysOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/regenerateKeys", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// RegenerateKeysThenPoll performs RegenerateKeys then polls until it's completed
+func (c OnlineEndpointClient) RegenerateKeysThenPoll(ctx context.Context, id OnlineEndpointId, input RegenerateEndpointKeysRequest) error {
+	result, err := c.RegenerateKeys(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing RegenerateKeys: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after RegenerateKeys: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/method_update.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/method_update.go
@@ -1,0 +1,75 @@
+package onlineendpoint
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *OnlineEndpointTrackedResource
+}
+
+// Update ...
+func (c OnlineEndpointClient) Update(ctx context.Context, id OnlineEndpointId, input PartialMinimalTrackedResourceWithIdentity) (result UpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPatch,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// UpdateThenPoll performs Update then polls until it's completed
+func (c OnlineEndpointClient) UpdateThenPoll(ctx context.Context, id OnlineEndpointId, input PartialMinimalTrackedResourceWithIdentity) error {
+	result, err := c.Update(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Update: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Update: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/model_endpointauthkeys.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/model_endpointauthkeys.go
@@ -1,0 +1,9 @@
+package onlineendpoint
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type EndpointAuthKeys struct {
+	PrimaryKey   *string `json:"primaryKey,omitempty"`
+	SecondaryKey *string `json:"secondaryKey,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/model_endpointauthtoken.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/model_endpointauthtoken.go
@@ -1,0 +1,11 @@
+package onlineendpoint
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type EndpointAuthToken struct {
+	AccessToken         *string `json:"accessToken,omitempty"`
+	ExpiryTimeUtc       *int64  `json:"expiryTimeUtc,omitempty"`
+	RefreshAfterTimeUtc *int64  `json:"refreshAfterTimeUtc,omitempty"`
+	TokenType           *string `json:"tokenType,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/model_onlineendpoint.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/model_onlineendpoint.go
@@ -1,0 +1,18 @@
+package onlineendpoint
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OnlineEndpoint struct {
+	AuthMode            EndpointAuthMode           `json:"authMode"`
+	Compute             *string                    `json:"compute,omitempty"`
+	Description         *string                    `json:"description,omitempty"`
+	Keys                *EndpointAuthKeys          `json:"keys,omitempty"`
+	MirrorTraffic       *map[string]int64          `json:"mirrorTraffic,omitempty"`
+	Properties          *map[string]string         `json:"properties,omitempty"`
+	ProvisioningState   *EndpointProvisioningState `json:"provisioningState,omitempty"`
+	PublicNetworkAccess *PublicNetworkAccessType   `json:"publicNetworkAccess,omitempty"`
+	ScoringUri          *string                    `json:"scoringUri,omitempty"`
+	SwaggerUri          *string                    `json:"swaggerUri,omitempty"`
+	Traffic             *map[string]int64          `json:"traffic,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/model_onlineendpointtrackedresource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/model_onlineendpointtrackedresource.go
@@ -1,0 +1,22 @@
+package onlineendpoint
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OnlineEndpointTrackedResource struct {
+	Id         *string                                  `json:"id,omitempty"`
+	Identity   *identity.LegacySystemAndUserAssignedMap `json:"identity,omitempty"`
+	Kind       *string                                  `json:"kind,omitempty"`
+	Location   string                                   `json:"location"`
+	Name       *string                                  `json:"name,omitempty"`
+	Properties OnlineEndpoint                           `json:"properties"`
+	Sku        *Sku                                     `json:"sku,omitempty"`
+	SystemData *systemdata.SystemData                   `json:"systemData,omitempty"`
+	Tags       *map[string]string                       `json:"tags,omitempty"`
+	Type       *string                                  `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/model_partialmanagedserviceidentity.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/model_partialmanagedserviceidentity.go
@@ -1,0 +1,9 @@
+package onlineendpoint
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PartialManagedServiceIdentity struct {
+	Type                   *ManagedServiceIdentityType `json:"type,omitempty"`
+	UserAssignedIdentities *map[string]interface{}     `json:"userAssignedIdentities,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/model_partialminimaltrackedresourcewithidentity.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/model_partialminimaltrackedresourcewithidentity.go
@@ -1,0 +1,9 @@
+package onlineendpoint
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PartialMinimalTrackedResourceWithIdentity struct {
+	Identity *PartialManagedServiceIdentity `json:"identity,omitempty"`
+	Tags     *map[string]string             `json:"tags,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/model_regenerateendpointkeysrequest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/model_regenerateendpointkeysrequest.go
@@ -1,0 +1,9 @@
+package onlineendpoint
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RegenerateEndpointKeysRequest struct {
+	KeyType  KeyType `json:"keyType"`
+	KeyValue *string `json:"keyValue,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/model_sku.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/model_sku.go
@@ -1,0 +1,12 @@
+package onlineendpoint
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Sku struct {
+	Capacity *int64   `json:"capacity,omitempty"`
+	Family   *string  `json:"family,omitempty"`
+	Name     string   `json:"name"`
+	Size     *string  `json:"size,omitempty"`
+	Tier     *SkuTier `json:"tier,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/predicates.go
@@ -1,0 +1,37 @@
+package onlineendpoint
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OnlineEndpointTrackedResourceOperationPredicate struct {
+	Id       *string
+	Kind     *string
+	Location *string
+	Name     *string
+	Type     *string
+}
+
+func (p OnlineEndpointTrackedResourceOperationPredicate) Matches(input OnlineEndpointTrackedResource) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Kind != nil && (input.Kind == nil || *p.Kind != *input.Kind) {
+		return false
+	}
+
+	if p.Location != nil && *p.Location != input.Location {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint/version.go
@@ -1,0 +1,10 @@
+package onlineendpoint
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2025-06-01"
+
+func userAgent() string {
+	return "hashicorp/go-azure-sdk/onlineendpoint/2025-06-01"
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -690,6 +690,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/workflowtrig
 github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/datastore
 github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/machinelearningcomputes
 github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/managednetwork
+github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/onlineendpoint
 github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2025-06-01/workspaces
 github.com/hashicorp/go-azure-sdk/resource-manager/maintenance/2023-04-01/configurationassignments
 github.com/hashicorp/go-azure-sdk/resource-manager/maintenance/2023-04-01/maintenanceconfigurations

--- a/website/docs/r/machine_learning_online_endpoint.html.markdown
+++ b/website/docs/r/machine_learning_online_endpoint.html.markdown
@@ -1,0 +1,139 @@
+---
+subcategory: "Machine Learning"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_machine_learning_online_endpoint"
+description: |-
+  Manages a Machine Learning Online Endpoint.
+---
+
+# azurerm_machine_learning_online_endpoint
+
+Manages a Machine Learning Online Endpoint.
+
+## Example Usage
+
+```hcl
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resource-group"
+  location = "West Europe"
+}
+
+resource "azurerm_application_insights" "example" {
+  name                = "example-application-insights"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  application_type    = "web"
+}
+
+resource "azurerm_key_vault" "example" {
+  name                = "example-key-vault"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  sku_name            = "standard"
+}
+
+resource "azurerm_storage_account" "example" {
+  name                     = "examplestorageaccount"
+  location                 = azurerm_resource_group.example.location
+  resource_group_name      = azurerm_resource_group.example.name
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_machine_learning_workspace" "example" {
+  name                    = "example-machine-learning-workspac"
+  location                = azurerm_resource_group.example.location
+  resource_group_name     = azurerm_resource_group.example.name
+  application_insights_id = azurerm_application_insights.example.id
+  key_vault_id            = azurerm_key_vault.example.id
+  storage_account_id      = azurerm_storage_account.example.id
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_machine_learning_online_endpoint" "example" {
+  name                          = "example-machine-learning-online"
+  machine_learning_workspace_id = azurerm_machine_learning_workspace.example.id
+  location                      = azurerm_resource_group.example.location
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the Machine Learning Online Endpoint. Changing this forces a new resource to be created.
+
+-> **Note:** The `name` must start with a letter, contain only letters, digits, or dashes, end with a letter or digit, and be between 3 and 32 characters.
+
+* `machine_learning_workspace_id` - (Required) The ID of the Machine Learning Workspace in which the Online Endpoint should exist. Changing this forces a new resource to be created.
+
+* `location` - (Required) The Azure Region where the Machine Learning Online Endpoint should exist. Changing this forces a new resource to be created.
+
+* `identity` - (Required) An `identity` block as defined below. Changing this forces a new resource to be created.
+
+* `authentication_mode` - (Optional) The authentication mode for the Machine Learning Online Endpoint. Possible values are `AADToken`, `AMLToken`, and `Key`. Defaults to `Key`.
+
+* `description` - (Optional) The description of the Machine Learning Online Endpoint.
+
+~> **Note:** The `description` cannot be changed after the Machine Learning Online Endpoint has been created.
+
+* `properties` - (Optional) A mapping of properties to assign to the Machine Learning Online Endpoint. Changing this forces a new resource to be created.
+
+* `public_network_access_enabled` - (Optional) Should `public network access` be enabled? Defaults to `true`.
+
+* `tags` - (Optional) A mapping of tags which should be assigned to the Machine Learning Online Endpoint.
+
+---
+
+An `identity` block supports the following:
+
+* `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this Machine Learning Online Endpoint. Possible values are `SystemAssigned` and `UserAssigned`. Changing this forces a new resource to be created.
+
+* `identity_ids` - (Optional) Specifies a list of User Assigned Managed Identity IDs to be assigned to this Machine Learning Online Endpoint. Changing this forces a new resource to be created.
+
+~> **Note:** This is required when `type` is set to `UserAssigned`.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Machine Learning Online Endpoint.
+
+* `rest_endpoint` - The REST endpoint of the Machine Learning Online Endpoint.
+
+* `swagger_uri` - The Swagger URI of the Machine Learning Online Endpoint.
+
+---
+
+An `identity` block exports the following:
+
+* `principal_id` - The Principal ID associated with this Managed Service Identity.
+
+* `tenant_id` - The Tenant ID associated with this Managed Service Identity.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/configure#define-operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Machine Learning Online Endpoint.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Machine Learning Online Endpoint.
+* `update` - (Defaults to 30 minutes) Used when updating the Machine Learning Online Endpoint.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Machine Learning Online Endpoint.
+
+## Import
+
+A Machine Learning Online Endpoint can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_machine_learning_online_endpoint.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.MachineLearningServices/workspaces/workspace1/onlineEndpoints/onlineEndpoint1
+```

--- a/website/docs/r/machine_learning_online_endpoint.html.markdown
+++ b/website/docs/r/machine_learning_online_endpoint.html.markdown
@@ -137,3 +137,9 @@ A Machine Learning Online Endpoint can be imported using the `resource id`, e.g.
 ```shell
 terraform import azurerm_machine_learning_online_endpoint.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.MachineLearningServices/workspaces/workspace1/onlineEndpoints/onlineEndpoint1
 ```
+
+## API Providers
+<!-- This section is generated, changes will be overwritten -->
+This resource uses the following Azure API Providers:
+
+* `Microsoft.MachineLearningServices` - 2025-06-01


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

The PR implements the managed [ML online endpoint](https://learn.microsoft.com/en-us/azure/machine-learning/concept-endpoints-online?view=azureml-api-2#managed-online-endpoints) resource.

### Attribute Coverage

Here is a list of all the attributes, their coverage, and explanation:

```
name:                          Included      Required with validation
machine_learning_workspace id: Included      Required with validation
location                       Included      
identity                       Included      Required `SystemOrUserAssignedIdentityRequiredForceNew`
properties.properties:         Included      It can only be set at creation time as it immutable afterwards.
keys:                          Not included  These are not returned and managed internally.
traffic:                       Not included  It can't be set at the time of endpoint creation, as the deployments must be created before traffic can be set. Will revisit it after the TF resource for "deployment" is implemented.
mirror_traffic:                Not included  It's again a percentage of live traffic to mirror to a deployment.
kind:                          Not included  It's metadata used by portal/tooling/etc to render different UX experiences for resources of the same type. We can include it in data source.
sku:                           Not included  Sku struct has 5 fields (Name, Capacity, Family, Size, Tier). For Online Endpoints specifically, the SKU is not typically set by users — managed online endpoints don't require SKU configuration (the compute is specified via compute_id instead). The Azure API accepts it as optional, but it's not a meaningful user-facing field for this resource type.
scoring_uri:                   Included      Compute only. Renamed to rest_endpoint to match portal. Useful to be passed to other resources or output.
swagger_uri:                   Included      Compute only. Useful to be passed to other resources or output.
compute:                       Not included  As per documentation - "Name of the compute target to run the endpoint deployments on. This field is only applicable for endpoint deployments to Azure Arc-enabled Kubernetes clusters (the compute target specified in this field must have type: kubernetes). Don't specify this field if you're doing managed online inference.". As we don't support TF resource for AML Kubernetes compute, skipping it.
description:                   Included      But the API doesn't allow to update it once set. Instead of adding a ForceNew which is actively harmful as endpoints have active traffic, added a `customizeDiff` to emit a plan time validation.
tags:                          Included
```

### Notes about specific arguments

- `Identity`: Based on API behaviour, identity is required and supported values are `SystemAssigned` and `UserAssigned` but not `SystemAssigned, UserAssigned`.

  Also, there is a **[blocker issue](https://github.com/Azure/azure-rest-api-specs/issues/41597)** where system assigned identity is not able to handle null user identities:
  ```
    "identity": {
        "type": "SystemAssigned",
        "userAssignedIdentities": null
    },
  ```
  This PR is blocked unless this issue is resolved

- `name` validation: The API returns multiple validation messages based on different naming inputs. It's also different on the Azure Portal. The name applied in this PR is based on the REST API testing and validation.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”

<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

TBA

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_machine_learning_online_endpoint` - new resource ([#32011](https://github.com/hashicorp/terraform-provider-azurerm/pull/32011))

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

The PR uses AI assitance in resource creation, writing acceptance tests, and documentation.

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
