### PR TITLE
wiring vcr http client into provider

### DIFF
--- a/internal/clients/builder.go
+++ b/internal/clients/builder.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
@@ -33,6 +34,7 @@ type ClientBuilder struct {
 	StorageUseAzureAD           bool
 	SubscriptionID              string
 	TerraformVersion            string
+	HttpClient                  *http.Client
 }
 
 const azureStackEnvironmentError = `
@@ -150,6 +152,7 @@ func Build(ctx context.Context, builder ClientBuilder) (*Client, error) {
 		StorageUseAzureAD:           builder.StorageUseAzureAD,
 
 		ResourceManagerEndpoint: *resourceManagerEndpoint,
+		HTTPClient:              builder.HttpClient,
 	}
 
 	if err := client.Build(ctx, o); err != nil {

--- a/internal/common/client_options.go
+++ b/internal/common/client_options.go
@@ -5,6 +5,7 @@ package common
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 
@@ -59,6 +60,8 @@ type ClientOptions struct {
 
 	// TODO: Remove when all go-autorest clients are gone
 	SkipProviderReg bool
+
+	HTTPClient *http.Client
 }
 
 // Configure set up a resourcemanager.Client using an auth.Authorizer from hashicorp/go-azure-sdk
@@ -76,6 +79,9 @@ func (o ClientOptions) Configure(c client.BaseClient, authorizer auth.Authorizer
 
 	c.AppendRequestMiddleware(requestLoggerMiddleware("AzureRM"))
 	c.AppendResponseMiddleware(responseLoggerMiddleware("AzureRM"))
+
+	c.SetHTTPClient(o.HTTPClient)
+
 }
 
 // ConfigureClient sets up an autorest.Client using an autorest.Authorizer

--- a/internal/provider/framework/factory_builder.go
+++ b/internal/provider/framework/factory_builder.go
@@ -5,6 +5,7 @@ package framework
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
@@ -29,11 +30,20 @@ func ProtoV6ProviderFactoriesInit(_ context.Context, providerNames ...string) ma
 }
 
 func ProtoV5ProviderFactoriesInit(ctx context.Context, providerNames ...string) map[string]func() (tfprotov5.ProviderServer, error) {
+	return protoV5ProviderFactoriesInit(ctx, nil, providerNames...)
+}
+
+// ProtoV5ProviderFactoriesInitWithHTTPClient creates provider factories with a custom HTTP client.
+func ProtoV5ProviderFactoriesInitWithHTTPClient(ctx context.Context, httpClient *http.Client, providerNames ...string) map[string]func() (tfprotov5.ProviderServer, error) {
+	return protoV5ProviderFactoriesInit(ctx, httpClient, providerNames...)
+}
+
+func protoV5ProviderFactoriesInit(ctx context.Context, httpClient *http.Client, providerNames ...string) map[string]func() (tfprotov5.ProviderServer, error) {
 	factories := make(map[string]func() (tfprotov5.ProviderServer, error), len(providerNames))
 
 	for _, name := range providerNames {
 		factories[name] = func() (tfprotov5.ProviderServer, error) {
-			providerServerFactory, _, err := ProtoV5ProviderServerFactory(ctx)
+			providerServerFactory, _, err := protoV5ProviderServerFactory(ctx, httpClient)
 			if err != nil {
 				return nil, err
 			}
@@ -46,7 +56,17 @@ func ProtoV5ProviderFactoriesInit(ctx context.Context, providerNames ...string) 
 }
 
 func ProtoV5ProviderServerFactory(ctx context.Context) (func() tfprotov5.ProviderServer, *schema.Provider, error) {
-	v2Provider := provider.AzureProvider()
+	return protoV5ProviderServerFactory(ctx, nil)
+}
+
+// protoV5ProviderServerFactory creates a provider server factory with an optional custom HTTP client.
+func protoV5ProviderServerFactory(ctx context.Context, httpClient *http.Client) (func() tfprotov5.ProviderServer, *schema.Provider, error) {
+	var v2Provider *schema.Provider
+	if httpClient != nil {
+		v2Provider = provider.AzureProviderWithHTTPClient(httpClient)
+	} else {
+		v2Provider = provider.AzureProvider()
+	}
 
 	providers := []func() tfprotov5.ProviderServer{
 		v2Provider.GRPCProvider,

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -6,6 +6,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -24,11 +25,16 @@ import (
 )
 
 func AzureProvider() *schema.Provider {
-	return azureProvider(false)
+	return azureProvider(false, nil)
 }
 
 func TestAzureProvider() *schema.Provider {
-	return azureProvider(true)
+	return azureProvider(true, nil)
+}
+
+// AzureProviderWithHTTPClient creates a provider with a custom HTTP client.
+func AzureProviderWithHTTPClient(httpClient *http.Client) *schema.Provider {
+	return azureProvider(false, httpClient)
 }
 
 func ValidatePartnerID(i interface{}, k string) ([]string, []error) {
@@ -80,7 +86,7 @@ func ValidatePartnerID(i interface{}, k string) ([]string, []error) {
 	}
 }
 
-func azureProvider(supportLegacyTestSuite bool) *schema.Provider {
+func azureProvider(supportLegacyTestSuite bool, httpClient *http.Client) *schema.Provider {
 	dataSources := make(map[string]*schema.Resource)
 	resources := make(map[string]*schema.Resource)
 
@@ -404,7 +410,7 @@ func azureProvider(supportLegacyTestSuite bool) *schema.Provider {
 		ResourcesMap:   resources,
 	}
 
-	p.ConfigureContextFunc = providerConfigure(p)
+	p.ConfigureContextFunc = providerConfigure(p, httpClient)
 
 	if !providerfeatures.FivePointOh() {
 		p.Schema["resource_provider_registrations"].DefaultFunc = schema.EnvDefaultFunc("ARM_RESOURCE_PROVIDER_REGISTRATIONS", resourceproviders.ProviderRegistrationsLegacy)
@@ -416,7 +422,8 @@ func azureProvider(supportLegacyTestSuite bool) *schema.Provider {
 // providerConfigure is used to configure the cloud environment and authentication.
 // To configure behavioral aspects of the provider, use the buildClient function instead.
 // This separation allows us to robustly test different authentication scenarios.
-func providerConfigure(p *schema.Provider) schema.ConfigureContextFunc {
+// The httpClient parameter is optional and used for VCR testing.
+func providerConfigure(p *schema.Provider, httpClient *http.Client) schema.ConfigureContextFunc {
 	return func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 		subscriptionId := d.Get("subscription_id").(string)
 		if subscriptionId == "" {
@@ -521,13 +528,14 @@ func providerConfigure(p *schema.Provider) schema.ConfigureContextFunc {
 			EnableAuthenticationUsingADOPipelineOIDC:   enableOidc,
 		}
 
-		return buildClient(ctx, p, d, authConfig)
+		return buildClient(ctx, p, d, authConfig, httpClient)
 	}
 }
 
 // buildClient is used to configure behavioral aspects of the provider. To configure the
 // cloud environment and authentication-related settings, use the providerConfigure function.
-func buildClient(ctx context.Context, p *schema.Provider, d *schema.ResourceData, authConfig *auth.Credentials) (*clients.Client, diag.Diagnostics) {
+// The httpClient parameter is optional and used for VCR testing.
+func buildClient(ctx context.Context, p *schema.Provider, d *schema.ResourceData, authConfig *auth.Credentials, httpClient *http.Client) (*clients.Client, diag.Diagnostics) {
 	providerRegistrations := d.Get("resource_provider_registrations").(string)
 
 	// TODO: Remove in v5.0
@@ -588,6 +596,7 @@ func buildClient(ctx context.Context, p *schema.Provider, d *schema.ResourceData
 		StorageUseAzureAD:           d.Get("storage_use_azuread").(bool),
 		SubscriptionID:              d.Get("subscription_id").(string),
 		TerraformVersion:            p.TerraformVersion,
+		HttpClient:                  httpClient,
 
 		// this field is intentionally not exposed in the provider block, since it's only used for
 		// platform level tracing
@@ -601,6 +610,7 @@ func buildClient(ctx context.Context, p *schema.Provider, d *schema.ResourceData
 	}
 
 	client, err := clients.Build(stopCtx, clientBuilder)
+
 	if err != nil {
 		return nil, diag.FromErr(err)
 	}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -588,7 +588,7 @@ func TestAccProvider_cliAuth(t *testing.T) {
 			AzureCliSubscriptionIDHint:        d.Get("subscription_id").(string),
 		}
 
-		return buildClient(ctx, provider, d, authConfig)
+		return buildClient(ctx, provider, d, authConfig, nil)
 	}
 
 	d := provider.Configure(ctx, terraform.NewResourceConfigRaw(nil))
@@ -660,7 +660,7 @@ func TestAccProvider_clientCertificateAuth(t *testing.T) {
 			EnableAuthenticatingUsingClientCertificate: true,
 		}
 
-		return buildClient(ctx, provider, d, authConfig)
+		return buildClient(ctx, provider, d, authConfig, nil)
 	}
 
 	d := provider.Configure(ctx, terraform.NewResourceConfigRaw(nil))
@@ -733,7 +733,7 @@ func testAccProvider_clientSecretAuthFromEnvironment(t *testing.T) {
 			EnableAuthenticatingUsingClientSecret: true,
 		}
 
-		return buildClient(ctx, provider, d, authConfig)
+		return buildClient(ctx, provider, d, authConfig, nil)
 	}
 
 	d := provider.Configure(ctx, terraform.NewResourceConfigRaw(nil))
@@ -801,7 +801,7 @@ func testAccProvider_clientSecretAuthFromFiles(t *testing.T) {
 			EnableAuthenticatingUsingClientSecret: true,
 		}
 
-		return buildClient(ctx, provider, d, authConfig)
+		return buildClient(ctx, provider, d, authConfig, nil)
 	}
 
 	d := provider.Configure(ctx, terraform.NewResourceConfigRaw(nil))
@@ -861,7 +861,7 @@ func TestAccProvider_genericOidcAuth(t *testing.T) {
 			OIDCAssertionToken:            *oidcToken,
 		}
 
-		return buildClient(ctx, provider, d, authConfig)
+		return buildClient(ctx, provider, d, authConfig, nil)
 	}
 
 	d := provider.Configure(ctx, terraform.NewResourceConfigRaw(nil))
@@ -920,7 +920,7 @@ func TestAccProvider_githubOidcAuth(t *testing.T) {
 			EnableAuthenticationUsingGitHubOIDC: true,
 		}
 
-		return buildClient(ctx, provider, d, authConfig)
+		return buildClient(ctx, provider, d, authConfig, nil)
 	}
 
 	d := provider.Configure(ctx, terraform.NewResourceConfigRaw(nil))
@@ -983,7 +983,7 @@ func TestAccProvider_adoOidcAuth(t *testing.T) {
 			EnableAuthenticationUsingADOPipelineOIDC: true,
 		}
 
-		return buildClient(ctx, provider, d, authConfig)
+		return buildClient(ctx, provider, d, authConfig, nil)
 	}
 
 	d := provider.Configure(ctx, terraform.NewResourceConfigRaw(nil))
@@ -1049,7 +1049,7 @@ func TestAccProvider_aksWorkloadIdentityAuth(t *testing.T) {
 			EnableAuthenticationUsingOIDC: true,
 		}
 
-		return buildClient(ctx, provider, d, authConfig)
+		return buildClient(ctx, provider, d, authConfig, nil)
 	}
 
 	// Ensure we enable AKS Workload Identity else the configuration will not be detected

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/client/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/client/client.go
@@ -318,6 +318,8 @@ type Client struct {
 
 	// ResponseMiddlewares is a slice of functions that are called in order before a response is parsed and returned
 	ResponseMiddlewares *[]ResponseMiddleware
+
+	HttpClient *http.Client
 }
 
 // NewClient returns a new Client configured with sensible defaults
@@ -345,6 +347,14 @@ func (c *Client) SetUserAgent(userAgent string) {
 // GetUserAgent retrieves the configured user agent for the client
 func (c *Client) GetUserAgent() string {
 	return c.UserAgent
+}
+
+func (c *Client) SetHTTPClient(httpClient *http.Client) {
+	c.HttpClient = httpClient
+}
+
+func (c *Client) GetHTTPClient() *http.Client {
+	return c.HttpClient
 }
 
 // AppendRequestMiddleware appends a request middleware function for the client
@@ -741,6 +751,10 @@ func (c *Client) retryableClient(ctx context.Context, checkRetry retryablehttp.C
 			ForceAttemptHTTP2:     true,
 			MaxIdleConnsPerHost:   runtime.GOMAXPROCS(0) + 1,
 		},
+	}
+
+	if c.HttpClient != nil {
+		r.HTTPClient = c.HttpClient
 	}
 
 	return

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/client/interface.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/client/interface.go
@@ -41,6 +41,8 @@ type BaseClient interface {
 
 	// ClearResponseMiddlewares removes all response middleware functions for the client
 	ClearResponseMiddlewares()
+	
+	SetHTTPClient(*http.Client)
 }
 
 // RequestRetryFunc is a function that determines whether an HTTP request has failed due to eventual consistency and should be retried


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


These changes injects vcr http client into azure provider and configure's go-azure-sdk to use vcrEnabledHttp client for making http calls. 

as this is a part of Spike, so I've made changes to go-azure-sdk vendor directory instead of sdk codebase. Once we align on these changes will raise PR separately for go-azure-sdk.

vendor file changes : 

go-azure-sdk/sdk/client/interface.go
added SetHTTPClient in BaseClient interface so that vcr http client can be configured into azure-sdk

go-azure-sdk/sdk/client/client.go
in retrableHttp overriding httpClient with custom http client ( vcrClient)  if present

provider code base 

internal/common/client_options.go

In Configure method calling baseClient's SetHTTPClient with vcrHttpClient. 











## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

