### PR TITLE
made changes into acceptance test util files for vcr flow

### DIFF
--- a/internal/acceptance/data.go
+++ b/internal/acceptance/data.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/vcr"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 )
 
@@ -83,6 +84,12 @@ func BuildTestData(t *testing.T, resourceType string, resourceLabel string) Test
 	testData.Subscriptions = Subscriptions{
 		Primary:   os.Getenv("ARM_SUBSCRIPTION_ID"),
 		Secondary: os.Getenv("ARM_SUBSCRIPTION_ID_ALT"),
+	}
+
+	// Override with VCR-managed values when VCR is active (recording or replaying)
+	if vcr.IsVCRActive() {
+		testData.RandomInteger = vcr.RandTimeIntVCR(t, testData.RandomInteger)
+		testData.RandomString = vcr.RandStringVCR(t, testData.RandomString)
 	}
 
 	return testData

--- a/internal/acceptance/testcase.go
+++ b/internal/acceptance/testcase.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/helpers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/testclient"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/types"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/vcr"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
@@ -98,6 +99,10 @@ func (td TestData) ResourceTest(t *testing.T, testResource types.TestResource, s
 			return helpers.CheckDestroyedFunc(client, testResource, td.ResourceType, td.ResourceName)(s)
 		},
 		Steps: steps,
+	}
+	if vcr.IsVCRActive() {
+		td.runAcceptanceTestWithVCR(t, testCase)
+		return
 	}
 	td.runAcceptanceTest(t, testCase)
 }
@@ -188,6 +193,20 @@ func RunTestsInSequence(t *testing.T, tests map[string]map[string]func(t *testin
 func (td TestData) runAcceptanceTest(t *testing.T, testCase resource.TestCase) {
 	testCase.ExternalProviders = td.externalProviders()
 	testCase.ProtoV5ProviderFactories = framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm", "azurerm-alt")
+
+	resource.ParallelTest(t, testCase)
+}
+
+// runAcceptanceTestWithVCR runs acceptance test with VCR HTTP client for recording/playback.
+func (td TestData) runAcceptanceTestWithVCR(t *testing.T, testCase resource.TestCase) {
+	testCase.ExternalProviders = td.externalProviders()
+	if _, err := testclient.BuildWithVcr(t); err != nil {
+		t.Fatalf("building VCR test client: %+v", err)
+	}
+	// Get VCR HTTP client
+	httpClient := vcr.GetHTTPClient(t)
+	testCase.ProtoV5ProviderFactories = framework.ProtoV5ProviderFactoriesInitWithHTTPClient(
+		context.Background(), httpClient, "azurerm", "azurerm-alt")
 
 	resource.ParallelTest(t, testCase)
 }

--- a/internal/acceptance/testclient/client.go
+++ b/internal/acceptance/testclient/client.go
@@ -6,11 +6,14 @@ package testclient
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"sync"
+	"testing"
 
 	"github.com/hashicorp/go-azure-sdk/sdk/auth"
 	"github.com/hashicorp/go-azure-sdk/sdk/environments"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/vcr"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 )
@@ -20,7 +23,7 @@ var (
 	clientLock = &sync.Mutex{}
 )
 
-func Build() (*clients.Client, error) {
+func buildClient(httpClient *http.Client) (*clients.Client, error) {
 	clientLock.Lock()
 	defer clientLock.Unlock()
 
@@ -70,6 +73,7 @@ func Build() (*clients.Client, error) {
 			Features:          features.Default(),
 			StorageUseAzureAD: false,
 			SubscriptionID:    os.Getenv("ARM_SUBSCRIPTION_ID"),
+			HttpClient:        httpClient,
 		}
 
 		client, err := clients.Build(ctx, clientBuilder)
@@ -81,4 +85,12 @@ func Build() (*clients.Client, error) {
 	}
 
 	return _client, nil
+}
+
+func Build() (*clients.Client, error) {
+	return buildClient(nil)
+}
+
+func BuildWithVcr(t *testing.T) (*clients.Client, error) {
+	return buildClient(vcr.GetHTTPClient(t))
 }

--- a/internal/services/apimanagement/api_management_resource.go
+++ b/internal/services/apimanagement/api_management_resource.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -65,6 +66,14 @@ var (
 	apimTlsRsaWithAes256CbcShaCiphers        = "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Ciphers.TLS_RSA_WITH_AES_256_CBC_SHA"
 	apimTlsRsaWithAes128CbcShaCiphers        = "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Ciphers.TLS_RSA_WITH_AES_128_CBC_SHA"
 )
+
+func replayAwareApiManagementPollInterval(defaultInterval time.Duration) time.Duration {
+	if strings.EqualFold(strings.TrimSpace(os.Getenv("VCR_MODE")), "REPLAY") {
+		return 0
+	}
+
+	return defaultInterval
+}
 
 func resourceApiManagementService() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
@@ -1444,7 +1453,7 @@ func resourceApiManagementServiceDelete(d *pluginsdk.ResourceData, meta interfac
 			return fmt.Errorf("polling deleting %s: %+v", id, err)
 		}
 		if pollerType != nil {
-			poller := pollers.NewPoller(pollerType, 20*time.Second, pollers.DefaultNumberOfDroppedConnectionsToAllow)
+			poller := pollers.NewPoller(pollerType, replayAwareApiManagementPollInterval(20*time.Second), pollers.DefaultNumberOfDroppedConnectionsToAllow)
 			if err := poller.PollUntilDone(ctx); err != nil {
 				return fmt.Errorf("polling deleting %s: %+v", id, err)
 			}
@@ -1477,7 +1486,7 @@ func resourceApiManagementServiceDelete(d *pluginsdk.ResourceData, meta interfac
 					return fmt.Errorf("polling deleting %s: %+v", id, err)
 				}
 				if pollerType != nil {
-					poller := pollers.NewPoller(pollerType, 20*time.Second, pollers.DefaultNumberOfDroppedConnectionsToAllow)
+					poller := pollers.NewPoller(pollerType, replayAwareApiManagementPollInterval(20*time.Second), pollers.DefaultNumberOfDroppedConnectionsToAllow)
 					if err := poller.PollUntilDone(ctx); err != nil {
 						return fmt.Errorf("polling purging the deleting %s: %+v", id, err)
 					}

--- a/internal/services/apimanagement/custompollers/api_management_api_poller.go
+++ b/internal/services/apimanagement/custompollers/api_management_api_poller.go
@@ -27,11 +27,11 @@ type apiManagementAPIPoller struct {
 var (
 	pollingSuccess = pollers.PollResult{
 		Status:       pollers.PollingStatusSucceeded,
-		PollInterval: 10 * time.Second,
+		PollInterval: replayAwarePollInterval(10 * time.Second),
 	}
 	pollingInProgress = pollers.PollResult{
 		Status:       pollers.PollingStatusInProgress,
-		PollInterval: 10 * time.Second,
+		PollInterval: replayAwarePollInterval(10 * time.Second),
 	}
 )
 
@@ -75,6 +75,7 @@ func (p options) ToQuery() *client.QueryParams {
 }
 
 func (p apiManagementAPIPoller) Poll(ctx context.Context) (*pollers.PollResult, error) {
+
 	if p.asyncID == "" {
 		return &pollingSuccess, nil
 	}

--- a/internal/services/apimanagement/custompollers/api_management_poller.go
+++ b/internal/services/apimanagement/custompollers/api_management_poller.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -33,14 +34,21 @@ type operationResult struct {
 
 type status string
 
+func replayAwarePollInterval(defaultInterval time.Duration) time.Duration {
+	if strings.EqualFold(strings.TrimSpace(os.Getenv("VCR_MODE")), "REPLAY") {
+		return 0
+	}
+	return defaultInterval
+}
+
 var (
 	pollingDeleteSuccess = pollers.PollResult{
 		Status:       pollers.PollingStatusSucceeded,
-		PollInterval: 20 * time.Second,
+		PollInterval: replayAwarePollInterval(20 * time.Second),
 	}
 	pollingDeleteInProgress = pollers.PollResult{
 		Status:       pollers.PollingStatusInProgress,
-		PollInterval: 20 * time.Second,
+		PollInterval: replayAwarePollInterval(20 * time.Second),
 	}
 )
 
@@ -98,6 +106,7 @@ func (p apiManagementPoller) Poll(ctx context.Context) (*pollers.PollResult, err
 	}
 
 	if resp.Response != nil {
+
 		var respBody []byte
 		respBody, err = io.ReadAll(resp.Body)
 		if err != nil {

--- a/internal/services/resource/custompollers/resource_group_create_poller.go
+++ b/internal/services/resource/custompollers/resource_group_create_poller.go
@@ -3,6 +3,8 @@ package custompollers
 import (
 	"context"
 	"fmt"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
@@ -21,20 +23,27 @@ var _ pollers.PollerType = &resourceGroupCreatePoller{}
 var (
 	successCount   = 3 // emulates ContinuousTargetOccurrence
 	pollingSuccess = &pollers.PollResult{
-		PollInterval: 5 * time.Second,
+		PollInterval: replayAwareResourceGroupCreatePollInterval(5 * time.Second),
 		Status:       pollers.PollingStatusSucceeded,
 	}
 	pollingInProgress = &pollers.PollResult{
 		HttpResponse: nil,
-		PollInterval: 5 * time.Second,
+		PollInterval: replayAwareResourceGroupCreatePollInterval(5 * time.Second),
 		Status:       pollers.PollingStatusInProgress,
 	}
 	pollingFailed = &pollers.PollResult{
 		HttpResponse: nil,
-		PollInterval: 5 * time.Second,
+		PollInterval: replayAwareResourceGroupCreatePollInterval(5 * time.Second),
 		Status:       pollers.PollingStatusFailed,
 	}
 )
+
+func replayAwareResourceGroupCreatePollInterval(defaultInterval time.Duration) time.Duration {
+	if strings.EqualFold(strings.TrimSpace(os.Getenv("VCR_MODE")), "REPLAY") {
+		return 0
+	}
+	return defaultInterval
+}
 
 func NewResourceGroupCreatePoller(client *resourcegroups.ResourceGroupsClient, id commonids.ResourceGroupId) *resourceGroupCreatePoller {
 	return &resourceGroupCreatePoller{

--- a/internal/services/resource/custompollers/resource_group_prevent_delete_poller.go
+++ b/internal/services/resource/custompollers/resource_group_prevent_delete_poller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -18,6 +19,14 @@ import (
 type resourceGroupPreventDeletePoller struct {
 	client *resourcegroups.ResourceGroupsClient
 	id     commonids.ResourceGroupId
+}
+
+func replayAwareResourceGroupDeletePollInterval(defaultInterval time.Duration) time.Duration {
+	if strings.EqualFold(strings.TrimSpace(os.Getenv("VCR_MODE")), "REPLAY") {
+		return 0
+	}
+
+	return defaultInterval
 }
 
 var _ pollers.PollerType = &resourceGroupPreventDeletePoller{}
@@ -51,7 +60,7 @@ func (p resourceGroupPreventDeletePoller) Poll(ctx context.Context) (*pollers.Po
 
 	if len(nestedResourceIds) > 0 {
 		return &pollers.PollResult{
-			PollInterval: 30 * time.Second,
+			PollInterval: replayAwareResourceGroupDeletePollInterval(30 * time.Second),
 			Status:       pollers.PollingStatusInProgress,
 		}, resourceGroupContainsItemsError(p.id.ResourceGroupName, nestedResourceIds)
 	}

--- a/internal/services/resource/resource_group_resource.go
+++ b/internal/services/resource/resource_group_resource.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -29,6 +31,14 @@ import (
 //go:generate go run ../../tools/generator-tests resourceidentity -resource-name resource_group -properties "name"
 
 const resourceGroupResourceName = "azurerm_resource_group"
+
+func replayAwareResourceGroupPollInterval(defaultInterval time.Duration) time.Duration {
+	if strings.EqualFold(strings.TrimSpace(os.Getenv("VCR_MODE")), "REPLAY") {
+		return 0
+	}
+
+	return defaultInterval
+}
 
 func resourceResourceGroup() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
@@ -98,7 +108,7 @@ func resourceResourceGroupCreate(d *pluginsdk.ResourceData, meta interface{}) er
 
 	// custom poller to account for replication delays in the eventual consistency responses of newly created RG resources
 	pollerType := custompollers.NewResourceGroupCreatePoller(client, id)
-	poller := pollers.NewPoller(pollerType, 10*time.Second, pollers.DefaultNumberOfDroppedConnectionsToAllow)
+	poller := pollers.NewPoller(pollerType, replayAwareResourceGroupPollInterval(10*time.Second), pollers.DefaultNumberOfDroppedConnectionsToAllow)
 	if err = poller.PollUntilDone(ctx); err != nil {
 		return err
 	}
@@ -198,7 +208,7 @@ func resourceResourceGroupDelete(d *pluginsdk.ResourceData, meta interface{}) er
 		defer deletePollerCancel()
 
 		pollerType := custompollers.NewResourceGroupPreventDeletePoller(client, *id)
-		poller := pollers.NewRetryOnErrorPoller(pollerType, 10*time.Second, pollers.DefaultNumberOfDroppedConnectionsToAllow, true)
+		poller := pollers.NewRetryOnErrorPoller(pollerType, replayAwareResourceGroupPollInterval(10*time.Second), pollers.DefaultNumberOfDroppedConnectionsToAllow, true)
 		if err := poller.PollUntilDone(deletePollerContext); err != nil {
 			return err
 		}

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager/poller.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager/poller.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/go-azure-sdk/sdk/client"
 	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
@@ -45,7 +47,7 @@ func PollerFromResponse(response *client.Response, client *Client) (poller polle
 		strings.EqualFold(response.Request.Method, "POST") ||
 		strings.EqualFold(response.Request.Method, "PUT")
 	if statusCodesToCheckProvisioningState && contentTypeMatchesForProvisioningStateCheck && methodIsApplicable {
-		provisioningState, provisioningStateErr := provisioningStatePollerFromResponse(response, lroIsSelfReference, client, DefaultPollingInterval)
+		provisioningState, provisioningStateErr := provisioningStatePollerFromResponse(response, lroIsSelfReference, client, defaultPollingInterval())
 		if provisioningStateErr != nil {
 			return pollers.Poller{}, fmt.Errorf("building provisioningState poller: %+v", provisioningStateErr)
 		}
@@ -55,7 +57,7 @@ func PollerFromResponse(response *client.Response, client *Client) (poller polle
 	// finally, if it was a Delete that returned a 200/204
 	statusCodesToCheckDelete := response.StatusCode == http.StatusOK || response.StatusCode == http.StatusCreated || response.StatusCode == http.StatusAccepted || response.StatusCode == http.StatusNoContent
 	if methodIsDelete && statusCodesToCheckDelete {
-		deletePoller, deletePollerErr := deletePollerFromResponse(response, client, DefaultPollingInterval)
+		deletePoller, deletePollerErr := deletePollerFromResponse(response, client, defaultPollingInterval())
 		if deletePollerErr != nil {
 			return pollers.Poller{}, fmt.Errorf("building delete poller: %+v", deletePollerErr)
 		}
@@ -63,6 +65,13 @@ func PollerFromResponse(response *client.Response, client *Client) (poller polle
 	}
 
 	return pollers.Poller{}, fmt.Errorf("no applicable pollers were found for the response")
+}
+
+func defaultPollingInterval() time.Duration {
+	if strings.EqualFold(strings.TrimSpace(os.Getenv("VCR_MODE")), "REPLAY") {
+		return 0 * time.Millisecond
+	}
+	return DefaultPollingInterval
 }
 
 func isLROSelfReference(lroPollingUri, originalRequestUri string) bool {

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager/poller_lro.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager/poller_lro.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -33,6 +34,14 @@ type longRunningOperationPoller struct {
 	maxDroppedConnections  int
 }
 
+func replayAwareLongRunningOperationPollInterval(defaultInterval time.Duration) time.Duration {
+	if strings.EqualFold(strings.TrimSpace(os.Getenv("VCR_MODE")), "REPLAY") {
+		return 0
+	}
+
+	return defaultInterval
+}
+
 func pollingUriForLongRunningOperation(resp *client.Response) string {
 	pollingUrl := resp.Header.Get("Azure-AsyncOperation")
 	if pollingUrl == "" {
@@ -44,7 +53,7 @@ func pollingUriForLongRunningOperation(resp *client.Response) string {
 func longRunningOperationPollerFromResponse(resp *client.Response, client *client.Client) (*longRunningOperationPoller, error) {
 	poller := longRunningOperationPoller{
 		client:                client,
-		initialRetryDuration:  10 * time.Second,
+		initialRetryDuration:  replayAwareLongRunningOperationPollInterval(10 * time.Second),
 		maxDroppedConnections: 3,
 	}
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR enables running acceptance tests via VCR flow. 
- tested TestAccApiManagementLogger_basicEventHub and TestAccResourceGroup_basic with VCR flow. 
- incase of VCR reading randomId from file instead of generating it.

- Had to override polling interval with 0 incase of VCR_REPLAY mode as acceptance tests were taking considerable amount of time even when no real network calls were being made.
Alternative approach : https://github.com/hashicorp/terraform-provider-azurerm/pull/32017 


Steps to run acceptance tests using VCR .

1. Run tests in RECORD mode by setting VCR_MODE=RECORD.
```
make acctests SERVICE='apimanagement' TESTARGS='-run=TestAccApiManagementLogger_basicEventHub' TESTTIMEOUT='90m' VCR_MODE=RECORD
```

2. Running tests in REPLAY mode by passing VCR_MODE=REPLAY ( use only if no changes in acceptance tests)
```
make acctests SERVICE='apimanagement' TESTARGS='-run=TestAccApiManagementLogger_basicEventHub' TESTTIMEOUT='90m' VCR_MODE=REPLAY VCR_DEBUG=1
```


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs
