### PR TITLE
made changes into acceptance test util files for vcr flow

### DIFF
--- a/internal/acceptance/data.go
+++ b/internal/acceptance/data.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/vcr"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 )
 
@@ -83,6 +84,12 @@ func BuildTestData(t *testing.T, resourceType string, resourceLabel string) Test
 	testData.Subscriptions = Subscriptions{
 		Primary:   os.Getenv("ARM_SUBSCRIPTION_ID"),
 		Secondary: os.Getenv("ARM_SUBSCRIPTION_ID_ALT"),
+	}
+
+	// Override with VCR-managed values when VCR is active (recording or replaying)
+	if vcr.IsVCRActive() {
+		testData.RandomInteger = vcr.RandTimeIntVCR(t, testData.RandomInteger)
+		testData.RandomString = vcr.RandStringVCR(t, testData.RandomString)
 	}
 
 	return testData

--- a/internal/acceptance/testcase.go
+++ b/internal/acceptance/testcase.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/helpers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/testclient"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/types"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/vcr"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 )
 
@@ -98,6 +99,10 @@ func (td TestData) ResourceTest(t *testing.T, testResource types.TestResource, s
 			return helpers.CheckDestroyedFunc(client, testResource, td.ResourceType, td.ResourceName)(s)
 		},
 		Steps: steps,
+	}
+	if vcr.IsVCRActive() {
+		td.runAcceptanceTestWithVCR(t, testCase)
+		return
 	}
 	td.runAcceptanceTest(t, testCase)
 }
@@ -188,6 +193,20 @@ func RunTestsInSequence(t *testing.T, tests map[string]map[string]func(t *testin
 func (td TestData) runAcceptanceTest(t *testing.T, testCase resource.TestCase) {
 	testCase.ExternalProviders = td.externalProviders()
 	testCase.ProtoV5ProviderFactories = framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm", "azurerm-alt")
+
+	resource.ParallelTest(t, testCase)
+}
+
+// runAcceptanceTestWithVCR runs acceptance test with VCR HTTP client for recording/playback.
+func (td TestData) runAcceptanceTestWithVCR(t *testing.T, testCase resource.TestCase) {
+	testCase.ExternalProviders = td.externalProviders()
+	if _, err := testclient.BuildWithVcr(t); err != nil {
+		t.Fatalf("building VCR test client: %+v", err)
+	}
+	// Get VCR HTTP client
+	httpClient := vcr.GetHTTPClient(t)
+	testCase.ProtoV5ProviderFactories = framework.ProtoV5ProviderFactoriesInitWithHTTPClient(
+		context.Background(), httpClient, "azurerm", "azurerm-alt")
 
 	resource.ParallelTest(t, testCase)
 }

--- a/internal/acceptance/testclient/client.go
+++ b/internal/acceptance/testclient/client.go
@@ -6,11 +6,14 @@ package testclient
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"sync"
+	"testing"
 
 	"github.com/hashicorp/go-azure-sdk/sdk/auth"
 	"github.com/hashicorp/go-azure-sdk/sdk/environments"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/vcr"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 )
@@ -20,7 +23,7 @@ var (
 	clientLock = &sync.Mutex{}
 )
 
-func Build() (*clients.Client, error) {
+func buildClient(httpClient *http.Client) (*clients.Client, error) {
 	clientLock.Lock()
 	defer clientLock.Unlock()
 
@@ -70,6 +73,7 @@ func Build() (*clients.Client, error) {
 			Features:          features.Default(),
 			StorageUseAzureAD: false,
 			SubscriptionID:    os.Getenv("ARM_SUBSCRIPTION_ID"),
+			HttpClient:        httpClient,
 		}
 
 		client, err := clients.Build(ctx, clientBuilder)
@@ -81,4 +85,12 @@ func Build() (*clients.Client, error) {
 	}
 
 	return _client, nil
+}
+
+func Build() (*clients.Client, error) {
+	return buildClient(nil)
+}
+
+func BuildWithVcr(t *testing.T) (*clients.Client, error) {
+	return buildClient(vcr.GetHTTPClient(t))
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/client/pollers/poller.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/client/pollers/poller.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -135,6 +137,9 @@ func (p *Poller) PollUntilDone(ctx context.Context) error {
 			// determine the next retry duration / how long to poll for
 			if p.latestResponse != nil {
 				retryDuration = p.latestResponse.PollInterval
+			}
+			if strings.EqualFold(strings.TrimSpace(os.Getenv("VCR_MODE")), "REPLAY") {
+				retryDuration = 0
 			}
 			endTime := time.Now().Add(retryDuration)
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR enables running acceptance tests via VCR flow. 
- tested TestAccApiManagementLogger_basicEventHub and TestAccResourceGroup_basic with VCR flow. 
- instead of overriding polling interval into individual pollers, it over rides retry duration to 0 in centralised poller. PollUntilDone method.

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs
