### PR TITLE
containers: allow Ubuntu2404 for AKS os_sku

### DIFF
--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -333,6 +333,7 @@ func resourceKubernetesClusterNodePoolSchema() map[string]*pluginsdk.Schema {
 				string(agentpools.OSSKUAzureLinuxThree),
 				string(agentpools.OSSKUUbuntu),
 				string(agentpools.OSSKUUbuntuTwoTwoZeroFour),
+				string(agentpools.OSSKUUbuntuTwoFourZeroFour),
 				string(agentpools.OSSKUWindowsTwoZeroOneNine),
 				string(agentpools.OSSKUWindowsTwoZeroTwoTwo),
 			}, false),

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -191,6 +191,7 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 							string(agentpools.OSSKUAzureLinuxThree),
 							string(agentpools.OSSKUUbuntu),
 							string(agentpools.OSSKUUbuntuTwoTwoZeroFour),
+							string(agentpools.OSSKUUbuntuTwoFourZeroFour),
 							string(agentpools.OSSKUWindowsTwoZeroOneNine),
 							string(agentpools.OSSKUWindowsTwoZeroTwoTwo),
 						}, false),

--- a/internal/services/containers/kubernetes_os_sku_validation_test.go
+++ b/internal/services/containers/kubernetes_os_sku_validation_test.go
@@ -1,0 +1,42 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package containers
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+func TestKubernetesClusterNodePoolSchemaAcceptsUbuntu2404(t *testing.T) {
+	validate := resourceKubernetesClusterNodePoolSchema()["os_sku"].ValidateFunc
+	if validate == nil {
+		t.Fatal("node pool os_sku ValidateFunc is nil")
+	}
+
+	if warnings, errs := validate("Ubuntu2404", "os_sku"); len(warnings) != 0 || len(errs) != 0 {
+		t.Fatalf("expected Ubuntu2404 to be accepted for node pool os_sku, got warnings=%v errs=%v", warnings, errs)
+	}
+}
+
+func TestKubernetesClusterDefaultNodePoolSchemaAcceptsUbuntu2404(t *testing.T) {
+	defaultNodePool := resourceKubernetesCluster().Schema["default_node_pool"]
+	if defaultNodePool == nil {
+		t.Fatal("default_node_pool schema is nil")
+	}
+
+	defaultNodePoolResource, ok := defaultNodePool.Elem.(*pluginsdk.Resource)
+	if !ok {
+		t.Fatalf("expected default_node_pool elem to be a resource, got %T", defaultNodePool.Elem)
+	}
+
+	validate := defaultNodePoolResource.Schema["os_sku"].ValidateFunc
+	if validate == nil {
+		t.Fatal("default node pool os_sku ValidateFunc is nil")
+	}
+
+	if warnings, errs := validate("Ubuntu2404", "os_sku"); len(warnings) != 0 || len(errs) != 0 {
+		t.Fatalf("expected Ubuntu2404 to be accepted for default node pool os_sku, got warnings=%v errs=%v", warnings, errs)
+	}
+}


### PR DESCRIPTION
## Community Note
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This is a follow-up to the AKS containerservice API update in #31401.

AKS now supports `Ubuntu2404` for both:
- `azurerm_kubernetes_cluster_node_pool.os_sku`
- `azurerm_kubernetes_cluster.default_node_pool.os_sku`

but the provider schema validation still rejects that value in both code paths.

This change updates the validation lists to accept `Ubuntu2404` and adds small offline tests that lock in the expected schema behavior for both resources.

This is intended to close the remaining schema gap reported in #29827.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them.
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

Local test run:

```text
$ go test ./internal/services/containers -run "TestKubernetes.*Ubuntu2404" -count=1
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/containers	0.009s
```

I did not run Azure acceptance tests for this change because the patch is limited to schema validation and the added tests are offline schema-level coverage.


## Change Log

* `azurerm_kubernetes_cluster` - support `Ubuntu2404` in `default_node_pool.os_sku` [GH-29827]
* `azurerm_kubernetes_cluster_node_pool` - support `Ubuntu2404` in `os_sku` [GH-29827]


This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #29827


## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

AI was used to help identify the remaining schema-validation call sites and draft the initial offline schema tests. The final patch and local validation were reviewed and run manually.


## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

No changes to security controls.

