### PR TITLE
`azurerm_mssql_virtual_machine` - set `temp_db_settings.luns` as optional

### DIFF
--- a/internal/services/mssql/helper/sql_virtual_machine_storage_settings.go
+++ b/internal/services/mssql/helper/sql_virtual_machine_storage_settings.go
@@ -71,7 +71,7 @@ func SQLTempDBStorageSettingSchema() *pluginsdk.Schema {
 				},
 				"luns": {
 					Type:     pluginsdk.TypeList,
-					Required: true,
+					Optional: true,
 					Elem: &pluginsdk.Schema{
 						Type: pluginsdk.TypeInt,
 					},

--- a/internal/services/mssql/mssql_virtual_machine_resource.go
+++ b/internal/services/mssql/mssql_virtual_machine_resource.go
@@ -572,7 +572,7 @@ func resourceMsSqlVirtualMachineCreateUpdate(d *pluginsdk.ResourceData, meta int
 			},
 			SqlManagement:                &sqlManagement,
 			SqlServerLicenseType:         &sqlServerLicenseType,
-			StorageConfigurationSettings: expandSqlVirtualMachineStorageConfigurationSettings(d.Get("storage_configuration").([]interface{})),
+			StorageConfigurationSettings: expandSqlVirtualMachineStorageConfigurationSettings(d.Get("storage_configuration").([]interface{}), isTempDbLunsInConfig(d)),
 			VirtualMachineResourceId:     pointer.To(d.Get("virtual_machine_id").(string)),
 		},
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
@@ -1245,7 +1245,7 @@ func mssqlVMCredentialNameDiffSuppressFunc(_, old, new string, _ *pluginsdk.Reso
 	return false
 }
 
-func expandSqlVirtualMachineStorageConfigurationSettings(input []interface{}) *sqlvirtualmachines.StorageConfigurationSettings {
+func expandSqlVirtualMachineStorageConfigurationSettings(input []interface{}, tempDbLunsInConfig bool) *sqlvirtualmachines.StorageConfigurationSettings {
 	if len(input) == 0 || input[0] == nil {
 		return nil
 	}
@@ -1260,8 +1260,22 @@ func expandSqlVirtualMachineStorageConfigurationSettings(input []interface{}) *s
 		SqlSystemDbOnDataDisk: pointer.To(storageSettings["system_db_on_data_disk_enabled"].(bool)),
 		SqlDataSettings:       expandSqlVirtualMachineDataStorageSettings(storageSettings["data_settings"].([]interface{})),
 		SqlLogSettings:        expandSqlVirtualMachineDataStorageSettings(storageSettings["log_settings"].([]interface{})),
-		SqlTempDbSettings:     expandSqlVirtualMachineTempDbSettings(storageSettings["temp_db_settings"].([]interface{})),
+		SqlTempDbSettings:     expandSqlVirtualMachineTempDbSettings(storageSettings["temp_db_settings"].([]interface{}), tempDbLunsInConfig),
 	}
+}
+
+func isTempDbLunsInConfig(d *pluginsdk.ResourceData) bool {
+	tempDbLunsInConfig := false
+	if rawConfig := d.GetRawConfig().AsValueMap(); rawConfig != nil {
+		if sc := rawConfig["storage_configuration"]; !sc.IsNull() && sc.LengthInt() > 0 {
+			if td := sc.AsValueSlice()[0].AsValueMap()["temp_db_settings"]; !td.IsNull() && td.LengthInt() > 0 {
+				if luns := td.AsValueSlice()[0].AsValueMap()["luns"]; !luns.IsNull() {
+					tempDbLunsInConfig = true
+				}
+			}
+		}
+	}
+	return tempDbLunsInConfig
 }
 
 func flattenSqlVirtualMachineStorageConfigurationSettings(input *sqlvirtualmachines.StorageConfigurationSettings, storageWorkloadType string) []interface{} {
@@ -1338,14 +1352,19 @@ func flattenSqlVirtualMachineStorageSettings(input *sqlvirtualmachines.SQLStorag
 	return []interface{}{attrs}
 }
 
-func expandSqlVirtualMachineTempDbSettings(input []interface{}) *sqlvirtualmachines.SQLTempDbSettings {
+func expandSqlVirtualMachineTempDbSettings(input []interface{}, lunsInConfig bool) *sqlvirtualmachines.SQLTempDbSettings {
 	if len(input) == 0 || input[0] == nil {
 		return nil
 	}
 	tempDbSettings := input[0].(map[string]interface{})
 
+	var luns *[]int64
+	if lunsInConfig {
+		luns = expandSqlVirtualMachineStorageSettingsLuns(tempDbSettings["luns"].([]interface{}))
+	}
+
 	return &sqlvirtualmachines.SQLTempDbSettings{
-		Luns:            expandSqlVirtualMachineStorageSettingsLuns(tempDbSettings["luns"].([]interface{})),
+		Luns:            luns,
 		DefaultFilePath: pointer.To(tempDbSettings["default_file_path"].(string)),
 		DataFileCount:   pointer.To(int64(tempDbSettings["data_file_count"].(int))),
 		DataFileSize:    pointer.To(int64(tempDbSettings["data_file_size_mb"].(int))),

--- a/internal/services/mssql/mssql_virtual_machine_resource.go
+++ b/internal/services/mssql/mssql_virtual_machine_resource.go
@@ -1265,17 +1265,22 @@ func expandSqlVirtualMachineStorageConfigurationSettings(input []interface{}, te
 }
 
 func isTempDbLunsInConfig(d *pluginsdk.ResourceData) bool {
-	tempDbLunsInConfig := false
-	if rawConfig := d.GetRawConfig().AsValueMap(); rawConfig != nil {
-		if sc := rawConfig["storage_configuration"]; !sc.IsNull() && sc.LengthInt() > 0 {
-			if td := sc.AsValueSlice()[0].AsValueMap()["temp_db_settings"]; !td.IsNull() && td.LengthInt() > 0 {
-				if luns := td.AsValueSlice()[0].AsValueMap()["luns"]; !luns.IsNull() {
-					tempDbLunsInConfig = true
-				}
-			}
-		}
+	rawConfig := d.GetRawConfig().AsValueMap()
+	if rawConfig == nil {
+		return false
 	}
-	return tempDbLunsInConfig
+
+	sc := rawConfig["storage_configuration"]
+	if sc.IsNull() || sc.LengthInt() == 0 {
+		return false
+	}
+
+	td := sc.AsValueSlice()[0].AsValueMap()["temp_db_settings"]
+	if td.IsNull() || td.LengthInt() == 0 {
+		return false
+	}
+
+	return !td.AsValueSlice()[0].AsValueMap()["luns"].IsNull()
 }
 
 func flattenSqlVirtualMachineStorageConfigurationSettings(input *sqlvirtualmachines.StorageConfigurationSettings, storageWorkloadType string) []interface{} {

--- a/internal/services/mssql/mssql_virtual_machine_resource.go
+++ b/internal/services/mssql/mssql_virtual_machine_resource.go
@@ -1293,9 +1293,9 @@ func flattenSqlVirtualMachineStorageConfigurationSettings(input *sqlvirtualmachi
 		diskType = string(*input.DiskConfigurationType)
 	}
 
-	systemDbOnDataDisk := false
+	var systemDbOnDataDisk *bool
 	if input.SqlSystemDbOnDataDisk != nil {
-		systemDbOnDataDisk = *input.SqlSystemDbOnDataDisk
+		systemDbOnDataDisk = input.SqlSystemDbOnDataDisk
 	}
 
 	output := map[string]interface{}{
@@ -1309,8 +1309,7 @@ func flattenSqlVirtualMachineStorageConfigurationSettings(input *sqlvirtualmachi
 
 	if output["storage_workload_type"].(string) == "" && output["disk_type"] == "" &&
 		len(output["data_settings"].([]interface{})) == 0 &&
-		len(output["log_settings"].([]interface{})) == 0 &&
-		len(output["temp_db_settings"].([]interface{})) == 0 {
+		len(output["log_settings"].([]interface{})) == 0 {
 		return []interface{}{}
 	}
 

--- a/internal/services/mssql/mssql_virtual_machine_resource.go
+++ b/internal/services/mssql/mssql_virtual_machine_resource.go
@@ -1380,7 +1380,7 @@ func expandSqlVirtualMachineTempDbSettings(input []interface{}, lunsInConfig boo
 }
 
 func flattenSqlVirtualMachineTempDbSettings(input *sqlvirtualmachines.SQLTempDbSettings) []interface{} {
-	if input == nil || input.Luns == nil {
+	if input == nil {
 		return []interface{}{}
 	}
 	attrs := make(map[string]interface{})

--- a/internal/services/mssql/mssql_virtual_machine_resource.go
+++ b/internal/services/mssql/mssql_virtual_machine_resource.go
@@ -1380,16 +1380,8 @@ func expandSqlVirtualMachineTempDbSettings(input []interface{}, lunsInConfig boo
 }
 
 func flattenSqlVirtualMachineTempDbSettings(input *sqlvirtualmachines.SQLTempDbSettings) []interface{} {
-	if input == nil || (input.DataFileCount == nil &&
-		input.DataFileSize == nil &&
-		input.DataGrowth == nil &&
-		input.DefaultFilePath == nil &&
-		input.LogFileSize == nil &&
-		input.LogGrowth == nil &&
-		input.Luns == nil &&
-		input.PersistFolder == nil &&
-		input.PersistFolderPath == nil &&
-		input.UseStoragePool == nil) {
+	// Check mandatory field `default_file_path` to determine if TempDbSettings is set.
+	if input == nil || input.DefaultFilePath == nil {
 		return []interface{}{}
 	}
 	attrs := make(map[string]interface{})

--- a/internal/services/mssql/mssql_virtual_machine_resource.go
+++ b/internal/services/mssql/mssql_virtual_machine_resource.go
@@ -1293,9 +1293,9 @@ func flattenSqlVirtualMachineStorageConfigurationSettings(input *sqlvirtualmachi
 		diskType = string(*input.DiskConfigurationType)
 	}
 
-	var systemDbOnDataDisk *bool
+	systemDbOnDataDisk := false
 	if input.SqlSystemDbOnDataDisk != nil {
-		systemDbOnDataDisk = input.SqlSystemDbOnDataDisk
+		systemDbOnDataDisk = *input.SqlSystemDbOnDataDisk
 	}
 
 	output := map[string]interface{}{
@@ -1309,7 +1309,8 @@ func flattenSqlVirtualMachineStorageConfigurationSettings(input *sqlvirtualmachi
 
 	if output["storage_workload_type"].(string) == "" && output["disk_type"] == "" &&
 		len(output["data_settings"].([]interface{})) == 0 &&
-		len(output["log_settings"].([]interface{})) == 0 {
+		len(output["log_settings"].([]interface{})) == 0 &&
+		len(output["temp_db_settings"].([]interface{})) == 0 {
 		return []interface{}{}
 	}
 
@@ -1379,7 +1380,16 @@ func expandSqlVirtualMachineTempDbSettings(input []interface{}, lunsInConfig boo
 }
 
 func flattenSqlVirtualMachineTempDbSettings(input *sqlvirtualmachines.SQLTempDbSettings) []interface{} {
-	if input == nil {
+	if input == nil || (input.DataFileCount == nil &&
+		input.DataFileSize == nil &&
+		input.DataGrowth == nil &&
+		input.DefaultFilePath == nil &&
+		input.LogFileSize == nil &&
+		input.LogGrowth == nil &&
+		input.Luns == nil &&
+		input.PersistFolder == nil &&
+		input.PersistFolderPath == nil &&
+		input.UseStoragePool == nil) {
 		return []interface{}{}
 	}
 	attrs := make(map[string]interface{})

--- a/internal/services/mssql/mssql_virtual_machine_resource_test.go
+++ b/internal/services/mssql/mssql_virtual_machine_resource_test.go
@@ -331,6 +331,35 @@ func TestAccMsSqlVirtualMachine_storageConfigurationSystemDbOnDataDisk(t *testin
 	})
 }
 
+func TestAccMsSqlVirtualMachine_storageConfigurationTempDbLuns(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mssql_virtual_machine", "test")
+	r := MssqlVirtualMachineResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.storageConfigurationTempDbWithLuns(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.storageConfigurationTempDbWithoutLuns(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.storageConfigurationTempDbWithLuns(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccMsSqlVirtualMachine_assessmentSettings(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_virtual_machine", "test")
 	r := MssqlVirtualMachineResource{}
@@ -1173,6 +1202,109 @@ resource "azurerm_mssql_virtual_machine" "test" {
   ]
 }
 `, r.template(data), data.RandomInteger, enabled)
+}
+
+func (r MssqlVirtualMachineResource) storageConfigurationTempDbWithLuns(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_managed_disk" "test" {
+  name                 = "accmd-sqlvm-%[2]d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  storage_account_type = "Standard_LRS"
+  create_option        = "Empty"
+  disk_size_gb         = 10
+}
+
+resource "azurerm_virtual_machine_data_disk_attachment" "test" {
+  managed_disk_id    = azurerm_managed_disk.test.id
+  virtual_machine_id = azurerm_virtual_machine.test.id
+  lun                = "0"
+  caching            = "None"
+}
+
+resource "azurerm_mssql_virtual_machine" "test" {
+  virtual_machine_id = azurerm_virtual_machine.test.id
+  sql_license_type   = "PAYG"
+
+  storage_configuration {
+    disk_type             = "NEW"
+    storage_workload_type = "OLTP"
+
+    data_settings {
+      luns              = [0]
+      default_file_path = "F:\\SQLData"
+    }
+
+    log_settings {
+      luns              = [0]
+      default_file_path = "F:\\SQLLog"
+    }
+
+    temp_db_settings {
+      luns              = [0]
+      default_file_path = "F:\\SQLTemp"
+      log_file_size_mb  = 512
+    }
+  }
+
+  depends_on = [
+    azurerm_virtual_machine_data_disk_attachment.test
+  ]
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r MssqlVirtualMachineResource) storageConfigurationTempDbWithoutLuns(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_managed_disk" "test" {
+  name                 = "accmd-sqlvm-%[2]d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  storage_account_type = "Standard_LRS"
+  create_option        = "Empty"
+  disk_size_gb         = 10
+}
+
+resource "azurerm_virtual_machine_data_disk_attachment" "test" {
+  managed_disk_id    = azurerm_managed_disk.test.id
+  virtual_machine_id = azurerm_virtual_machine.test.id
+  lun                = "0"
+  caching            = "None"
+}
+
+resource "azurerm_mssql_virtual_machine" "test" {
+  virtual_machine_id = azurerm_virtual_machine.test.id
+  sql_license_type   = "PAYG"
+
+  storage_configuration {
+    disk_type             = "NEW"
+    storage_workload_type = "OLTP"
+
+    data_settings {
+      luns              = [0]
+      default_file_path = "F:\\SQLData"
+    }
+
+    log_settings {
+      luns              = [0]
+      default_file_path = "F:\\SQLLog"
+    }
+
+    temp_db_settings {
+      default_file_path = "F:\\SQLTemp"
+      log_file_size_mb  = 512
+    }
+  }
+
+  depends_on = [
+    azurerm_virtual_machine_data_disk_attachment.test
+  ]
+}
+`, r.template(data), data.RandomInteger)
 }
 
 func (r MssqlVirtualMachineResource) assessmentSettingsWeekly(data acceptance.TestData) string {

--- a/internal/services/mssql/mssql_virtual_machine_resource_test.go
+++ b/internal/services/mssql/mssql_virtual_machine_resource_test.go
@@ -1295,7 +1295,7 @@ resource "azurerm_mssql_virtual_machine" "test" {
     }
 
     temp_db_settings {
-      default_file_path = "F:\\SQLTemp"
+      default_file_path = "D:\\SQLTemp"
       log_file_size_mb  = 512
     }
   }

--- a/internal/services/mssql/mssql_virtual_machine_resource_test.go
+++ b/internal/services/mssql/mssql_virtual_machine_resource_test.go
@@ -1072,7 +1072,7 @@ func (r MssqlVirtualMachineResource) storageConfiguration(data acceptance.TestDa
 %[1]s
 
 resource "azurerm_managed_disk" "test" {
-  name                 = "accmd-sqlvm-%[2]d"
+  name                 = "acctest-sqlvm-%[2]d"
   location             = azurerm_resource_group.test.location
   resource_group_name  = azurerm_resource_group.test.name
   storage_account_type = "Standard_LRS"
@@ -1124,7 +1124,7 @@ func (r MssqlVirtualMachineResource) storageConfigurationRevert(data acceptance.
 %[1]s
 
 resource "azurerm_managed_disk" "test" {
-  name                 = "accmd-sqlvm-%[2]d"
+  name                 = "acctest-sqlvm-%[2]d"
   location             = azurerm_resource_group.test.location
   resource_group_name  = azurerm_resource_group.test.name
   storage_account_type = "Standard_LRS"
@@ -1155,7 +1155,7 @@ func (r MssqlVirtualMachineResource) storageConfigurationSystemDbOnDataDisk(data
 %[1]s
 
 resource "azurerm_managed_disk" "test" {
-  name                 = "accmd-sqlvm-%[2]d"
+  name                 = "acctest-sqlvm-%[2]d"
   location             = azurerm_resource_group.test.location
   resource_group_name  = azurerm_resource_group.test.name
   storage_account_type = "Standard_LRS"
@@ -1209,7 +1209,7 @@ func (r MssqlVirtualMachineResource) storageConfigurationTempDbWithLuns(data acc
 %[1]s
 
 resource "azurerm_managed_disk" "test" {
-  name                 = "accmd-sqlvm-%[2]d"
+  name                 = "acctest-sqlvm-%[2]d"
   location             = azurerm_resource_group.test.location
   resource_group_name  = azurerm_resource_group.test.name
   storage_account_type = "Standard_LRS"
@@ -1261,7 +1261,7 @@ func (r MssqlVirtualMachineResource) storageConfigurationTempDbWithoutLuns(data 
 %[1]s
 
 resource "azurerm_managed_disk" "test" {
-  name                 = "accmd-sqlvm-%[2]d"
+  name                 = "acctest-sqlvm-%[2]d"
   location             = azurerm_resource_group.test.location
   resource_group_name  = azurerm_resource_group.test.name
   storage_account_type = "Standard_LRS"

--- a/website/docs/r/mssql_virtual_machine.html.markdown
+++ b/website/docs/r/mssql_virtual_machine.html.markdown
@@ -178,7 +178,7 @@ The `temp_db_settings` block supports the following:
 
 * `default_file_path` - (Required) The SQL Server default path
 
-* `luns` - (Optional) A list of Logical Unit Numbers for the disks. Setting empty list of leaving blank will result in tempdb being created on the same disks as the user databases.
+* `luns` - (Optional) A list of Logical Unit Numbers for the disks. Setting it to empty list or leaving it blank will result in tempdb being created on the same disks as the user databases.
 
 * `data_file_count` - (Optional) The SQL Server default file count. This value defaults to `8`
 

--- a/website/docs/r/mssql_virtual_machine.html.markdown
+++ b/website/docs/r/mssql_virtual_machine.html.markdown
@@ -178,7 +178,7 @@ The `temp_db_settings` block supports the following:
 
 * `default_file_path` - (Required) The SQL Server default path
 
-* `luns` - (Required) A list of Logical Unit Numbers for the disks.
+* `luns` - (Optional) A list of Logical Unit Numbers for the disks. Setting empty list of leaving blank will result in tempdb being created on the same disks as the user databases.
 
 * `data_file_count` - (Optional) The SQL Server default file count. This value defaults to `8`
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

1. Mark `temp_db_settings.luns` as optional
2. Send `null` value in API request instead of empty list when `temp_db_settings.luns` is not present

**NOTE**: this resolves [issue](https://github.com/hashicorp/terraform-provider-azurerm/issues/30170), user should be able to create resource with non-present `temp_db_settings.luns` field.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

<img width="619" height="1254" alt="image" src="https://github.com/user-attachments/assets/14c82a46-3b7f-4859-8713-e18a312afbf4" />


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_mssql_virtual_machine` - set `temp_db_settings.luns` as optional [GH-32041]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #30170


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
