### PR TITLE
`azurerm_bastion_host` - support `private_only_enabled`

### DIFF
--- a/internal/services/network/bastion_host_data_source.go
+++ b/internal/services/network/bastion_host_data_source.go
@@ -70,6 +70,11 @@ func dataSourceBastionHost() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"private_only_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
+
 			"scale_units": {
 				Type:     pluginsdk.TypeInt,
 				Computed: true,
@@ -146,6 +151,7 @@ func dataSourceBastionHostRead(d *pluginsdk.ResourceData, meta interface{}) erro
 			d.Set("shareable_link_enabled", props.EnableShareableLink)
 			d.Set("tunneling_enabled", props.EnableTunneling)
 			d.Set("session_recording_enabled", props.EnableSessionRecording)
+			d.Set("private_only_enabled", props.EnablePrivateOnlyBastion)
 
 			copyPasteEnabled := true
 			if props.DisableCopyPaste != nil {

--- a/internal/services/network/bastion_host_resource.go
+++ b/internal/services/network/bastion_host_resource.go
@@ -309,19 +309,10 @@ func resourceBastionHostCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 		parameters.Properties.EnableSessionRecording = pointer.To(sessionRecordingEnabled)
 	}
 
-	ipConfigs := d.Get("ip_configuration").([]interface{})
-	privateOnlyEnabled := false
 	if sku == bastionhosts.BastionHostSkuNamePremium {
-		if len(ipConfigs) > 0 {
-			ipConfigMap := ipConfigs[0].(map[string]interface{})
-			if v, ok := ipConfigMap["public_ip_address_id"]; ok && v.(string) != "" {
-				privateOnlyEnabled = true
-			}
+		if _, ok := d.GetOk("ip_configuration.0.public_ip_address_id"); !ok {
+			parameters.Properties.EnablePrivateOnlyBastion = pointer.To(true)
 		}
-	}
-
-	if privateOnlyEnabled {
-		parameters.Properties.EnablePrivateOnlyBastion = pointer.To(privateOnlyEnabled)
 	}
 
 	zones := zones.ExpandUntyped(d.Get("zones").(*schema.Set).List())

--- a/internal/services/network/bastion_host_resource.go
+++ b/internal/services/network/bastion_host_resource.go
@@ -147,13 +147,6 @@ func resourceBastionHost() *pluginsdk.Resource {
 				Default:  false,
 			},
 
-			"private_only_enabled": {
-				Type:     pluginsdk.TypeBool,
-				Optional: true,
-				Default:  false,
-				ForceNew: true,
-			},
-
 			"session_recording_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
@@ -172,6 +165,12 @@ func resourceBastionHost() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"private_only_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+				ForceNew: true,
+			},
+
 			"tags": commonschema.Tags(),
 
 			"zones": commonschema.ZonesMultipleOptionalForceNew(),
@@ -187,35 +186,22 @@ func resourceBastionHost() *pluginsdk.Resource {
 			}),
 			func(ctx context.Context, d *pluginsdk.ResourceDiff, meta interface{}) error {
 				sku := bastionhosts.BastionHostSkuName(d.Get("sku").(string))
-				privateOnlyEnabled := d.Get("private_only_enabled").(bool)
-
-				if privateOnlyEnabled && sku != bastionhosts.BastionHostSkuNamePremium {
-					return errors.New("`private_only_enabled` is only supported when `sku` is `Premium`")
-				}
 
 				// GetRawConfig is used because `public_ip_address_id` may reference another resource and be unknown during plan.
 				// d.Get() returns "" for unknown values, which would incorrectly trigger the required check.
 				// By inspecting the raw config, we can distinguish between "not set" and "unknown" and skip validation when unknown.
 				rawConfig := d.GetRawConfig()
 				ipConfigRaw := rawConfig.AsValueMap()["ip_configuration"]
-				ipConfiguration := d.Get("ip_configuration").([]interface{})
-				if privateOnlyEnabled {
-					if !ipConfigRaw.IsNull() && ipConfigRaw.IsKnown() && len(ipConfiguration) > 0 {
-						ipConfigMap := ipConfiguration[0].(map[string]interface{})
-						if v, ok := ipConfigMap["public_ip_address_id"]; ok && v.(string) != "" {
-							return errors.New("`public_ip_address_id` must not be set when `private_only_enabled` is `true`")
-						}
-					}
-				} else if sku != bastionhosts.BastionHostSkuNameDeveloper {
-					if len(ipConfiguration) == 0 {
-						return errors.New("`ip_configuration` with `public_ip_address_id` is required when `private_only_enabled` is `false`")
-					}
 
-					if !ipConfigRaw.IsNull() && ipConfigRaw.IsKnown() {
-						pipRaw := ipConfigRaw.AsValueSlice()[0].AsValueMap()["public_ip_address_id"]
-						if pipRaw.IsKnown() && (pipRaw.IsNull() || pipRaw.AsString() == "") {
-							return errors.New("`public_ip_address_id` is required in `ip_configuration` when `private_only_enabled` is `false`")
-						}
+				// Basic and Standard SKUs require public_ip_address_id; Developer uses virtual_network_id instead.
+				// Premium without public_ip_address_id enables private-only mode.
+				if sku != bastionhosts.BastionHostSkuNamePremium && sku != bastionhosts.BastionHostSkuNameDeveloper {
+					if ipConfigRaw.IsNull() || !ipConfigRaw.IsKnown() || len(ipConfigRaw.AsValueSlice()) == 0 {
+						return errors.New("`ip_configuration` with `public_ip_address_id` is required when `sku` is `Basic` or `Standard`")
+					}
+					pipRaw := ipConfigRaw.AsValueSlice()[0].AsValueMap()["public_ip_address_id"]
+					if pipRaw.IsKnown() && (pipRaw.IsNull() || pipRaw.AsString() == "") {
+						return errors.New("`public_ip_address_id` must be set in `ip_configuration` when `sku` is `Basic` or `Standard`")
 					}
 				}
 
@@ -240,7 +226,6 @@ func resourceBastionHostCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 	fileCopyEnabled := d.Get("file_copy_enabled").(bool)
 	ipConnectEnabled := d.Get("ip_connect_enabled").(bool)
 	kerberosEnabled := d.Get("kerberos_enabled").(bool)
-	privateOnlyEnabled := d.Get("private_only_enabled").(bool)
 	shareableLinkEnabled := d.Get("shareable_link_enabled").(bool)
 	tunnelingEnabled := d.Get("tunneling_enabled").(bool)
 	sessionRecordingEnabled := d.Get("session_recording_enabled").(bool)
@@ -322,6 +307,17 @@ func resourceBastionHostCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 
 	if sessionRecordingEnabled {
 		parameters.Properties.EnableSessionRecording = pointer.To(sessionRecordingEnabled)
+	}
+
+	ipConfigs := d.Get("ip_configuration").([]interface{})
+	privateOnlyEnabled := false
+	if sku == bastionhosts.BastionHostSkuNamePremium {
+		if len(ipConfigs) > 0 {
+			ipConfigMap := ipConfigs[0].(map[string]interface{})
+			if v, ok := ipConfigMap["public_ip_address_id"]; ok && v.(string) != "" {
+				privateOnlyEnabled = true
+			}
+		}
 	}
 
 	if privateOnlyEnabled {

--- a/internal/services/network/bastion_host_resource.go
+++ b/internal/services/network/bastion_host_resource.go
@@ -100,7 +100,7 @@ func resourceBastionHost() *pluginsdk.Resource {
 						},
 						"public_ip_address_id": {
 							Type:         pluginsdk.TypeString,
-							Required:     true,
+							Optional:     true,
 							ForceNew:     true,
 							ValidateFunc: commonids.ValidatePublicIPAddressID,
 						},
@@ -146,6 +146,13 @@ func resourceBastionHost() *pluginsdk.Resource {
 				Default:  false,
 			},
 
+			"private_only_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  false,
+				ForceNew: true,
+			},
+
 			"session_recording_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
@@ -177,6 +184,35 @@ func resourceBastionHost() *pluginsdk.Resource {
 				}
 				return false
 			}),
+			func(ctx context.Context, d *pluginsdk.ResourceDiff, meta interface{}) error {
+				sku := bastionhosts.BastionHostSkuName(d.Get("sku").(string))
+				privateOnlyEnabled := d.Get("private_only_enabled").(bool)
+
+				if privateOnlyEnabled && (sku != bastionhosts.BastionHostSkuNameStandard && sku != bastionhosts.BastionHostSkuNamePremium) {
+					return fmt.Errorf("`private_only_enabled` is only supported when `sku` is `Standard` or `Premium`")
+				}
+
+				ipConfiguration := d.Get("ip_configuration").([]interface{})
+				if privateOnlyEnabled {
+					if len(ipConfiguration) > 0 {
+						ipConfigMap := ipConfiguration[0].(map[string]interface{})
+						if v, ok := ipConfigMap["public_ip_address_id"]; ok && v.(string) != "" {
+							return fmt.Errorf("`public_ip_address_id` must not be set when `private_only_enabled` is `true`")
+						}
+					}
+				} else if sku != bastionhosts.BastionHostSkuNameDeveloper {
+					if len(ipConfiguration) == 0 {
+						return fmt.Errorf("`ip_configuration` with `public_ip_address_id` is required when `private_only_enabled` is `false`")
+					}
+					
+					ipConfigMap := ipConfiguration[0].(map[string]interface{})
+					if v, ok := ipConfigMap["public_ip_address_id"]; !ok || v.(string) == "" {
+						return fmt.Errorf("`public_ip_address_id` is required in `ip_configuration` when `private_only_enabled` is `false`")
+					}
+				}
+
+				return nil
+			},
 		),
 	}
 }
@@ -196,6 +232,7 @@ func resourceBastionHostCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 	fileCopyEnabled := d.Get("file_copy_enabled").(bool)
 	ipConnectEnabled := d.Get("ip_connect_enabled").(bool)
 	kerberosEnabled := d.Get("kerberos_enabled").(bool)
+	privateOnlyEnabled := d.Get("private_only_enabled").(bool)
 	shareableLinkEnabled := d.Get("shareable_link_enabled").(bool)
 	tunnelingEnabled := d.Get("tunneling_enabled").(bool)
 	sessionRecordingEnabled := d.Get("session_recording_enabled").(bool)
@@ -277,6 +314,10 @@ func resourceBastionHostCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 
 	if sessionRecordingEnabled {
 		parameters.Properties.EnableSessionRecording = pointer.To(sessionRecordingEnabled)
+	}
+
+	if privateOnlyEnabled {
+		parameters.Properties.EnablePrivateOnlyBastion = pointer.To(privateOnlyEnabled)
 	}
 
 	zones := zones.ExpandUntyped(d.Get("zones").(*schema.Set).List())
@@ -450,6 +491,7 @@ func resourceBastionHostRead(d *pluginsdk.ResourceData, meta interface{}) error 
 			d.Set("shareable_link_enabled", props.EnableShareableLink)
 			d.Set("tunneling_enabled", props.EnableTunneling)
 			d.Set("session_recording_enabled", props.EnableSessionRecording)
+			d.Set("private_only_enabled", props.EnablePrivateOnlyBastion)
 
 			virtualNetworkId := ""
 			if vnet := props.VirtualNetwork; vnet != nil {
@@ -507,21 +549,23 @@ func expandBastionHostIPConfiguration(input []interface{}) (ipConfigs *[]bastion
 	property := input[0].(map[string]interface{})
 	ipConfName := property["name"].(string)
 	subID := property["subnet_id"].(string)
-	pipID := property["public_ip_address_id"].(string)
 
-	return &[]bastionhosts.BastionHostIPConfiguration{
-		{
-			Name: &ipConfName,
-			Properties: &bastionhosts.BastionHostIPConfigurationPropertiesFormat{
-				Subnet: bastionhosts.SubResource{
-					Id: &subID,
-				},
-				PublicIPAddress: &bastionhosts.SubResource{
-					Id: &pipID,
-				},
+	ipConfig := bastionhosts.BastionHostIPConfiguration{
+		Name: &ipConfName,
+		Properties: &bastionhosts.BastionHostIPConfigurationPropertiesFormat{
+			Subnet: bastionhosts.SubResource{
+				Id: &subID,
 			},
 		},
 	}
+
+	if pipID, ok := property["public_ip_address_id"].(string); ok && pipID != "" {
+		ipConfig.Properties.PublicIPAddress = &bastionhosts.SubResource{
+			Id: &pipID,
+		}
+	}
+
+	return &[]bastionhosts.BastionHostIPConfiguration{ipConfig}
 }
 
 func flattenBastionHostIPConfiguration(ipConfigs *[]bastionhosts.BastionHostIPConfiguration) []interface{} {

--- a/internal/services/network/bastion_host_resource.go
+++ b/internal/services/network/bastion_host_resource.go
@@ -189,8 +189,8 @@ func resourceBastionHost() *pluginsdk.Resource {
 				sku := bastionhosts.BastionHostSkuName(d.Get("sku").(string))
 				privateOnlyEnabled := d.Get("private_only_enabled").(bool)
 
-				if privateOnlyEnabled && (sku != bastionhosts.BastionHostSkuNameStandard && sku != bastionhosts.BastionHostSkuNamePremium) {
-					return errors.New("`private_only_enabled` is only supported when `sku` is `Standard` or `Premium`")
+				if privateOnlyEnabled && sku != bastionhosts.BastionHostSkuNamePremium {
+					return errors.New("`private_only_enabled` is only supported when `sku` is `Premium`")
 				}
 
 				// GetRawConfig is used because `public_ip_address_id` may reference another resource and be unknown during plan.

--- a/internal/services/network/bastion_host_resource.go
+++ b/internal/services/network/bastion_host_resource.go
@@ -5,6 +5,7 @@ package network
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"time"
@@ -189,7 +190,7 @@ func resourceBastionHost() *pluginsdk.Resource {
 				privateOnlyEnabled := d.Get("private_only_enabled").(bool)
 
 				if privateOnlyEnabled && (sku != bastionhosts.BastionHostSkuNameStandard && sku != bastionhosts.BastionHostSkuNamePremium) {
-					return fmt.Errorf("`private_only_enabled` is only supported when `sku` is `Standard` or `Premium`")
+					return errors.New("`private_only_enabled` is only supported when `sku` is `Standard` or `Premium`")
 				}
 
 				ipConfiguration := d.Get("ip_configuration").([]interface{})
@@ -197,17 +198,17 @@ func resourceBastionHost() *pluginsdk.Resource {
 					if len(ipConfiguration) > 0 {
 						ipConfigMap := ipConfiguration[0].(map[string]interface{})
 						if v, ok := ipConfigMap["public_ip_address_id"]; ok && v.(string) != "" {
-							return fmt.Errorf("`public_ip_address_id` must not be set when `private_only_enabled` is `true`")
+							return errors.New("`public_ip_address_id` must not be set when `private_only_enabled` is `true`")
 						}
 					}
 				} else if sku != bastionhosts.BastionHostSkuNameDeveloper {
 					if len(ipConfiguration) == 0 {
-						return fmt.Errorf("`ip_configuration` with `public_ip_address_id` is required when `private_only_enabled` is `false`")
+						return errors.New("`ip_configuration` with `public_ip_address_id` is required when `private_only_enabled` is `false`")
 					}
-					
+
 					ipConfigMap := ipConfiguration[0].(map[string]interface{})
 					if v, ok := ipConfigMap["public_ip_address_id"]; !ok || v.(string) == "" {
-						return fmt.Errorf("`public_ip_address_id` is required in `ip_configuration` when `private_only_enabled` is `false`")
+						return errors.New("`public_ip_address_id` is required in `ip_configuration` when `private_only_enabled` is `false`")
 					}
 				}
 

--- a/internal/services/network/bastion_host_resource.go
+++ b/internal/services/network/bastion_host_resource.go
@@ -168,7 +168,6 @@ func resourceBastionHost() *pluginsdk.Resource {
 			"private_only_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Computed: true,
-				ForceNew: true,
 			},
 
 			"tags": commonschema.Tags(),

--- a/internal/services/network/bastion_host_resource.go
+++ b/internal/services/network/bastion_host_resource.go
@@ -193,9 +193,14 @@ func resourceBastionHost() *pluginsdk.Resource {
 					return errors.New("`private_only_enabled` is only supported when `sku` is `Standard` or `Premium`")
 				}
 
+				// GetRawConfig is used because `public_ip_address_id` may reference another resource and be unknown during plan.
+				// d.Get() returns "" for unknown values, which would incorrectly trigger the required check.
+				// By inspecting the raw config, we can distinguish between "not set" and "unknown" and skip validation when unknown.
+				rawConfig := d.GetRawConfig()
+				ipConfigRaw := rawConfig.AsValueMap()["ip_configuration"]
 				ipConfiguration := d.Get("ip_configuration").([]interface{})
 				if privateOnlyEnabled {
-					if len(ipConfiguration) > 0 {
+					if !ipConfigRaw.IsNull() && ipConfigRaw.IsKnown() && len(ipConfiguration) > 0 {
 						ipConfigMap := ipConfiguration[0].(map[string]interface{})
 						if v, ok := ipConfigMap["public_ip_address_id"]; ok && v.(string) != "" {
 							return errors.New("`public_ip_address_id` must not be set when `private_only_enabled` is `true`")
@@ -206,9 +211,11 @@ func resourceBastionHost() *pluginsdk.Resource {
 						return errors.New("`ip_configuration` with `public_ip_address_id` is required when `private_only_enabled` is `false`")
 					}
 
-					ipConfigMap := ipConfiguration[0].(map[string]interface{})
-					if v, ok := ipConfigMap["public_ip_address_id"]; !ok || v.(string) == "" {
-						return errors.New("`public_ip_address_id` is required in `ip_configuration` when `private_only_enabled` is `false`")
+					if !ipConfigRaw.IsNull() && ipConfigRaw.IsKnown() {
+						pipRaw := ipConfigRaw.AsValueSlice()[0].AsValueMap()["public_ip_address_id"]
+						if pipRaw.IsKnown() && (pipRaw.IsNull() || pipRaw.AsString() == "") {
+							return errors.New("`public_ip_address_id` is required in `ip_configuration` when `private_only_enabled` is `false`")
+						}
 					}
 				}
 

--- a/internal/services/network/bastion_host_resource.go
+++ b/internal/services/network/bastion_host_resource.go
@@ -310,9 +310,8 @@ func resourceBastionHostCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 	}
 
 	if sku == bastionhosts.BastionHostSkuNamePremium {
-		if _, ok := d.GetOk("ip_configuration.0.public_ip_address_id"); !ok {
-			parameters.Properties.EnablePrivateOnlyBastion = pointer.To(true)
-		}
+		_, ok := d.GetOk("ip_configuration.0.public_ip_address_id")
+		parameters.Properties.EnablePrivateOnlyBastion = pointer.To(!ok)
 	}
 
 	zones := zones.ExpandUntyped(d.Get("zones").(*schema.Set).List())

--- a/internal/services/network/bastion_host_resource_test.go
+++ b/internal/services/network/bastion_host_resource_test.go
@@ -154,6 +154,36 @@ func TestAccBastionHost_premiumSku(t *testing.T) {
 	})
 }
 
+func TestAccBastionHost_privateOnly(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_bastion_host", "test")
+	r := BastionHostResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.privateOnly(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccBastionHost_privateOnlyPremium(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_bastion_host", "test")
+	r := BastionHostResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.privateOnlyPremium(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (BastionHostResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := bastionhosts.ParseBastionHostID(state.ID)
 	if err != nil {
@@ -516,4 +546,88 @@ resource "azurerm_bastion_host" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger, data.RandomString)
+}
+
+func (BastionHostResource) privateOnly(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-bastion-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestVNet%s"
+  address_space       = ["192.168.1.0/24"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "AzureBastionSubnet"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["192.168.1.224/27"]
+}
+
+resource "azurerm_bastion_host" "test" {
+  name                 = "acctestBastion%s"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  sku                  = "Standard"
+  private_only_enabled = true
+
+  ip_configuration {
+    name      = "ip-configuration"
+    subnet_id = azurerm_subnet.test.id
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
+}
+
+func (BastionHostResource) privateOnlyPremium(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-bastion-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestVNet%s"
+  address_space       = ["192.168.1.0/24"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "AzureBastionSubnet"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["192.168.1.224/27"]
+}
+
+resource "azurerm_bastion_host" "test" {
+  name                      = "acctestBastion%s"
+  location                  = azurerm_resource_group.test.location
+  resource_group_name       = azurerm_resource_group.test.name
+  sku                       = "Premium"
+  private_only_enabled      = true
+  file_copy_enabled         = true
+  ip_connect_enabled        = true
+  tunneling_enabled         = true
+  session_recording_enabled = true
+
+  ip_configuration {
+    name      = "ip-configuration"
+    subnet_id = azurerm_subnet.test.id
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
 }

--- a/internal/services/network/bastion_host_resource_test.go
+++ b/internal/services/network/bastion_host_resource_test.go
@@ -163,6 +163,7 @@ func TestAccBastionHost_privateOnly(t *testing.T) {
 			Config: r.privateOnly(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("private_only_enabled").HasValue("true"),
 			),
 		},
 		data.ImportStep(),
@@ -559,11 +560,10 @@ resource "azurerm_subnet" "test" {
 }
 
 resource "azurerm_bastion_host" "test" {
-  name                 = "acctestBastion%s"
-  location             = azurerm_resource_group.test.location
-  resource_group_name  = azurerm_resource_group.test.name
-  sku                  = "Premium"
-  private_only_enabled = true
+  name                = "acctestBastion%s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Premium"
 
   ip_configuration {
     name      = "ip-configuration"

--- a/internal/services/network/bastion_host_resource_test.go
+++ b/internal/services/network/bastion_host_resource_test.go
@@ -169,21 +169,6 @@ func TestAccBastionHost_privateOnly(t *testing.T) {
 	})
 }
 
-func TestAccBastionHost_privateOnlyPremium(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_bastion_host", "test")
-	r := BastionHostResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.privateOnlyPremium(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-	})
-}
-
 func (BastionHostResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := bastionhosts.ParseBastionHostID(state.ID)
 	if err != nil {
@@ -577,52 +562,8 @@ resource "azurerm_bastion_host" "test" {
   name                 = "acctestBastion%s"
   location             = azurerm_resource_group.test.location
   resource_group_name  = azurerm_resource_group.test.name
-  sku                  = "Standard"
+  sku                  = "Premium"
   private_only_enabled = true
-
-  ip_configuration {
-    name      = "ip-configuration"
-    subnet_id = azurerm_subnet.test.id
-  }
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
-}
-
-func (BastionHostResource) privateOnlyPremium(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-bastion-%d"
-  location = "%s"
-}
-
-resource "azurerm_virtual_network" "test" {
-  name                = "acctestVNet%s"
-  address_space       = ["192.168.1.0/24"]
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-}
-
-resource "azurerm_subnet" "test" {
-  name                 = "AzureBastionSubnet"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["192.168.1.224/27"]
-}
-
-resource "azurerm_bastion_host" "test" {
-  name                      = "acctestBastion%s"
-  location                  = azurerm_resource_group.test.location
-  resource_group_name       = azurerm_resource_group.test.name
-  sku                       = "Premium"
-  private_only_enabled      = true
-  file_copy_enabled         = true
-  ip_connect_enabled        = true
-  tunneling_enabled         = true
-  session_recording_enabled = true
 
   ip_configuration {
     name      = "ip-configuration"

--- a/website/docs/d/bastion_host.html.markdown
+++ b/website/docs/d/bastion_host.html.markdown
@@ -58,7 +58,7 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `session_recording_enabled` - Is Session Recording feature enabled for the Bastion Host.
 
-* `private_only_enabled` - Is the Bastion Host deployed in Private-Only mode.
+* `private_only_enabled` - Whether Private-Only deployment is enabled for the Bastion Host. 
 
 * `dns_name` - The FQDN for the Bastion Host.
 

--- a/website/docs/d/bastion_host.html.markdown
+++ b/website/docs/d/bastion_host.html.markdown
@@ -58,7 +58,7 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `session_recording_enabled` - Is Session Recording feature enabled for the Bastion Host.
 
-* `private_only_enabled` - Is the Bastion Host deployed in Private-Only mode (without a public IP address).
+* `private_only_enabled` - Is the Bastion Host deployed in Private-Only mode.
 
 * `dns_name` - The FQDN for the Bastion Host.
 
@@ -75,8 +75,6 @@ A `ip_configuration` block supports the following:
 * `subnet_id` - Reference to the subnet in which this Bastion Host has been created.
 
 * `public_ip_address_id` - Reference to a Public IP Address associated to this Bastion Host.
-
-* `private_ip_allocation_method` - The Private IP address allocation method.
 
 ## Timeouts
 

--- a/website/docs/d/bastion_host.html.markdown
+++ b/website/docs/d/bastion_host.html.markdown
@@ -58,6 +58,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `session_recording_enabled` - Is Session Recording feature enabled for the Bastion Host.
 
+* `private_only_enabled` - Is the Bastion Host deployed in Private-Only mode (without a public IP address).
+
 * `dns_name` - The FQDN for the Bastion Host.
 
 * `tags` - A mapping of tags assigned to the Bastion Host.
@@ -73,6 +75,8 @@ A `ip_configuration` block supports the following:
 * `subnet_id` - Reference to the subnet in which this Bastion Host has been created.
 
 * `public_ip_address_id` - Reference to a Public IP Address associated to this Bastion Host.
+
+* `private_ip_allocation_method` - The Private IP address allocation method.
 
 ## Timeouts
 

--- a/website/docs/r/bastion_host.html.markdown
+++ b/website/docs/r/bastion_host.html.markdown
@@ -88,7 +88,7 @@ The following arguments are supported:
 
 * `private_only_enabled` - (Optional) Is Private-Only deployment enabled for the Bastion Host. Defaults to `false`. Changing this forces a new resource to be created.
 
-~> **Note:** `private_only_enabled` is only supported when `sku` is `Standard` or `Premium`. When `private_only_enabled` is `true`, `public_ip_address_id` in `ip_configuration` must not be specified.
+~> **Note:** `private_only_enabled` is only supported when `sku` is `Premium`. When `private_only_enabled` is `true`, `public_ip_address_id` in `ip_configuration` must not be specified.
 
 * `scale_units` - (Optional) The number of scale units with which to provision the Bastion Host. Possible values are between `2` and `50`. Defaults to `2`.
 

--- a/website/docs/r/bastion_host.html.markdown
+++ b/website/docs/r/bastion_host.html.markdown
@@ -86,10 +86,6 @@ The following arguments are supported:
 
 ~> **Note:** `kerberos_enabled` is only supported when `sku` is `Standard` or `Premium`.
 
-* `private_only_enabled` - (Optional) Is Private-Only deployment enabled for the Bastion Host. Defaults to `false`. Changing this forces a new resource to be created.
-
-~> **Note:** `private_only_enabled` is only supported when `sku` is `Premium`. When `private_only_enabled` is `true`, `public_ip_address_id` in `ip_configuration` must not be specified.
-
 * `scale_units` - (Optional) The number of scale units with which to provision the Bastion Host. Possible values are between `2` and `50`. Defaults to `2`.
 
 ~> **Note:** `scale_units` only can be changed when `sku` is `Standard` or `Premium`. `scale_units` is always `2` when `sku` is `Basic`.
@@ -124,7 +120,7 @@ A `ip_configuration` block supports the following:
 
 * `public_ip_address_id` - (Optional) Reference to a Public IP Address to associate with this Bastion Host. Changing this forces a new resource to be created.
 
-~> **Note:** `public_ip_address_id` is required when `private_only_enabled` is `false`.
+~> **Note:** `public_ip_address_id` is required when `sku` is `Basic` or `Standard`. When `sku` is `Premium` and `public_ip_address_id` is omitted, the Bastion Host is deployed in Private-Only mode (`private_only_enabled` will be `true`).
 
 ## Attributes Reference
 
@@ -133,6 +129,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 * `id` - The ID of the Bastion Host.
 
 * `dns_name` - The FQDN for the Bastion Host.
+
+* `private_only_enabled` - Whether Private-Only deployment is enabled for the Bastion Host. 
 
 ## Timeouts
 

--- a/website/docs/r/bastion_host.html.markdown
+++ b/website/docs/r/bastion_host.html.markdown
@@ -86,6 +86,10 @@ The following arguments are supported:
 
 ~> **Note:** `kerberos_enabled` is only supported when `sku` is `Standard` or `Premium`.
 
+* `private_only_enabled` - (Optional) Is Private-Only deployment enabled for the Bastion Host. Defaults to `false`. Changing this forces a new resource to be created.
+
+~> **Note:** `private_only_enabled` is only supported when `sku` is `Standard` or `Premium`. When `private_only_enabled` is `true`, `public_ip_address_id` in `ip_configuration` must not be specified.
+
 * `scale_units` - (Optional) The number of scale units with which to provision the Bastion Host. Possible values are between `2` and `50`. Defaults to `2`.
 
 ~> **Note:** `scale_units` only can be changed when `sku` is `Standard` or `Premium`. `scale_units` is always `2` when `sku` is `Basic`.
@@ -118,7 +122,9 @@ A `ip_configuration` block supports the following:
 
 ~> **Note:** The Subnet used for the Bastion Host must have the name `AzureBastionSubnet` and the subnet mask must be at least a `/26`.
 
-* `public_ip_address_id` - (Required) Reference to a Public IP Address to associate with this Bastion Host. Changing this forces a new resource to be created.
+* `public_ip_address_id` - (Optional) Reference to a Public IP Address to associate with this Bastion Host. Changing this forces a new resource to be created.
+
+~> **Note:** `public_ip_address_id` is required when `private_only_enabled` is `false`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Support private only bastion host

swagger: https://github.com/Azure/azure-rest-api-specs/blob/main/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-01-01/bastionHost.json#L812-L817
doc: https://learn.microsoft.com/en-us/azure/bastion/private-only-deployment


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

<img width="3192" height="1105" alt="image" src="https://github.com/user-attachments/assets/2fb960e5-1a4f-4cc0-b447-bcd4dd25285a" />


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_bastion_host` - Support `private_only_enabled`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #31951 
Fixes #28220

## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
