### PR TITLE
New resource: `azurerm_palo_alto_next_generation_firewall_metrics`

### DIFF
--- a/internal/services/paloalto/palo_alto_next_generation_firewall_metrics_resource.go
+++ b/internal/services/paloalto/palo_alto_next_generation_firewall_metrics_resource.go
@@ -14,6 +14,7 @@ import (
 	metricsobjectfirewall "github.com/hashicorp/go-azure-sdk/resource-manager/paloaltonetworks/2025-10-08/metricsobjectfirewallresources"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
@@ -60,7 +61,7 @@ func (r NextGenerationFirewallMetricsResource) Arguments() map[string]*schema.Sc
 		"application_insights_resource_id": {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
-			ValidateFunc: validation.StringIsNotEmpty,
+			ValidateFunc: azure.ValidateResourceID,
 		},
 	}
 }
@@ -147,7 +148,10 @@ func (r NextGenerationFirewallMetricsResource) Read() sdk.ResourceFunc {
 
 			if model := existing.Model; model != nil {
 				props := model.Properties
-				state.ApplicationInsightsConnectionString = props.ApplicationInsightsConnectionString
+				// Azure may redact the connection string on GET; preserve the config value in state
+				if props.ApplicationInsightsConnectionString != "" {
+					state.ApplicationInsightsConnectionString = props.ApplicationInsightsConnectionString
+				}
 				state.ApplicationInsightsResourceID = props.ApplicationInsightsResourceId
 				state.PanEtag = pointer.From(props.PanEtag)
 			}
@@ -178,6 +182,10 @@ func (r NextGenerationFirewallMetricsResource) Update() sdk.ResourceFunc {
 			existing, err := client.MetricsObjectFirewallGet(ctx, metricsFirewallId)
 			if err != nil {
 				return fmt.Errorf("retrieving Metrics for %s: %+v", metricsFirewallId, err)
+			}
+
+			if existing.Model == nil {
+				return fmt.Errorf("retrieving Metrics for %s: `model` was nil", metricsFirewallId)
 			}
 
 			update := *existing.Model

--- a/internal/services/paloalto/palo_alto_next_generation_firewall_metrics_resource.go
+++ b/internal/services/paloalto/palo_alto_next_generation_firewall_metrics_resource.go
@@ -1,0 +1,222 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package paloalto
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	firewalls "github.com/hashicorp/go-azure-sdk/resource-manager/paloaltonetworks/2025-10-08/firewallresources"
+	metricsobjectfirewall "github.com/hashicorp/go-azure-sdk/resource-manager/paloaltonetworks/2025-10-08/metricsobjectfirewallresources"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type NextGenerationFirewallMetricsResource struct{}
+
+type NextGenerationFirewallMetricsModel struct {
+	FirewallID                          string `tfschema:"firewall_id"`
+	ApplicationInsightsConnectionString string `tfschema:"application_insights_connection_string"`
+	ApplicationInsightsResourceID       string `tfschema:"application_insights_resource_id"`
+	PanEtag                             string `tfschema:"pan_etag"`
+}
+
+var _ sdk.ResourceWithUpdate = NextGenerationFirewallMetricsResource{}
+
+func (r NextGenerationFirewallMetricsResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return firewalls.ValidateFirewallID
+}
+
+func (r NextGenerationFirewallMetricsResource) ResourceType() string {
+	return "azurerm_palo_alto_next_generation_firewall_metrics"
+}
+
+func (r NextGenerationFirewallMetricsResource) ModelObject() interface{} {
+	return &NextGenerationFirewallMetricsModel{}
+}
+
+func (r NextGenerationFirewallMetricsResource) Arguments() map[string]*schema.Schema {
+	return map[string]*pluginsdk.Schema{
+		"firewall_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: firewalls.ValidateFirewallID,
+		},
+
+		"application_insights_connection_string": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			Sensitive:    true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"application_insights_resource_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+	}
+}
+
+func (r NextGenerationFirewallMetricsResource) Attributes() map[string]*schema.Schema {
+	return map[string]*pluginsdk.Schema{
+		"pan_etag": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+	}
+}
+
+func (r NextGenerationFirewallMetricsResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.PaloAlto.MetricsObjectFirewallResources
+
+			var model NextGenerationFirewallMetricsModel
+			if err := metadata.Decode(&model); err != nil {
+				return err
+			}
+
+			firewallId, err := firewalls.ParseFirewallID(model.FirewallID)
+			if err != nil {
+				return err
+			}
+
+			metricsFirewallId := metricsobjectfirewall.NewFirewallID(firewallId.SubscriptionId, firewallId.ResourceGroupName, firewallId.FirewallName)
+
+			existing, err := client.MetricsObjectFirewallGet(ctx, metricsFirewallId)
+			if err != nil {
+				if !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for presence of existing Metrics for %s: %+v", metricsFirewallId, err)
+				}
+			}
+			if !response.WasNotFound(existing.HttpResponse) {
+				return metadata.ResourceRequiresImport(r.ResourceType(), firewallId)
+			}
+
+			input := metricsobjectfirewall.MetricsObjectFirewallResource{
+				Properties: metricsobjectfirewall.MetricsObject{
+					ApplicationInsightsConnectionString: model.ApplicationInsightsConnectionString,
+					ApplicationInsightsResourceId:       model.ApplicationInsightsResourceID,
+				},
+			}
+
+			if err = client.MetricsObjectFirewallCreateOrUpdateThenPoll(ctx, metricsFirewallId, input); err != nil {
+				return fmt.Errorf("creating Metrics for %s: %+v", metricsFirewallId, err)
+			}
+
+			metadata.SetID(firewallId)
+
+			return nil
+		},
+	}
+}
+
+func (r NextGenerationFirewallMetricsResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.PaloAlto.MetricsObjectFirewallResources
+
+			firewallId, err := firewalls.ParseFirewallID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			metricsFirewallId := metricsobjectfirewall.NewFirewallID(firewallId.SubscriptionId, firewallId.ResourceGroupName, firewallId.FirewallName)
+
+			existing, err := client.MetricsObjectFirewallGet(ctx, metricsFirewallId)
+			if err != nil {
+				if response.WasNotFound(existing.HttpResponse) {
+					return metadata.MarkAsGone(firewallId)
+				}
+				return fmt.Errorf("reading Metrics for %s: %+v", metricsFirewallId, err)
+			}
+
+			state := NextGenerationFirewallMetricsModel{
+				FirewallID: firewallId.ID(),
+			}
+
+			if model := existing.Model; model != nil {
+				props := model.Properties
+				state.ApplicationInsightsConnectionString = props.ApplicationInsightsConnectionString
+				state.ApplicationInsightsResourceID = props.ApplicationInsightsResourceId
+				state.PanEtag = pointer.From(props.PanEtag)
+			}
+
+			return metadata.Encode(&state)
+		},
+	}
+}
+
+func (r NextGenerationFirewallMetricsResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.PaloAlto.MetricsObjectFirewallResources
+
+			var model NextGenerationFirewallMetricsModel
+			if err := metadata.Decode(&model); err != nil {
+				return err
+			}
+
+			firewallId, err := firewalls.ParseFirewallID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			metricsFirewallId := metricsobjectfirewall.NewFirewallID(firewallId.SubscriptionId, firewallId.ResourceGroupName, firewallId.FirewallName)
+
+			existing, err := client.MetricsObjectFirewallGet(ctx, metricsFirewallId)
+			if err != nil {
+				return fmt.Errorf("retrieving Metrics for %s: %+v", metricsFirewallId, err)
+			}
+
+			update := *existing.Model
+
+			if metadata.ResourceData.HasChange("application_insights_connection_string") {
+				update.Properties.ApplicationInsightsConnectionString = model.ApplicationInsightsConnectionString
+			}
+
+			if metadata.ResourceData.HasChange("application_insights_resource_id") {
+				update.Properties.ApplicationInsightsResourceId = model.ApplicationInsightsResourceID
+			}
+
+			if err = client.MetricsObjectFirewallCreateOrUpdateThenPoll(ctx, metricsFirewallId, update); err != nil {
+				return fmt.Errorf("updating Metrics for %s: %+v", metricsFirewallId, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func (r NextGenerationFirewallMetricsResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.PaloAlto.MetricsObjectFirewallResources
+
+			firewallId, err := firewalls.ParseFirewallID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			metricsFirewallId := metricsobjectfirewall.NewFirewallID(firewallId.SubscriptionId, firewallId.ResourceGroupName, firewallId.FirewallName)
+
+			if err = client.MetricsObjectFirewallDeleteThenPoll(ctx, metricsFirewallId); err != nil {
+				return fmt.Errorf("deleting Metrics for %s: %+v", metricsFirewallId, err)
+			}
+
+			return nil
+		},
+	}
+}

--- a/internal/services/paloalto/palo_alto_next_generation_firewall_metrics_resource.go
+++ b/internal/services/paloalto/palo_alto_next_generation_firewall_metrics_resource.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	firewalls "github.com/hashicorp/go-azure-sdk/resource-manager/paloaltonetworks/2025-10-08/firewallresources"
@@ -26,7 +25,6 @@ type NextGenerationFirewallMetricsModel struct {
 	FirewallID                          string `tfschema:"firewall_id"`
 	ApplicationInsightsConnectionString string `tfschema:"application_insights_connection_string"`
 	ApplicationInsightsResourceID       string `tfschema:"application_insights_resource_id"`
-	PanEtag                             string `tfschema:"pan_etag"`
 }
 
 var _ sdk.ResourceWithUpdate = NextGenerationFirewallMetricsResource{}
@@ -63,12 +61,7 @@ func (r NextGenerationFirewallMetricsResource) Arguments() map[string]*schema.Sc
 }
 
 func (r NextGenerationFirewallMetricsResource) Attributes() map[string]*schema.Schema {
-	return map[string]*pluginsdk.Schema{
-		"pan_etag": {
-			Type:     pluginsdk.TypeString,
-			Computed: true,
-		},
-	}
+	return map[string]*pluginsdk.Schema{}
 }
 
 func (r NextGenerationFirewallMetricsResource) Create() sdk.ResourceFunc {
@@ -92,7 +85,7 @@ func (r NextGenerationFirewallMetricsResource) Create() sdk.ResourceFunc {
 			existing, err := client.MetricsObjectFirewallGet(ctx, metricsFirewallId)
 			if err != nil {
 				if !response.WasNotFound(existing.HttpResponse) {
-					return fmt.Errorf("checking for presence of existing Metrics for %s: %+v", metricsFirewallId, err)
+					return fmt.Errorf("checking for presence of existing %s: %+v", metricsFirewallId, err)
 				}
 			}
 			if !response.WasNotFound(existing.HttpResponse) {
@@ -135,7 +128,7 @@ func (r NextGenerationFirewallMetricsResource) Read() sdk.ResourceFunc {
 				if response.WasNotFound(existing.HttpResponse) {
 					return metadata.MarkAsGone(firewallId)
 				}
-				return fmt.Errorf("reading Metrics for %s: %+v", metricsFirewallId, err)
+				return fmt.Errorf("retrieving %s: %+v", metricsFirewallId, err)
 			}
 
 			state := NextGenerationFirewallMetricsModel{
@@ -150,7 +143,6 @@ func (r NextGenerationFirewallMetricsResource) Read() sdk.ResourceFunc {
 					state.ApplicationInsightsConnectionString = props.ApplicationInsightsConnectionString
 				}
 				state.ApplicationInsightsResourceID = props.ApplicationInsightsResourceId
-				state.PanEtag = pointer.From(props.PanEtag)
 			}
 
 			return metadata.Encode(&state)
@@ -178,11 +170,11 @@ func (r NextGenerationFirewallMetricsResource) Update() sdk.ResourceFunc {
 
 			existing, err := client.MetricsObjectFirewallGet(ctx, metricsFirewallId)
 			if err != nil {
-				return fmt.Errorf("retrieving Metrics for %s: %+v", metricsFirewallId, err)
+				return fmt.Errorf("retrieving %s: %+v", metricsFirewallId, err)
 			}
 
 			if existing.Model == nil {
-				return fmt.Errorf("retrieving Metrics for %s: `model` was nil", metricsFirewallId)
+				return fmt.Errorf("retrieving %s: `model` was nil", metricsFirewallId)
 			}
 
 			update := *existing.Model

--- a/internal/services/paloalto/palo_alto_next_generation_firewall_metrics_resource.go
+++ b/internal/services/paloalto/palo_alto_next_generation_firewall_metrics_resource.go
@@ -79,7 +79,7 @@ func (r NextGenerationFirewallMetricsResource) Create() sdk.ResourceFunc {
 
 			var model NextGenerationFirewallMetricsModel
 			if err := metadata.Decode(&model); err != nil {
-				return err
+				return fmt.Errorf("decoding: %+v", err)
 			}
 
 			firewallId, err := firewalls.ParseFirewallID(model.FirewallID)
@@ -166,7 +166,7 @@ func (r NextGenerationFirewallMetricsResource) Update() sdk.ResourceFunc {
 
 			var model NextGenerationFirewallMetricsModel
 			if err := metadata.Decode(&model); err != nil {
-				return err
+				return fmt.Errorf("decoding: %+v", err)
 			}
 
 			firewallId, err := firewalls.ParseFirewallID(metadata.ResourceData.Id())

--- a/internal/services/paloalto/palo_alto_next_generation_firewall_metrics_resource.go
+++ b/internal/services/paloalto/palo_alto_next_generation_firewall_metrics_resource.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	firewalls "github.com/hashicorp/go-azure-sdk/resource-manager/paloaltonetworks/2025-10-08/firewallresources"
 	metricsobjectfirewall "github.com/hashicorp/go-azure-sdk/resource-manager/paloaltonetworks/2025-10-08/metricsobjectfirewallresources"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -44,12 +45,7 @@ func (r NextGenerationFirewallMetricsResource) ModelObject() interface{} {
 
 func (r NextGenerationFirewallMetricsResource) Arguments() map[string]*schema.Schema {
 	return map[string]*pluginsdk.Schema{
-		"firewall_id": {
-			Type:         pluginsdk.TypeString,
-			Required:     true,
-			ForceNew:     true,
-			ValidateFunc: firewalls.ValidateFirewallID,
-		},
+		"firewall_id": commonschema.ResourceIDReferenceRequiredForceNew(&firewalls.FirewallId{}),
 
 		"application_insights_connection_string": {
 			Type:         pluginsdk.TypeString,
@@ -111,10 +107,10 @@ func (r NextGenerationFirewallMetricsResource) Create() sdk.ResourceFunc {
 			}
 
 			if err = client.MetricsObjectFirewallCreateOrUpdateThenPoll(ctx, metricsFirewallId, input); err != nil {
-				return fmt.Errorf("creating Metrics for %s: %+v", metricsFirewallId, err)
+				return fmt.Errorf("creating %s: %+v", metricsFirewallId, err)
 			}
 
-			metadata.SetID(firewallId)
+			metadata.SetID(metricsFirewallId)
 
 			return nil
 		},
@@ -199,7 +195,7 @@ func (r NextGenerationFirewallMetricsResource) Update() sdk.ResourceFunc {
 			}
 
 			if err = client.MetricsObjectFirewallCreateOrUpdateThenPoll(ctx, metricsFirewallId, update); err != nil {
-				return fmt.Errorf("updating Metrics for %s: %+v", metricsFirewallId, err)
+				return fmt.Errorf("updating %s: %+v", metricsFirewallId, err)
 			}
 
 			return nil
@@ -221,7 +217,7 @@ func (r NextGenerationFirewallMetricsResource) Delete() sdk.ResourceFunc {
 			metricsFirewallId := metricsobjectfirewall.NewFirewallID(firewallId.SubscriptionId, firewallId.ResourceGroupName, firewallId.FirewallName)
 
 			if err = client.MetricsObjectFirewallDeleteThenPoll(ctx, metricsFirewallId); err != nil {
-				return fmt.Errorf("deleting Metrics for %s: %+v", metricsFirewallId, err)
+				return fmt.Errorf("deleting %s: %+v", metricsFirewallId, err)
 			}
 
 			return nil

--- a/internal/services/paloalto/palo_alto_next_generation_firewall_metrics_resource.go
+++ b/internal/services/paloalto/palo_alto_next_generation_firewall_metrics_resource.go
@@ -144,7 +144,8 @@ func (r NextGenerationFirewallMetricsResource) Read() sdk.ResourceFunc {
 
 			if model := existing.Model; model != nil {
 				props := model.Properties
-				// Azure may redact the connection string on GET; preserve the config value in state
+				// Default to current state value in case the API redacts the field on GET
+				state.ApplicationInsightsConnectionString = metadata.ResourceData.Get("application_insights_connection_string").(string)
 				if props.ApplicationInsightsConnectionString != "" {
 					state.ApplicationInsightsConnectionString = props.ApplicationInsightsConnectionString
 				}

--- a/internal/services/paloalto/palo_alto_next_generation_firewall_metrics_resource_test.go
+++ b/internal/services/paloalto/palo_alto_next_generation_firewall_metrics_resource_test.go
@@ -248,6 +248,7 @@ resource "azurerm_palo_alto_next_generation_firewall_virtual_network_local_rules
   name                = "acctest-ngfwvn-%[1]d"
   resource_group_name = azurerm_resource_group.test.name
   rulestack_id        = azurerm_palo_alto_local_rulestack.test.id
+  plan_id             = "panw-cngfw-payg"
 
   network_profile {
     public_ip_address_ids = [azurerm_public_ip.test.id]

--- a/internal/services/paloalto/palo_alto_next_generation_firewall_metrics_resource_test.go
+++ b/internal/services/paloalto/palo_alto_next_generation_firewall_metrics_resource_test.go
@@ -220,7 +220,7 @@ resource "azurerm_subnet_network_security_group_association" "test2" {
 }
 
 resource "azurerm_palo_alto_local_rulestack" "test" {
-  name                = "testAcc-palrs-%[1]d"
+  name                = "acctest-palrs-%[1]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = "%[2]s"
 
@@ -228,7 +228,7 @@ resource "azurerm_palo_alto_local_rulestack" "test" {
 }
 
 resource "azurerm_palo_alto_local_rulestack_rule" "test" {
-  name         = "testacc-palr-%[1]d"
+  name         = "acctest-palr-%[1]d"
   rulestack_id = azurerm_palo_alto_local_rulestack.test.id
   priority     = 1001
   action       = "Allow"

--- a/internal/services/paloalto/palo_alto_next_generation_firewall_metrics_resource_test.go
+++ b/internal/services/paloalto/palo_alto_next_generation_firewall_metrics_resource_test.go
@@ -1,0 +1,265 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package paloalto_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	firewalls "github.com/hashicorp/go-azure-sdk/resource-manager/paloaltonetworks/2025-10-08/firewallresources"
+	metricsobjectfirewall "github.com/hashicorp/go-azure-sdk/resource-manager/paloaltonetworks/2025-10-08/metricsobjectfirewallresources"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type NextGenerationFirewallMetricsResourceTest struct{}
+
+func (r NextGenerationFirewallMetricsResourceTest) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := firewalls.ParseFirewallID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	metricsFirewallId := metricsobjectfirewall.NewFirewallID(id.SubscriptionId, id.ResourceGroupName, id.FirewallName)
+
+	resp, err := client.PaloAlto.MetricsObjectFirewallResources.MetricsObjectFirewallGet(ctx, metricsFirewallId)
+	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			return pointer.To(false), nil
+		}
+		return nil, fmt.Errorf("retrieving Metrics for %s: %+v", metricsFirewallId, err)
+	}
+
+	return pointer.To(resp.Model != nil), nil
+}
+
+func TestAccPaloAltoNextGenerationFirewallMetrics_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_palo_alto_next_generation_firewall_metrics", "test")
+	r := NextGenerationFirewallMetricsResourceTest{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("application_insights_connection_string"),
+	})
+}
+
+func TestAccPaloAltoNextGenerationFirewallMetrics_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_palo_alto_next_generation_firewall_metrics", "test")
+	r := NextGenerationFirewallMetricsResourceTest{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func TestAccPaloAltoNextGenerationFirewallMetrics_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_palo_alto_next_generation_firewall_metrics", "test")
+	r := NextGenerationFirewallMetricsResourceTest{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("application_insights_connection_string"),
+		{
+			Config: r.update(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("application_insights_connection_string"),
+	})
+}
+
+func (r NextGenerationFirewallMetricsResourceTest) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_palo_alto_next_generation_firewall_metrics" "test" {
+  firewall_id                            = azurerm_palo_alto_next_generation_firewall_virtual_network_local_rulestack.test.id
+  application_insights_connection_string = azurerm_application_insights.test.connection_string
+  application_insights_resource_id       = azurerm_application_insights.test.id
+}
+`, r.template(data))
+}
+
+func (r NextGenerationFirewallMetricsResourceTest) requiresImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_palo_alto_next_generation_firewall_metrics" "import" {
+  firewall_id                            = azurerm_palo_alto_next_generation_firewall_metrics.test.firewall_id
+  application_insights_connection_string = azurerm_palo_alto_next_generation_firewall_metrics.test.application_insights_connection_string
+  application_insights_resource_id       = azurerm_palo_alto_next_generation_firewall_metrics.test.application_insights_resource_id
+}
+`, r.basic(data))
+}
+
+func (r NextGenerationFirewallMetricsResourceTest) update(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_palo_alto_next_generation_firewall_metrics" "test" {
+  firewall_id                            = azurerm_palo_alto_next_generation_firewall_virtual_network_local_rulestack.test.id
+  application_insights_connection_string = azurerm_application_insights.test2.connection_string
+  application_insights_resource_id       = azurerm_application_insights.test2.id
+}
+`, r.template(data))
+}
+
+func (r NextGenerationFirewallMetricsResourceTest) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-PANGFWMETRICS-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_application_insights" "test" {
+  name                = "acctestappinsights-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  application_type    = "web"
+}
+
+resource "azurerm_application_insights" "test2" {
+  name                = "acctestappinsights2-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  application_type    = "web"
+}
+
+resource "azurerm_public_ip" "test" {
+  name                = "acctestpublicip-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
+
+resource "azurerm_network_security_group" "test" {
+  name                = "acctestnsg-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvnet-%[1]d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test1" {
+  name                 = "acctest-pangfw-%[1]d-1"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.1.0/24"]
+
+  delegation {
+    name = "trusted"
+
+    service_delegation {
+      name = "PaloAltoNetworks.Cloudngfw/firewalls"
+      actions = [
+        "Microsoft.Network/virtualNetworks/subnets/join/action",
+      ]
+    }
+  }
+}
+
+resource "azurerm_subnet_network_security_group_association" "test1" {
+  subnet_id                 = azurerm_subnet.test1.id
+  network_security_group_id = azurerm_network_security_group.test.id
+}
+
+resource "azurerm_subnet" "test2" {
+  name                 = "acctest-pangfw-%[1]d-2"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+
+  delegation {
+    name = "untrusted"
+
+    service_delegation {
+      name = "PaloAltoNetworks.Cloudngfw/firewalls"
+      actions = [
+        "Microsoft.Network/virtualNetworks/subnets/join/action",
+      ]
+    }
+  }
+}
+
+resource "azurerm_subnet_network_security_group_association" "test2" {
+  subnet_id                 = azurerm_subnet.test2.id
+  network_security_group_id = azurerm_network_security_group.test.id
+}
+
+resource "azurerm_palo_alto_local_rulestack" "test" {
+  name                = "testAcc-palrs-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = "%[2]s"
+
+  depends_on = [azurerm_subnet_network_security_group_association.test1, azurerm_subnet_network_security_group_association.test2]
+}
+
+resource "azurerm_palo_alto_local_rulestack_rule" "test" {
+  name         = "testacc-palr-%[1]d"
+  rulestack_id = azurerm_palo_alto_local_rulestack.test.id
+  priority     = 1001
+  action       = "Allow"
+  protocol     = "application-default"
+  applications = ["any"]
+
+  destination {
+    cidrs = ["any"]
+  }
+
+  source {
+    cidrs = ["any"]
+  }
+}
+
+resource "azurerm_palo_alto_next_generation_firewall_virtual_network_local_rulestack" "test" {
+  name                = "acctest-ngfwvn-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  rulestack_id        = azurerm_palo_alto_local_rulestack.test.id
+
+  network_profile {
+    public_ip_address_ids = [azurerm_public_ip.test.id]
+
+    vnet_configuration {
+      virtual_network_id  = azurerm_virtual_network.test.id
+      trusted_subnet_id   = azurerm_subnet.test1.id
+      untrusted_subnet_id = azurerm_subnet.test2.id
+    }
+  }
+
+  depends_on = [azurerm_palo_alto_local_rulestack_rule.test]
+}
+`, data.RandomInteger, data.Locations.Primary)
+}

--- a/internal/services/paloalto/palo_alto_next_generation_firewall_metrics_resource_test.go
+++ b/internal/services/paloalto/palo_alto_next_generation_firewall_metrics_resource_test.go
@@ -33,7 +33,7 @@ func (r NextGenerationFirewallMetricsResourceTest) Exists(ctx context.Context, c
 		if response.WasNotFound(resp.HttpResponse) {
 			return pointer.To(false), nil
 		}
-		return nil, fmt.Errorf("retrieving Metrics for %s: %+v", metricsFirewallId, err)
+		return nil, fmt.Errorf("retrieving %s: %+v", metricsFirewallId, err)
 	}
 
 	return pointer.To(resp.Model != nil), nil
@@ -93,6 +93,14 @@ func TestAccPaloAltoNextGenerationFirewallMetrics_update(t *testing.T) {
 
 func (r NextGenerationFirewallMetricsResourceTest) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
 %[1]s
 
 resource "azurerm_palo_alto_next_generation_firewall_metrics" "test" {
@@ -119,6 +127,14 @@ resource "azurerm_palo_alto_next_generation_firewall_metrics" "import" {
 
 func (r NextGenerationFirewallMetricsResourceTest) update(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
 %[1]s
 
 resource "azurerm_palo_alto_next_generation_firewall_metrics" "test" {
@@ -133,14 +149,6 @@ resource "azurerm_palo_alto_next_generation_firewall_metrics" "test" {
 
 func (r NextGenerationFirewallMetricsResourceTest) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {
-    resource_group {
-      prevent_deletion_if_contains_resources = false
-    }
-  }
-}
-
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-PANGFWMETRICS-%[1]d"
   location = "%[2]s"

--- a/internal/services/paloalto/palo_alto_next_generation_firewall_metrics_resource_test.go
+++ b/internal/services/paloalto/palo_alto_next_generation_firewall_metrics_resource_test.go
@@ -99,6 +99,8 @@ resource "azurerm_palo_alto_next_generation_firewall_metrics" "test" {
   firewall_id                            = azurerm_palo_alto_next_generation_firewall_virtual_network_local_rulestack.test.id
   application_insights_connection_string = azurerm_application_insights.test.connection_string
   application_insights_resource_id       = azurerm_application_insights.test.id
+
+  depends_on = [azurerm_role_assignment.test]
 }
 `, r.template(data))
 }
@@ -123,6 +125,8 @@ resource "azurerm_palo_alto_next_generation_firewall_metrics" "test" {
   firewall_id                            = azurerm_palo_alto_next_generation_firewall_virtual_network_local_rulestack.test.id
   application_insights_connection_string = azurerm_application_insights.test2.connection_string
   application_insights_resource_id       = azurerm_application_insights.test2.id
+
+  depends_on = [azurerm_role_assignment.test2]
 }
 `, r.template(data))
 }
@@ -130,7 +134,11 @@ resource "azurerm_palo_alto_next_generation_firewall_metrics" "test" {
 func (r NextGenerationFirewallMetricsResourceTest) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
 }
 
 resource "azurerm_resource_group" "test" {
@@ -138,18 +146,48 @@ resource "azurerm_resource_group" "test" {
   location = "%[2]s"
 }
 
-resource "azurerm_application_insights" "test" {
-  name                = "acctestappinsights-%[1]d"
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctestuami-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_log_analytics_workspace" "test" {
+  name                = "acctestlaw-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  application_type    = "web"
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+}
+
+resource "azurerm_application_insights" "test" {
+  name                          = "acctestappinsights-%[1]d"
+  location                      = azurerm_resource_group.test.location
+  resource_group_name           = azurerm_resource_group.test.name
+  workspace_id                  = azurerm_log_analytics_workspace.test.id
+  application_type              = "other"
+  local_authentication_disabled = true
 }
 
 resource "azurerm_application_insights" "test2" {
-  name                = "acctestappinsights2-%[1]d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  application_type    = "web"
+  name                          = "acctestappinsights2-%[1]d"
+  location                      = azurerm_resource_group.test.location
+  resource_group_name           = azurerm_resource_group.test.name
+  workspace_id                  = azurerm_log_analytics_workspace.test.id
+  application_type              = "other"
+  local_authentication_disabled = true
+}
+
+resource "azurerm_role_assignment" "test" {
+  scope                = azurerm_application_insights.test.id
+  role_definition_name = "Monitoring Metrics Publisher"
+  principal_id         = azurerm_user_assigned_identity.test.principal_id
+}
+
+resource "azurerm_role_assignment" "test2" {
+  scope                = azurerm_application_insights.test2.id
+  role_definition_name = "Monitoring Metrics Publisher"
+  principal_id         = azurerm_user_assigned_identity.test.principal_id
 }
 
 resource "azurerm_public_ip" "test" {
@@ -249,6 +287,11 @@ resource "azurerm_palo_alto_next_generation_firewall_virtual_network_local_rules
   resource_group_name = azurerm_resource_group.test.name
   rulestack_id        = azurerm_palo_alto_local_rulestack.test.id
   plan_id             = "panw-cngfw-payg"
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
 
   network_profile {
     public_ip_address_ids = [azurerm_public_ip.test.id]

--- a/internal/services/paloalto/palo_alto_next_generation_firewall_metrics_resource_test.go
+++ b/internal/services/paloalto/palo_alto_next_generation_firewall_metrics_resource_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/go-azure-helpers/lang/response"
 	firewalls "github.com/hashicorp/go-azure-sdk/resource-manager/paloaltonetworks/2025-10-08/firewallresources"
 	metricsobjectfirewall "github.com/hashicorp/go-azure-sdk/resource-manager/paloaltonetworks/2025-10-08/metricsobjectfirewallresources"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -30,9 +29,6 @@ func (r NextGenerationFirewallMetricsResourceTest) Exists(ctx context.Context, c
 
 	resp, err := client.PaloAlto.MetricsObjectFirewallResources.MetricsObjectFirewallGet(ctx, metricsFirewallId)
 	if err != nil {
-		if response.WasNotFound(resp.HttpResponse) {
-			return pointer.To(false), nil
-		}
 		return nil, fmt.Errorf("retrieving %s: %+v", metricsFirewallId, err)
 	}
 

--- a/internal/services/paloalto/palo_alto_next_generation_firewall_virtual_network_local_rulestack_resource.go
+++ b/internal/services/paloalto/palo_alto_next_generation_firewall_virtual_network_local_rulestack_resource.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	firewalls "github.com/hashicorp/go-azure-sdk/resource-manager/paloaltonetworks/2025-10-08/firewallresources"
@@ -27,15 +28,16 @@ import (
 type NextGenerationFirewallVNetLocalRulestackResource struct{}
 
 type NextGenerationFirewallVnetLocalRulestackModel struct {
-	Name               string                      `tfschema:"name"`
-	ResourceGroupName  string                      `tfschema:"resource_group_name"`
-	NetworkProfile     []schema.NetworkProfileVnet `tfschema:"network_profile"`
-	RuleStackId        string                      `tfschema:"rulestack_id"`
-	DNSSettings        []schema.DNSSettings        `tfschema:"dns_settings"`
-	FrontEnd           []schema.DestinationNAT     `tfschema:"destination_nat"`
-	MarketplaceOfferId string                      `tfschema:"marketplace_offer_id"`
-	PlanId             string                      `tfschema:"plan_id"`
-	Tags               map[string]interface{}      `tfschema:"tags"`
+	Name               string                       `tfschema:"name"`
+	ResourceGroupName  string                       `tfschema:"resource_group_name"`
+	NetworkProfile     []schema.NetworkProfileVnet  `tfschema:"network_profile"`
+	RuleStackId        string                       `tfschema:"rulestack_id"`
+	DNSSettings        []schema.DNSSettings         `tfschema:"dns_settings"`
+	FrontEnd           []schema.DestinationNAT      `tfschema:"destination_nat"`
+	MarketplaceOfferId string                       `tfschema:"marketplace_offer_id"`
+	PlanId             string                       `tfschema:"plan_id"`
+	Identity           []identity.ModelUserAssigned `tfschema:"identity"`
+	Tags               map[string]interface{}       `tfschema:"tags"`
 }
 
 var _ sdk.ResourceWithUpdate = NextGenerationFirewallVNetLocalRulestackResource{}
@@ -82,6 +84,8 @@ func (r NextGenerationFirewallVNetLocalRulestackResource) Arguments() map[string
 			Default:      "panw-cngfw-payg",
 			ValidateFunc: validation.StringLenBetween(1, 50),
 		},
+
+		"identity": commonschema.UserAssignedIdentityOptional(),
 
 		"tags": commonschema.Tags(),
 	}
@@ -138,6 +142,11 @@ func (r NextGenerationFirewallVNetLocalRulestackResource) Create() sdk.ResourceF
 
 			loc := location.Normalize(ruleStack.Model.Location)
 
+			expandedIdentity, err := expandUserAssignedIdentityToLegacy(model.Identity)
+			if err != nil {
+				return fmt.Errorf("expanding `identity`: %+v", err)
+			}
+
 			firewall := firewalls.FirewallResource{
 				Location: loc,
 				Properties: firewalls.FirewallDeploymentProperties{
@@ -157,7 +166,8 @@ func (r NextGenerationFirewallVNetLocalRulestackResource) Create() sdk.ResourceF
 					},
 					FrontEndSettings: schema.ExpandDestinationNAT(model.FrontEnd),
 				},
-				Tags: tags.Expand(model.Tags),
+				Identity: expandedIdentity,
+				Tags:     tags.Expand(model.Tags),
 			}
 
 			locks.ByID(ruleStackID.ID())
@@ -213,6 +223,12 @@ func (r NextGenerationFirewallVNetLocalRulestackResource) Read() sdk.ResourceFun
 				state.MarketplaceOfferId = props.MarketplaceDetails.OfferId
 
 				state.PlanId = props.PlanData.PlanId
+
+				flattenedIdentity, err := flattenUserAssignedIdentityFromLegacy(model.Identity)
+				if err != nil {
+					return fmt.Errorf("flattening `identity`: %+v", err)
+				}
+				state.Identity = flattenedIdentity
 
 				state.Tags = tags.Flatten(existing.Model.Tags)
 			}
@@ -309,6 +325,14 @@ func (r NextGenerationFirewallVNetLocalRulestackResource) Update() sdk.ResourceF
 
 			firewall.Properties = props
 
+			if metadata.ResourceData.HasChange("identity") {
+				expandedIdentity, err := expandUserAssignedIdentityToLegacy(model.Identity)
+				if err != nil {
+					return fmt.Errorf("expanding `identity`: %+v", err)
+				}
+				firewall.Identity = expandedIdentity
+			}
+
 			if metadata.ResourceData.HasChange("tags") {
 				firewall.Tags = tags.Expand(model.Tags)
 			}
@@ -320,4 +344,32 @@ func (r NextGenerationFirewallVNetLocalRulestackResource) Update() sdk.ResourceF
 			return nil
 		},
 	}
+}
+
+func expandUserAssignedIdentityToLegacy(input []identity.ModelUserAssigned) (*identity.LegacySystemAndUserAssignedMap, error) {
+expanded, err := identity.ExpandUserAssignedMapFromModel(input)
+if err != nil {
+return nil, err
+}
+
+return &identity.LegacySystemAndUserAssignedMap{
+Type:        expanded.Type,
+IdentityIds: expanded.IdentityIds,
+}, nil
+}
+
+func flattenUserAssignedIdentityFromLegacy(input *identity.LegacySystemAndUserAssignedMap) ([]identity.ModelUserAssigned, error) {
+if input == nil {
+return []identity.ModelUserAssigned{}, nil
+}
+
+flattened, err := identity.FlattenUserAssignedMapToModel(&identity.UserAssignedMap{
+Type:        input.Type,
+IdentityIds: input.IdentityIds,
+})
+if err != nil {
+return nil, err
+}
+
+return *flattened, nil
 }

--- a/internal/services/paloalto/palo_alto_next_generation_firewall_virtual_network_local_rulestack_resource.go
+++ b/internal/services/paloalto/palo_alto_next_generation_firewall_virtual_network_local_rulestack_resource.go
@@ -347,29 +347,29 @@ func (r NextGenerationFirewallVNetLocalRulestackResource) Update() sdk.ResourceF
 }
 
 func expandUserAssignedIdentityToLegacy(input []identity.ModelUserAssigned) (*identity.LegacySystemAndUserAssignedMap, error) {
-expanded, err := identity.ExpandUserAssignedMapFromModel(input)
-if err != nil {
-return nil, err
-}
+	expanded, err := identity.ExpandUserAssignedMapFromModel(input)
+	if err != nil {
+		return nil, err
+	}
 
-return &identity.LegacySystemAndUserAssignedMap{
-Type:        expanded.Type,
-IdentityIds: expanded.IdentityIds,
-}, nil
+	return &identity.LegacySystemAndUserAssignedMap{
+		Type:        expanded.Type,
+		IdentityIds: expanded.IdentityIds,
+	}, nil
 }
 
 func flattenUserAssignedIdentityFromLegacy(input *identity.LegacySystemAndUserAssignedMap) ([]identity.ModelUserAssigned, error) {
-if input == nil {
-return []identity.ModelUserAssigned{}, nil
-}
+	if input == nil {
+		return []identity.ModelUserAssigned{}, nil
+	}
 
-flattened, err := identity.FlattenUserAssignedMapToModel(&identity.UserAssignedMap{
-Type:        input.Type,
-IdentityIds: input.IdentityIds,
-})
-if err != nil {
-return nil, err
-}
+	flattened, err := identity.FlattenUserAssignedMapToModel(&identity.UserAssignedMap{
+		Type:        input.Type,
+		IdentityIds: input.IdentityIds,
+	})
+	if err != nil {
+		return nil, err
+	}
 
-return *flattened, nil
+	return *flattened, nil
 }

--- a/internal/services/paloalto/registration.go
+++ b/internal/services/paloalto/registration.go
@@ -35,11 +35,11 @@ func (r Registration) Resources() []sdk.Resource {
 	return []sdk.Resource{
 		LocalRuleStack{},
 		LocalRuleStackCertificate{},
+		LocalRuleStackPrefixList{},
+		LocalRuleStackRule{},
 		LocalRulestackFQDNList{},
 		LocalRulestackOutboundTrustCertificateAssociationResource{},
 		LocalRulestackOutboundUnTrustCertificateAssociationResource{},
-		LocalRuleStackPrefixList{},
-		LocalRuleStackRule{},
 		NetworkVirtualApplianceResource{},
 		NextGenerationFirewallMetricsResource{},
 		NextGenerationFirewallVHubLocalRuleStackResource{},

--- a/internal/services/paloalto/registration.go
+++ b/internal/services/paloalto/registration.go
@@ -41,6 +41,7 @@ func (r Registration) Resources() []sdk.Resource {
 		LocalRuleStackPrefixList{},
 		LocalRuleStackRule{},
 		NetworkVirtualApplianceResource{},
+		NextGenerationFirewallMetricsResource{},
 		NextGenerationFirewallVHubLocalRuleStackResource{},
 		NextGenerationFirewallVHubPanoramaResource{},
 		NextGenerationFirewallVHubStrataCloudManagerResource{},

--- a/website/docs/r/palo_alto_next_generation_firewall_metrics.html.markdown
+++ b/website/docs/r/palo_alto_next_generation_firewall_metrics.html.markdown
@@ -1,0 +1,187 @@
+---
+subcategory: "Palo Alto"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_palo_alto_next_generation_firewall_metrics"
+description: |-
+  Manages a Palo Alto Next Generation Firewall Metrics configuration.
+---
+
+# azurerm_palo_alto_next_generation_firewall_metrics
+
+Manages a Palo Alto Next Generation Firewall Metrics configuration.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_application_insights" "example" {
+  name                = "example-appinsights"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  application_type    = "web"
+}
+
+resource "azurerm_public_ip" "example" {
+  name                = "example-publicip"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
+
+resource "azurerm_network_security_group" "example" {
+  name                = "example-nsg"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+}
+
+resource "azurerm_virtual_network" "example" {
+  name                = "example-vnet"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+}
+
+resource "azurerm_subnet" "trust" {
+  name                 = "example-trust-subnet"
+  resource_group_name  = azurerm_resource_group.example.name
+  virtual_network_name = azurerm_virtual_network.example.name
+  address_prefixes     = ["10.0.1.0/24"]
+
+  delegation {
+    name = "trusted"
+
+    service_delegation {
+      name = "PaloAltoNetworks.Cloudngfw/firewalls"
+      actions = [
+        "Microsoft.Network/virtualNetworks/subnets/join/action",
+      ]
+    }
+  }
+}
+
+resource "azurerm_subnet_network_security_group_association" "trust" {
+  subnet_id                 = azurerm_subnet.trust.id
+  network_security_group_id = azurerm_network_security_group.example.id
+}
+
+resource "azurerm_subnet" "untrust" {
+  name                 = "example-untrust-subnet"
+  resource_group_name  = azurerm_resource_group.example.name
+  virtual_network_name = azurerm_virtual_network.example.name
+  address_prefixes     = ["10.0.2.0/24"]
+
+  delegation {
+    name = "untrusted"
+
+    service_delegation {
+      name = "PaloAltoNetworks.Cloudngfw/firewalls"
+      actions = [
+        "Microsoft.Network/virtualNetworks/subnets/join/action",
+      ]
+    }
+  }
+}
+
+resource "azurerm_subnet_network_security_group_association" "untrust" {
+  subnet_id                 = azurerm_subnet.untrust.id
+  network_security_group_id = azurerm_network_security_group.example.id
+}
+
+resource "azurerm_palo_alto_local_rulestack" "example" {
+  name                = "example-rulestack"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+
+  depends_on = [
+    azurerm_subnet_network_security_group_association.trust,
+    azurerm_subnet_network_security_group_association.untrust,
+  ]
+}
+
+resource "azurerm_palo_alto_local_rulestack_rule" "example" {
+  name         = "example-rule"
+  rulestack_id = azurerm_palo_alto_local_rulestack.example.id
+  priority     = 1001
+  action       = "Allow"
+  protocol     = "application-default"
+  applications = ["any"]
+
+  destination {
+    cidrs = ["any"]
+  }
+
+  source {
+    cidrs = ["any"]
+  }
+}
+
+resource "azurerm_palo_alto_next_generation_firewall_virtual_network_local_rulestack" "example" {
+  name                = "example-ngfw"
+  resource_group_name = azurerm_resource_group.example.name
+  rulestack_id        = azurerm_palo_alto_local_rulestack.example.id
+
+  network_profile {
+    public_ip_address_ids = [azurerm_public_ip.example.id]
+
+    vnet_configuration {
+      virtual_network_id  = azurerm_virtual_network.example.id
+      trusted_subnet_id   = azurerm_subnet.trust.id
+      untrusted_subnet_id = azurerm_subnet.untrust.id
+    }
+  }
+
+  depends_on = [azurerm_palo_alto_local_rulestack_rule.example]
+}
+
+resource "azurerm_palo_alto_next_generation_firewall_metrics" "example" {
+  firewall_id                            = azurerm_palo_alto_next_generation_firewall_virtual_network_local_rulestack.example.id
+  application_insights_connection_string = azurerm_application_insights.example.connection_string
+  application_insights_resource_id       = azurerm_application_insights.example.id
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `firewall_id` - (Required) The ID of the Palo Alto Next Generation Firewall. Changing this forces a new resource to be created.
+
+* `application_insights_connection_string` - (Required) The connection string of the Application Insights resource used for metrics collection.
+
+* `application_insights_resource_id` - (Required) The resource ID of the Application Insights resource used for metrics collection.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Palo Alto Next Generation Firewall Metrics configuration. This is the same as the `firewall_id`.
+
+* `pan_etag` - A read-only string representing the last create or update operation on this resource.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Palo Alto Next Generation Firewall Metrics.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Palo Alto Next Generation Firewall Metrics.
+* `update` - (Defaults to 30 minutes) Used when updating the Palo Alto Next Generation Firewall Metrics.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Palo Alto Next Generation Firewall Metrics.
+
+## Import
+
+Palo Alto Next Generation Firewall Metrics can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_palo_alto_next_generation_firewall_metrics.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/PaloAltoNetworks.Cloudngfw/firewalls/myFirewall
+```
+
+## API Providers
+<!-- This section is generated, changes will be overwritten -->
+This resource uses the following Azure API Providers:
+
+* `PaloAltoNetworks.Cloudngfw` - 2025-10-08

--- a/website/docs/r/palo_alto_next_generation_firewall_metrics.html.markdown
+++ b/website/docs/r/palo_alto_next_generation_firewall_metrics.html.markdown
@@ -161,8 +161,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the Palo Alto Next Generation Firewall Metrics configuration. This is the same as the `firewall_id`.
 
-* `pan_etag` - A read-only string representing the last create or update operation on this resource.
-
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/configure#define-operation-timeouts) for certain actions:

--- a/website/docs/r/palo_alto_next_generation_firewall_metrics.html.markdown
+++ b/website/docs/r/palo_alto_next_generation_firewall_metrics.html.markdown
@@ -165,7 +165,7 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 ## Timeouts
 
-The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/configure#define-operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Palo Alto Next Generation Firewall Metrics.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Palo Alto Next Generation Firewall Metrics.
@@ -177,7 +177,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 Palo Alto Next Generation Firewall Metrics can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_palo_alto_next_generation_firewall_metrics.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/PaloAltoNetworks.Cloudngfw/firewalls/myFirewall
+terraform import azurerm_palo_alto_next_generation_firewall_metrics.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/PaloAltoNetworks.Cloudngfw/firewalls/firewall1
 ```
 
 ## API Providers

--- a/website/docs/r/palo_alto_next_generation_firewall_virtual_network_local_rulestack.html.markdown
+++ b/website/docs/r/palo_alto_next_generation_firewall_virtual_network_local_rulestack.html.markdown
@@ -153,6 +153,8 @@ The following arguments are supported:
 
 * `dns_settings` - (Optional) A `dns_settings` block as defined below.
 
+* `identity` - (Optional) An `identity` block as defined below.
+
 * `tags` - (Optional) A mapping of tags which should be assigned to the Palo Alto Next Generation Firewall Virtual Network Local Rulestack.
 
 ---
@@ -192,6 +194,14 @@ A `frontend_config` block supports the following:
 * `public_ip_address_id` - (Required) The ID of the Public IP Address on which to receive traffic. 
 
 ~> **Note:** This must be an Azure Public IP address ID also specified in the `public_ip_address_ids` list.
+
+---
+
+An `identity` block supports the following:
+
+* `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this Palo Alto Next Generation Firewall Virtual Network Local Rulestack. The only possible value is `UserAssigned`.
+
+* `identity_ids` - (Required) Specifies a list of User Assigned Managed Identity IDs to be assigned to this Palo Alto Next Generation Firewall Virtual Network Local Rulestack.
 
 ---
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```
 === RUN   TestAccPaloAltoNextGenerationFirewallMetrics_basic
 === PAUSE TestAccPaloAltoNextGenerationFirewallMetrics_basic
 === CONT  TestAccPaloAltoNextGenerationFirewallMetrics_basic
 --- PASS: TestAccPaloAltoNextGenerationFirewallMetrics_basic (2510.63s)
 PASS
 ok     github.com/hashicorp/terraform-provider-azurerm/internal/services/paloalto      2510.698s

 === RUN   TestAccPaloAltoNextGenerationFirewallMetrics_requiresImport
 === PAUSE TestAccPaloAltoNextGenerationFirewallMetrics_requiresImport
 === RUN   TestAccPaloAltoNextGenerationFirewallMetrics_update
 === PAUSE TestAccPaloAltoNextGenerationFirewallMetrics_update
 === CONT  TestAccPaloAltoNextGenerationFirewallMetrics_requiresImport
 === CONT  TestAccPaloAltoNextGenerationFirewallMetrics_update
 --- PASS: TestAccPaloAltoNextGenerationFirewallMetrics_requiresImport (2264.62s)
 --- PASS: TestAccPaloAltoNextGenerationFirewallMetrics_update         (2365.72s)
 PASS
 ok     github.com/hashicorp/terraform-provider-azurerm/internal/services/paloalto      2365.795s
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
