### PR TITLE
azurerm_firewall_policy_rule_collection_group - fix timeout expiring while waiting for policy lock

### DIFF
--- a/internal/services/firewall/firewall_policy_rule_collection_group_resource.go
+++ b/internal/services/firewall/firewall_policy_rule_collection_group_resource.go
@@ -460,8 +460,6 @@ func resourceFirewallPolicyRuleCollectionGroup() *pluginsdk.Resource {
 
 func resourceFirewallPolicyRuleCollectionGroupCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.FirewallPolicyRuleCollectionGroups
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
-	defer cancel()
 
 	policyId, err := firewallpolicies.ParseFirewallPolicyID(d.Get("firewall_policy_id").(string))
 	if err != nil {
@@ -469,6 +467,16 @@ func resourceFirewallPolicyRuleCollectionGroupCreateUpdate(d *pluginsdk.Resource
 	}
 
 	id := firewallpolicyrulecollectiongroups.NewRuleCollectionGroupID(policyId.SubscriptionId, policyId.ResourceGroupName, policyId.FirewallPolicyName, d.Get("name").(string))
+
+	// NOTE: Acquire the lock before creating the timeout context. Azure enforces serial processing
+	// on firewall policy rule collection groups within the same policy, responding with 409
+	// AnotherOperationInProgress for concurrent requests. The timeout context must be created after
+	// the lock is acquired so that time spent waiting for the lock does not consume the timeout budget.
+	locks.ByName(policyId.FirewallPolicyName, AzureFirewallPolicyResourceName)
+	defer locks.UnlockByName(policyId.FirewallPolicyName, AzureFirewallPolicyResourceName)
+
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
 
 	if d.IsNewResource() {
 		resp, err := client.Get(ctx, id)
@@ -482,9 +490,6 @@ func resourceFirewallPolicyRuleCollectionGroupCreateUpdate(d *pluginsdk.Resource
 			return tf.ImportAsExistsError("azurerm_firewall_policy_rule_collection_group", id.ID())
 		}
 	}
-
-	locks.ByName(policyId.FirewallPolicyName, AzureFirewallPolicyResourceName)
-	defer locks.UnlockByName(policyId.FirewallPolicyName, AzureFirewallPolicyResourceName)
 
 	param := firewallpolicyrulecollectiongroups.FirewallPolicyRuleCollectionGroup{
 		Properties: &firewallpolicyrulecollectiongroups.FirewallPolicyRuleCollectionGroupProperties{
@@ -568,16 +573,21 @@ func resourceFirewallPolicyRuleCollectionGroupSetFlatten(d *pluginsdk.ResourceDa
 
 func resourceFirewallPolicyRuleCollectionGroupDelete(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.FirewallPolicyRuleCollectionGroups
-	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
-	defer cancel()
 
 	id, err := firewallpolicyrulecollectiongroups.ParseRuleCollectionGroupID(d.Id())
 	if err != nil {
 		return err
 	}
 
+	// NOTE: Acquire the lock before creating the timeout context. Azure enforces serial processing
+	// on firewall policy rule collection groups within the same policy, responding with 409
+	// AnotherOperationInProgress for concurrent requests. The timeout context must be created after
+	// the lock is acquired so that time spent waiting for the lock does not consume the timeout budget.
 	locks.ByName(id.FirewallPolicyName, AzureFirewallPolicyResourceName)
 	defer locks.UnlockByName(id.FirewallPolicyName, AzureFirewallPolicyResourceName)
+
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
 
 	if err = client.DeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %s: %+v", id, err)


### PR DESCRIPTION
## Summary

- Fix timeout-before-lock ordering in `azurerm_firewall_policy_rule_collection_group` CreateUpdate and Delete functions
- Prevents operations from timing out when multiple rule collection groups target the same firewall policy

## Problem

We recently started seeing timeouts when deploying multiple `azurerm_firewall_policy_rule_collection_group` resources that target the same firewall policy, Terraform processes them in parallel. Azure enforces serial processing on the same firewall policy, responding with `409 AnotherOperationInProgress` for concurrent requests.

The provider already serializes these operations using `locks.ByName()`, which prevents the 409 errors. However, the **timeout context** (`context.WithTimeout` with a 30-minute deadline) was created **before** the lock was acquired:

```go
ctx, cancel := timeouts.ForCreateUpdate(...)  // 30-minute timer STARTS HERE
// ...
locks.ByName(...)                              // BLOCKS here, timer keeps ticking
// ...
client.CreateOrUpdateThenPoll(ctx, id, param)  // ctx may have insufficient time remaining
```

When N goroutines compete for the same lock, all N timers start simultaneously. Goroutines that wait for the lock have their timeout budget consumed by wait time, eventually causing `context.DeadlineExceeded` errors that manifest as operation timeouts.

## Fix

Move lock acquisition **before** the timeout context creation, so each operation gets its full timeout regardless of how long it waited for the lock:

```go
locks.ByName(...)                              // BLOCKS here, no timer yet
// ...
ctx, cancel := timeouts.ForCreateUpdate(...)  // 30-minute timer starts AFTER lock acquired
// ...
client.CreateOrUpdateThenPoll(ctx, id, param)  // full 30 minutes available
```

Applied to both `resourceFirewallPolicyRuleCollectionGroupCreateUpdate` and `resourceFirewallPolicyRuleCollectionGroupDelete`.

## Side effects

- The existence check (`client.Get`) in CreateUpdate is now inside the lock scope

## Note

All 6 firewall resource files have this same timeout-before-lock pattern. This PR only fixes `firewall_policy_rule_collection_group_resource.go`. The same fix can be applied to other resources separately if needed.