### PR TITLE
azurerm_kubernetes_cluster / azurerm_kubernetes_cluster_node_pool - add support for Windows2025 os_sku

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,6 @@ ENHANCEMENTS:
 * dependencies: `Go` - upgrade to version 1.25.8 ([#31907](https://github.com/hashicorp/terraform-provider-azurerm/issues/31907))
 * `azurerm_bastion_host` - Upgrade API to `2025-01-01` ([#32030](https://github.com/hashicorp/terraform-provider-azurerm/issues/32030))
 * `azurerm_kubernetes_cluster` - add support for migration from Azure or Kubenet CNI to Azure CNI Overlay ([#30959](https://github.com/hashicorp/terraform-provider-azurerm/issues/30959))
-* `azurerm_kubernetes_cluster` - add support for the `Windows2025` `os_sku` value ([#XXXXX](https://github.com/hashicorp/terraform-provider-azurerm/issues/XXXXX))
-* `azurerm_kubernetes_cluster_node_pool` - add support for the `Windows2025` `os_sku` value ([#XXXXX](https://github.com/hashicorp/terraform-provider-azurerm/issues/XXXXX))
 * `azurerm_search_service`: add support for `endpoint` attribute ([#32010](https://github.com/hashicorp/terraform-provider-azurerm/issues/32010))
 * `cognitive_account_rai_blocklist_resource` - add support for the `tags` property ([#31871](https://github.com/hashicorp/terraform-provider-azurerm/issues/31871))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ ENHANCEMENTS:
 * dependencies: `Go` - upgrade to version 1.25.8 ([#31907](https://github.com/hashicorp/terraform-provider-azurerm/issues/31907))
 * `azurerm_bastion_host` - Upgrade API to `2025-01-01` ([#32030](https://github.com/hashicorp/terraform-provider-azurerm/issues/32030))
 * `azurerm_kubernetes_cluster` - add support for migration from Azure or Kubenet CNI to Azure CNI Overlay ([#30959](https://github.com/hashicorp/terraform-provider-azurerm/issues/30959))
+* `azurerm_kubernetes_cluster` - add support for the `Windows2025` `os_sku` value ([#XXXXX](https://github.com/hashicorp/terraform-provider-azurerm/issues/XXXXX))
+* `azurerm_kubernetes_cluster_node_pool` - add support for the `Windows2025` `os_sku` value ([#XXXXX](https://github.com/hashicorp/terraform-provider-azurerm/issues/XXXXX))
 * `azurerm_search_service`: add support for `endpoint` attribute ([#32010](https://github.com/hashicorp/terraform-provider-azurerm/issues/32010))
 * `cognitive_account_rai_blocklist_resource` - add support for the `tags` property ([#31871](https://github.com/hashicorp/terraform-provider-azurerm/issues/31871))
 

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -336,6 +336,7 @@ func resourceKubernetesClusterNodePoolSchema() map[string]*pluginsdk.Schema {
 				string(agentpools.OSSKUUbuntuTwoFourZeroFour),
 				string(agentpools.OSSKUWindowsTwoZeroOneNine),
 				string(agentpools.OSSKUWindowsTwoZeroTwoTwo),
+				string(agentpools.OSSKUWindowsTwoZeroTwoFive),
 			}, false),
 		},
 

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -800,6 +800,22 @@ func TestAccKubernetesClusterNodePool_windows2022(t *testing.T) {
 	})
 }
 
+func TestAccKubernetesClusterNodePool_windows2025(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster_node_pool", "test")
+	r := KubernetesClusterNodePoolResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.windows2025Config(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("tags.Os").HasValue("Windows"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccKubernetesClusterNodePool_windowsAndLinux(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster_node_pool", "test")
 	r := KubernetesClusterNodePoolResource{}
@@ -2756,6 +2772,32 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   node_count            = 1
   os_type               = "Windows"
   os_sku                = "Windows2022"
+  tags = {
+    Os = "Windows"
+  }
+  upgrade_settings {
+    max_surge = "10%%"
+  }
+}
+`, r.templateWindowsConfig(data))
+}
+
+func (r KubernetesClusterNodePoolResource) windows2025Config(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_kubernetes_cluster_node_pool" "test" {
+  name                  = "windoz"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
+  vm_size               = "Standard_DS2_v2"
+  node_count            = 1
+  os_type               = "Windows"
+  os_sku                = "Windows2025"
+  fips_enabled          = true
   tags = {
     Os = "Windows"
   }

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -194,6 +194,7 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 							string(agentpools.OSSKUUbuntuTwoFourZeroFour),
 							string(agentpools.OSSKUWindowsTwoZeroOneNine),
 							string(agentpools.OSSKUWindowsTwoZeroTwoTwo),
+							string(agentpools.OSSKUWindowsTwoZeroTwoFive),
 						}, false),
 					},
 

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2025-10-01/agentpools/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2025-10-01/agentpools/constants.go
@@ -659,6 +659,7 @@ const (
 	OSSKUUbuntuTwoTwoZeroFour  OSSKU = "Ubuntu2204"
 	OSSKUWindowsTwoZeroOneNine OSSKU = "Windows2019"
 	OSSKUWindowsTwoZeroTwoTwo  OSSKU = "Windows2022"
+	OSSKUWindowsTwoZeroTwoFive OSSKU = "Windows2025"
 )
 
 func PossibleValuesForOSSKU() []string {
@@ -671,6 +672,7 @@ func PossibleValuesForOSSKU() []string {
 		string(OSSKUUbuntuTwoTwoZeroFour),
 		string(OSSKUWindowsTwoZeroOneNine),
 		string(OSSKUWindowsTwoZeroTwoTwo),
+		string(OSSKUWindowsTwoZeroTwoFive),
 	}
 }
 
@@ -697,6 +699,7 @@ func parseOSSKU(input string) (*OSSKU, error) {
 		"ubuntu2204":  OSSKUUbuntuTwoTwoZeroFour,
 		"windows2019": OSSKUWindowsTwoZeroOneNine,
 		"windows2022": OSSKUWindowsTwoZeroTwoTwo,
+		"windows2025": OSSKUWindowsTwoZeroTwoFive,
 	}
 	if v, ok := vals[strings.ToLower(input)]; ok {
 		return &v, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2025-10-01/managedclusters/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2025-10-01/managedclusters/constants.go
@@ -1644,6 +1644,7 @@ const (
 	OSSKUUbuntuTwoTwoZeroFour  OSSKU = "Ubuntu2204"
 	OSSKUWindowsTwoZeroOneNine OSSKU = "Windows2019"
 	OSSKUWindowsTwoZeroTwoTwo  OSSKU = "Windows2022"
+	OSSKUWindowsTwoZeroTwoFive OSSKU = "Windows2025"
 )
 
 func PossibleValuesForOSSKU() []string {
@@ -1656,6 +1657,7 @@ func PossibleValuesForOSSKU() []string {
 		string(OSSKUUbuntuTwoTwoZeroFour),
 		string(OSSKUWindowsTwoZeroOneNine),
 		string(OSSKUWindowsTwoZeroTwoTwo),
+		string(OSSKUWindowsTwoZeroTwoFive),
 	}
 }
 
@@ -1682,6 +1684,7 @@ func parseOSSKU(input string) (*OSSKU, error) {
 		"ubuntu2204":  OSSKUUbuntuTwoTwoZeroFour,
 		"windows2019": OSSKUWindowsTwoZeroOneNine,
 		"windows2022": OSSKUWindowsTwoZeroTwoTwo,
+		"windows2025": OSSKUWindowsTwoZeroTwoFive,
 	}
 	if v, ok := vals[strings.ToLower(input)]; ok {
 		return &v, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2025-10-01/snapshots/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2025-10-01/snapshots/constants.go
@@ -20,6 +20,7 @@ const (
 	OSSKUUbuntuTwoTwoZeroFour  OSSKU = "Ubuntu2204"
 	OSSKUWindowsTwoZeroOneNine OSSKU = "Windows2019"
 	OSSKUWindowsTwoZeroTwoTwo  OSSKU = "Windows2022"
+	OSSKUWindowsTwoZeroTwoFive OSSKU = "Windows2025"
 )
 
 func PossibleValuesForOSSKU() []string {
@@ -32,6 +33,7 @@ func PossibleValuesForOSSKU() []string {
 		string(OSSKUUbuntuTwoTwoZeroFour),
 		string(OSSKUWindowsTwoZeroOneNine),
 		string(OSSKUWindowsTwoZeroTwoTwo),
+		string(OSSKUWindowsTwoZeroTwoFive),
 	}
 }
 
@@ -58,6 +60,7 @@ func parseOSSKU(input string) (*OSSKU, error) {
 		"ubuntu2204":  OSSKUUbuntuTwoTwoZeroFour,
 		"windows2019": OSSKUWindowsTwoZeroOneNine,
 		"windows2022": OSSKUWindowsTwoZeroTwoTwo,
+		"windows2025": OSSKUWindowsTwoZeroTwoFive,
 	}
 	if v, ok := vals[strings.ToLower(input)]; ok {
 		return &v, nil

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -423,9 +423,11 @@ A `default_node_pool` block supports the following:
 
 * `os_disk_type` - (Optional) The type of disk which should be used for the Operating System. Possible values are `Ephemeral` and `Managed`. Defaults to `Managed`. `temporary_name_for_rotation` must be specified when attempting a change.
 
-* `os_sku` - (Optional) Specifies the OS SKU used by the agent pool. Possible values are `AzureLinux`, `AzureLinux3`, `Ubuntu`, `Ubuntu2204`, `Ubuntu2404`, `Windows2019` and `Windows2022`. If not specified, the default is `Ubuntu` when os_type=Linux or `Windows2019` if os_type=Windows (`Windows2022` Kubernetes ≥1.33). Changing between `AzureLinux` and `Ubuntu` does not replace the resource; otherwise `temporary_name_for_rotation` must be specified when attempting a change.
+* `os_sku` - (Optional) Specifies the OS SKU used by the agent pool. Possible values are `AzureLinux`, `AzureLinux3`, `Ubuntu`, `Ubuntu2204`, `Ubuntu2404`, `Windows2019`, `Windows2022` and `Windows2025`. If not specified, the default is `Ubuntu` when os_type=Linux or `Windows2019` if os_type=Windows (`Windows2022` Kubernetes ≥1.33). Changing between `AzureLinux` and `Ubuntu` does not replace the resource; otherwise `temporary_name_for_rotation` must be specified when attempting a change.
 
 -> **Note:** `Windows2019` is deprecated and not supported for Kubernetes version ≥1.33.
+
+-> **Note:** `Windows2025` requires `fips_enabled` to be set to `true`.
 
 * `pod_subnet_id` - (Optional) The ID of the Subnet where the pods in the default Node Pool should exist.
 

--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -124,9 +124,11 @@ The following arguments are supported:
 
 * `pod_subnet_id` - (Optional) The ID of the Subnet where the pods in the Node Pool should exist. Changing this property requires specifying `temporary_name_for_rotation`.
 
-* `os_sku` - (Optional) Specifies the OS SKU used by the agent pool. Possible values are `AzureLinux`, `AzureLinux3`, `Ubuntu`, `Ubuntu2204`, `Ubuntu2404`, `Windows2019` and `Windows2022`. If not specified, the default is `Ubuntu` when os_type=Linux or `Windows2019` if os_type=Windows (`Windows2022` Kubernetes ≥1.33). Changing between `AzureLinux` and `Ubuntu` does not replace the resource; any other change forces a new resource to be created.
+* `os_sku` - (Optional) Specifies the OS SKU used by the agent pool. Possible values are `AzureLinux`, `AzureLinux3`, `Ubuntu`, `Ubuntu2204`, `Ubuntu2404`, `Windows2019`, `Windows2022` and `Windows2025`. If not specified, the default is `Ubuntu` when os_type=Linux or `Windows2019` if os_type=Windows (`Windows2022` Kubernetes ≥1.33). Changing between `AzureLinux` and `Ubuntu` does not replace the resource; any other change forces a new resource to be created.
 
 -> **Note:** `Windows2019` is deprecated and not supported for Kubernetes version ≥1.33.
+
+-> **Note:** `Windows2025` requires `fips_enabled` to be set to `true`.
 
 * `os_type` - (Optional) The Operating System which should be used for this Node Pool. Changing this forces a new resource to be created. Possible values are `Linux` and `Windows`. Defaults to `Linux`.
 


### PR DESCRIPTION
## Summary

- Add `Windows2025` as a valid `os_sku` value for `azurerm_kubernetes_cluster` (default node pool) and `azurerm_kubernetes_cluster_node_pool`
- Azure AKS has GA'd Windows Server 2025 support starting from Kubernetes 1.33
- Note: Windows 2025 requires `fips_enabled = true` as FIPS cannot be disabled on Windows Server 2025 and later

## Changes

- Added `OSSKUWindowsTwoZeroTwoFive` constant to vendored SDK (agentpools, managedclusters, snapshots)
- Added `Windows2025` to `os_sku` validation in both node pool resources
- Added acceptance test for `Windows2025` node pool with `fips_enabled = true`
- Updated documentation with `Windows2025` in possible values and FIPS requirement note

## Test plan

- [x] `go build ./internal/services/containers/...` passes
- [x] `TestAccKubernetesClusterNodePool_windows2025` - manually verified on AKS 1.33 cluster with `os_sku = "Windows2025"` and `fips_enabled = true`, node pool created successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)