### PR TITLE
azurerm_iothub - add default value for min_tls_version to prevent force replacement

### DIFF
--- a/internal/services/iothub/iothub_resource.go
+++ b/internal/services/iothub/iothub_resource.go
@@ -594,6 +594,7 @@ func resourceIotHub() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Default:  "1.2",
 				ValidateFunc: validation.StringInSlice([]string{
 					"1.2",
 				}, false),

--- a/website/docs/r/iothub.html.markdown
+++ b/website/docs/r/iothub.html.markdown
@@ -168,7 +168,7 @@ The following arguments are supported:
 
 * `public_network_access_enabled` - (Optional) Is the IotHub resource accessible from a public network?
 
-* `min_tls_version` - (Optional) Specifies the minimum TLS version to support for this hub. The only valid value is `1.2`. Changing this forces a new resource to be created.
+* `min_tls_version` - (Optional) Specifies the minimum TLS version to support for this hub. The only valid value is `1.2`. Defaults to `1.2`. Changing this forces a new resource to be created.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
## Community Note

* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

The `min_tls_version` field on `azurerm_iothub` is `Optional` and `ForceNew` but has no `Default` and is not `Computed`. When the Azure API returns `"1.2"` during a state refresh and the field is omitted from config, Terraform sees `"1.2" -> null` and plans a destructive force replacement of the entire IoT Hub, cascading into destruction of dependent resources (EventGrid system topics, event subscriptions, role assignments).

This PR adds `Default: "1.2"` to the schema, which:
- Prevents unintended force replacement when the field is omitted
- Is consistent with how other resources (`azurerm_storage_account`, `azurerm_redis_cache`) handle `min_tls_version`
- Is consistent with the v3.0 upgrade guide which stated all resources would default `min_tls_version` to `"1.2"`
- Is safe since `"1.2"` is already the only valid value (enforced by `ValidateFunc`)

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them.
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.

## Testing

No new tests added. The change adds a schema default that matches the only valid value allowed by `ValidateFunc`. Existing tests should continue to pass as behavior is unchanged for configs that already set `min_tls_version = "1.2"`.

## Change Log

* `azurerm_iothub` - add `Default: "1.2"` for `min_tls_version` to prevent unintended force replacement when the field is omitted from config

This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature
- [ ] Enhancement
- [ ] Breaking Change

## Related Issue(s)

Fixes #32087

## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made with the assistance of AI/LLMs (Claude) for research, root cause analysis, and drafting the PR description.

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

No changes to security controls.
