### PR TITLE
`azurerm_kubernetes_cluster_node_pool` - fix `gpu_driver` state drift causing forced node pool recreation

### DIFF
--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -229,6 +229,7 @@ func resourceKubernetesClusterNodePoolSchema() map[string]*pluginsdk.Schema {
 		"gpu_driver": {
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
+			Computed:     true,
 			ForceNew:     true,
 			ValidateFunc: validation.StringInSlice(agentpools.PossibleValuesForGPUDriver(), false),
 		},

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -103,6 +103,7 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 					"gpu_driver": {
 						Type:         pluginsdk.TypeString,
 						Optional:     true,
+						Computed:     true,
 						ForceNew:     true,
 						ValidateFunc: validation.StringInSlice(agentpools.PossibleValuesForGPUDriver(), false),
 					},


### PR DESCRIPTION
## Community Note

* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

Fixes #30990.

The `gpu_driver` field (added in #29954 / v4.40.0) is defined as `Optional + ForceNew` but is missing `Computed: true`. Azure's API returns `"Install"` as the default for GPU-enabled node pools. On Read, the provider stores this API-returned value in state. For existing GPU node pools created before v4.40.0 (without `gpu_driver` in their Terraform config), this causes Terraform to detect a diff:

```
-/+ resource "azurerm_kubernetes_cluster_node_pool" "gpu" {
      - gpu_driver = "Install" -> null # forces replacement
```

Since `ForceNew` is set, this **silently forces node pool recreation**. This is particularly damaging for customers using NVIDIA gpu-operator to manage their own GPU drivers — the recreated pool comes up with AKS-managed GPU drivers enabled, conflicting with gpu-operator and leaving nodes without `nvidia.com/gpu` allocatable resources.

## Fix

Add `Computed: true` to the `gpu_driver` schema in both:
- `kubernetes_cluster_node_pool_resource.go` (standalone node pool resource)
- `kubernetes_nodepool.go` (default node pool in `azurerm_kubernetes_cluster`)

This follows the exact same pattern as the adjacent `kubelet_disk_type` field, which is also `Optional + Computed + ForceNew`.

With `Computed: true`, Terraform accepts the API-returned default without showing a diff when the user hasn't set `gpu_driver` in config.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate closing keywords below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them.
- [x] I have successfully run tests with my changes locally.

## Testing

Existing `TestAccKubernetesClusterNodePool_gpuDriver` test continues to pass since it explicitly sets `gpu_driver = "Install"`. The fix only affects the case where `gpu_driver` is omitted from config.