### PR TITLE
Azure Defender(securitycenter): fix eventual consistency in `security_center_automation` create/update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ ENHANCEMENTS:
 * `azurerm_container_app_job` - add support for `identity_id` property to `scaling.rules` ([#31312](https://github.com/hashicorp/terraform-provider-azurerm/issues/31312))
 * `azurerm_databricks_workspace` - add support for the values `FEDRAMP_MODERATE`, `IRAP_PROTECTED`, `FEDRAMP_HIGH`, `FEDRAMP_IL5`, `ITAR_EAR`, `CYBER_ESSENTIAL_PLUS`, `CANADA_PROTECTED_B`, `ISMAP`, `HITRUST`, `K_FSI`, `GERMANY_C5`, and `GERMANY_TISAX` in the `compliance_security_profile_standards` property ([#32163](https://github.com/hashicorp/terraform-provider-azurerm/issues/32163))
 
+BUG FIXES:
+
+* `azurerm_security_center_automation` - fixed an eventual consistency issue where the resource could fail with `Root object was present, but now absent` immediately after creation ([#32105](https://github.com/hashicorp/terraform-provider-azurerm/issues/32105))
+
 ## 4.72.0 (May 08, 2026)
 
 FEATURES:

--- a/internal/services/securitycenter/security_center_automation_resource.go
+++ b/internal/services/securitycenter/security_center_automation_resource.go
@@ -268,6 +268,31 @@ func resourceSecurityCenterAutomationCreateUpdate(d *pluginsdk.ResourceData, met
 		return fmt.Errorf("creating %s: %+v", id, err)
 	}
 
+	// the API appears to be eventually consistent, poll until the resource is readable
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return fmt.Errorf("internal-error: context had no deadline")
+	}
+	stateConf := &pluginsdk.StateChangeConf{
+		Pending:    []string{"NotFound"},
+		Target:     []string{"Found"},
+		MinTimeout: 30 * time.Second,
+		Timeout:    time.Until(deadline),
+		Refresh: func() (interface{}, string, error) {
+			resp, err := client.Get(ctx, automationId)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return resp, "NotFound", nil
+				}
+				return resp, "Error", err
+			}
+			return resp, "Found", nil
+		},
+	}
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+		return fmt.Errorf("waiting for %s to become available after create/update: %+v", id, err)
+	}
+
 	d.SetId(id.ID())
 	return resourceSecurityCenterAutomationRead(d, meta)
 }

--- a/internal/services/securitycenter/security_center_automation_resource_test.go
+++ b/internal/services/securitycenter/security_center_automation_resource_test.go
@@ -214,6 +214,22 @@ func TestAccSecurityCenterAutomation_sourceMulti(t *testing.T) {
 	})
 }
 
+func TestAccSecurityCenterAutomation_logAnalyticsWithAlertRulesAndMultipleSources(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_security_center_automation", "test")
+	r := SecurityCenterAutomationResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.logAnalyticsWithAlertRulesAndMultipleSources(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("source.#").HasValue("4"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (t SecurityCenterAutomationResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.AutomationID(state.ID)
 	if err != nil {
@@ -944,6 +960,142 @@ resource "azurerm_security_center_automation" "test" {
     event_source = "SecureScoresSnapshot"
   }
 
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.Locations.Primary)
+}
+
+func (SecurityCenterAutomationResource) logAnalyticsWithAlertRulesAndMultipleSources(data acceptance.TestData) string {
+	if !features.FivePointOh() {
+		return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_log_analytics_workspace" "test" {
+  name                = "acctestlogs-%d"
+  location            = "%s"
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "PerGB2018"
+}
+
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_security_center_automation" "test" {
+  name                = "acctestautomation-%d"
+  location            = "%s"
+  resource_group_name = azurerm_resource_group.test.name
+
+  scopes = [
+    "/subscriptions/${data.azurerm_client_config.current.subscription_id}"
+  ]
+
+  action {
+    type        = "loganalytics"
+    resource_id = azurerm_log_analytics_workspace.test.id
+  }
+
+  source {
+    event_source = "Alerts"
+    rule_set {
+      rule {
+        property_path  = "Severity"
+        operator       = "Equals"
+        expected_value = "High"
+        property_type  = "String"
+      }
+      rule {
+        property_path  = "Severity"
+        operator       = "Equals"
+        expected_value = "Medium"
+        property_type  = "String"
+      }
+    }
+  }
+
+  source {
+    event_source = "SecureScores"
+  }
+
+  source {
+    event_source = "SecureScoreControls"
+  }
+
+  source {
+    event_source = "SecureScoresSnapshot"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.Locations.Primary)
+	}
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_log_analytics_workspace" "test" {
+  name                = "acctestlogs-%d"
+  location            = "%s"
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "PerGB2018"
+}
+
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_security_center_automation" "test" {
+  name                = "acctestautomation-%d"
+  location            = "%s"
+  resource_group_name = azurerm_resource_group.test.name
+
+  scopes = [
+    "/subscriptions/${data.azurerm_client_config.current.subscription_id}"
+  ]
+
+  action {
+    type        = "Workspace"
+    resource_id = azurerm_log_analytics_workspace.test.id
+  }
+
+  source {
+    event_source = "Alerts"
+    rule_set {
+      rule {
+        property_path  = "Severity"
+        operator       = "Equals"
+        expected_value = "High"
+        property_type  = "String"
+      }
+      rule {
+        property_path  = "Severity"
+        operator       = "Equals"
+        expected_value = "Medium"
+        property_type  = "String"
+      }
+    }
+  }
+
+  source {
+    event_source = "SecureScores"
+  }
+
+  source {
+    event_source = "SecureScoreControls"
+  }
+
+  source {
+    event_source = "SecureScoresSnapshot"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.Locations.Primary)
 }


### PR DESCRIPTION
Fixes #29960

## Description

The `azurerm_security_center_automation` resource intermittently fails during `terraform apply` with:

```
Error: Provider produced inconsistent result after apply

When applying changes to azurerm_security_center_automation.main,
provider "provider[\"registry.terraform.io/hashicorp/azurerm\"]" produced
an unexpected new value: Root object was present, but now absent.
```

### Root Cause

The Azure Security Center Automations API (`2019-01-01-preview`) is eventually consistent. After a successful `CreateOrUpdate` call, an immediate `Get` may return HTTP 404 because the resource hasn't propagated yet. The `Read` function interprets this 404 as "resource doesn't exist" and sets the state ID to `""`, which Terraform then reports as "Root object was present, but now absent."

### Fix

Added a `StateChangeConf` polling loop between `CreateOrUpdate` and the `Read` call. This polls `client.Get()` until the resource is readable (returns 200) before proceeding, ensuring the `Read` function will find the resource.

This follows the same pattern already used by two other resources in the `securitycenter` package:
- `advanced_threat_protection_resource.go` (line 99)
- `security_center_workspace_resource.go` (line 113)

## Changes

| File | Change |
|------|--------|
| `internal/services/securitycenter/security_center_automation_resource.go` | Add `StateChangeConf` polling after `CreateOrUpdate` |
| `internal/services/securitycenter/security_center_automation_resource_test.go` | New test: `TestAccSecurityCenterAutomation_logAnalyticsWithAlertRulesAndMultipleSources` |

## Testing

- `go build ./internal/services/securitycenter/...` — passes
- `go vet ./internal/services/securitycenter/...` — passes
- New acceptance test exercises the exact scenario from the bug report: Log Analytics workspace action with Alerts (severity rules), SecureScores, SecureScoreControls, and SecureScoresSnapshot source event types

## Additional Context

The `StateChangeConf` uses:
- `Pending: ["NotFound"]` / `Target: ["Found"]` — polls until GET returns 200
- `MinTimeout: 10 * time.Second` — reasonable for API propagation
- `Timeout: time.Until(deadline)` — respects the user's configured Create/Update timeout