### PR TITLE
azurerm_bastion_host: support `private_only_enabled` for private-only deployment

### DIFF
--- a/internal/services/network/bastion_host_data_source.go
+++ b/internal/services/network/bastion_host_data_source.go
@@ -95,6 +95,11 @@ func dataSourceBastionHost() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"private_only_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
+
 			"dns_name": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
@@ -146,6 +151,7 @@ func dataSourceBastionHostRead(d *pluginsdk.ResourceData, meta interface{}) erro
 			d.Set("shareable_link_enabled", props.EnableShareableLink)
 			d.Set("tunneling_enabled", props.EnableTunneling)
 			d.Set("session_recording_enabled", props.EnableSessionRecording)
+			d.Set("private_only_enabled", props.EnablePrivateOnlyBastion)
 
 			copyPasteEnabled := true
 			if props.DisableCopyPaste != nil {

--- a/internal/services/network/bastion_host_resource.go
+++ b/internal/services/network/bastion_host_resource.go
@@ -100,7 +100,7 @@ func resourceBastionHost() *pluginsdk.Resource {
 						},
 						"public_ip_address_id": {
 							Type:         pluginsdk.TypeString,
-							Required:     true,
+							Optional:     true,
 							ForceNew:     true,
 							ValidateFunc: commonids.ValidatePublicIPAddressID,
 						},
@@ -147,6 +147,12 @@ func resourceBastionHost() *pluginsdk.Resource {
 			},
 
 			"session_recording_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
+			"private_only_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
 				Default:  false,
@@ -199,6 +205,7 @@ func resourceBastionHostCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 	shareableLinkEnabled := d.Get("shareable_link_enabled").(bool)
 	tunnelingEnabled := d.Get("tunneling_enabled").(bool)
 	sessionRecordingEnabled := d.Get("session_recording_enabled").(bool)
+	privateOnlyEnabled := d.Get("private_only_enabled").(bool)
 
 	if scaleUnits > 2 && (sku != bastionhosts.BastionHostSkuNameStandard && sku != bastionhosts.BastionHostSkuNamePremium) {
 		return fmt.Errorf("`scale_units` only can be changed when `sku` is `Standard` or `Premium`. `scale_units` is always `2` when `sku` is `Basic`")
@@ -226,6 +233,22 @@ func resourceBastionHostCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 
 	if sessionRecordingEnabled && sku != bastionhosts.BastionHostSkuNamePremium {
 		return fmt.Errorf("`session_recording_enabled` is only supported when `sku` is `Premium`")
+	}
+
+	if privateOnlyEnabled && sku != bastionhosts.BastionHostSkuNamePremium {
+		return fmt.Errorf("`private_only_enabled` is only supported when `sku` is `Premium`")
+	}
+
+	ipConfiguration := d.Get("ip_configuration").([]interface{})
+	if sku != bastionhosts.BastionHostSkuNameDeveloper {
+		if len(ipConfiguration) == 0 {
+			return fmt.Errorf("`ip_configuration` is required when `sku` is not `Developer`")
+		}
+		if !privateOnlyEnabled {
+			if v := ipConfiguration[0].(map[string]interface{})["public_ip_address_id"].(string); v == "" {
+				return fmt.Errorf("`ip_configuration.0.public_ip_address_id` is required when `private_only_enabled` is `false`")
+			}
+		}
 	}
 
 	existing, err := client.Get(ctx, id)
@@ -277,6 +300,10 @@ func resourceBastionHostCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 
 	if sessionRecordingEnabled {
 		parameters.Properties.EnableSessionRecording = pointer.To(sessionRecordingEnabled)
+	}
+
+	if privateOnlyEnabled {
+		parameters.Properties.EnablePrivateOnlyBastion = pointer.To(privateOnlyEnabled)
 	}
 
 	zones := zones.ExpandUntyped(d.Get("zones").(*schema.Set).List())
@@ -392,6 +419,14 @@ func resourceBastionHostUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 		payload.Properties.EnableSessionRecording = pointer.To(sessionRecordingEnabled)
 	}
 
+	if d.HasChange("private_only_enabled") {
+		privateOnlyEnabled := d.Get("private_only_enabled").(bool)
+		if privateOnlyEnabled && sku != bastionhosts.BastionHostSkuNamePremium {
+			return fmt.Errorf("`private_only_enabled` is only supported when `sku` is `Premium`")
+		}
+		payload.Properties.EnablePrivateOnlyBastion = pointer.To(privateOnlyEnabled)
+	}
+
 	if d.HasChange("tags") {
 		payload.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
 	}
@@ -450,6 +485,7 @@ func resourceBastionHostRead(d *pluginsdk.ResourceData, meta interface{}) error 
 			d.Set("shareable_link_enabled", props.EnableShareableLink)
 			d.Set("tunneling_enabled", props.EnableTunneling)
 			d.Set("session_recording_enabled", props.EnableSessionRecording)
+			d.Set("private_only_enabled", props.EnablePrivateOnlyBastion)
 
 			virtualNetworkId := ""
 			if vnet := props.VirtualNetwork; vnet != nil {
@@ -509,19 +545,22 @@ func expandBastionHostIPConfiguration(input []interface{}) (ipConfigs *[]bastion
 	subID := property["subnet_id"].(string)
 	pipID := property["public_ip_address_id"].(string)
 
-	return &[]bastionhosts.BastionHostIPConfiguration{
-		{
-			Name: &ipConfName,
-			Properties: &bastionhosts.BastionHostIPConfigurationPropertiesFormat{
-				Subnet: bastionhosts.SubResource{
-					Id: &subID,
-				},
-				PublicIPAddress: &bastionhosts.SubResource{
-					Id: &pipID,
-				},
+	ipConfig := bastionhosts.BastionHostIPConfiguration{
+		Name: &ipConfName,
+		Properties: &bastionhosts.BastionHostIPConfigurationPropertiesFormat{
+			Subnet: bastionhosts.SubResource{
+				Id: &subID,
 			},
 		},
 	}
+
+	if pipID != "" {
+		ipConfig.Properties.PublicIPAddress = &bastionhosts.SubResource{
+			Id: &pipID,
+		}
+	}
+
+	return &[]bastionhosts.BastionHostIPConfiguration{ipConfig}
 }
 
 func flattenBastionHostIPConfiguration(ipConfigs *[]bastionhosts.BastionHostIPConfiguration) []interface{} {

--- a/internal/services/network/bastion_host_resource_test.go
+++ b/internal/services/network/bastion_host_resource_test.go
@@ -154,6 +154,23 @@ func TestAccBastionHost_premiumSku(t *testing.T) {
 	})
 }
 
+func TestAccBastionHost_privateOnlyEnabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_bastion_host", "test")
+	r := BastionHostResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.privateOnlyEnabled(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("private_only_enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("sku").HasValue("Premium"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (BastionHostResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := bastionhosts.ParseBastionHostID(state.ID)
 	if err != nil {
@@ -516,4 +533,50 @@ resource "azurerm_bastion_host" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger, data.RandomString)
+}
+
+func (BastionHostResource) privateOnlyEnabled(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-bastion-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestVNet%s"
+  address_space       = ["192.168.1.0/24"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "AzureBastionSubnet"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["192.168.1.224/27"]
+}
+
+resource "azurerm_bastion_host" "test" {
+  name                      = "acctestBastion%s"
+  location                  = azurerm_resource_group.test.location
+  resource_group_name       = azurerm_resource_group.test.name
+  sku                       = "Premium"
+  private_only_enabled      = true
+  file_copy_enabled         = true
+  ip_connect_enabled        = true
+  kerberos_enabled          = true
+  shareable_link_enabled    = true
+  tunneling_enabled         = true
+  session_recording_enabled = true
+
+  ip_configuration {
+    name      = "ip-configuration"
+    subnet_id = azurerm_subnet.test.id
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
 }

--- a/website/docs/d/bastion_host.html.markdown
+++ b/website/docs/d/bastion_host.html.markdown
@@ -58,6 +58,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `session_recording_enabled` - Is Session Recording feature enabled for the Bastion Host.
 
+* `private_only_enabled` - Is Private-Only deployment enabled for the Bastion Host.
+
 * `dns_name` - The FQDN for the Bastion Host.
 
 * `tags` - A mapping of tags assigned to the Bastion Host.

--- a/website/docs/r/bastion_host.html.markdown
+++ b/website/docs/r/bastion_host.html.markdown
@@ -102,6 +102,10 @@ The following arguments are supported:
 
 ~> **Note:** `session_recording_enabled` is only supported when `sku` is `Premium`.
 
+* `private_only_enabled` - (Optional) Is Private-Only deployment enabled for the Bastion Host. When `true`, the Bastion Host is deployed without a public IP address and can only be accessed through private connectivity. Defaults to `false`.
+
+~> **Note:** `private_only_enabled` is only supported when `sku` is `Premium`. When `private_only_enabled` is `true`, the `public_ip_address_id` in the `ip_configuration` block is not required.
+
 * `virtual_network_id` - (Optional) The ID of the Virtual Network for the Developer Bastion Host. Changing this forces a new resource to be created.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
@@ -118,7 +122,9 @@ A `ip_configuration` block supports the following:
 
 ~> **Note:** The Subnet used for the Bastion Host must have the name `AzureBastionSubnet` and the subnet mask must be at least a `/26`.
 
-* `public_ip_address_id` - (Required) Reference to a Public IP Address to associate with this Bastion Host. Changing this forces a new resource to be created.
+* `public_ip_address_id` - (Optional) Reference to a Public IP Address to associate with this Bastion Host. Changing this forces a new resource to be created.
+
+~> **Note:** `public_ip_address_id` is required when `private_only_enabled` is `false`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Community Note
* Please vote on this PR by adding a :thumbsup: reaction to the original PR to help the community and maintainers prioritize.
* Please do not leave "+1" comments, they generate extra noise for PR reviewers and do not help prioritize.

## Description

This PR adds support for Azure Bastion private-only deployment mode by introducing the `private_only_enabled` attribute to the `azurerm_bastion_host` resource and data source.

Azure Bastion Premium SKU supports [private-only deployment](https://learn.microsoft.com/en-us/azure/bastion/private-only-deployment), where the bastion host is deployed without a public IP address and can only be accessed through private connectivity. Currently, the Terraform provider requires `public_ip_address_id` in the `ip_configuration` block, blocking users from deploying private-only bastion hosts.

### Changes

**Resource (`azurerm_bastion_host`):**
- Added `private_only_enabled` attribute (Optional, bool, defaults to `false`)
- Changed `public_ip_address_id` in `ip_configuration` from Required to Optional
- Added imperative validation: `private_only_enabled` requires Premium SKU
- Added imperative validation: `public_ip_address_id` required when `private_only_enabled` is `false` and `sku` is not `Developer`
- Wired `EnablePrivateOnlyBastion` API property in Create, Update, and Read functions
- Updated `expandBastionHostIPConfiguration` to handle nil `public_ip_address_id`

**Data Source (`azurerm_bastion_host`):**
- Added `private_only_enabled` as a Computed attribute
- Read `EnablePrivateOnlyBastion` from API response

**Tests:**
- Added `TestAccBastionHost_privateOnlyEnabled` acceptance test

**Documentation:**
- Documented `private_only_enabled` attribute on resource and data source
- Updated `public_ip_address_id` from Required to Optional with note about `private_only_enabled`

### Example Usage (Private-Only)

```hcl
resource "azurerm_bastion_host" "example" {
  name                 = "example-bastion"
  location             = azurerm_resource_group.example.location
  resource_group_name  = azurerm_resource_group.example.name
  sku                  = "Premium"
  private_only_enabled = true

  ip_configuration {
    name      = "configuration"
    subnet_id = azurerm_subnet.example.id
  }
}
```

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. Fixes #28220
- [x] I have updated tests (acceptance tests).
- [x] I have updated the documentation.
- [x] I have added labels to the PR if applicable.

## Related Issue(s)

Fixes #28220

## Testing

New acceptance test: `TestAccBastionHost_privateOnlyEnabled`

The SDK already has `EnablePrivateOnlyBastion *bool` in `BastionHostPropertiesFormat` (API version `2025-01-01`), so no vendor changes were needed.