### PR TITLE
`kubernetes_cluster_node_pool_data_source.go` : add `node_image_version`

### DIFF
--- a/internal/services/containers/kubernetes_cluster_node_pool_data_source.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_data_source.go
@@ -265,11 +265,7 @@ func dataSourceKubernetesClusterNodePoolRead(d *pluginsdk.ResourceData, meta int
 			return fmt.Errorf("setting `node_taints`: %+v", err)
 		}
 
-		nodeImageVersion := ""
-		if props.NodeImageVersion != nil {
-			nodeImageVersion = *props.NodeImageVersion
-		}
-		d.Set("node_image_version", nodeImageVersion)
+		d.Set("node_image_version", *props.NodeImageVersion)
 
 		d.Set("orchestrator_version", props.OrchestratorVersion)
 		osDiskSizeGB := 0

--- a/internal/services/containers/kubernetes_cluster_node_pool_data_source.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_data_source.go
@@ -111,6 +111,11 @@ func dataSourceKubernetesClusterNodePool() *pluginsdk.Resource {
 				},
 			},
 
+			"node_image_version": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
 			"orchestrator_version": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
@@ -259,6 +264,12 @@ func dataSourceKubernetesClusterNodePoolRead(d *pluginsdk.ResourceData, meta int
 		if err := d.Set("node_taints", utils.FlattenStringSlice(props.NodeTaints)); err != nil {
 			return fmt.Errorf("setting `node_taints`: %+v", err)
 		}
+
+		nodeImageVersion := ""
+		if props.NodeImageVersion != nil {
+			nodeImageVersion = *props.NodeImageVersion
+		}
+		d.Set("node_image_version", nodeImageVersion)
 
 		d.Set("orchestrator_version", props.OrchestratorVersion)
 		osDiskSizeGB := 0

--- a/internal/services/containers/kubernetes_cluster_node_pool_data_source.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_data_source.go
@@ -265,7 +265,7 @@ func dataSourceKubernetesClusterNodePoolRead(d *pluginsdk.ResourceData, meta int
 			return fmt.Errorf("setting `node_taints`: %+v", err)
 		}
 
-		d.Set("node_image_version", *props.NodeImageVersion)
+		d.Set("node_image_version", props.NodeImageVersion)
 
 		d.Set("orchestrator_version", props.OrchestratorVersion)
 		osDiskSizeGB := 0

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -300,6 +300,11 @@ func resourceKubernetesClusterNodePoolSchema() map[string]*pluginsdk.Schema {
 			},
 		},
 
+		"node_image_version": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
 		"orchestrator_version": {
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
@@ -1202,6 +1207,12 @@ func resourceKubernetesClusterNodePoolRead(d *pluginsdk.ResourceData, meta inter
 		if err := d.Set("node_taints", utils.FlattenStringSlice(props.NodeTaints)); err != nil {
 			return fmt.Errorf("setting `node_taints`: %+v", err)
 		}
+
+		nodeImageVersion := ""
+		if props.NodeImageVersion != nil {
+			nodeImageVersion = *props.NodeImageVersion
+		}
+		d.Set("node_image_version", nodeImageVersion)
 
 		// NOTE: workaround for migration from 2022-01-02-preview (<3.12.0) to 2022-03-02-preview (>=3.12.0). Before terraform apply is run against the new API, Azure will respond only with currentOrchestratorVersion, orchestratorVersion will be absent. More details: https://github.com/hashicorp/terraform-provider-azurerm/issues/17833#issuecomment-1227583353
 		if props.OrchestratorVersion != nil {

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -1208,11 +1208,7 @@ func resourceKubernetesClusterNodePoolRead(d *pluginsdk.ResourceData, meta inter
 			return fmt.Errorf("setting `node_taints`: %+v", err)
 		}
 
-		nodeImageVersion := ""
-		if props.NodeImageVersion != nil {
-			nodeImageVersion = *props.NodeImageVersion
-		}
-		d.Set("node_image_version", nodeImageVersion)
+		d.Set("node_image_version", *props.NodeImageVersion)
 
 		// NOTE: workaround for migration from 2022-01-02-preview (<3.12.0) to 2022-03-02-preview (>=3.12.0). Before terraform apply is run against the new API, Azure will respond only with currentOrchestratorVersion, orchestratorVersion will be absent. More details: https://github.com/hashicorp/terraform-provider-azurerm/issues/17833#issuecomment-1227583353
 		if props.OrchestratorVersion != nil {

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -1208,7 +1208,7 @@ func resourceKubernetesClusterNodePoolRead(d *pluginsdk.ResourceData, meta inter
 			return fmt.Errorf("setting `node_taints`: %+v", err)
 		}
 
-		d.Set("node_image_version", *props.NodeImageVersion)
+		d.Set("node_image_version", props.NodeImageVersion)
 
 		// NOTE: workaround for migration from 2022-01-02-preview (<3.12.0) to 2022-03-02-preview (>=3.12.0). Before terraform apply is run against the new API, Azure will respond only with currentOrchestratorVersion, orchestratorVersion will be absent. More details: https://github.com/hashicorp/terraform-provider-azurerm/issues/17833#issuecomment-1227583353
 		if props.OrchestratorVersion != nil {

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -1520,13 +1520,6 @@ resource "azurerm_kubernetes_cluster" "test" {
   identity {
     type = "SystemAssigned"
   }
-
-  lifecycle {
-    ignore_changes = [
-      oidc_issuer_enabled,
-      oidc_issuer_url,
-    ]
-  }
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "test" {
@@ -1622,13 +1615,6 @@ resource "azurerm_kubernetes_cluster" "test" {
   identity {
     type = "SystemAssigned"
   }
-
-  lifecycle {
-    ignore_changes = [
-      oidc_issuer_enabled,
-      oidc_issuer_url,
-    ]
-  }
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "test" {
@@ -1686,13 +1672,6 @@ resource "azurerm_kubernetes_cluster" "test" {
 
   identity {
     type = "SystemAssigned"
-  }
-
-  lifecycle {
-    ignore_changes = [
-      oidc_issuer_enabled,
-      oidc_issuer_url,
-    ]
   }
 }
 
@@ -1764,13 +1743,6 @@ resource "azurerm_kubernetes_cluster" "test" {
 
   identity {
     type = "SystemAssigned"
-  }
-
-  lifecycle {
-    ignore_changes = [
-      oidc_issuer_enabled,
-      oidc_issuer_url,
-    ]
   }
 
   network_profile {
@@ -1850,13 +1822,6 @@ resource "azurerm_kubernetes_cluster" "test" {
   identity {
     type         = "UserAssigned"
     identity_ids = [azurerm_user_assigned_identity.test.id]
-  }
-
-  lifecycle {
-    ignore_changes = [
-      oidc_issuer_enabled,
-      oidc_issuer_url,
-    ]
   }
 
   depends_on = [
@@ -2275,13 +2240,6 @@ resource "azurerm_kubernetes_cluster" "test" {
   identity {
     type = "SystemAssigned"
   }
-
-  lifecycle {
-    ignore_changes = [
-      oidc_issuer_enabled,
-      oidc_issuer_url,
-    ]
-  }
 }
 resource "azurerm_kubernetes_cluster_node_pool" "test" {
   name                  = "internal"
@@ -2355,13 +2313,6 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
   identity {
     type = "SystemAssigned"
-  }
-
-  lifecycle {
-    ignore_changes = [
-      oidc_issuer_enabled,
-      oidc_issuer_url,
-    ]
   }
 }
 resource "azurerm_proximity_placement_group" "test" {
@@ -2761,13 +2712,6 @@ resource "azurerm_kubernetes_cluster" "test" {
     type = "SystemAssigned"
   }
 
-  lifecycle {
-    ignore_changes = [
-      oidc_issuer_enabled,
-      oidc_issuer_url,
-    ]
-  }
-
   windows_profile {
     admin_username = "azureuser"
     admin_password = "P@55W0rd1234!h@2h1C0rP"
@@ -2879,13 +2823,6 @@ resource "azurerm_kubernetes_cluster" "test" {
   identity {
     type = "SystemAssigned"
   }
-
-  lifecycle {
-    ignore_changes = [
-      oidc_issuer_enabled,
-      oidc_issuer_url,
-    ]
-  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
@@ -2930,13 +2867,6 @@ resource "azurerm_kubernetes_cluster" "test" {
   identity {
     type = "SystemAssigned"
   }
-
-  lifecycle {
-    ignore_changes = [
-      oidc_issuer_enabled,
-      oidc_issuer_url,
-    ]
-  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
@@ -2965,13 +2895,6 @@ resource "azurerm_kubernetes_cluster" "test" {
 
   identity {
     type = "SystemAssigned"
-  }
-
-  lifecycle {
-    ignore_changes = [
-      oidc_issuer_enabled,
-      oidc_issuer_url,
-    ]
   }
 
   windows_profile {
@@ -3126,13 +3049,6 @@ resource "azurerm_kubernetes_cluster" "test" {
   identity {
     type = "SystemAssigned"
   }
-
-  lifecycle {
-    ignore_changes = [
-      oidc_issuer_enabled,
-      oidc_issuer_url,
-    ]
-  }
 }
 resource "azurerm_kubernetes_cluster_node_pool" "test" {
   name                        = "internal"
@@ -3172,13 +3088,6 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
   identity {
     type = "SystemAssigned"
-  }
-
-  lifecycle {
-    ignore_changes = [
-      oidc_issuer_enabled,
-      oidc_issuer_url,
-    ]
   }
 }
 resource "azurerm_kubernetes_cluster_node_pool" "test" {
@@ -3251,13 +3160,6 @@ resource "azurerm_kubernetes_cluster" "test" {
     type         = "UserAssigned"
     identity_ids = [azurerm_user_assigned_identity.test.id]
   }
-
-  lifecycle {
-    ignore_changes = [
-      oidc_issuer_enabled,
-      oidc_issuer_url,
-    ]
-  }
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "test" {
@@ -3325,13 +3227,6 @@ resource "azurerm_kubernetes_cluster" "test" {
   identity {
     type = "SystemAssigned"
   }
-
-  lifecycle {
-    ignore_changes = [
-      oidc_issuer_enabled,
-      oidc_issuer_url,
-    ]
-  }
 }
 resource "azurerm_kubernetes_cluster_node_pool" "test" {
   name                  = "internal"
@@ -3369,13 +3264,6 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
   identity {
     type = "SystemAssigned"
-  }
-
-  lifecycle {
-    ignore_changes = [
-      oidc_issuer_enabled,
-      oidc_issuer_url,
-    ]
   }
 }
 resource "azurerm_kubernetes_cluster_node_pool" "test" {
@@ -3416,13 +3304,6 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
   identity {
     type = "SystemAssigned"
-  }
-
-  lifecycle {
-    ignore_changes = [
-      oidc_issuer_enabled,
-      oidc_issuer_url,
-    ]
   }
   network_profile {
     network_plugin = "azure"
@@ -3479,13 +3360,6 @@ resource "azurerm_kubernetes_cluster" "test" {
   identity {
     type = "SystemAssigned"
   }
-
-  lifecycle {
-    ignore_changes = [
-      oidc_issuer_enabled,
-      oidc_issuer_url,
-    ]
-  }
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "test" {
@@ -3537,13 +3411,6 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
   identity {
     type = "SystemAssigned"
-  }
-
-  lifecycle {
-    ignore_changes = [
-      oidc_issuer_enabled,
-      oidc_issuer_url,
-    ]
   }
 }
 
@@ -3597,13 +3464,6 @@ resource "azurerm_kubernetes_cluster" "test" {
   identity {
     type = "SystemAssigned"
   }
-
-  lifecycle {
-    ignore_changes = [
-      oidc_issuer_enabled,
-      oidc_issuer_url,
-    ]
-  }
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "source" {
@@ -3643,13 +3503,6 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
   identity {
     type = "SystemAssigned"
-  }
-
-  lifecycle {
-    ignore_changes = [
-      oidc_issuer_enabled,
-      oidc_issuer_url,
-    ]
   }
 }
 
@@ -3710,13 +3563,6 @@ resource "azurerm_kubernetes_cluster" "test" {
   identity {
     type = "SystemAssigned"
   }
-
-  lifecycle {
-    ignore_changes = [
-      oidc_issuer_enabled,
-      oidc_issuer_url,
-    ]
-  }
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "test" {
@@ -3758,13 +3604,6 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
   identity {
     type = "SystemAssigned"
-  }
-
-  lifecycle {
-    ignore_changes = [
-      oidc_issuer_enabled,
-      oidc_issuer_url,
-    ]
   }
 }
 
@@ -3837,13 +3676,6 @@ resource "azurerm_kubernetes_cluster" "test" {
 
   identity {
     type = "SystemAssigned"
-  }
-
-  lifecycle {
-    ignore_changes = [
-      oidc_issuer_enabled,
-      oidc_issuer_url,
-    ]
   }
 
   network_profile {
@@ -3919,13 +3751,6 @@ resource "azurerm_kubernetes_cluster" "test" {
   identity {
     type = "SystemAssigned"
   }
-
-  lifecycle {
-    ignore_changes = [
-      oidc_issuer_enabled,
-      oidc_issuer_url,
-    ]
-  }
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "test" {
@@ -4000,13 +3825,6 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
   identity {
     type = "SystemAssigned"
-  }
-
-  lifecycle {
-    ignore_changes = [
-      oidc_issuer_enabled,
-      oidc_issuer_url,
-    ]
   }
 }
 

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -1520,6 +1520,13 @@ resource "azurerm_kubernetes_cluster" "test" {
   identity {
     type = "SystemAssigned"
   }
+
+  lifecycle {
+    ignore_changes = [
+      oidc_issuer_enabled,
+      oidc_issuer_url,
+    ]
+  }
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "test" {
@@ -1615,6 +1622,13 @@ resource "azurerm_kubernetes_cluster" "test" {
   identity {
     type = "SystemAssigned"
   }
+
+  lifecycle {
+    ignore_changes = [
+      oidc_issuer_enabled,
+      oidc_issuer_url,
+    ]
+  }
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "test" {
@@ -1672,6 +1686,13 @@ resource "azurerm_kubernetes_cluster" "test" {
 
   identity {
     type = "SystemAssigned"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      oidc_issuer_enabled,
+      oidc_issuer_url,
+    ]
   }
 }
 
@@ -1743,6 +1764,13 @@ resource "azurerm_kubernetes_cluster" "test" {
 
   identity {
     type = "SystemAssigned"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      oidc_issuer_enabled,
+      oidc_issuer_url,
+    ]
   }
 
   network_profile {
@@ -1822,6 +1850,13 @@ resource "azurerm_kubernetes_cluster" "test" {
   identity {
     type         = "UserAssigned"
     identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+
+  lifecycle {
+    ignore_changes = [
+      oidc_issuer_enabled,
+      oidc_issuer_url,
+    ]
   }
 
   depends_on = [
@@ -2240,6 +2275,13 @@ resource "azurerm_kubernetes_cluster" "test" {
   identity {
     type = "SystemAssigned"
   }
+
+  lifecycle {
+    ignore_changes = [
+      oidc_issuer_enabled,
+      oidc_issuer_url,
+    ]
+  }
 }
 resource "azurerm_kubernetes_cluster_node_pool" "test" {
   name                  = "internal"
@@ -2313,6 +2355,13 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
   identity {
     type = "SystemAssigned"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      oidc_issuer_enabled,
+      oidc_issuer_url,
+    ]
   }
 }
 resource "azurerm_proximity_placement_group" "test" {
@@ -2712,6 +2761,13 @@ resource "azurerm_kubernetes_cluster" "test" {
     type = "SystemAssigned"
   }
 
+  lifecycle {
+    ignore_changes = [
+      oidc_issuer_enabled,
+      oidc_issuer_url,
+    ]
+  }
+
   windows_profile {
     admin_username = "azureuser"
     admin_password = "P@55W0rd1234!h@2h1C0rP"
@@ -3070,6 +3126,13 @@ resource "azurerm_kubernetes_cluster" "test" {
   identity {
     type = "SystemAssigned"
   }
+
+  lifecycle {
+    ignore_changes = [
+      oidc_issuer_enabled,
+      oidc_issuer_url,
+    ]
+  }
 }
 resource "azurerm_kubernetes_cluster_node_pool" "test" {
   name                        = "internal"
@@ -3109,6 +3172,13 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
   identity {
     type = "SystemAssigned"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      oidc_issuer_enabled,
+      oidc_issuer_url,
+    ]
   }
 }
 resource "azurerm_kubernetes_cluster_node_pool" "test" {
@@ -3181,6 +3251,13 @@ resource "azurerm_kubernetes_cluster" "test" {
     type         = "UserAssigned"
     identity_ids = [azurerm_user_assigned_identity.test.id]
   }
+
+  lifecycle {
+    ignore_changes = [
+      oidc_issuer_enabled,
+      oidc_issuer_url,
+    ]
+  }
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "test" {
@@ -3248,6 +3325,13 @@ resource "azurerm_kubernetes_cluster" "test" {
   identity {
     type = "SystemAssigned"
   }
+
+  lifecycle {
+    ignore_changes = [
+      oidc_issuer_enabled,
+      oidc_issuer_url,
+    ]
+  }
 }
 resource "azurerm_kubernetes_cluster_node_pool" "test" {
   name                  = "internal"
@@ -3285,6 +3369,13 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
   identity {
     type = "SystemAssigned"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      oidc_issuer_enabled,
+      oidc_issuer_url,
+    ]
   }
 }
 resource "azurerm_kubernetes_cluster_node_pool" "test" {
@@ -3325,6 +3416,13 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
   identity {
     type = "SystemAssigned"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      oidc_issuer_enabled,
+      oidc_issuer_url,
+    ]
   }
   network_profile {
     network_plugin = "azure"
@@ -3381,6 +3479,13 @@ resource "azurerm_kubernetes_cluster" "test" {
   identity {
     type = "SystemAssigned"
   }
+
+  lifecycle {
+    ignore_changes = [
+      oidc_issuer_enabled,
+      oidc_issuer_url,
+    ]
+  }
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "test" {
@@ -3432,6 +3537,13 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
   identity {
     type = "SystemAssigned"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      oidc_issuer_enabled,
+      oidc_issuer_url,
+    ]
   }
 }
 
@@ -3485,6 +3597,13 @@ resource "azurerm_kubernetes_cluster" "test" {
   identity {
     type = "SystemAssigned"
   }
+
+  lifecycle {
+    ignore_changes = [
+      oidc_issuer_enabled,
+      oidc_issuer_url,
+    ]
+  }
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "source" {
@@ -3524,6 +3643,13 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
   identity {
     type = "SystemAssigned"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      oidc_issuer_enabled,
+      oidc_issuer_url,
+    ]
   }
 }
 
@@ -3584,6 +3710,13 @@ resource "azurerm_kubernetes_cluster" "test" {
   identity {
     type = "SystemAssigned"
   }
+
+  lifecycle {
+    ignore_changes = [
+      oidc_issuer_enabled,
+      oidc_issuer_url,
+    ]
+  }
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "test" {
@@ -3625,6 +3758,13 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
   identity {
     type = "SystemAssigned"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      oidc_issuer_enabled,
+      oidc_issuer_url,
+    ]
   }
 }
 
@@ -3697,6 +3837,13 @@ resource "azurerm_kubernetes_cluster" "test" {
 
   identity {
     type = "SystemAssigned"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      oidc_issuer_enabled,
+      oidc_issuer_url,
+    ]
   }
 
   network_profile {
@@ -3772,6 +3919,13 @@ resource "azurerm_kubernetes_cluster" "test" {
   identity {
     type = "SystemAssigned"
   }
+
+  lifecycle {
+    ignore_changes = [
+      oidc_issuer_enabled,
+      oidc_issuer_url,
+    ]
+  }
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "test" {
@@ -3846,6 +4000,13 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
   identity {
     type = "SystemAssigned"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      oidc_issuer_enabled,
+      oidc_issuer_url,
+    ]
   }
 }
 

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -36,6 +36,7 @@ func TestAccKubernetesClusterNodePool_autoScale(t *testing.T) {
 			Config: r.autoScaleConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("node_image_version").Exists(),
 				check.That(data.ResourceName).Key("tags.%").HasValue("0"),
 			),
 		},
@@ -2822,6 +2823,13 @@ resource "azurerm_kubernetes_cluster" "test" {
   identity {
     type = "SystemAssigned"
   }
+
+  lifecycle {
+    ignore_changes = [
+      oidc_issuer_enabled,
+      oidc_issuer_url,
+    ]
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
@@ -2866,6 +2874,13 @@ resource "azurerm_kubernetes_cluster" "test" {
   identity {
     type = "SystemAssigned"
   }
+
+  lifecycle {
+    ignore_changes = [
+      oidc_issuer_enabled,
+      oidc_issuer_url,
+    ]
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
@@ -2894,6 +2909,13 @@ resource "azurerm_kubernetes_cluster" "test" {
 
   identity {
     type = "SystemAssigned"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      oidc_issuer_enabled,
+      oidc_issuer_url,
+    ]
   }
 
   windows_profile {

--- a/website/docs/d/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/d/kubernetes_cluster_node_pool.html.markdown
@@ -60,6 +60,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `node_count` - The current number of Nodes in the Node Pool.
 
+* `node_image_version` - The current node image version running on this Node Pool.
+
 * `node_labels` - A map of Kubernetes Labels applied to each Node in this Node Pool.
 
 * `node_public_ip_prefix_id` - Resource ID for the Public IP Addresses Prefix for the nodes in this Agent Pool.

--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -334,6 +334,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the Kubernetes Cluster Node Pool.
 
+* `node_image_version` - The current node image version running on this Node Pool.
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/configure#define-operation-timeouts) for certain actions:


### PR DESCRIPTION
* Add missing `node_image_version` field to the resource and data source
* Fixed failing resource tests

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_kubernetes_cluster_node_pool ` - support for the `node_image_version` property [[GH-32078](https://github.com/hashicorp/terraform-provider-azurerm/issues/32078)]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
