### PR TITLE
`testing` - remove all references to `basic` sku for `azurerm_public_ip` retired in 2025

### DIFF
--- a/internal/services/batch/batch_pool_resource_test.go
+++ b/internal/services/batch/batch_pool_resource_test.go
@@ -1796,7 +1796,6 @@ resource "azurerm_public_ip" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Dynamic"
-  sku                 = "Basic"
   domain_name_label   = "acctestpip%d"
 }
 

--- a/internal/services/compute/image_data_source_test.go
+++ b/internal/services/compute/image_data_source_test.go
@@ -90,7 +90,6 @@ resource "azurerm_public_ip" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Dynamic"
-  sku                 = "Basic"
   domain_name_label   = "acctestpip%d"
 }
 
@@ -224,7 +223,6 @@ resource "azurerm_public_ip" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Dynamic"
-  sku                 = "Basic"
   domain_name_label   = "acctestpip%d"
 }
 

--- a/internal/services/compute/image_resource_test.go
+++ b/internal/services/compute/image_resource_test.go
@@ -953,7 +953,6 @@ resource "azurerm_public_ip" "test" {
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Static"
   domain_name_label   = local.domain_name_label
-  sku                 = "Basic"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString, data.RandomInteger, data.RandomInteger)
 }

--- a/internal/services/compute/linux_virtual_machine_resource_images_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_images_test.go
@@ -166,7 +166,6 @@ resource "azurerm_public_ip" "test" {
   resource_group_name = "${azurerm_resource_group.test.name}"
   allocation_method   = "Static"
   domain_name_label   = local.vm_name
-  sku                 = "Basic"
 }
 
 resource "azurerm_network_interface" "public" {

--- a/internal/services/compute/linux_virtual_machine_resource_network_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_network_test.go
@@ -496,7 +496,6 @@ resource "azurerm_public_ip" "first" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Dynamic"
-  sku                 = "Basic"
 }
 
 resource "azurerm_network_interface" "first" {
@@ -517,7 +516,6 @@ resource "azurerm_public_ip" "second" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Dynamic"
-  sku                 = "Basic"
 }
 
 resource "azurerm_network_interface" "second" {
@@ -898,7 +896,6 @@ resource "azurerm_public_ip" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = %q
-  sku                 = "Basic"
 }
 
 resource "azurerm_network_interface" "test" {
@@ -925,7 +922,6 @@ resource "azurerm_public_ip" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = %q
-  sku                 = "Basic"
 }
 
 resource "azurerm_network_interface" "test" {

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource_images_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource_images_test.go
@@ -363,7 +363,6 @@ resource "azurerm_public_ip" "source" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Dynamic"
-  sku                 = "Basic"
 }
 
 resource "azurerm_network_interface" "source" {

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_test.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource_test.go
@@ -2199,7 +2199,6 @@ resource "azurerm_public_ip" "gwtest" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Dynamic"
-  sku                 = "Basic"
 }
 
 resource "azurerm_application_gateway" "test" {

--- a/internal/services/compute/windows_virtual_machine_resource_network_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_network_test.go
@@ -476,7 +476,6 @@ resource "azurerm_public_ip" "first" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Dynamic"
-  sku                 = "Basic"
 }
 
 resource "azurerm_network_interface" "first" {
@@ -497,7 +496,6 @@ resource "azurerm_public_ip" "second" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Dynamic"
-  sku                 = "Basic"
 }
 
 resource "azurerm_network_interface" "second" {
@@ -842,7 +840,6 @@ resource "azurerm_public_ip" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = %q
-  sku                 = "Basic"
 }
 
 resource "azurerm_network_interface" "test" {
@@ -869,7 +866,6 @@ resource "azurerm_public_ip" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = %q
-  sku                 = "Basic"
 }
 
 resource "azurerm_network_interface" "test" {

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource_images_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource_images_test.go
@@ -376,7 +376,6 @@ resource "azurerm_public_ip" "source" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Dynamic"
-  sku                 = "Basic"
 }
 
 resource "azurerm_network_interface" "source" {

--- a/internal/services/dns/dns_a_record_resource_test.go
+++ b/internal/services/dns/dns_a_record_resource_test.go
@@ -335,7 +335,6 @@ resource "azurerm_public_ip" "test" {
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Dynamic"
   ip_version          = "IPv4"
-  sku                 = "Basic"
 }
 
 resource "azurerm_dns_a_record" "test" {
@@ -370,7 +369,6 @@ resource "azurerm_public_ip" "test2" {
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Dynamic"
   ip_version          = "IPv4"
-  sku                 = "Basic"
 }
 
 resource "azurerm_dns_a_record" "test" {
@@ -405,7 +403,6 @@ resource "azurerm_public_ip" "test" {
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Dynamic"
   ip_version          = "IPv4"
-  sku                 = "Basic"
 }
 
 resource "azurerm_dns_a_record" "test" {

--- a/internal/services/dns/dns_aaaa_record_resource_test.go
+++ b/internal/services/dns/dns_aaaa_record_resource_test.go
@@ -361,7 +361,6 @@ resource "azurerm_public_ip" "test" {
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Dynamic"
   ip_version          = "IPv6"
-  sku                 = "Basic"
 }
 
 resource "azurerm_dns_aaaa_record" "test" {
@@ -396,7 +395,6 @@ resource "azurerm_public_ip" "test2" {
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Dynamic"
   ip_version          = "IPv6"
-  sku                 = "Basic"
 }
 
 resource "azurerm_dns_aaaa_record" "test" {
@@ -431,7 +429,6 @@ resource "azurerm_public_ip" "test" {
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Dynamic"
   ip_version          = "IPv6"
-  sku                 = "Basic"
 }
 
 resource "azurerm_dns_aaaa_record" "test" {

--- a/internal/services/mssql/mssql_virtual_machine_resource_list_test.go
+++ b/internal/services/mssql/mssql_virtual_machine_resource_list_test.go
@@ -101,7 +101,6 @@ resource "azurerm_public_ip" "vm" {
   name                = "acctest-PIP-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  sku                 = "Basic"
   allocation_method   = "Dynamic"
 }
 

--- a/internal/services/mssql/mssql_virtual_machine_resource_test.go
+++ b/internal/services/mssql/mssql_virtual_machine_resource_test.go
@@ -447,7 +447,6 @@ resource "azurerm_public_ip" "vm" {
   name                = "acctest-PIP-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  sku                 = "Basic"
   allocation_method   = "Dynamic"
 }
 

--- a/internal/services/network/virtual_network_gateway_connection_data_source_test.go
+++ b/internal/services/network/virtual_network_gateway_connection_data_source_test.go
@@ -109,7 +109,6 @@ resource "azurerm_public_ip" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Dynamic"
-  sku                 = "Basic"
 }
 
 resource "azurerm_virtual_network_gateway" "test" {
@@ -195,7 +194,6 @@ resource "azurerm_public_ip" "test_1" {
   location            = azurerm_resource_group.test_1.location
   resource_group_name = azurerm_resource_group.test_1.name
   allocation_method   = "Dynamic"
-  sku                 = "Basic"
 }
 
 resource "azurerm_virtual_network_gateway" "test_1" {
@@ -251,7 +249,6 @@ resource "azurerm_public_ip" "test_2" {
   location            = azurerm_resource_group.test_2.location
   resource_group_name = azurerm_resource_group.test_2.name
   allocation_method   = "Dynamic"
-  sku                 = "Basic"
 }
 
 resource "azurerm_virtual_network_gateway" "test_2" {

--- a/internal/services/network/virtual_network_gateway_connection_resource_test.go
+++ b/internal/services/network/virtual_network_gateway_connection_resource_test.go
@@ -375,7 +375,6 @@ resource "azurerm_public_ip" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Dynamic"
-  sku                 = "Basic"
 }
 
 resource "azurerm_virtual_network_gateway" "test" {
@@ -452,7 +451,6 @@ resource "azurerm_public_ip" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Dynamic"
-  sku                 = "Basic"
 }
 
 resource "azurerm_virtual_network_gateway" "test" {
@@ -775,7 +773,6 @@ resource "azurerm_public_ip" "test_1" {
   location            = azurerm_resource_group.test_1.location
   resource_group_name = azurerm_resource_group.test_1.name
   allocation_method   = "Dynamic"
-  sku                 = "Basic"
 }
 
 resource "azurerm_virtual_network_gateway" "test_1" {
@@ -831,7 +828,6 @@ resource "azurerm_public_ip" "test_2" {
   location            = azurerm_resource_group.test_2.location
   resource_group_name = azurerm_resource_group.test_2.name
   allocation_method   = "Dynamic"
-  sku                 = "Basic"
 }
 
 resource "azurerm_virtual_network_gateway" "test_2" {
@@ -1614,7 +1610,6 @@ resource "azurerm_public_ip" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Dynamic"
-  sku                 = "Basic"
 }
 
 resource "azurerm_virtual_network_gateway" "test" {

--- a/internal/services/network/virtual_network_gateway_data_source_test.go
+++ b/internal/services/network/virtual_network_gateway_data_source_test.go
@@ -54,7 +54,6 @@ resource "azurerm_public_ip" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Dynamic"
-  sku                 = "Basic"
 }
 
 resource "azurerm_virtual_network_gateway" "test" {

--- a/internal/services/network/virtual_network_gateway_nat_rule_resource_test.go
+++ b/internal/services/network/virtual_network_gateway_nat_rule_resource_test.go
@@ -269,7 +269,6 @@ resource "azurerm_public_ip" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Dynamic"
-  sku                 = "Basic"
 }
 
 resource "azurerm_virtual_network_gateway" "test" {

--- a/internal/services/network/virtual_network_gateway_resource_test.go
+++ b/internal/services/network/virtual_network_gateway_resource_test.go
@@ -512,7 +512,6 @@ resource "azurerm_public_ip" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Dynamic"
-  sku                 = "Basic"
 }
 
 resource "azurerm_virtual_network_gateway" "test" {
@@ -583,7 +582,6 @@ resource "azurerm_public_ip" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Dynamic"
-  sku                 = "Basic"
 }
 
 resource "azurerm_virtual_network_gateway" "test" {
@@ -1822,7 +1820,6 @@ resource "azurerm_public_ip" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Dynamic"
-  sku                 = "Basic"
 }
 
 data "azurerm_extended_locations" "test" {

--- a/internal/services/recoveryservices/backup_protected_vm_resource_test.go
+++ b/internal/services/recoveryservices/backup_protected_vm_resource_test.go
@@ -360,7 +360,6 @@ resource "azurerm_public_ip" "test" {
   name                = "acctest-ip"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  sku                 = "Basic"
   allocation_method   = "Dynamic"
   domain_name_label   = "acctestip%d"
 }
@@ -506,7 +505,6 @@ resource "azurerm_public_ip" "test" {
   name                = "acctest-ip"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  sku                 = "Basic"
   allocation_method   = "Dynamic"
   domain_name_label   = "acctestip%[1]d"
 }
@@ -650,7 +648,6 @@ resource "azurerm_public_ip" "test" {
   name                = "acctest-ip"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  sku                 = "Basic"
   allocation_method   = "Dynamic"
   domain_name_label   = "acctestip%d"
 }
@@ -796,7 +793,6 @@ resource "azurerm_public_ip" "test" {
   name                = "acctest-ip"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  sku                 = "Basic"
   allocation_method   = "Dynamic"
   domain_name_label   = "acctestip%d"
 }
@@ -871,7 +867,6 @@ resource "azurerm_public_ip" "test" {
   name                = "acctest-ip"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  sku                 = "Basic"
   allocation_method   = "Dynamic"
   domain_name_label   = "acctestip%d"
 }
@@ -1051,7 +1046,6 @@ resource "azurerm_public_ip" "test" {
   name                = "acctest-ip"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  sku                 = "Basic"
   allocation_method   = "Dynamic"
   domain_name_label   = "acctestip%d"
 }
@@ -1335,7 +1329,6 @@ resource "azurerm_public_ip" "test" {
   name                = "acctest-ip"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  sku                 = "Basic"
   allocation_method   = "Dynamic"
   domain_name_label   = "acctestip%[1]d"
 }


### PR DESCRIPTION
It is no longer possible to create new resources on this sku. Value defaults to `standard`.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
