### PR TITLE
`azurerm_resource_group` - fix parallelism issue in `create_poller`

### DIFF
--- a/internal/services/resource/custompollers/resource_group_create_poller.go
+++ b/internal/services/resource/custompollers/resource_group_create_poller.go
@@ -12,14 +12,18 @@ import (
 )
 
 type resourceGroupCreatePoller struct {
-	client *resourcegroups.ResourceGroupsClient
-	id     commonids.ResourceGroupId
+	client       *resourcegroups.ResourceGroupsClient
+	id           commonids.ResourceGroupId
+	successCount int
 }
 
 var _ pollers.PollerType = &resourceGroupCreatePoller{}
 
+const (
+	defaultSuccessCount = 3
+)
+
 var (
-	successCount   = 3 // emulates ContinuousTargetOccurrence
 	pollingSuccess = &pollers.PollResult{
 		PollInterval: 5 * time.Second,
 		Status:       pollers.PollingStatusSucceeded,
@@ -38,23 +42,24 @@ var (
 
 func NewResourceGroupCreatePoller(client *resourcegroups.ResourceGroupsClient, id commonids.ResourceGroupId) *resourceGroupCreatePoller {
 	return &resourceGroupCreatePoller{
-		client: client,
-		id:     id,
+		client:       client,
+		id:           id,
+		successCount: defaultSuccessCount,
 	}
 }
 
-func (p resourceGroupCreatePoller) Poll(ctx context.Context) (*pollers.PollResult, error) {
+func (p *resourceGroupCreatePoller) Poll(ctx context.Context) (*pollers.PollResult, error) {
 	rg, err := p.client.Get(ctx, p.id)
 	if err != nil {
 		if response.WasNotFound(rg.HttpResponse) {
-			successCount = 3
+			p.successCount = defaultSuccessCount
 			return pollingInProgress, nil
 		}
 		return pollingFailed, fmt.Errorf("retrieving %s: %+v", p.id, err)
 	}
 
-	if successCount > 1 {
-		successCount--
+	if p.successCount > 1 {
+		p.successCount--
 		return pollingInProgress, nil
 	}
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
Moves a global var to a poller-local value to fix a rare edge case where many RGs are being created at once can cause the poller to exit early.

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource_group` - fix parallelism issue in `create_poller`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
