### PR TITLE
List and identity implementation - azurerm_web_pubsub

### DIFF
--- a/internal/services/signalr/registration.go
+++ b/internal/services/signalr/registration.go
@@ -88,5 +88,7 @@ func (r Registration) EphemeralResources() []func() ephemeral.EphemeralResource 
 }
 
 func (r Registration) ListResources() []sdk.FrameworkListWrappedResource {
-	return []sdk.FrameworkListWrappedResource{}
+	return []sdk.FrameworkListWrappedResource{
+		WebPubSubListResource{},
+	}
 }

--- a/internal/services/signalr/web_pubsub_resource.go
+++ b/internal/services/signalr/web_pubsub_resource.go
@@ -28,6 +28,8 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name web_pubsub -service-package-name signalr -properties "name,resource_group_name"
+
 func resourceWebPubSub() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
 		Create: resourceWebPubSubCreateUpdate,
@@ -47,10 +49,11 @@ func resourceWebPubSub() *pluginsdk.Resource {
 		}),
 		SchemaVersion: 1,
 
-		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := webpubsub.ParseWebPubSubID(id)
-			return err
-		}),
+		Importer: pluginsdk.ImporterValidatingIdentity(&webpubsub.WebPubSubId{}),
+
+		Identity: &schema.ResourceIdentity{
+			SchemaFunc: pluginsdk.GenerateIdentitySchema(&webpubsub.WebPubSubId{}),
+		},
 
 		Schema: map[string]*pluginsdk.Schema{
 			"name": {
@@ -279,6 +282,10 @@ func resourceWebPubSubCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 	}
 
 	d.SetId(id.ID())
+	if err := pluginsdk.SetResourceIdentityData(d, &id); err != nil {
+		return err
+	}
+
 	return resourceWebPubSubRead(d, meta)
 }
 
@@ -307,78 +314,7 @@ func resourceWebPubSubRead(d *pluginsdk.ResourceData, meta interface{}) error {
 		return fmt.Errorf("listing keys for %s: %+v", *id, err)
 	}
 
-	d.Set("name", id.WebPubSubName)
-	d.Set("resource_group_name", id.ResourceGroupName)
-
-	if model := resp.Model; model != nil {
-		d.Set("location", location.Normalize(model.Location))
-
-		skuName := ""
-		skuCapacity := int64(0)
-		if model.Sku != nil {
-			skuName = model.Sku.Name
-			skuCapacity = *model.Sku.Capacity
-		}
-		d.Set("sku", skuName)
-		d.Set("capacity", skuCapacity)
-
-		if props := model.Properties; props != nil {
-			d.Set("external_ip", props.ExternalIP)
-			d.Set("hostname", props.HostName)
-			d.Set("public_port", props.PublicPort)
-			d.Set("server_port", props.ServerPort)
-			d.Set("version", props.Version)
-
-			aadAuthEnabled := true
-			if props.DisableAadAuth != nil {
-				aadAuthEnabled = !(*props.DisableAadAuth)
-			}
-			d.Set("aad_auth_enabled", aadAuthEnabled)
-
-			disableLocalAuth := false
-			if props.DisableLocalAuth != nil {
-				disableLocalAuth = !(*props.DisableLocalAuth)
-			}
-			d.Set("local_auth_enabled", disableLocalAuth)
-
-			publicNetworkAccessEnabled := true
-			if props.PublicNetworkAccess != nil {
-				publicNetworkAccessEnabled = strings.EqualFold(*props.PublicNetworkAccess, "Enabled")
-			}
-			d.Set("public_network_access_enabled", publicNetworkAccessEnabled)
-
-			tlsClientCertEnabled := false
-			if props.Tls != nil && props.Tls.ClientCertEnabled != nil {
-				tlsClientCertEnabled = *props.Tls.ClientCertEnabled
-			}
-			d.Set("tls_client_cert_enabled", tlsClientCertEnabled)
-
-			if err := d.Set("live_trace", flattenLiveTraceConfig(props.LiveTraceConfiguration)); err != nil {
-				return fmt.Errorf("setting `live_trace`:%+v", err)
-			}
-
-			identity, err := identity.FlattenSystemOrUserAssignedMap(model.Identity)
-			if err != nil {
-				return fmt.Errorf("flattening `identity`: %+v", err)
-			}
-			if err := d.Set("identity", identity); err != nil {
-				return fmt.Errorf("setting `identity`: %+v", err)
-			}
-
-			if err := tags.FlattenAndSet(d, model.Tags); err != nil {
-				return fmt.Errorf("setting `tags`: %+v", err)
-			}
-		}
-	}
-
-	if model := keys.Model; model != nil {
-		d.Set("primary_access_key", model.PrimaryKey)
-		d.Set("primary_connection_string", model.PrimaryConnectionString)
-		d.Set("secondary_access_key", model.SecondaryKey)
-		d.Set("secondary_connection_string", model.SecondaryConnectionString)
-	}
-
-	return nil
+	return resourceWebPubSubFlatten(d, id, resp.Model, keys.Model)
 }
 
 func resourceWebPubSubDelete(d *pluginsdk.ResourceData, meta interface{}) error {
@@ -514,4 +450,79 @@ func webPubsubProvisioningStateRefreshFunc(ctx context.Context, client *webpubsu
 
 		return res, provisioningState, nil
 	}
+}
+
+func resourceWebPubSubFlatten(d *pluginsdk.ResourceData, id *webpubsub.WebPubSubId, model *webpubsub.WebPubSubResource, keyModel *webpubsub.WebPubSubKeys) error {
+	d.Set("name", id.WebPubSubName)
+	d.Set("resource_group_name", id.ResourceGroupName)
+
+	if model != nil {
+		d.Set("location", location.Normalize(model.Location))
+
+		skuName := ""
+		skuCapacity := int64(0)
+		if model.Sku != nil {
+			skuName = model.Sku.Name
+			skuCapacity = *model.Sku.Capacity
+		}
+		d.Set("sku", skuName)
+		d.Set("capacity", skuCapacity)
+
+		if props := model.Properties; props != nil {
+			d.Set("external_ip", props.ExternalIP)
+			d.Set("hostname", props.HostName)
+			d.Set("public_port", props.PublicPort)
+			d.Set("server_port", props.ServerPort)
+			d.Set("version", props.Version)
+
+			aadAuthEnabled := true
+			if props.DisableAadAuth != nil {
+				aadAuthEnabled = !(*props.DisableAadAuth)
+			}
+			d.Set("aad_auth_enabled", aadAuthEnabled)
+
+			disableLocalAuth := false
+			if props.DisableLocalAuth != nil {
+				disableLocalAuth = !(*props.DisableLocalAuth)
+			}
+			d.Set("local_auth_enabled", disableLocalAuth)
+
+			publicNetworkAccessEnabled := true
+			if props.PublicNetworkAccess != nil {
+				publicNetworkAccessEnabled = strings.EqualFold(*props.PublicNetworkAccess, "Enabled")
+			}
+			d.Set("public_network_access_enabled", publicNetworkAccessEnabled)
+
+			tlsClientCertEnabled := false
+			if props.Tls != nil && props.Tls.ClientCertEnabled != nil {
+				tlsClientCertEnabled = *props.Tls.ClientCertEnabled
+			}
+			d.Set("tls_client_cert_enabled", tlsClientCertEnabled)
+
+			if err := d.Set("live_trace", flattenLiveTraceConfig(props.LiveTraceConfiguration)); err != nil {
+				return fmt.Errorf("setting `live_trace`:%+v", err)
+			}
+
+			identityValue, err := identity.FlattenSystemOrUserAssignedMap(model.Identity)
+			if err != nil {
+				return fmt.Errorf("flattening `identity`: %+v", err)
+			}
+			if err := d.Set("identity", identityValue); err != nil {
+				return fmt.Errorf("setting `identity`: %+v", err)
+			}
+
+			if err := tags.FlattenAndSet(d, model.Tags); err != nil {
+				return fmt.Errorf("setting `tags`: %+v", err)
+			}
+		}
+	}
+
+	if keyModel != nil {
+		d.Set("primary_access_key", keyModel.PrimaryKey)
+		d.Set("primary_connection_string", keyModel.PrimaryConnectionString)
+		d.Set("secondary_access_key", keyModel.SecondaryKey)
+		d.Set("secondary_connection_string", keyModel.SecondaryConnectionString)
+	}
+
+	return pluginsdk.SetResourceIdentityData(d, id)
 }

--- a/internal/services/signalr/web_pubsub_resource.go
+++ b/internal/services/signalr/web_pubsub_resource.go
@@ -30,6 +30,8 @@ import (
 
 //go:generate go run ../../tools/generator-tests resourceidentity -resource-name web_pubsub -service-package-name signalr -properties "name,resource_group_name"
 
+const webPubSubResourceType = "azurerm_web_pubsub"
+
 func resourceWebPubSub() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
 		Create: resourceWebPubSubCreateUpdate,
@@ -222,7 +224,7 @@ func resourceWebPubSubCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 			}
 		}
 		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError("azurerm_web_pubsub", id.ID())
+			return tf.ImportAsExistsError(webPubSubResourceType, id.ID())
 		}
 	}
 

--- a/internal/services/signalr/web_pubsub_resource_identity_gen_test.go
+++ b/internal/services/signalr/web_pubsub_resource_identity_gen_test.go
@@ -1,0 +1,39 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package signalr_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
+)
+
+func TestAccWebPubsub_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_web_pubsub", "test")
+	r := WebPubsubResource{}
+
+	checkedFields := map[string]struct{}{
+		"subscription_id":     {},
+		"name":                {},
+		"resource_group_name": {},
+	}
+
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				customstatecheck.ExpectAllIdentityFieldsAreChecked("azurerm_web_pubsub.test", checkedFields),
+				statecheck.ExpectIdentityValue("azurerm_web_pubsub.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_web_pubsub.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_web_pubsub.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
+			},
+		},
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
+}

--- a/internal/services/signalr/web_pubsub_resource_list.go
+++ b/internal/services/signalr/web_pubsub_resource_list.go
@@ -1,0 +1,94 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package signalr
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/webpubsub/2024-03-01/webpubsub"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type WebPubSubListResource struct{}
+
+var _ sdk.FrameworkListWrappedResource = new(WebPubSubListResource)
+
+func (r WebPubSubListResource) ResourceFunc() *pluginsdk.Resource {
+	return resourceWebPubSub()
+}
+
+func (r WebPubSubListResource) Metadata(_ context.Context, _ resource.MetadataRequest, response *resource.MetadataResponse) {
+	response.TypeName = "azurerm_web_pubsub"
+}
+
+func (r WebPubSubListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream, metadata sdk.ResourceMetadata) {
+	client := metadata.Client.SignalR.WebPubSubClient.WebPubSub
+
+	var data sdk.DefaultListModel
+	if diags := request.Config.Get(ctx, &data); diags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	subscriptionID := metadata.SubscriptionId
+	if !data.SubscriptionId.IsNull() {
+		subscriptionID = data.SubscriptionId.ValueString()
+	}
+
+	results := make([]webpubsub.WebPubSubResource, 0)
+
+	switch {
+	case !data.ResourceGroupName.IsNull():
+		resp, err := client.ListByResourceGroupComplete(ctx, commonids.NewResourceGroupID(subscriptionID, data.ResourceGroupName.ValueString()))
+		if err != nil {
+			sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("listing `%s`", "azurerm_web_pubsub"), err)
+			return
+		}
+		results = resp.Items
+	default:
+		resp, err := client.ListBySubscriptionComplete(ctx, commonids.NewSubscriptionID(subscriptionID))
+		if err != nil {
+			sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("listing `%s`", "azurerm_web_pubsub"), err)
+			return
+		}
+		results = resp.Items
+	}
+
+	stream.Results = func(push func(list.ListResult) bool) {
+		for _, item := range results {
+			result := request.NewListResult(ctx)
+			result.DisplayName = pointer.From(item.Name)
+
+			id, err := webpubsub.ParseWebPubSubIDInsensitively(pointer.From(item.Id))
+			if err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, "parsing Web PubSub ID", err)
+				return
+			}
+
+			rd := resourceWebPubSub().Data(&terraform.InstanceState{})
+			rd.SetId(id.ID())
+
+			if err := resourceWebPubSubFlatten(rd, id, &item, nil); err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, "flattening Web PubSub", err)
+				return
+			}
+
+			sdk.EncodeListResult(ctx, rd, &result)
+			if result.Diagnostics.HasError() {
+				push(result)
+				return
+			}
+			if !push(result) {
+				return
+			}
+		}
+	}
+}

--- a/internal/services/signalr/web_pubsub_resource_list.go
+++ b/internal/services/signalr/web_pubsub_resource_list.go
@@ -26,7 +26,7 @@ func (r WebPubSubListResource) ResourceFunc() *pluginsdk.Resource {
 }
 
 func (r WebPubSubListResource) Metadata(_ context.Context, _ resource.MetadataRequest, response *resource.MetadataResponse) {
-	response.TypeName = "azurerm_web_pubsub"
+	response.TypeName = webPubSubResourceType
 }
 
 func (r WebPubSubListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream, metadata sdk.ResourceMetadata) {
@@ -49,14 +49,14 @@ func (r WebPubSubListResource) List(ctx context.Context, request list.ListReques
 	case !data.ResourceGroupName.IsNull():
 		resp, err := client.ListByResourceGroupComplete(ctx, commonids.NewResourceGroupID(subscriptionID, data.ResourceGroupName.ValueString()))
 		if err != nil {
-			sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("listing `%s`", "azurerm_web_pubsub"), err)
+			sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("listing `%s`", webPubSubResourceType), err)
 			return
 		}
 		results = resp.Items
 	default:
 		resp, err := client.ListBySubscriptionComplete(ctx, commonids.NewSubscriptionID(subscriptionID))
 		if err != nil {
-			sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("listing `%s`", "azurerm_web_pubsub"), err)
+			sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("listing `%s`", webPubSubResourceType), err)
 			return
 		}
 		results = resp.Items

--- a/internal/services/signalr/web_pubsub_resource_list_test.go
+++ b/internal/services/signalr/web_pubsub_resource_list_test.go
@@ -1,0 +1,83 @@
+package signalr_test
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccWebPubsub_list(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_web_pubsub", "test")
+	r := WebPubsubResource{}
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basic(data),
+			},
+			{
+				Query:  true,
+				Config: r.basicListQuery(),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLengthAtLeast("azurerm_web_pubsub.list", 1),
+					querycheck.ExpectIdentity(
+						"azurerm_web_pubsub.list",
+						map[string]knownvalue.Check{
+							"name":                knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"resource_group_name": knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"subscription_id":     knownvalue.StringExact(data.Subscriptions.Primary),
+						},
+					),
+				},
+			},
+			{
+				Query:  true,
+				Config: r.basicListQueryByResourceGroupName(data),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLength("azurerm_web_pubsub.list", 1),
+					querycheck.ExpectIdentity(
+						"azurerm_web_pubsub.list",
+						map[string]knownvalue.Check{
+							"name":                knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"resource_group_name": knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"subscription_id":     knownvalue.StringExact(data.Subscriptions.Primary),
+						},
+					),
+				},
+			},
+		},
+	})
+}
+
+func (WebPubsubResource) basicListQuery() string {
+	return `
+list "azurerm_web_pubsub" "list" {
+  provider = azurerm
+  config {}
+}
+`
+}
+
+func (WebPubsubResource) basicListQueryByResourceGroupName(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+list "azurerm_web_pubsub" "list" {
+  provider = azurerm
+  config {
+    resource_group_name = "acctestRG-wps-%d"
+  }
+}
+`, data.RandomInteger)
+}

--- a/internal/services/signalr/web_pubsub_resource_list_test.go
+++ b/internal/services/signalr/web_pubsub_resource_list_test.go
@@ -2,7 +2,6 @@ package signalr_test
 
 import (
 	"context"
-	"fmt"
 	"regexp"
 	"strconv"
 	"testing"
@@ -72,12 +71,12 @@ list "azurerm_web_pubsub" "list" {
 }
 
 func (WebPubsubResource) basicListQueryByResourceGroupName(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+	return `
 list "azurerm_web_pubsub" "list" {
   provider = azurerm
   config {
-    resource_group_name = "acctestRG-wps-%d"
+    resource_group_name = azurerm_resource_group.test.name
   }
 }
-`, data.RandomInteger)
+`
 }

--- a/internal/services/signalr/web_pubsub_resource_list_test.go
+++ b/internal/services/signalr/web_pubsub_resource_list_test.go
@@ -44,7 +44,7 @@ func TestAccWebPubsub_list(t *testing.T) {
 			},
 			{
 				Query:  true,
-				Config: r.basicListQueryByResourceGroupName(data),
+				Config: r.basicListQueryByResourceGroupName(),
 				QueryResultChecks: []querycheck.QueryResultCheck{
 					querycheck.ExpectLength("azurerm_web_pubsub.list", 1),
 					querycheck.ExpectIdentity(

--- a/internal/services/signalr/web_pubsub_resource_list_test.go
+++ b/internal/services/signalr/web_pubsub_resource_list_test.go
@@ -70,7 +70,7 @@ list "azurerm_web_pubsub" "list" {
 `
 }
 
-func (WebPubsubResource) basicListQueryByResourceGroupName(data acceptance.TestData) string {
+func (WebPubsubResource) basicListQueryByResourceGroupName() string {
 	return `
 list "azurerm_web_pubsub" "list" {
   provider = azurerm

--- a/website/docs/list-resources/web_pubsub.html.markdown
+++ b/website/docs/list-resources/web_pubsub.html.markdown
@@ -1,0 +1,41 @@
+---
+subcategory: "Messaging"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_web_pubsub"
+description: |-
+    Lists Web PubSub resources.
+---
+
+# List resource: azurerm_web_pubsub
+
+Lists Web PubSub resources.
+
+## Example Usage
+
+### List all Web PubSub resources in a subscription
+
+```hcl
+list "azurerm_web_pubsub" "example" {
+  provider = azurerm
+  config {}
+}
+```
+
+### List all Web PubSub resources in a specific resource group
+
+```hcl
+list "azurerm_web_pubsub" "example" {
+  provider = azurerm
+  config {
+    resource_group_name = "myresourcegroup"
+  }
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `resource_group_name` - (Optional) The name of the resource group to query.
+
+* `subscription_id` - (Optional) The Subscription ID to query. Defaults to the value specified in the Provider Configuration.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
List and identity implementation for azurerm_web_pubsub

Teamcity run link: https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_SIGNALR/644465?buildTab=overview 


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
