### PR TITLE
`azurerm_subscription` - Reorder delete operations to cancel subscription then delete alias

### DIFF
--- a/internal/services/subscription/subscription_resource.go
+++ b/internal/services/subscription/subscription_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"slices"
 	"time"
 
 	"github.com/google/uuid"
@@ -405,6 +406,36 @@ func resourceSubscriptionDelete(d *pluginsdk.ResourceData, meta interface{}) err
 	if subscriptionName == "" || subscriptionId == "" {
 		return fmt.Errorf("one or both of Subscription Name (%q) and Subscription ID (%q) could not be determined", subscriptionName, subscriptionId)
 	}
+
+	// The below order matters: Cancel the subscription, then removing the alias.
+	// The alias is the *main* handle of this terraform resource, we shall only delete it as the last step to avoid trailing partial state,
+	// which otherwise can't be mitigated by a second `terraform run` (the Read() regards this resource is gone since alias is deleted).
+
+	// Cancel the Subscription
+	if !meta.(*clients.Client).Features.Subscription.PreventCancellationOnDestroy {
+		if slices.Contains([]subscriptions.SubscriptionState{subscriptions.SubscriptionStateDisabled, subscriptions.SubscriptionStateWarned}, pointer.From(sub.Model.State)) {
+			log.Printf("[DEBUG] Subscription %s is already cancelled", subscriptionId)
+		} else {
+			log.Printf("[DEBUG] Cancelling subscription %s", subscriptionId)
+
+			opts := subscriptionAlias.DefaultSubscriptionCancelOperationOptions()
+			// TODO: support a Provider `features` flag to enable deleting a Subscription containing Resources
+			// This is a dangerous operation, and likely wants a similar default value as to that for Resource Groups
+			if _, err := aliasClient.SubscriptionCancel(ctx, subscriptionResourceId, opts); err != nil {
+				return fmt.Errorf("failed to cancel Subscription: %+v", err)
+			}
+
+			deadline, _ := ctx.Deadline()
+			deleteDeadline := time.Until(deadline)
+
+			if err := waitForSubscriptionStateToSettle(ctx, client, subscriptionResourceId, "Cancelled", deleteDeadline); err != nil {
+				return fmt.Errorf("failed to cancel Subscription %q (Alias %q): %+v", subscriptionId, id.AliasName, err)
+			}
+		}
+	} else {
+		log.Printf("[DEBUG] Skipping subscription %s cancellation due to feature flag.", *id)
+	}
+
 	// remove the alias
 	if _, count, err := checkExistingAliases(ctx, *aliasClient, subscriptionId); err != nil {
 		if count > 1 {
@@ -417,27 +448,6 @@ func resourceSubscriptionDelete(d *pluginsdk.ResourceData, meta interface{}) err
 		if !response.WasNotFound(resp.HttpResponse) {
 			return fmt.Errorf("could not delete Alias %q for Subscription %q (ID: %q): %+v", id.AliasName, subscriptionName, subscriptionId, err)
 		}
-	}
-
-	// Cancel the Subscription
-	if !meta.(*clients.Client).Features.Subscription.PreventCancellationOnDestroy {
-		log.Printf("[DEBUG] Cancelling subscription %s", subscriptionId)
-
-		opts := subscriptionAlias.DefaultSubscriptionCancelOperationOptions()
-		// TODO: support a Provider `features` flag to enable deleting a Subscription containing Resources
-		// This is a dangerous operation, and likely wants a similar default value as to that for Resource Groups
-		if _, err := aliasClient.SubscriptionCancel(ctx, subscriptionResourceId, opts); err != nil {
-			return fmt.Errorf("failed to cancel Subscription: %+v", err)
-		}
-
-		deadline, _ := ctx.Deadline()
-		deleteDeadline := time.Until(deadline)
-
-		if err := waitForSubscriptionStateToSettle(ctx, client, subscriptionResourceId, "Cancelled", deleteDeadline); err != nil {
-			return fmt.Errorf("failed to cancel Subscription %q (Alias %q): %+v", subscriptionId, id.AliasName, err)
-		}
-	} else {
-		log.Printf("[DEBUG] Skipping subscription %s cancellation due to feature flag.", *id)
 	}
 
 	return nil


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR reorders the deletion logic in the `azurerm_subscription` resource to cancel the subscription **before** deleting the alias, rather than the previous order (delete alias first, then cancel).

### Changes

- **Reordered delete operations** — The subscription cancellation step now runs before the alias removal. The alias is the primary handle for the Terraform resource, so deleting it last avoids leaving partial state that can't be recovered by a subsequent `terraform apply` (since `Read()` treats the resource as gone once the alias is deleted).
- **Added idempotency for cancellation** — Before attempting to cancel, the code now checks if the subscription is already in a `Disabled` or `Warned` state and skips the cancellation call if so, preventing unnecessary API errors.

### Why it matters

The previous ordering could leave the subscription in a problematic state — if the alias was deleted but the cancellation failed, Terraform would consider the resource gone (no alias) yet the subscription would remain active. By cancelling first and deleting the alias last, any failure leaves the resource in a state that Terraform can still manage and retry.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

Two tests are made:

1. Running the acctest with temporary hack to allow Azure CLI auth (since only my user account has the permission to manage sub):

    ```
    💢 TF_ACC=1 go test -v -timeout 1h -run=TestAccSubscriptionResource_basic ./internal/services/subscription
    === RUN   TestAccSubscriptionResource_basic
    === PAUSE TestAccSubscriptionResource_basic
    === CONT  TestAccSubscriptionResource_basic
        testcase.go:203: Step 1/1 error: Check failed: Check 1/1 error: running exists func for "azurerm_subscription.test": retrieving Subscription Alias "testAcc-260409175454761125": subscriptions.SubscriptionsClient#AliasGet: Failure responding to request: StatusCode=401 -- Original Error: autorest/azure: Service returned an error. Status=401 Code="UserNotAuthorized" Message="User does not have access Microsoft.Subscription/aliases/write over scope /providers/Microsoft.Subscription/aliases/testAcc-260409175454761125"
    --- FAIL: TestAccSubscriptionResource_basic (752.31s)
    FAIL
    FAIL	github.com/hashicorp/terraform-provider-azurerm/internal/services/subscription	752.331s
    FAIL
    ```

    This test failed at the check since the check will build a new test client which disables the CLI auth. Apart from that the whole create-delete lifecycle works.

2. Manual test to simulate the potential error in the mid scenario: Manually cancel the subscripton -> Wait for a while -> Run `terraform destroy` to destroy the tracked subscription. This also works as expected. 


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #32128


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
