### PR TITLE
azurerm_container_group - Add the cce_policy parameter to container groups for confidential containers

### DIFF
--- a/internal/services/containers/container_group_resource.go
+++ b/internal/services/containers/container_group_resource.go
@@ -508,6 +508,14 @@ func resourceContainerGroup() *pluginsdk.Resource {
 				ForceNew:     true,
 				ValidateFunc: validation.StringInSlice(containerinstance.PossibleValuesForContainerGroupPriority(), false),
 			},
+
+			"cce_policy": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
 		},
 		CustomizeDiff: func(ctx context.Context, d *pluginsdk.ResourceDiff, i interface{}) error {
 			if p := d.Get("priority").(string); p == string(containerinstance.ContainerGroupPrioritySpot) {
@@ -747,6 +755,12 @@ func resourceContainerGroupCreate(d *pluginsdk.ResourceData, meta interface{}) e
 		containerGroup.Properties.Priority = pointer.ToEnum[containerinstance.ContainerGroupPriority](priority)
 	}
 
+	if ccePolicy := d.Get("cce_policy").(string); ccePolicy != "" {
+		containerGroup.Properties.ConfidentialComputeProperties = &containerinstance.ConfidentialComputeProperties{
+			CcePolicy: pointer.To(ccePolicy),
+		}
+	}
+
 	// Avoid parallel provisioning if "subnet_ids" are given.
 	if subnets != nil && len(*subnets) != 0 {
 		for _, item := range *subnets {
@@ -948,6 +962,10 @@ func resourceContainerGroupRead(d *pluginsdk.ResourceData, meta interface{}) err
 		}
 		if err := d.Set("subnet_ids", subnets); err != nil {
 			return fmt.Errorf("setting `subnet_ids`: %+v", err)
+		}
+
+		if ccProps := props.ConfidentialComputeProperties; ccProps != nil {
+			d.Set("cce_policy", pointer.From(ccProps.CcePolicy))
 		}
 
 		if kvProps := props.EncryptionProperties; kvProps != nil {

--- a/internal/services/containers/container_group_resource_test.go
+++ b/internal/services/containers/container_group_resource_test.go
@@ -2855,3 +2855,102 @@ resource "azurerm_container_group" "test" {
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomString, data.RandomInteger)
 }
+
+func TestAccContainerGroup_ccePolicyConfidential(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_group", "test")
+	r := ContainerGroupResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.ccePolicyConfidential(data, "cGFja2FnZSBwb2xpY3kKCmFwaV92ZXJzaW9uIDo9ICIwLjEuMCIKCm1vdW50X2RldmljZSA6PSB7ImFsbG93ZWQiOiB0cnVlfQoKbW91bnRfb3ZlcmxheSA6PSB7ImFsbG93ZWQiOiB0cnVlfQoKY3JlYXRlX2NvbnRhaW5lciA6PSB7ImFsbG93ZWQiOiB0cnVlfQoKdW5tb3VudF9kZXZpY2UgOj0geyJhbGxvd2VkIjogdHJ1ZX0KCnVubW91bnRfb3ZlcmxheSA6PSB7ImFsbG93ZWQiOiB0cnVlfQoKZXhlY19pbl9jb250YWluZXIgOj0geyJhbGxvd2VkIjogdHJ1ZX0KCmV4ZWNfZXh0ZXJuYWwgOj0geyJhbGxvd2VkIjogdHJ1ZX0KCnNodXRkb3duX2NvbnRhaW5lciA6PSB7ImFsbG93ZWQiOiB0cnVlfQo="),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("cce_policy"),
+	})
+}
+
+func TestAccContainerGroup_ccePolicyConfidentialDefault(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_group", "test")
+	r := ContainerGroupResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.ccePolicyConfidentialDefault(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("cce_policy"),
+	})
+}
+
+func (ContainerGroupResource) ccePolicyConfidentialDefault(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_container_group" "test" {
+  name                = "acctestcontainergroup-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  ip_address_type     = "Public"
+  os_type             = "Linux"
+  sku                 = "Confidential"
+
+  container {
+    name   = "hw"
+    image  = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
+    cpu    = "0.5"
+    memory = "0.5"
+
+    ports {
+      port     = 80
+      protocol = "TCP"
+    }
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (ContainerGroupResource) ccePolicyConfidential(data acceptance.TestData, ccePolicy string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_container_group" "test" {
+  name                = "acctestcontainergroup-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  ip_address_type     = "Public"
+  os_type             = "Linux"
+  sku                 = "Confidential"
+  cce_policy          = "%s"
+
+  container {
+    name   = "hw"
+    image  = "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
+    cpu    = "0.5"
+    memory = "0.5"
+
+    ports {
+      port     = 80
+      protocol = "TCP"
+    }
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, ccePolicy)
+}

--- a/website/docs/r/container_group.html.markdown
+++ b/website/docs/r/container_group.html.markdown
@@ -103,6 +103,8 @@ The following arguments are supported:
 
 * `image_registry_credential` - (Optional) An `image_registry_credential` block as documented below. Changing this forces a new resource to be created.
 
+* `cce_policy` - (Optional) The base64-encoded Confidential Compute Enforcement (CCE) policy for the Container Group. When `sku` is set to `Confidential` and this is not specified, Azure will generate a default allow-all policy. Changing this forces a new resource to be created.
+
 * `priority` - (Optional) The priority of the Container Group. Possible values are `Regular` and `Spot`. Changing this forces a new resource to be created.
 
 ~> **Note:** When `priority` is set to `Spot`, the `ip_address_type` has to be `None`.


### PR DESCRIPTION

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR adds the Optional parameter "cce_policy" in the azurerm_container_group resource, allowing a custom ccePolicy on the resource when the "Confidential" sku is used.


## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [X] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [X] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [X] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [X] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [X] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [X] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

Tests have been executed locally on the new test case, on the francecentral  location only.
I did not re-execute all the tests in the containers service, it would have exceeded my quota for this change.

Traces:
` go test -timeout 60m   -run ^TestAccContainerGroup_ccePolicyConfidential$   github.com/hashicorp/terraform-provider-azurerm/internal/services/containers   -v
=== RUN   TestAccContainerGroup_ccePolicyConfidential
=== PAUSE TestAccContainerGroup_ccePolicyConfidential
=== CONT  TestAccContainerGroup_ccePolicyConfidential
--- PASS: TestAccContainerGroup_ccePolicyConfidential (132.27s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/containers    132.299s`

`go test -timeout 60m   -run ^TestAccContainerGroup_ccePolicyConfidentialDefault$   github.com/hashicorp/terraform-provider-azurerm/internal/services/containers   -v
=== RUN   TestAccContainerGroup_ccePolicyConfidentialDefault
=== PAUSE TestAccContainerGroup_ccePolicyConfidentialDefault
=== CONT  TestAccContainerGroup_ccePolicyConfidentialDefault
--- PASS: TestAccContainerGroup_ccePolicyConfidentialDefault (134.69s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/containers    134.725s`

## Change Log


* `azurerm_container_group` - support for the `cce_policy` property


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [X] Enhancement
- [ ] Breaking Change


## Related Issue(s)

No related issue found (looked for "cce", no match).


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [X] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

AI was used to quickly find the appropriate portion of the code to update, and review the changes. 

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
