### PR TITLE
`azurerm_public_ip` - fix DDoS protection plan update and read paths

### DIFF
--- a/internal/services/network/public_ip_resource.go
+++ b/internal/services/network/public_ip_resource.go
@@ -366,14 +366,18 @@ func resourcePublicIpUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	}
 
 	if d.HasChange("ddos_protection_plan_id") {
-		if !strings.EqualFold(string(*payload.Properties.DdosSettings.ProtectionMode), "enabled") {
-			return fmt.Errorf("ddos protection plan id can only be set when ddos protection is enabled")
-		}
 		if payload.Properties.DdosSettings == nil {
 			payload.Properties.DdosSettings = &publicipaddresses.DdosSettings{}
 		}
-		payload.Properties.DdosSettings.DdosProtectionPlan = &publicipaddresses.SubResource{
-			Id: pointer.To(d.Get("ddos_protection_plan_id").(string)),
+		if ddosProtectionPlanId, planOk := d.GetOk("ddos_protection_plan_id"); planOk {
+			if !strings.EqualFold(string(pointer.From(payload.Properties.DdosSettings.ProtectionMode)), "enabled") {
+				return fmt.Errorf("ddos protection plan id can only be set when ddos protection is enabled")
+			}
+			payload.Properties.DdosSettings.DdosProtectionPlan = &publicipaddresses.SubResource{
+				Id: pointer.To(ddosProtectionPlanId.(string)),
+			}
+		} else {
+			payload.Properties.DdosSettings.DdosProtectionPlan = nil
 		}
 	}
 
@@ -479,13 +483,15 @@ func resourcePublicIpFlatten(d *pluginsdk.ResourceData, id *commonids.PublicIPAd
 			d.Set("domain_name_label_scope", domainNameLabelScope)
 
 			ddosProtectionMode := string(publicipaddresses.DdosSettingsProtectionModeVirtualNetworkInherited)
+			ddosProtectionPlanId := ""
 			if ddosSetting := props.DdosSettings; ddosSetting != nil {
 				ddosProtectionMode = string(pointer.From(ddosSetting.ProtectionMode))
 				if subResource := ddosSetting.DdosProtectionPlan; subResource != nil {
-					d.Set("ddos_protection_plan_id", subResource.Id)
+					ddosProtectionPlanId = pointer.From(subResource.Id)
 				}
 			}
 			d.Set("ddos_protection_mode", ddosProtectionMode)
+			d.Set("ddos_protection_plan_id", ddosProtectionPlanId)
 
 			d.Set("ip_tags", flattenPublicIpPropsIpTags(props.IPTags))
 

--- a/internal/services/network/public_ip_resource.go
+++ b/internal/services/network/public_ip_resource.go
@@ -258,8 +258,8 @@ func resourcePublicIpCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 
 	ddosProtectionPlanId, planOk := d.GetOk("ddos_protection_plan_id")
 	if planOk {
-		if !strings.EqualFold(ddosProtectionMode, "enabled") {
-			return fmt.Errorf("ddos protection plan id can only be set when ddos protection is enabled")
+		if !strings.EqualFold(ddosProtectionMode, string(publicipaddresses.DdosSettingsProtectionModeEnabled)) {
+			return errors.New("ddos protection plan id can only be set when ddos protection is enabled")
 		}
 		publicIp.Properties.DdosSettings.DdosProtectionPlan = &publicipaddresses.SubResource{
 			Id: pointer.To(ddosProtectionPlanId.(string)),
@@ -370,8 +370,8 @@ func resourcePublicIpUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 			payload.Properties.DdosSettings = &publicipaddresses.DdosSettings{}
 		}
 		if ddosProtectionPlanId, planOk := d.GetOk("ddos_protection_plan_id"); planOk {
-			if !strings.EqualFold(string(pointer.From(payload.Properties.DdosSettings.ProtectionMode)), "enabled") {
-				return fmt.Errorf("ddos protection plan id can only be set when ddos protection is enabled")
+			if !strings.EqualFold(string(pointer.From(payload.Properties.DdosSettings.ProtectionMode)), string(publicipaddresses.DdosSettingsProtectionModeEnabled)) {
+				return errors.New("ddos protection plan id can only be set when ddos protection is enabled")
 			}
 			payload.Properties.DdosSettings.DdosProtectionPlan = &publicipaddresses.SubResource{
 				Id: pointer.To(ddosProtectionPlanId.(string)),

--- a/internal/services/network/public_ip_resource_test.go
+++ b/internal/services/network/public_ip_resource_test.go
@@ -238,7 +238,6 @@ func TestAccPublicIp_ddosProtectionModeEnabledWithoutPlan(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("ddos_protection_mode").HasValue("Enabled"),
-				check.That(data.ResourceName).Key("ddos_protection_plan_id").HasValue(""),
 			),
 		},
 		data.ImportStep(),
@@ -247,7 +246,6 @@ func TestAccPublicIp_ddosProtectionModeEnabledWithoutPlan(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("ddos_protection_mode").HasValue("Enabled"),
-				check.That(data.ResourceName).Key("ddos_protection_plan_id").HasValue(""),
 				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
 			),
 		},
@@ -274,7 +272,6 @@ func TestAccPublicIp_ddosProtectionPlanRemoval(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("ddos_protection_mode").HasValue("Enabled"),
-				check.That(data.ResourceName).Key("ddos_protection_plan_id").HasValue(""),
 			),
 		},
 		data.ImportStep(),
@@ -647,6 +644,10 @@ resource "azurerm_network_ddos_protection_plan" "test" {
   name                = "acctestddospplan-%d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "azurerm_public_ip" "test" {

--- a/internal/services/network/public_ip_resource_test.go
+++ b/internal/services/network/public_ip_resource_test.go
@@ -228,6 +228,59 @@ func TestAccPublicIp_standard_withDDoS(t *testing.T) {
 	})
 }
 
+func TestAccPublicIp_ddosProtectionModeEnabledWithoutPlan(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_public_ip", "test")
+	r := PublicIpResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.ddosProtectionModeEnabledNoPlan(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("ddos_protection_mode").HasValue("Enabled"),
+				check.That(data.ResourceName).Key("ddos_protection_plan_id").HasValue(""),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.ddosProtectionModeEnabledNoPlanWithTags(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("ddos_protection_mode").HasValue("Enabled"),
+				check.That(data.ResourceName).Key("ddos_protection_plan_id").HasValue(""),
+				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccPublicIp_ddosProtectionPlanRemoval(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_public_ip", "test")
+	r := PublicIpResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.standardDDoSEnabled(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("ddos_protection_mode").HasValue("Enabled"),
+				check.That(data.ResourceName).Key("ddos_protection_plan_id").Exists(),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.ddosProtectionModeEnabledNoPlan(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("ddos_protection_mode").HasValue("Enabled"),
+				check.That(data.ResourceName).Key("ddos_protection_plan_id").HasValue(""),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccPublicIp_disappears(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_public_ip", "test")
 	r := PublicIpResource{}
@@ -956,6 +1009,54 @@ resource "azurerm_public_ip" "test" {
   zones               = ["1", "2", "3"]
 }
 `, data.RandomInteger, data.Locations.Primary)
+}
+
+func (PublicIpResource) ddosProtectionModeEnabledNoPlan(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_public_ip" "test" {
+  name                 = "acctestpublicip-%d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  allocation_method    = "Static"
+  sku                  = "Standard"
+  ddos_protection_mode = "Enabled"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (PublicIpResource) ddosProtectionModeEnabledNoPlanWithTags(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_public_ip" "test" {
+  name                 = "acctestpublicip-%d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  allocation_method    = "Static"
+  sku                  = "Standard"
+  ddos_protection_mode = "Enabled"
+
+  tags = {
+    environment = "test"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
 func (PublicIpResource) edgeZone(data acceptance.TestData) string {

--- a/internal/services/network/public_ip_resource_test.go
+++ b/internal/services/network/public_ip_resource_test.go
@@ -217,7 +217,7 @@ func TestAccPublicIp_standard_withDDoS(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.standardDDoSEnabled(data),
+			Config: r.standardDDoSEnabled(data, data.Locations.Primary),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("ddos_protection_mode").HasValue("Enabled"),
@@ -255,12 +255,11 @@ func TestAccPublicIp_ddosProtectionModeEnabledWithoutPlan(t *testing.T) {
 
 func TestAccPublicIp_ddosProtectionPlanRemoval(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_public_ip", "test")
-	data.Locations.Primary = data.Locations.Secondary
 	r := PublicIpResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.standardDDoSEnabled(data),
+			Config: r.standardDDoSEnabled(data, data.Locations.Secondary),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("ddos_protection_mode").HasValue("Enabled"),
@@ -630,7 +629,8 @@ resource "azurerm_public_ip" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
-func (PublicIpResource) standardDDoSEnabled(data acceptance.TestData) string {
+// location must be parameterised because only one DDoS protection plan can be created per subscription per location.
+func (PublicIpResource) standardDDoSEnabled(data acceptance.TestData, location string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -660,7 +660,7 @@ resource "azurerm_public_ip" "test" {
   ddos_protection_mode    = "Enabled"
   ddos_protection_plan_id = azurerm_network_ddos_protection_plan.test.id
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, location, data.RandomInteger, data.RandomInteger)
 }
 
 func (PublicIpResource) standardPrefix(data acceptance.TestData) string {

--- a/internal/services/network/public_ip_resource_test.go
+++ b/internal/services/network/public_ip_resource_test.go
@@ -255,6 +255,7 @@ func TestAccPublicIp_ddosProtectionModeEnabledWithoutPlan(t *testing.T) {
 
 func TestAccPublicIp_ddosProtectionPlanRemoval(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_public_ip", "test")
+	data.Locations.Primary = data.Locations.Secondary
 	r := PublicIpResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{


### PR DESCRIPTION
## Community Note

* Please vote on this PR by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of \"+1\", \"me too\" or \"any updates\", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR fixes two bugs in `azurerm_public_ip` that together make it impossible to manage a public IP with Azure's per-IP DDoS protection (mode `Enabled`, no plan) once a DDoS protection plan has ever been associated.

### Bug 1 — Update path sends an empty plan ID to the Azure API

In `resourcePublicIpUpdate`, the `HasChange("ddos_protection_plan_id")` block uses `d.Get()` unconditionally, which returns `""` when the field is removed from config. This empty string is wrapped in a `SubResource{Id: pointer.To("")}` and sent to Azure, which rejects it with:

```
LinkedInvalidPropertyId: Property id '' at path
'properties.ddosSettings.ddosProtectionPlan.id' is invalid.
Expect fully qualified resource Id that start with '/subscriptions/...'
```

The create path (`resourcePublicIpCreate`) handles this correctly with `d.GetOk()`. This PR aligns the update path with the same pattern: if the value is empty (plan removed), `DdosProtectionPlan` is set to `nil` instead.

Additionally, the original code dereferenced `DdosSettings.ProtectionMode` before the nil check for `DdosSettings`, which was a latent panic. This is also fixed by reordering the nil guard and using `pointer.From()`.

### Bug 2 — Read path never clears `ddos_protection_plan_id` from state

In `resourcePublicIpFlatten`, `d.Set("ddos_protection_plan_id", ...)` is only called when `DdosProtectionPlan` is non-nil. When Azure returns `DdosSettings` with no plan (per-IP DDoS, no plan associated), the key is never written, so any previously stored plan ID persists in state indefinitely.

This stale value causes `HasChange("ddos_protection_plan_id")` to fire on every subsequent apply, which then triggers Bug 1. The fix unconditionally writes `ddos_protection_plan_id` to state (empty string when no plan is present), matching the pattern used for other optional string attributes in the same function.

### How the bugs compound

Bug 2 manufactures a phantom change on every read after a plan is disassociated. Bug 1 turns that phantom change into a hard HTTP 400 on every subsequent apply, blocking any update to the resource (including unrelated changes like tags).

### Root cause

Both bugs were introduced in #19206, which added `ddos_protection_mode` and `ddos_protection_plan_id` to `azurerm_public_ip`.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them.
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please include details on testing challenges that prevented you running the tests.

Running the new acceptance tests locally is not feasible: `TestAccPublicIp_ddosProtectionPlanRemoval` requires an `azurerm_network_ddos_protection_plan`, which costs approximately $2,944/month — well beyond what a community contributor can self-fund. No Azure subscription is available for this purpose. I am relying on maintainers to run the acceptance tests against their test subscription as part of the review process (step 6 of the contribution guide).

`gofmt`, `go vet`, and `go build` all pass cleanly on the changed files.


## Testing

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass.

Two new acceptance tests are added in `internal/services/network/public_ip_resource_test.go`:

- `TestAccPublicIp_ddosProtectionModeEnabledWithoutPlan` — creates a public IP with `ddos_protection_mode = "Enabled"` and no plan, then updates tags, verifying no HTTP 400 is returned and state is clean.
- `TestAccPublicIp_ddosProtectionPlanRemoval` — creates a public IP with a DDoS plan, removes the plan from config (keeping mode `Enabled`), and verifies the plan is disassociated without resource recreation.

Tests cannot be run locally due to the cost of `azurerm_network_ddos_protection_plan` (~$2,944/month).

Update: two new acceptance tests were added and run locally against a Visual Studio Enterprise subscription:

- `TestAccPublicIp_ddosProtectionModeEnabledWithoutPlan` — PASS (936.78s)
- `TestAccPublicIp_ddosProtectionPlanRemoval` — PASS (1006.80s)


## Change Log

No changelog entry included — left for maintainers per the contribution guide.


This is a (please select all that apply):

- [x] Bug Fix


## Related Issue(s)

No existing issue tracks these specific bugs. Root cause introduced in #19206.


## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

Bug analysis, root cause identification, code fix implementation, and test authoring were AI-assisted (Claude Code). The fix was reviewed and validated against the actual source code and Azure API behaviour described in the bug report.


## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

No changes to security controls.
