### PR TITLE
azurerm_storage_account - support for the geo_priority_replication_en…

### DIFF
--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -710,6 +710,12 @@ func resourceStorageAccount() *pluginsdk.Resource {
 				Default:  false,
 			},
 
+			"geo_priority_replication_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
 			"large_file_share_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
@@ -1178,6 +1184,14 @@ func resourceStorageAccount() *pluginsdk.Resource {
 					keys := sortedKeysFromSlice(storageKindsSupportHns)
 					return fmt.Errorf("`is_hns_enabled` can only be used for accounts with `account_kind` set to one of: %+v", strings.Join(keys, " / "))
 				}
+
+				if d.Get("geo_priority_replication_enabled").(bool) {
+					replicationType := strings.ToUpper(d.Get("account_replication_type").(string))
+					if replicationType != "GRS" && replicationType != "GZRS" {
+						return fmt.Errorf("`geo_priority_replication_enabled` can only be used when `account_replication_type` is `GRS` or `GZRS`")
+					}
+				}
+
 				return nil
 			}),
 			pluginsdk.ForceNewIfChange("account_replication_type", func(ctx context.Context, old, new, meta interface{}) bool {
@@ -1441,10 +1455,13 @@ func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 			IsHnsEnabled:                 pointer.To(isHnsEnabled),
 			IsLocalUserEnabled:           pointer.To(d.Get("local_user_enabled").(bool)),
 			IsSftpEnabled:                pointer.To(d.Get("sftp_enabled").(bool)),
-			MinimumTlsVersion:            pointer.To(storageaccounts.MinimumTlsVersion(d.Get("min_tls_version").(string))),
-			NetworkAcls:                  expandAccountNetworkRules(d.Get("network_rules").([]interface{}), tenantId),
-			PublicNetworkAccess:          pointer.To(publicNetworkAccess),
-			SasPolicy:                    expandAccountSASPolicy(d.Get("sas_policy").([]interface{})),
+			GeoPriorityReplicationStatus: &storageaccounts.GeoPriorityReplicationStatus{
+				IsBlobEnabled: pointer.To(d.Get("geo_priority_replication_enabled").(bool)),
+			},
+			MinimumTlsVersion:   pointer.To(storageaccounts.MinimumTlsVersion(d.Get("min_tls_version").(string))),
+			NetworkAcls:         expandAccountNetworkRules(d.Get("network_rules").([]interface{}), tenantId),
+			PublicNetworkAccess: pointer.To(publicNetworkAccess),
+			SasPolicy:           expandAccountSASPolicy(d.Get("sas_policy").([]interface{})),
 		},
 		Sku: storageaccounts.Sku{
 			Name: storageaccounts.SkuName(fmt.Sprintf("%s%s_%s", string(accountTier), provisionedBillingModelVersion, replicationType)),
@@ -1775,6 +1792,7 @@ func resourceStorageAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 		IsNfsV3Enabled:                        existing.Model.Properties.IsNfsV3Enabled,
 		IsSftpEnabled:                         existing.Model.Properties.IsSftpEnabled,
 		IsLocalUserEnabled:                    existing.Model.Properties.IsLocalUserEnabled,
+		GeoPriorityReplicationStatus:          existing.Model.Properties.GeoPriorityReplicationStatus,
 		IsHnsEnabled:                          existing.Model.Properties.IsHnsEnabled,
 		MinimumTlsVersion:                     existing.Model.Properties.MinimumTlsVersion,
 		NetworkAcls:                           existing.Model.Properties.NetworkAcls,
@@ -1890,6 +1908,11 @@ func resourceStorageAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 	}
 	if d.HasChange("sftp_enabled") {
 		props.IsSftpEnabled = pointer.To(d.Get("sftp_enabled").(bool))
+	}
+	if d.HasChange("geo_priority_replication_enabled") {
+		props.GeoPriorityReplicationStatus = &storageaccounts.GeoPriorityReplicationStatus{
+			IsBlobEnabled: pointer.To(d.Get("geo_priority_replication_enabled").(bool)),
+		}
 	}
 	if d.HasChange("immutability_policy") {
 		props.ImmutableStorageWithVersioning = expandAccountImmutabilityPolicy(d.Get("immutability_policy").([]interface{}))
@@ -2195,6 +2218,12 @@ func resourceStorageAccountFlatten(ctx context.Context, d *pluginsdk.ResourceDat
 		}
 		d.Set("secondary_location", pointer.From(props.SecondaryLocation))
 		d.Set("sftp_enabled", pointer.From(props.IsSftpEnabled))
+
+		geoPriorityReplicationEnabled := false
+		if props.GeoPriorityReplicationStatus != nil {
+			geoPriorityReplicationEnabled = pointer.From(props.GeoPriorityReplicationStatus.IsBlobEnabled)
+		}
+		d.Set("geo_priority_replication_enabled", geoPriorityReplicationEnabled)
 
 		// NOTE: The Storage API returns `null` rather than the default value in the API response for existing
 		// resources when a new field gets added - meaning we need to default the values below.

--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -5653,3 +5653,85 @@ resource "azurerm_storage_account" "test" {
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
+
+func TestAccStorageAccount_geoPriorityReplication(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
+	r := StorageAccountResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.geoPriorityReplication(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("geo_priority_replication_enabled").HasValue("true"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.geoPriorityReplication(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("geo_priority_replication_enabled").HasValue("false"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccStorageAccount_geoPriorityReplicationInvalidReplicationType(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
+	r := StorageAccountResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:      r.geoPriorityReplicationInvalidReplicationType(data),
+			ExpectError: regexp.MustCompile("`geo_priority_replication_enabled` can only be used when `account_replication_type` is `GRS` or `GZRS`"),
+		},
+	})
+}
+
+func (r StorageAccountResource) geoPriorityReplication(data acceptance.TestData, enabled bool) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-storage-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                = "unlikely23exst2acct%s"
+  resource_group_name = azurerm_resource_group.test.name
+
+  location                         = azurerm_resource_group.test.location
+  account_tier                     = "Standard"
+  account_replication_type         = "GRS"
+  geo_priority_replication_enabled = %t
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, enabled)
+}
+
+func (r StorageAccountResource) geoPriorityReplicationInvalidReplicationType(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-storage-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                = "unlikely23exst2acct%s"
+  resource_group_name = azurerm_resource_group.test.name
+
+  location                         = azurerm_resource_group.test.location
+  account_tier                     = "Standard"
+  account_replication_type         = "LRS"
+  geo_priority_replication_enabled = true
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -102,6 +102,10 @@ The following arguments are supported:
 
 * `edge_zone` - (Optional) Specifies the Edge Zone within the Azure Region where this Storage Account should exist. Changing this forces a new Storage Account to be created.
 
+* `geo_priority_replication_enabled` - (Optional) Is Geo Priority Replication enabled for this Storage Account? Defaults to `false`.
+
+~> **Note:** `geo_priority_replication_enabled` can only be set to `true` when `account_replication_type` is `GRS` or `GZRS`.
+
 * `https_traffic_only_enabled` - (Optional) Boolean flag which forces HTTPS if enabled, see [here](https://docs.microsoft.com/azure/storage/storage-require-secure-transfer/) for more information. Defaults to `true`.
 
 * `min_tls_version` - (Optional) The minimum supported TLS version for the storage account. Possible values are `TLS1_0`, `TLS1_1` and `TLS1_2`. Defaults to `TLS1_2` for new storage accounts.


### PR DESCRIPTION
## Community Note
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR adds support for the `geo_priority_replication_enabled` property to the `azurerm_storage_account` resource, resolving #32143.

The new boolean argument maps to the `geoPriorityReplicationStatus.isBlobEnabled` field in the Azure Storage API ([2025-06-01](cci:9://file:///Users/jhern/Git/Terraform/terraform-provider-azurerm/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2025-06-01:0:0-0:0)) and enables Geo Priority Replication for blob data on GRS and GZRS storage accounts. When enabled, blob data is replicated with higher priority to the secondary region.

The property is restricted to `account_replication_type` values of `GRS` or `GZRS` and is enforced at plan time via `CustomizeDiff`.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Testing

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass.

Two acceptance tests were added and run successfully locally:

```
--- PASS: TestAccStorageAccount_geoPriorityReplicationInvalidReplicationType (12.38s)
--- PASS: TestAccStorageAccount_geoPriorityReplication (215.49s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       217.647s
```

- [TestAccStorageAccount_geoPriorityReplication](cci:1://file:///Users/jhern/Git/Terraform/terraform-provider-azurerm/internal/services/storage/storage_account_resource_test.go:5656:0-5678:1) — creates a GRS storage account with `geo_priority_replication_enabled = true`, imports state, updates to `false`, and imports again.
- [TestAccStorageAccount_geoPriorityReplicationInvalidReplicationType](cci:1://file:///Users/jhern/Git/Terraform/terraform-provider-azurerm/internal/services/storage/storage_account_resource_test.go:5680:0-5690:1) — verifies a plan-time error is returned when `geo_priority_replication_enabled = true` is used with a non-GRS/GZRS replication type (`LRS`).

<img width="3024" height="1190" alt="image" src="https://github.com/user-attachments/assets/24763273-7c6e-4c9a-b07e-14cdda055b07" />

## Change Log

* `azurerm_storage_account` - support for the `geo_priority_replication_enabled` property [GH-32143]


This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #32143


## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

Code generation, schema/CRUD implementation and documentation update


## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

No changes to security controls. This PR only exposes an existing Azure Storage API property (`geoPriorityReplicationStatus`) as a configurable Terraform argument.