### PR TITLE
`data.azurerm_storage_account_sas`/`data.azurerm_storage_account_blob_container_sas` - expand `permissions` block to include new fields 

### DIFF
--- a/internal/services/storage/storage_account_blob_container_sas_data_source.go
+++ b/internal/services/storage/storage_account_blob_container_sas_data_source.go
@@ -69,32 +69,72 @@ func dataSourceStorageAccountBlobContainerSharedAccessSignature() *pluginsdk.Res
 					Schema: map[string]*pluginsdk.Schema{
 						"read": {
 							Type:     pluginsdk.TypeBool,
-							Required: true,
+							Optional: true,
 						},
 
 						"add": {
 							Type:     pluginsdk.TypeBool,
-							Required: true,
+							Optional: true,
 						},
 
 						"create": {
 							Type:     pluginsdk.TypeBool,
-							Required: true,
+							Optional: true,
 						},
 
 						"write": {
 							Type:     pluginsdk.TypeBool,
-							Required: true,
+							Optional: true,
 						},
 
 						"delete": {
 							Type:     pluginsdk.TypeBool,
-							Required: true,
+							Optional: true,
+						},
+
+						"delete_version": {
+							Type:     pluginsdk.TypeBool,
+							Optional: true,
 						},
 
 						"list": {
 							Type:     pluginsdk.TypeBool,
-							Required: true,
+							Optional: true,
+						},
+
+						"tags": {
+							Type:     pluginsdk.TypeBool,
+							Optional: true,
+						},
+
+						"find": {
+							Type:     pluginsdk.TypeBool,
+							Optional: true,
+						},
+
+						"move": {
+							Type:     pluginsdk.TypeBool,
+							Optional: true,
+						},
+
+						"execute": {
+							Type:     pluginsdk.TypeBool,
+							Optional: true,
+						},
+
+						"ownership": {
+							Type:     pluginsdk.TypeBool,
+							Optional: true,
+						},
+
+						"permissions": {
+							Type:     pluginsdk.TypeBool,
+							Optional: true,
+						},
+
+						"set_immutability_policy": {
+							Type:     pluginsdk.TypeBool,
+							Optional: true,
 						},
 					},
 				},
@@ -184,30 +224,32 @@ func dataSourceStorageContainerSasRead(d *pluginsdk.ResourceData, _ interface{})
 }
 
 func BuildContainerPermissionsString(perms map[string]interface{}) string {
+	orderedPermissions := []struct {
+		name   string
+		letter string
+	}{
+		{"read", "r"},
+		{"add", "a"},
+		{"create", "c"},
+		{"write", "w"},
+		{"delete", "d"},
+		{"delete_version", "x"},
+		{"list", "l"},
+		{"tags", "t"},
+		{"find", "f"},
+		{"move", "m"},
+		{"execute", "e"},
+		{"ownership", "o"},
+		{"permissions", "p"},
+		{"set_immutability_policy", "i"},
+	}
+
 	retVal := ""
 
-	if val, pres := perms["read"].(bool); pres && val {
-		retVal += "r"
-	}
-
-	if val, pres := perms["add"].(bool); pres && val {
-		retVal += "a"
-	}
-
-	if val, pres := perms["create"].(bool); pres && val {
-		retVal += "c"
-	}
-
-	if val, pres := perms["write"].(bool); pres && val {
-		retVal += "w"
-	}
-
-	if val, pres := perms["delete"].(bool); pres && val {
-		retVal += "d"
-	}
-
-	if val, pres := perms["list"].(bool); pres && val {
-		retVal += "l"
+	for _, perm := range orderedPermissions {
+		if val, pres := perms[perm.name].(bool); pres && val {
+			retVal += perm.letter
+		}
 	}
 
 	return retVal

--- a/internal/services/storage/storage_account_blob_container_sas_data_source.go
+++ b/internal/services/storage/storage_account_blob_container_sas_data_source.go
@@ -63,7 +63,7 @@ func dataSourceStorageAccountBlobContainerSharedAccessSignature() *pluginsdk.Res
 
 			"permissions": {
 				Type:     pluginsdk.TypeList,
-				Required: true,
+				Optional: true,
 				MaxItems: 1,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
@@ -190,7 +190,10 @@ func dataSourceStorageContainerSasRead(d *pluginsdk.ResourceData, _ interface{})
 	contentLanguage := d.Get("content_language").(string)
 	contentType := d.Get("content_type").(string)
 
-	permissions := BuildContainerPermissionsString(permissionsIface[0].(map[string]interface{}))
+	permissions := ""
+	if len(permissionsIface) > 0 && permissionsIface[0] != nil {
+		permissions = BuildContainerPermissionsString(permissionsIface[0].(map[string]interface{}))
+	}
 
 	// Parse the connection string
 	kvp, err := storage.ParseAccountSASConnectionString(connString)

--- a/internal/services/storage/storage_account_blob_container_sas_data_source_test.go
+++ b/internal/services/storage/storage_account_blob_container_sas_data_source_test.go
@@ -35,7 +35,55 @@ func TestAccDataSourceStorageAccountBlobContainerSas_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("permissions.0.create").HasValue("false"),
 				check.That(data.ResourceName).Key("permissions.0.write").HasValue("false"),
 				check.That(data.ResourceName).Key("permissions.0.delete").HasValue("true"),
+				check.That(data.ResourceName).Key("permissions.0.delete_version").HasValue("true"),
 				check.That(data.ResourceName).Key("permissions.0.list").HasValue("true"),
+				check.That(data.ResourceName).Key("permissions.0.tags").HasValue("true"),
+				check.That(data.ResourceName).Key("permissions.0.find").HasValue("true"),
+				check.That(data.ResourceName).Key("permissions.0.move").HasValue("false"),
+				check.That(data.ResourceName).Key("permissions.0.execute").HasValue("false"),
+				check.That(data.ResourceName).Key("permissions.0.ownership").HasValue("true"),
+				check.That(data.ResourceName).Key("permissions.0.permissions").HasValue("true"),
+				check.That(data.ResourceName).Key("permissions.0.set_immutability_policy").HasValue("true"),
+				check.That(data.ResourceName).Key("cache_control").HasValue("max-age=5"),
+				check.That(data.ResourceName).Key("content_disposition").HasValue("inline"),
+				check.That(data.ResourceName).Key("content_encoding").HasValue("deflate"),
+				check.That(data.ResourceName).Key("content_language").HasValue("en-US"),
+				check.That(data.ResourceName).Key("content_type").HasValue("application/json"),
+				check.That(data.ResourceName).Key("sas").Exists(),
+			),
+		},
+	})
+}
+
+func TestAccDataSourceStorageAccountBlobContainerSas_partial(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_storage_account_blob_container_sas", "test")
+	utcNow := time.Now().UTC()
+	startDate := utcNow.Format(time.RFC3339)
+	endDate := utcNow.Add(time.Hour * 24).Format(time.RFC3339)
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: StorageAccountBlobContainerSASDataSource{}.partial(data, startDate, endDate),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("https_only").HasValue("true"),
+				check.That(data.ResourceName).Key("start").HasValue(startDate),
+				check.That(data.ResourceName).Key("expiry").HasValue(endDate),
+				check.That(data.ResourceName).Key("ip_address").HasValue("168.1.5.65"),
+				check.That(data.ResourceName).Key("permissions.#").HasValue("1"),
+				check.That(data.ResourceName).Key("permissions.0.read").HasValue("true"),
+				check.That(data.ResourceName).Key("permissions.0.add").HasValue("true"),
+				check.That(data.ResourceName).Key("permissions.0.create").HasValue("false"),
+				check.That(data.ResourceName).Key("permissions.0.write").HasValue("false"),
+				check.That(data.ResourceName).Key("permissions.0.delete").HasValue("true"),
+				check.That(data.ResourceName).Key("permissions.0.delete_version").HasValue("false"),
+				check.That(data.ResourceName).Key("permissions.0.list").HasValue("true"),
+				check.That(data.ResourceName).Key("permissions.0.tags").HasValue("false"),
+				check.That(data.ResourceName).Key("permissions.0.find").HasValue("false"),
+				check.That(data.ResourceName).Key("permissions.0.move").HasValue("false"),
+				check.That(data.ResourceName).Key("permissions.0.execute").HasValue("false"),
+				check.That(data.ResourceName).Key("permissions.0.ownership").HasValue("false"),
+				check.That(data.ResourceName).Key("permissions.0.permissions").HasValue("false"),
+				check.That(data.ResourceName).Key("permissions.0.set_immutability_policy").HasValue("false"),
 				check.That(data.ResourceName).Key("cache_control").HasValue("max-age=5"),
 				check.That(data.ResourceName).Key("content_disposition").HasValue("inline"),
 				check.That(data.ResourceName).Key("content_encoding").HasValue("deflate"),
@@ -84,12 +132,74 @@ data "azurerm_storage_account_blob_container_sas" "test" {
   expiry = "%s"
 
   permissions {
-    read   = true
-    add    = true
-    create = false
-    write  = false
-    delete = true
-    list   = true
+    read   				 					= true
+    add    				 					= true
+    create 				 					= false
+    write  				 					= false
+    delete 				 					= true
+		delete_version 					= true
+    list   									= true
+		tags   									= true
+		find   									= true
+		move   									= false
+		execute 								= false
+		ownership 							= true
+		permissions 						= true
+		set_immutability_policy = true
+  }
+
+  cache_control       = "max-age=5"
+  content_disposition = "inline"
+  content_encoding    = "deflate"
+  content_language    = "en-US"
+  content_type        = "application/json"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, startDate, endDate)
+}
+
+func (d StorageAccountBlobContainerSASDataSource) partial(data acceptance.TestData, startDate string, endDate string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "rg" {
+  name     = "acctestRG-storage-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "storage" {
+  name                = "acctestsads%s"
+  resource_group_name = azurerm_resource_group.rg.name
+
+  location                 = azurerm_resource_group.rg.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_container" "container" {
+  name                  = "sas-test"
+  storage_account_name  = azurerm_storage_account.storage.name
+  container_access_type = "private"
+}
+
+data "azurerm_storage_account_blob_container_sas" "test" {
+  connection_string = azurerm_storage_account.storage.primary_connection_string
+  container_name    = azurerm_storage_container.container.name
+  https_only        = true
+
+  ip_address = "168.1.5.65"
+
+  start  = "%s"
+  expiry = "%s"
+
+  permissions {
+    read   				 					= true
+    add    				 					= true
+    create 				 					= false
+    write  				 					= false
+    delete 				 					= true
+    list   									= true
   }
 
   cache_control       = "max-age=5"
@@ -113,6 +223,8 @@ func TestAccDataSourceStorageAccountBlobContainerSas_permissionsString(t *testin
 		{map[string]interface{}{"delete": true}, "d"},
 		{map[string]interface{}{"list": true}, "l"},
 		{map[string]interface{}{"add": true, "write": true, "read": true, "delete": true}, "rawd"},
+		{map[string]interface{}{"add": true, "write": false, "read": true, "delete": false}, "ra"},
+		{map[string]interface{}{"add": true, "write": true, "read": true, "delete": true, "delete_version": true, "list": true, "tags": true, "find": true, "move": true, "execute": true, "ownership": true, "permissions": true, "set_immutability_policy": true}, "rawdxltfmeopi"},
 	}
 
 	for _, test := range testCases {

--- a/internal/services/storage/storage_account_blob_container_sas_data_source_test.go
+++ b/internal/services/storage/storage_account_blob_container_sas_data_source_test.go
@@ -132,20 +132,20 @@ data "azurerm_storage_account_blob_container_sas" "test" {
   expiry = "%s"
 
   permissions {
-    read   				 					= true
-    add    				 					= true
-    create 				 					= false
-    write  				 					= false
-    delete 				 					= true
-		delete_version 					= true
-    list   									= true
-		tags   									= true
-		find   									= true
-		move   									= false
-		execute 								= false
-		ownership 							= true
-		permissions 						= true
-		set_immutability_policy = true
+    read                    = true
+    add                     = true
+    create                  = false
+    write                   = false
+    delete                  = true
+    delete_version          = true
+    list                    = true
+    tags                    = true
+    find                    = true
+    move                    = false
+    execute                 = false
+    ownership               = true
+    permissions             = true
+    set_immutability_policy = true
   }
 
   cache_control       = "max-age=5"
@@ -194,12 +194,12 @@ data "azurerm_storage_account_blob_container_sas" "test" {
   expiry = "%s"
 
   permissions {
-    read   				 					= true
-    add    				 					= true
-    create 				 					= false
-    write  				 					= false
-    delete 				 					= true
-    list   									= true
+    read   = true
+    add    = true
+    create = false
+    write  = false
+    delete = true
+    list   = true
   }
 
   cache_control       = "max-age=5"

--- a/internal/services/storage/storage_account_blob_container_sas_data_source_test.go
+++ b/internal/services/storage/storage_account_blob_container_sas_data_source_test.go
@@ -95,6 +95,21 @@ func TestAccDataSourceStorageAccountBlobContainerSas_partial(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceStorageAccountBlobContainerSas_noPermissions(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_storage_account_blob_container_sas", "test")
+	utcNow := time.Now().UTC()
+	startDate := utcNow.Format(time.RFC3339)
+	endDate := utcNow.Add(time.Hour * 24).Format(time.RFC3339)
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: StorageAccountBlobContainerSASDataSource{}.noPermissions(data, startDate, endDate),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("sas").Exists()),
+		},
+	})
+}
+
 func (d StorageAccountBlobContainerSASDataSource) basic(data acceptance.TestData, startDate string, endDate string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -201,6 +216,51 @@ data "azurerm_storage_account_blob_container_sas" "test" {
     delete = true
     list   = true
   }
+
+  cache_control       = "max-age=5"
+  content_disposition = "inline"
+  content_encoding    = "deflate"
+  content_language    = "en-US"
+  content_type        = "application/json"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, startDate, endDate)
+}
+
+func (d StorageAccountBlobContainerSASDataSource) noPermissions(data acceptance.TestData, startDate string, endDate string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "rg" {
+  name     = "acctestRG-storage-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "storage" {
+  name                = "acctestsads%s"
+  resource_group_name = azurerm_resource_group.rg.name
+
+  location                 = azurerm_resource_group.rg.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_container" "container" {
+  name                  = "sas-test"
+  storage_account_name  = azurerm_storage_account.storage.name
+  container_access_type = "private"
+}
+
+data "azurerm_storage_account_blob_container_sas" "test" {
+  connection_string = azurerm_storage_account.storage.primary_connection_string
+  container_name    = azurerm_storage_container.container.name
+  https_only        = true
+
+  ip_address = "168.1.5.65"
+
+  start  = "%s"
+  expiry = "%s"
 
   cache_control       = "max-age=5"
   content_disposition = "inline"

--- a/internal/services/storage/storage_account_sas_data_source.go
+++ b/internal/services/storage/storage_account_sas_data_source.go
@@ -133,52 +133,52 @@ func dataSourceStorageAccountSharedAccessSignature() *pluginsdk.Resource {
 					Schema: map[string]*pluginsdk.Schema{
 						"read": {
 							Type:     pluginsdk.TypeBool,
-							Required: true,
+							Optional: true,
 						},
 
 						"write": {
 							Type:     pluginsdk.TypeBool,
-							Required: true,
+							Optional: true,
 						},
 
 						"delete": {
 							Type:     pluginsdk.TypeBool,
-							Required: true,
+							Optional: true,
 						},
 
 						"list": {
 							Type:     pluginsdk.TypeBool,
-							Required: true,
+							Optional: true,
 						},
 
 						"add": {
 							Type:     pluginsdk.TypeBool,
-							Required: true,
+							Optional: true,
 						},
 
 						"create": {
 							Type:     pluginsdk.TypeBool,
-							Required: true,
+							Optional: true,
 						},
 
 						"update": {
 							Type:     pluginsdk.TypeBool,
-							Required: true,
+							Optional: true,
 						},
 
 						"process": {
 							Type:     pluginsdk.TypeBool,
-							Required: true,
+							Optional: true,
 						},
 
 						"tag": {
 							Type:     pluginsdk.TypeBool,
-							Required: true,
+							Optional: true,
 						},
 
 						"filter": {
 							Type:     pluginsdk.TypeBool,
-							Required: true,
+							Optional: true,
 						},
 					},
 				},

--- a/internal/services/storage/storage_account_sas_data_source.go
+++ b/internal/services/storage/storage_account_sas_data_source.go
@@ -127,7 +127,7 @@ func dataSourceStorageAccountSharedAccessSignature() *pluginsdk.Resource {
 
 			"permissions": {
 				Type:     pluginsdk.TypeList,
-				Required: true,
+				Optional: true,
 				MaxItems: 1,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
@@ -206,7 +206,11 @@ func dataSourceStorageAccountSasRead(d *pluginsdk.ResourceData, _ interface{}) e
 
 	resourceTypes := BuildResourceTypesString(resourceTypesIface[0].(map[string]interface{}))
 	services := BuildServicesString(servicesIface[0].(map[string]interface{}))
-	permissions := BuildPermissionsString(permissionsIface[0].(map[string]interface{}))
+
+	permissions := ""
+	if len(permissionsIface) > 0 && permissionsIface[0] != nil {
+		permissions = BuildContainerPermissionsString(permissionsIface[0].(map[string]interface{}))
+	}
 
 	// Parse the connection string
 	kvp, err := storage.ParseAccountSASConnectionString(connString)

--- a/internal/services/storage/storage_account_sas_data_source_test.go
+++ b/internal/services/storage/storage_account_sas_data_source_test.go
@@ -37,6 +37,23 @@ func TestAccDataSourceStorageAccountSas_basic(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceStorageAccountSas_noPermissions(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_storage_account_sas", "test")
+	ipAddresses := "10.0.0.1-10.0.0.4"
+	utcNow := time.Now().UTC()
+	startDate := utcNow.Format(time.RFC3339)
+	endDate := utcNow.Add(time.Hour * 24).Format(time.RFC3339)
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: StorageAccountSasDataSource{}.noPermissions(data, startDate, endDate, ipAddresses),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("sas").Exists(),
+			),
+		},
+	})
+}
+
 func (d StorageAccountSasDataSource) basic(data acceptance.TestData, startDate string, endDate string, ipAddresses string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -95,6 +112,55 @@ data "azurerm_storage_account_sas" "test" {
     tag     = false
     filter  = false
   }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, ipAddresses, startDate, endDate)
+}
+
+func (d StorageAccountSasDataSource) noPermissions(data acceptance.TestData, startDate string, endDate string, ipAddresses string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-storage-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                = "acctestsads%s"
+  resource_group_name = azurerm_resource_group.test.name
+
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  tags = {
+    environment = "production"
+  }
+}
+
+data "azurerm_storage_account_sas" "test" {
+  connection_string = azurerm_storage_account.test.primary_connection_string
+  https_only        = true
+  ip_addresses      = "%s"
+  signed_version    = "2019-10-10"
+
+  resource_types {
+    service   = true
+    container = false
+    object    = false
+  }
+
+  services {
+    blob  = true
+    queue = false
+    table = false
+    file  = false
+  }
+
+  start  = "%s"
+  expiry = "%s"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, ipAddresses, startDate, endDate)
 }

--- a/website/docs/d/storage_account_blob_container_sas.html.markdown
+++ b/website/docs/d/storage_account_blob_container_sas.html.markdown
@@ -98,17 +98,21 @@ output "sas_url_query_string" {
 
 A `permissions` block contains:
 
-* `read` - Should Read permissions be enabled for this SAS?
+* `read` - (Optional) Should Read permissions be enabled for this SAS?
+* `add` - (Optional) Should Add permissions be enabled for this SAS?
+* `create` - (Optional) Should Create permissions be enabled for this SAS?
+* `write` - (Optional) Should Write permissions be enabled for this SAS?
+* `delete` - (Optional) Should Delete permissions be enabled for this SAS?
+* `delete_version` - (Optional) Should Delete version permissions be enabled for this SAS?
+* `list` - (Optional) Should List permissions be enabled for this SAS?
+* `tags` - (Optional) Should Tags permissions be enabled for this SAS?
+* `find` - (Optional) Should Find permissions be enabled for this SAS?
+* `move` - (Optional) Should Move permissions be enabled for this SAS?
+* `execute` - (Optional) Should Execute permissions be enabled for this SAS?
+* `ownership` - (Optional) Should Ownership permissions be enabled for this SAS?
+* `permissions` - (Optional) Should Permissions permissions be enabled for this SAS?
+* `set_immutability_policy` - (Optional) Should Set Immutability Policy permissions be enabled for this SAS?
 
-* `add` - Should Add permissions be enabled for this SAS?
-
-* `create` - Should Create permissions be enabled for this SAS?
-
-* `write` - Should Write permissions be enabled for this SAS?
-
-* `delete` - Should Delete permissions be enabled for this SAS?
-
-* `list` - Should List permissions be enabled for this SAS?
 
 Refer to the [SAS creation reference from Azure](https://docs.microsoft.com/rest/api/storageservices/create-service-sas)
 for additional details on the fields above.

--- a/website/docs/d/storage_account_blob_container_sas.html.markdown
+++ b/website/docs/d/storage_account_blob_container_sas.html.markdown
@@ -68,21 +68,21 @@ output "sas_url_query_string" {
 
 ## Argument Reference
 
-* `connection_string` - The connection string for the storage account to which this SAS applies. Typically directly from the `primary_connection_string` attribute of a terraform created `azurerm_storage_account` resource.
+* `connection_string` - (Required) The connection string for the storage account to which this SAS applies. Typically directly from the `primary_connection_string` attribute of a terraform created `azurerm_storage_account` resource.
 
-* `container_name` - Name of the container.
+* `container_name` - (Required) Name of the container.
 
 * `https_only` - (Optional) Only permit `https` access. If `false`, both `http` and `https` are permitted. Defaults to `true`.
 
 * `ip_address` - (Optional) Single IPv4 address or range (connected with a dash) of IPv4 addresses.
 
-* `start` - The starting time and date of validity of this SAS. Must be a valid ISO-8601 format time/date string.
+* `start` - (Required) The starting time and date of validity of this SAS. Must be a valid ISO-8601 format time/date string.
 
-* `expiry` - The expiration time and date of this SAS. Must be a valid ISO-8601 format time/date string.
+* `expiry` - (Required) The expiration time and date of this SAS. Must be a valid ISO-8601 format time/date string.
 
 -> **NOTE:** The [ISO-8601 Time offset from UTC](https://en.wikipedia.org/wiki/ISO_8601#Time_offsets_from_UTC) is currently not supported by the service, which will result into 409 error.
 
-* `permissions` - A `permissions` block as defined below.
+* `permissions` - (Required) A `permissions` block as defined below.
 
 * `cache_control` - (Optional) The `Cache-Control` response header that is sent when this SAS token is used.
 
@@ -99,18 +99,31 @@ output "sas_url_query_string" {
 A `permissions` block contains:
 
 * `read` - (Optional) Should Read permissions be enabled for this SAS?
+
 * `add` - (Optional) Should Add permissions be enabled for this SAS?
+
 * `create` - (Optional) Should Create permissions be enabled for this SAS?
+
 * `write` - (Optional) Should Write permissions be enabled for this SAS?
+
 * `delete` - (Optional) Should Delete permissions be enabled for this SAS?
+
 * `delete_version` - (Optional) Should Delete version permissions be enabled for this SAS?
+
 * `list` - (Optional) Should List permissions be enabled for this SAS?
+
 * `tags` - (Optional) Should Tags permissions be enabled for this SAS?
+
 * `find` - (Optional) Should Find permissions be enabled for this SAS?
+
 * `move` - (Optional) Should Move permissions be enabled for this SAS?
+
 * `execute` - (Optional) Should Execute permissions be enabled for this SAS?
+
 * `ownership` - (Optional) Should Ownership permissions be enabled for this SAS?
+
 * `permissions` - (Optional) Should Permissions permissions be enabled for this SAS?
+
 * `set_immutability_policy` - (Optional) Should Set Immutability Policy permissions be enabled for this SAS?
 
 

--- a/website/docs/d/storage_account_blob_container_sas.html.markdown
+++ b/website/docs/d/storage_account_blob_container_sas.html.markdown
@@ -72,17 +72,11 @@ output "sas_url_query_string" {
 
 * `container_name` - (Required) Name of the container.
 
-* `https_only` - (Optional) Only permit `https` access. If `false`, both `http` and `https` are permitted. Defaults to `true`.
-
-* `ip_address` - (Optional) Single IPv4 address or range (connected with a dash) of IPv4 addresses.
-
 * `start` - (Required) The starting time and date of validity of this SAS. Must be a valid ISO-8601 format time/date string.
 
 * `expiry` - (Required) The expiration time and date of this SAS. Must be a valid ISO-8601 format time/date string.
 
--> **Note:** The [ISO-8601 Time offset from UTC](https://en.wikipedia.org/wiki/ISO_8601#Time_offsets_from_UTC) is currently not supported by the service, which will result into 409 error.
-
-* `permissions` - (Required) A `permissions` block as defined below.
+~> **Note:** The [ISO-8601 Time offset from UTC](https://en.wikipedia.org/wiki/ISO_8601#Time_offsets_from_UTC) is currently not supported by the service, which will result into 409 error.
 
 * `cache_control` - (Optional) The `Cache-Control` response header that is sent when this SAS token is used.
 
@@ -94,41 +88,45 @@ output "sas_url_query_string" {
 
 * `content_type` - (Optional) The `Content-Type` response header that is sent when this SAS token is used.
 
+* `https_only` - (Optional) Only permit `https` access. If `false`, both `http` and `https` are permitted. Defaults to `true`.
+
+* `ip_address` - (Optional) Single IPv4 address or range (connected with a dash) of IPv4 addresses.
+
+* `permissions` - (Optional) A `permissions` block as defined below.
+
 ---
 
 A `permissions` block contains:
-
-* `read` - (Optional) Should Read permissions be enabled for this SAS?
 
 * `add` - (Optional) Should Add permissions be enabled for this SAS?
 
 * `create` - (Optional) Should Create permissions be enabled for this SAS?
 
-* `write` - (Optional) Should Write permissions be enabled for this SAS?
-
 * `delete` - (Optional) Should Delete permissions be enabled for this SAS?
 
 * `delete_version` - (Optional) Should Delete version permissions be enabled for this SAS?
 
-* `list` - (Optional) Should List permissions be enabled for this SAS?
-
-* `tags` - (Optional) Should Tags permissions be enabled for this SAS?
+* `execute` - (Optional) Should Execute permissions be enabled for this SAS?
 
 * `find` - (Optional) Should Find permissions be enabled for this SAS?
 
-* `move` - (Optional) Should Move permissions be enabled for this SAS?
+* `list` - (Optional) Should List permissions be enabled for this SAS?
 
-* `execute` - (Optional) Should Execute permissions be enabled for this SAS?
+* `move` - (Optional) Should Move permissions be enabled for this SAS?
 
 * `ownership` - (Optional) Should Ownership permissions be enabled for this SAS?
 
 * `permissions` - (Optional) Should Permissions permissions be enabled for this SAS?
 
+* `read` - (Optional) Should Read permissions be enabled for this SAS?
+
 * `set_immutability_policy` - (Optional) Should Set Immutability Policy permissions be enabled for this SAS?
 
+* `tags` - (Optional) Should Tags permissions be enabled for this SAS?
 
-Refer to the [SAS creation reference from Azure](https://docs.microsoft.com/rest/api/storageservices/create-service-sas)
-for additional details on the fields above.
+* `write` - (Optional) Should Write permissions be enabled for this SAS?
+
+~> **Note:** Refer to the [SAS creation reference from Azure](https://docs.microsoft.com/rest/api/storageservices/create-service-sas) for additional details on the fields above.
 
 ## Attributes Reference
 

--- a/website/docs/d/storage_account_sas.html.markdown
+++ b/website/docs/d/storage_account_sas.html.markdown
@@ -118,16 +118,16 @@ A `services` block contains:
 
 A `permissions` block contains:
 
-* `read` - Should Read permissions be enabled for this SAS?
-* `write` - Should Write permissions be enabled for this SAS?
-* `delete` - Should Delete permissions be enabled for this SAS?
-* `list` - Should List permissions be enabled for this SAS?
-* `add` - Should Add permissions be enabled for this SAS?
-* `create` - Should Create permissions be enabled for this SAS?
-* `update` - Should Update permissions be enabled for this SAS?
-* `process` - Should Process permissions be enabled for this SAS?
-* `tag` - Should Get / Set Index Tags permissions be enabled for this SAS?
-* `filter` - Should Filter by Index Tags permissions be enabled for this SAS?
+* `read` - (Optional) Should Read permissions be enabled for this SAS?
+* `write` - (Optional) Should Write permissions be enabled for this SAS?
+* `delete` - (Optional) Should Delete permissions be enabled for this SAS?
+* `list` - (Optional) Should List permissions be enabled for this SAS?
+* `add` - (Optional) Should Add permissions be enabled for this SAS?
+* `create` - (Optional) Should Create permissions be enabled for this SAS?
+* `update` - (Optional) Should Update permissions be enabled for this SAS?
+* `process` - (Optional) Should Process permissions be enabled for this SAS?
+* `tag` - (Optional) Should Get / Set Index Tags permissions be enabled for this SAS?
+* `filter` - (Optional) Should Filter by Index Tags permissions be enabled for this SAS?
 
 Refer to the [SAS creation reference from Azure](https://docs.microsoft.com/rest/api/storageservices/constructing-an-account-sas)
 for additional details on the fields above.

--- a/website/docs/d/storage_account_sas.html.markdown
+++ b/website/docs/d/storage_account_sas.html.markdown
@@ -78,18 +78,25 @@ output "sas_url_query_string" {
 
 ## Argument Reference
 
-* `connection_string` - The connection string for the storage account to which this SAS applies. Typically directly from the `primary_connection_string` attribute of a terraform created `azurerm_storage_account` resource.
+* `connection_string` - (Required) The connection string for the storage account to which this SAS applies. Typically directly from the `primary_connection_string` attribute of a terraform created `azurerm_storage_account` resource.
+
 * `https_only` - (Optional) Only permit `https` access. If `false`, both `http` and `https` are permitted. Defaults to `true`.
+
 * `ip_addresses` - (Optional) IP address, or a range of IP addresses, from which to accept requests. When specifying a range, note that the range is inclusive.  
+
 * `signed_version` - (Optional) Specifies the signed storage service version to use to authorize requests made with this account SAS. Defaults to `2022-11-02`.
-* `resource_types` - A `resource_types` block as defined below.
-* `services` - A `services` block as defined below.
-* `start` - The starting time and date of validity of this SAS. Must be a valid ISO-8601 format time/date string.
-* `expiry` - The expiration time and date of this SAS. Must be a valid ISO-8601 format time/date string.
+
+* `resource_types` - (Required) A `resource_types` block as defined below.
+
+* `services` - (Required) A `services` block as defined below.
+
+* `start` - (Required) The starting time and date of validity of this SAS. Must be a valid ISO-8601 format time/date string.
+
+* `expiry` - (Required) The expiration time and date of this SAS. Must be a valid ISO-8601 format time/date string.
 
 -> **NOTE:** The [ISO-8601 Time offset from UTC](https://en.wikipedia.org/wiki/ISO_8601#Time_offsets_from_UTC) is currently not supported by the service, which will result into 409 error.
 
-* `permissions` - A `permissions` block as defined below.
+* `permissions` - (Required) A `permissions` block as defined below.
 
 ---
 
@@ -99,9 +106,11 @@ larger scope (affecting all sub-resources) than `object`.
 
 A `resource_types` block contains:
 
-* `service` - Should permission be granted to the entire service?
-* `container` - Should permission be granted to the container?
-* `object` - Should permission be granted only to a specific object?
+* `service` - (Required) Should permission be granted to the entire service?
+
+* `container` - (Required) Should permission be granted to the container?
+
+* `object` - (Required) Should permission be granted only to a specific object?
 
 ---
 
@@ -109,24 +118,36 @@ A `resource_types` block contains:
 
 A `services` block contains:
 
-* `blob` - Should permission be granted to `blob` services within this storage account?
-* `queue` - Should permission be granted to `queue` services within this storage account?
-* `table` - Should permission be granted to `table` services within this storage account?
-* `file` - Should permission be granted to `file` services within this storage account?
+* `blob` - (Required) Should permission be granted to `blob` services within this storage account?
+
+* `queue` - (Required) Should permission be granted to `queue` services within this storage account?
+
+* `table` - (Required) Should permission be granted to `table` services within this storage account?
+
+* `file` - (Required) Should permission be granted to `file` services within this storage account?
 
 ---
 
 A `permissions` block contains:
 
 * `read` - (Optional) Should Read permissions be enabled for this SAS?
+
 * `write` - (Optional) Should Write permissions be enabled for this SAS?
+
 * `delete` - (Optional) Should Delete permissions be enabled for this SAS?
+
 * `list` - (Optional) Should List permissions be enabled for this SAS?
+
 * `add` - (Optional) Should Add permissions be enabled for this SAS?
+
 * `create` - (Optional) Should Create permissions be enabled for this SAS?
+
 * `update` - (Optional) Should Update permissions be enabled for this SAS?
+
 * `process` - (Optional) Should Process permissions be enabled for this SAS?
+
 * `tag` - (Optional) Should Get / Set Index Tags permissions be enabled for this SAS?
+
 * `filter` - (Optional) Should Filter by Index Tags permissions be enabled for this SAS?
 
 Refer to the [SAS creation reference from Azure](https://docs.microsoft.com/rest/api/storageservices/constructing-an-account-sas)

--- a/website/docs/d/storage_account_sas.html.markdown
+++ b/website/docs/d/storage_account_sas.html.markdown
@@ -80,11 +80,9 @@ output "sas_url_query_string" {
 
 * `connection_string` - (Required) The connection string for the storage account to which this SAS applies. Typically directly from the `primary_connection_string` attribute of a terraform created `azurerm_storage_account` resource.
 
-* `https_only` - (Optional) Only permit `https` access. If `false`, both `http` and `https` are permitted. Defaults to `true`.
+* `expiry` - (Required) The expiration time and date of this SAS. Must be a valid ISO-8601 format time/date string.
 
-* `ip_addresses` - (Optional) IP address, or a range of IP addresses, from which to accept requests. When specifying a range, note that the range is inclusive.  
-
-* `signed_version` - (Optional) Specifies the signed storage service version to use to authorize requests made with this account SAS. Defaults to `2022-11-02`.
+~> **Note:** The [ISO-8601 Time offset from UTC](https://en.wikipedia.org/wiki/ISO_8601#Time_offsets_from_UTC) is currently not supported by the service, which will result into 409 error.
 
 * `resource_types` - (Required) A `resource_types` block as defined below.
 
@@ -92,11 +90,13 @@ output "sas_url_query_string" {
 
 * `start` - (Required) The starting time and date of validity of this SAS. Must be a valid ISO-8601 format time/date string.
 
-* `expiry` - (Required) The expiration time and date of this SAS. Must be a valid ISO-8601 format time/date string.
+* `https_only` - (Optional) Only permit `https` access. If `false`, both `http` and `https` are permitted. Defaults to `true`.
 
--> **Note:** The [ISO-8601 Time offset from UTC](https://en.wikipedia.org/wiki/ISO_8601#Time_offsets_from_UTC) is currently not supported by the service, which will result into 409 error.
+* `ip_addresses` - (Optional) IP address, or a range of IP addresses, from which to accept requests. When specifying a range, note that the range is inclusive.  
 
-* `permissions` - (Required) A `permissions` block as defined below.
+* `permissions` - (Optional) A `permissions` block as defined below.
+
+* `signed_version` - (Optional) Specifies the signed storage service version to use to authorize requests made with this account SAS. Defaults to `2022-11-02`.
 
 ---
 
@@ -106,11 +106,11 @@ larger scope (affecting all sub-resources) than `object`.
 
 A `resource_types` block contains:
 
-* `service` - (Required) Should permission be granted to the entire service?
-
 * `container` - (Required) Should permission be granted to the container?
 
 * `object` - (Required) Should permission be granted only to a specific object?
+
+* `service` - (Required) Should permission be granted to the entire service?
 
 ---
 
@@ -120,38 +120,37 @@ A `services` block contains:
 
 * `blob` - (Required) Should permission be granted to `blob` services within this storage account?
 
+* `file` - (Required) Should permission be granted to `file` services within this storage account?
+
 * `queue` - (Required) Should permission be granted to `queue` services within this storage account?
 
 * `table` - (Required) Should permission be granted to `table` services within this storage account?
-
-* `file` - (Required) Should permission be granted to `file` services within this storage account?
 
 ---
 
 A `permissions` block contains:
 
-* `read` - (Optional) Should Read permissions be enabled for this SAS?
-
-* `write` - (Optional) Should Write permissions be enabled for this SAS?
-
-* `delete` - (Optional) Should Delete permissions be enabled for this SAS?
-
-* `list` - (Optional) Should List permissions be enabled for this SAS?
-
 * `add` - (Optional) Should Add permissions be enabled for this SAS?
 
 * `create` - (Optional) Should Create permissions be enabled for this SAS?
 
-* `update` - (Optional) Should Update permissions be enabled for this SAS?
-
-* `process` - (Optional) Should Process permissions be enabled for this SAS?
-
-* `tag` - (Optional) Should Get / Set Index Tags permissions be enabled for this SAS?
+* `delete` - (Optional) Should Delete permissions be enabled for this SAS?
 
 * `filter` - (Optional) Should Filter by Index Tags permissions be enabled for this SAS?
 
-Refer to the [SAS creation reference from Azure](https://docs.microsoft.com/rest/api/storageservices/constructing-an-account-sas)
-for additional details on the fields above.
+* `list` - (Optional) Should List permissions be enabled for this SAS?
+
+* `process` - (Optional) Should Process permissions be enabled for this SAS?
+
+* `read` - (Optional) Should Read permissions be enabled for this SAS?
+
+* `tag` - (Optional) Should Get / Set Index Tags permissions be enabled for this SAS?
+
+* `update` - (Optional) Should Update permissions be enabled for this SAS?
+
+* `write` - (Optional) Should Write permissions be enabled for this SAS?
+
+~> **Note:** Refer to the [SAS creation reference from Azure](https://docs.microsoft.com/rest/api/storageservices/constructing-an-account-sas) for additional details on the fields above.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->
This PR supersedes #28452

This PR add support for more permissions on the storage container sas token data source as they are defined in: https://learn.microsoft.com/en-us/rest/api/storageservices/create-service-sas#permissions-for-a-directory-container-or-blob

To avoid a breaking change I switched the permissions properties to optional, existing terraform code should not be affected by this change and won't have more permissions than before.

As the `storage_account_blob_container_sas_data_source` and `azurerm_storage_account_sas` are very similar I also switched the permissions properties to optional to keep the same behavior between the two.

Another point to discuss, `tags` and `find` already exist in `azurerm_storage_account_sas` but are named respectively `tag` and `filter`. The documentation for them don't translate the permission letter to the same word . I followed the names of the container sas token documentation but you might want to reuse the same name as the storage account sas token to keep consistency in the provider, let me know and I'll edit the PR accordingly.

>Tags	t	Read or write the tags on a blob.
Find	f	Find blobs with index tags.
https://learn.microsoft.com/en-us/rest/api/storageservices/create-service-sas#permissions-for-a-directory-container-or-blob

vs

>- Tag (t): Permits blob tag operations.
>- Filter (f): Permits filtering by blob tag.
https://learn.microsoft.com/en-us/rest/api/storageservices/create-account-sas#specify-the-account-sas-parameters

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevent documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```
make acctests SERVICE=storage TESTARGS='-run="(TestAccDataSourceStorageAccountBlobContainerSas_*|TestAccDataSourceStorageAccountSas_*)"' TESTTIMEOUT='60m'
```
![image](https://github.com/user-attachments/assets/6aa2b409-db70-4195-9d83-81ef2d3937fe)

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-changelog.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `storage_account_blob_container_sas_data_source` - support for more permissions and make them optional


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)
Fixes #28421


> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
