### PR TITLE
azurerm_palo_alto_local_rulestack_rule: protocol_ports validation rejects valid API values ("any", port ranges)

### DIFF
--- a/internal/services/paloalto/palo_alto_local_rulestack_rule_resource.go
+++ b/internal/services/paloalto/palo_alto_local_rulestack_rule_resource.go
@@ -157,7 +157,7 @@ func (r LocalRuleStackRule) Arguments() map[string]*pluginsdk.Schema {
 			Optional: true,
 			ValidateFunc: validation.Any(
 				validate.ProtocolWithPort,
-				validation.StringInSlice([]string{protocolApplicationDefault}, false),
+				validation.StringInSlice([]string{protocolApplicationDefault, "any"}, false),
 			),
 			ExactlyOneOf: []string{"protocol", "protocol_ports"},
 		},

--- a/internal/services/paloalto/validate/protocol.go
+++ b/internal/services/paloalto/validate/protocol.go
@@ -16,9 +16,13 @@ func ProtocolWithPort(input interface{}, k string) (warnings []string, errors []
 		return
 	}
 
+	if v == "any" || v == "application-default" {
+		return
+	}
+
 	parts := strings.Split(v, ":")
 	if len(parts) != 2 {
-		errors = append(errors, fmt.Errorf("expected %s to be a two part string separated by a `:`, e.g. TCP:80", k))
+		errors = append(errors, fmt.Errorf("expected %s to be a two part string separated by a `:`, e.g. TCP:80, or a supported keyword like `any`", k))
 		return
 	}
 
@@ -26,9 +30,32 @@ func ProtocolWithPort(input interface{}, k string) (warnings []string, errors []
 		errors = append(errors, fmt.Errorf("protocol portion of %s must be one of `TCP` or `UDP`, got %q", k, parts[0]))
 	}
 
+	if strings.Contains(parts[1], "-") {
+		rangeParts := strings.Split(parts[1], "-")
+		if len(rangeParts) != 2 {
+			errors = append(errors, fmt.Errorf("port range in %s must be in format START-END, e.g. TCP:1024-1206", k))
+			return
+		}
+		startPort, err := strconv.Atoi(rangeParts[0])
+		if err != nil || startPort < 1 || startPort > 65535 {
+			errors = append(errors, fmt.Errorf("start port in %s must be an integer between 1 and 65535, got %q", k, rangeParts[0]))
+			return
+		}
+		endPort, err := strconv.Atoi(rangeParts[1])
+		if err != nil || endPort < 1 || endPort > 65535 {
+			errors = append(errors, fmt.Errorf("end port in %s must be an integer between 1 and 65535, got %q", k, rangeParts[1]))
+			return
+		}
+		if startPort > endPort {
+			errors = append(errors, fmt.Errorf("start port must be less than or equal to end port in %s", k))
+			return
+		}
+		return
+	}
+
 	port, err := strconv.Atoi(parts[1])
 	if err != nil || port == 0 || port > 65535 {
-		errors = append(errors, fmt.Errorf("port in %s must me an integer value between 1 and 65535, got %q", k, parts[1]))
+		errors = append(errors, fmt.Errorf("port in %s must be an integer value between 1 and 65535, got %q", k, parts[1]))
 	}
 
 	return

--- a/internal/services/paloalto/validate/protocol_test.go
+++ b/internal/services/paloalto/validate/protocol_test.go
@@ -1,0 +1,101 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package validate
+
+import (
+	"testing"
+)
+
+func TestProtocolWithPort(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantErrors int
+	}{
+		{
+			name:       "single port TCP",
+			input:      "TCP:80",
+			wantErrors: 0,
+		},
+		{
+			name:       "single port UDP",
+			input:      "UDP:443",
+			wantErrors: 0,
+		},
+		{
+			name:       "port range TCP",
+			input:      "TCP:1024-1206",
+			wantErrors: 0,
+		},
+		{
+			name:       "port range UDP",
+			input:      "UDP:5000-5100",
+			wantErrors: 0,
+		},
+		{
+			name:       "any keyword",
+			input:      "any",
+			wantErrors: 0,
+		},
+		{
+			name:       "application-default keyword",
+			input:      "application-default",
+			wantErrors: 0,
+		},
+		{
+			name:       "invalid single port zero",
+			input:      "TCP:0",
+			wantErrors: 1,
+		},
+		{
+			name:       "invalid port too high",
+			input:      "TCP:70000",
+			wantErrors: 1,
+		},
+		{
+			name:       "invalid start greater than end",
+			input:      "TCP:2000-1000",
+			wantErrors: 1,
+		},
+		{
+			name:       "invalid start port zero in range",
+			input:      "TCP:0-100",
+			wantErrors: 1,
+		},
+		{
+			name:       "invalid end port zero in range",
+			input:      "TCP:100-0",
+			wantErrors: 1,
+		},
+		{
+			name:       "invalid protocol",
+			input:      "ICMP:80",
+			wantErrors: 1,
+		},
+		{
+			name:       "invalid missing port",
+			input:      "TCP:",
+			wantErrors: 1,
+		},
+		{
+			name:       "invalid missing colon",
+			input:      "TCP80",
+			wantErrors: 1,
+		},
+		{
+			name:       "invalid malformed range",
+			input:      "TCP:100-200-300",
+			wantErrors: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, errors := ProtocolWithPort(tt.input, "test_field")
+			if len(errors) != tt.wantErrors {
+				t.Errorf("ProtocolWithPort(%q) got %d errors, want %d", tt.input, len(errors), tt.wantErrors)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Community Note
Please vote on this PR by adding a 👍 reaction to the original PR to help the community and maintainers prioritize for review  

Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review  

---

## Description
- Accept port ranges in format `TCP:1024-1206` and `UDP:5000-5100` in `protocol_ports`  
- Accept `any` and `application-default` as standalone values  
- Add unit tests for `ProtocolWithPort` validation function  

Fixes #32139 where the `ProtocolWithPort` validation function was too restrictive and rejected:
- Port ranges like `TCP:1024-1206`  
- The keyword `any` as a `protocol_ports` value  

This aligns the client-side validation with what the Azure ARM API (`protocolPortList`) and PAN Cloud NGFW accept.  

---

## PR Checklist
- [x] I have followed the guidelines in our Contributing Documentation.  
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.  
- [x] I have checked if my changes close any open issues. If so please include appropriate closing keywords below.  
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.  
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.  

For example: “resource_name_here - description of change e.g. adding property new_property_name_here”  

---

## Changes to existing Resource / Data Source
- [x] I have added an explanation of what my changes do and why I'd like you to include them.  
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.  
- [x] I have successfully run tests with my changes locally.  
- [ ] (For changes that include a state migration only). I have manually tested the migration path between relevant versions of the provider.  

---

## Testing
- [x] My submission includes Test coverage as described in the Contribution Guide and the tests pass.  

All 15 unit tests pass:
- Single ports: `TCP:80`, `UDP:443` ✓  
- Port ranges: `TCP:1024-1206`, `UDP:5000-5100` ✓  
- Keywords: `any`, `application-default` ✓  
- Invalid cases properly rejected ✓  

---

## Change Log
* azurerm_palo_alto_local_rulestack_rule - Support port ranges and `any` keyword in `protocol_ports` [GH-32139]  

---

## This is a (please select all that apply):
- [x] Bug Fix  
- [ ] New Feature (ie adding a service, resource, or data source)  
- [ ] Enhancement  
- [ ] Breaking Change  

---

## Related Issue(s)
Fixes #32139  

---

## AI Assistance Disclosure
- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs  

---

## Rollback Plan
If a change needs to be reverted, we will publish an updated version of the provider.  

---

## Changes to Security Controls
No changes to security controls (access controls, encryption, logging) in this pull request.  

---

## Note
If this PR changes meaningfully during the course of review please update the title and description as required.