### PR TITLE
azurerm_databricks_workspace - Add support for all currently available Compliance Security Profiles to the Databricks Workspace resource

### DIFF
--- a/examples/databricks/enhanced-security-compliance/main.tf
+++ b/examples/databricks/enhanced-security-compliance/main.tf
@@ -20,7 +20,7 @@ resource "azurerm_databricks_workspace" "example" {
   enhanced_security_compliance {
     automatic_cluster_update_enabled      = true
     compliance_security_profile_enabled   = true
-    compliance_security_profile_standards = ["HIPAA", "PCI_DSS"]
+    compliance_security_profile_standards = ["HIPAA", "PCI_DSS", "FEDRAMP_MODERATE", "IRAP_PROTECTED", "FEDRAMP_HIGH", "FEDRAMP_IL5", "ITAR_EAR", "CYBER_ESSENTIAL_PLUS", "CANADA_PROTECTED_B", "ISMAP", "HITRUST", "K_FSI", "GERMANY_C5", "GERMANY_TISAX"]
     enhanced_security_monitoring_enabled  = true
   }
 }

--- a/examples/databricks/enhanced-security-compliance/main.tf
+++ b/examples/databricks/enhanced-security-compliance/main.tf
@@ -20,7 +20,7 @@ resource "azurerm_databricks_workspace" "example" {
   enhanced_security_compliance {
     automatic_cluster_update_enabled      = true
     compliance_security_profile_enabled   = true
-    compliance_security_profile_standards = ["HIPAA", "PCI_DSS", "FEDRAMP_MODERATE", "IRAP_PROTECTED", "FEDRAMP_HIGH", "FEDRAMP_IL5", "ITAR_EAR", "CYBER_ESSENTIAL_PLUS", "CANADA_PROTECTED_B", "ISMAP", "HITRUST", "K_FSI", "GERMANY_C5", "GERMANY_TISAX"]
+    compliance_security_profile_standards = ["HIPAA", "PCI_DSS", "HITRUST", "GERMANY_C5", "GERMANY_TISAX"]
     enhanced_security_monitoring_enabled  = true
   }
 }

--- a/internal/services/databricks/databricks_workspace_data_source_test.go
+++ b/internal/services/databricks/databricks_workspace_data_source_test.go
@@ -60,7 +60,7 @@ func TestAccDatabricksWorkspaceDataSource_enhancedComplianceSecurity(t *testing.
 				check.That(data.ResourceName).Key("enhanced_security_compliance.#").HasValue("1"),
 				check.That(data.ResourceName).Key("enhanced_security_compliance.0.automatic_cluster_update_enabled").HasValue("true"),
 				check.That(data.ResourceName).Key("enhanced_security_compliance.0.compliance_security_profile_enabled").HasValue("true"),
-				check.That(data.ResourceName).Key("enhanced_security_compliance.0.compliance_security_profile_standards.#").HasValue("2"),
+				check.That(data.ResourceName).Key("enhanced_security_compliance.0.compliance_security_profile_standards.#").HasValue("5"),
 				check.That(data.ResourceName).Key("enhanced_security_compliance.0.enhanced_security_monitoring_enabled").HasValue("true"),
 			),
 		},
@@ -260,7 +260,7 @@ resource "azurerm_databricks_workspace" "test" {
   enhanced_security_compliance {
     automatic_cluster_update_enabled      = true
     compliance_security_profile_enabled   = true
-    compliance_security_profile_standards = ["PCI_DSS", "HIPAA", "FEDRAMP_MODERATE", "IRAP_PROTECTED", "FEDRAMP_HIGH", "FEDRAMP_IL5", "ITAR_EAR", "CYBER_ESSENTIAL_PLUS", "CANADA_PROTECTED_B", "ISMAP", "HITRUST", "K_FSI", "GERMANY_C5", "GERMANY_TISAX"]
+    compliance_security_profile_standards = ["PCI_DSS", "HIPAA", "HITRUST", "GERMANY_C5", "GERMANY_TISAX"]
     enhanced_security_monitoring_enabled  = true
   }
 }

--- a/internal/services/databricks/databricks_workspace_data_source_test.go
+++ b/internal/services/databricks/databricks_workspace_data_source_test.go
@@ -260,7 +260,7 @@ resource "azurerm_databricks_workspace" "test" {
   enhanced_security_compliance {
     automatic_cluster_update_enabled      = true
     compliance_security_profile_enabled   = true
-    compliance_security_profile_standards = ["PCI_DSS", "HIPAA"]
+    compliance_security_profile_standards = ["PCI_DSS", "HIPAA", "FEDRAMP_MODERATE", "IRAP_PROTECTED", "FEDRAMP_HIGH", "FEDRAMP_IL5", "ITAR_EAR", "CYBER_ESSENTIAL_PLUS", "CANADA_PROTECTED_B", "ISMAP", "HITRUST", "K_FSI", "GERMANY_C5", "GERMANY_TISAX"]
     enhanced_security_monitoring_enabled  = true
   }
 }

--- a/internal/services/databricks/databricks_workspace_resource_test.go
+++ b/internal/services/databricks/databricks_workspace_resource_test.go
@@ -530,7 +530,7 @@ func TestAccDatabricksWorkspace_enhancedComplianceSecurityWithInvalidStandardSku
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config:      r.enhancedSecurityCompliance(data, "standard", true, true, []string{"PCI_DSS", "HIPAA", "FEDRAMP_MODERATE", "IRAP_PROTECTED", "FEDRAMP_HIGH", "FEDRAMP_IL5", "ITAR_EAR", "CYBER_ESSENTIAL_PLUS", "CANADA_PROTECTED_B", "ISMAP", "HITRUST", "K_FSI", "GERMANY_C5", "GERMANY_TISAX"}, true),
+			Config:      r.enhancedSecurityCompliance(data, "standard", true, true, []string{"PCI_DSS", "HIPAA"}, true),
 			ExpectError: regexp.MustCompile("enhanced_security_compliance.*are only available with a `premium`"),
 		},
 	})
@@ -542,7 +542,7 @@ func TestAccDatabricksWorkspace_enhancedComplianceSecurityWithoutEnhancedSecurit
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config:      r.enhancedSecurityCompliance(data, "premium", true, true, []string{"PCI_DSS", "HIPAA", "FEDRAMP_MODERATE", "IRAP_PROTECTED", "FEDRAMP_HIGH", "FEDRAMP_IL5", "ITAR_EAR", "CYBER_ESSENTIAL_PLUS", "CANADA_PROTECTED_B", "ISMAP", "HITRUST", "K_FSI", "GERMANY_C5", "GERMANY_TISAX"}, false),
+			Config:      r.enhancedSecurityCompliance(data, "premium", true, true, []string{"PCI_DSS", "HIPAA"}, false),
 			ExpectError: regexp.MustCompile("`enhanced_security_monitoring_enabled` must be set to true when `compliance_security_profile_enabled` is set to true"),
 		},
 	})
@@ -554,7 +554,7 @@ func TestAccDatabricksWorkspace_enhancedComplianceSecurityWithoutAutomaticCluste
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config:      r.enhancedSecurityCompliance(data, "premium", false, true, []string{"PCI_DSS", "HIPAA", "FEDRAMP_MODERATE", "IRAP_PROTECTED", "FEDRAMP_HIGH", "FEDRAMP_IL5", "ITAR_EAR", "CYBER_ESSENTIAL_PLUS", "CANADA_PROTECTED_B", "ISMAP", "HITRUST", "K_FSI", "GERMANY_C5", "GERMANY_TISAX"}, true),
+			Config:      r.enhancedSecurityCompliance(data, "premium", false, true, []string{"PCI_DSS", "HIPAA"}, true),
 			ExpectError: regexp.MustCompile("`automatic_cluster_update_enabled` .* must be set to true when `compliance_security_profile_enabled` is set to true"),
 		},
 	})
@@ -566,7 +566,7 @@ func TestAccDatabricksWorkspace_enhancedComplianceSecurityWithInvalidComplianceS
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config:      r.enhancedSecurityCompliance(data, "premium", true, false, []string{"PCI_DSS", "HIPAA", "FEDRAMP_MODERATE", "IRAP_PROTECTED", "FEDRAMP_HIGH", "FEDRAMP_IL5", "ITAR_EAR", "CYBER_ESSENTIAL_PLUS", "CANADA_PROTECTED_B", "ISMAP", "HITRUST", "K_FSI", "GERMANY_C5", "GERMANY_TISAX"}, true),
+			Config:      r.enhancedSecurityCompliance(data, "premium", true, false, []string{"PCI_DSS", "HIPAA"}, true),
 			ExpectError: regexp.MustCompile("`compliance_security_profile_standards` cannot be set when `compliance_security_profile_enabled` is false"),
 		},
 	})

--- a/internal/services/databricks/databricks_workspace_resource_test.go
+++ b/internal/services/databricks/databricks_workspace_resource_test.go
@@ -482,7 +482,7 @@ func TestAccDatabricksWorkspace_enhancedComplianceSecurity(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.enhancedSecurityCompliance(data, "premium", true, true, []string{"PCI_DSS", "HIPAA"}, true),
+			Config: r.enhancedSecurityCompliance(data, "premium", true, true, []string{"PCI_DSS", "HIPAA", "FEDRAMP_MODERATE", "IRAP_PROTECTED", "FEDRAMP_HIGH", "FEDRAMP_IL5", "ITAR_EAR", "CYBER_ESSENTIAL_PLUS", "CANADA_PROTECTED_B", "ISMAP", "HITRUST", "K_FSI", "GERMANY_C5", "GERMANY_TISAX"}, true),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -524,7 +524,7 @@ func TestAccDatabricksWorkspace_enhancedComplianceSecurityWithInvalidStandardSku
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config:      r.enhancedSecurityCompliance(data, "standard", true, true, []string{"PCI_DSS", "HIPAA"}, true),
+			Config:      r.enhancedSecurityCompliance(data, "standard", true, true, []string{"PCI_DSS", "HIPAA", "FEDRAMP_MODERATE", "IRAP_PROTECTED", "FEDRAMP_HIGH", "FEDRAMP_IL5", "ITAR_EAR", "CYBER_ESSENTIAL_PLUS", "CANADA_PROTECTED_B", "ISMAP", "HITRUST", "K_FSI", "GERMANY_C5", "GERMANY_TISAX"}, true),
 			ExpectError: regexp.MustCompile("enhanced_security_compliance.*are only available with a `premium`"),
 		},
 	})
@@ -536,7 +536,7 @@ func TestAccDatabricksWorkspace_enhancedComplianceSecurityWithoutEnhancedSecurit
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config:      r.enhancedSecurityCompliance(data, "premium", true, true, []string{"PCI_DSS", "HIPAA"}, false),
+			Config:      r.enhancedSecurityCompliance(data, "premium", true, true, []string{"PCI_DSS", "HIPAA", "FEDRAMP_MODERATE", "IRAP_PROTECTED", "FEDRAMP_HIGH", "FEDRAMP_IL5", "ITAR_EAR", "CYBER_ESSENTIAL_PLUS", "CANADA_PROTECTED_B", "ISMAP", "HITRUST", "K_FSI", "GERMANY_C5", "GERMANY_TISAX"}, false),
 			ExpectError: regexp.MustCompile("`enhanced_security_monitoring_enabled` must be set to true when `compliance_security_profile_enabled` is set to true"),
 		},
 	})
@@ -548,7 +548,7 @@ func TestAccDatabricksWorkspace_enhancedComplianceSecurityWithoutAutomaticCluste
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config:      r.enhancedSecurityCompliance(data, "premium", false, true, []string{"PCI_DSS", "HIPAA"}, true),
+			Config:      r.enhancedSecurityCompliance(data, "premium", false, true, []string{"PCI_DSS", "HIPAA", "FEDRAMP_MODERATE", "IRAP_PROTECTED", "FEDRAMP_HIGH", "FEDRAMP_IL5", "ITAR_EAR", "CYBER_ESSENTIAL_PLUS", "CANADA_PROTECTED_B", "ISMAP", "HITRUST", "K_FSI", "GERMANY_C5", "GERMANY_TISAX"}, true),
 			ExpectError: regexp.MustCompile("`automatic_cluster_update_enabled` .* must be set to true when `compliance_security_profile_enabled` is set to true"),
 		},
 	})
@@ -560,7 +560,7 @@ func TestAccDatabricksWorkspace_enhancedComplianceSecurityWithInvalidComplianceS
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config:      r.enhancedSecurityCompliance(data, "premium", true, false, []string{"PCI_DSS", "HIPAA"}, true),
+			Config:      r.enhancedSecurityCompliance(data, "premium", true, false, []string{"PCI_DSS", "HIPAA", "FEDRAMP_MODERATE", "IRAP_PROTECTED", "FEDRAMP_HIGH", "FEDRAMP_IL5", "ITAR_EAR", "CYBER_ESSENTIAL_PLUS", "CANADA_PROTECTED_B", "ISMAP", "HITRUST", "K_FSI", "GERMANY_C5", "GERMANY_TISAX"}, true),
 			ExpectError: regexp.MustCompile("`compliance_security_profile_standards` cannot be set when `compliance_security_profile_enabled` is false"),
 		},
 	})

--- a/internal/services/databricks/databricks_workspace_resource_test.go
+++ b/internal/services/databricks/databricks_workspace_resource_test.go
@@ -476,12 +476,6 @@ func TestAccDatabricksWorkspace_altSubscriptionCmkDiskOnly(t *testing.T) {
 	})
 }
 
-/*
-The compliance security profile standards referenced in this test are available globally.
-
-You can find the regions that each compliance profile is available in under each subpage here:
-https://learn.microsoft.com/en-us/azure/databricks/security/privacy/security-profile
-*/
 func TestAccDatabricksWorkspace_enhancedComplianceSecurity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_databricks_workspace", "test")
 	r := DatabricksWorkspaceResource{}

--- a/internal/services/databricks/databricks_workspace_resource_test.go
+++ b/internal/services/databricks/databricks_workspace_resource_test.go
@@ -476,13 +476,19 @@ func TestAccDatabricksWorkspace_altSubscriptionCmkDiskOnly(t *testing.T) {
 	})
 }
 
+/*
+The compliance security profile standards referenced in this test are available globally.
+
+You can find the regions that each compliance profile is available in under each subpage here:
+https://learn.microsoft.com/en-us/azure/databricks/security/privacy/security-profile
+*/
 func TestAccDatabricksWorkspace_enhancedComplianceSecurity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_databricks_workspace", "test")
 	r := DatabricksWorkspaceResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.enhancedSecurityCompliance(data, "premium", true, true, []string{"PCI_DSS", "HIPAA", "FEDRAMP_MODERATE", "IRAP_PROTECTED", "FEDRAMP_HIGH", "FEDRAMP_IL5", "ITAR_EAR", "CYBER_ESSENTIAL_PLUS", "CANADA_PROTECTED_B", "ISMAP", "HITRUST", "K_FSI", "GERMANY_C5", "GERMANY_TISAX"}, true),
+			Config: r.enhancedSecurityCompliance(data, "premium", true, true, []string{"PCI_DSS", "HIPAA", "HITRUST", "GERMANY_C5", "GERMANY_TISAX"}, true),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),

--- a/internal/services/databricks/validate/compliance_security_profile_standards.go
+++ b/internal/services/databricks/validate/compliance_security_profile_standards.go
@@ -6,14 +6,38 @@ package validate
 type ComplianceStandard string
 
 const (
-	ComplianceStandardHIPAA  ComplianceStandard = "HIPAA"
-	ComplianceStandardNONE   ComplianceStandard = "NONE"
-	ComplianceStandardPCIDSS ComplianceStandard = "PCI_DSS"
+	ComplianceStandardHIPAA              ComplianceStandard = "HIPAA"
+	ComplianceStandardNONE               ComplianceStandard = "NONE"
+	ComplianceStandardPCIDSS             ComplianceStandard = "PCI_DSS"
+	ComplianceStandardFEDRAMPMODERATE    ComplianceStandard = "FEDRAMP_MODERATE"
+	ComplianceStandardIRAPPROTECTED      ComplianceStandard = "IRAP_PROTECTED"
+	ComplianceStandardFEDRAMPHIGH        ComplianceStandard = "FEDRAMP_HIGH"
+	ComplianceStandardFEDRAMPIL5         ComplianceStandard = "FEDRAMP_IL5"
+	ComplianceStandardITAREAR            ComplianceStandard = "ITAR_EAR"
+	ComplianceStandardCYBERESSENTIALPLUS ComplianceStandard = "CYBER_ESSENTIAL_PLUS"
+	ComplianceStandardCANADAPROTECTEDB   ComplianceStandard = "CANADA_PROTECTED_B"
+	ComplianceStandardISMAP              ComplianceStandard = "ISMAP"
+	ComplianceStandardHITRUST            ComplianceStandard = "HITRUST"
+	ComplianceStandardKFSI               ComplianceStandard = "K_FSI"
+	ComplianceStandardGERMANYC5          ComplianceStandard = "GERMANY_C5"
+	ComplianceStandardGERMANYTISAX       ComplianceStandard = "GERMANY_TISAX"
 )
 
 func PossibleValuesForComplianceStandard() []string {
 	return []string{
 		string(ComplianceStandardHIPAA),
 		string(ComplianceStandardPCIDSS),
+		string(ComplianceStandardFEDRAMPMODERATE),
+		string(ComplianceStandardIRAPPROTECTED),
+		string(ComplianceStandardFEDRAMPHIGH),
+		string(ComplianceStandardFEDRAMPIL5),
+		string(ComplianceStandardITAREAR),
+		string(ComplianceStandardCYBERESSENTIALPLUS),
+		string(ComplianceStandardCANADAPROTECTEDB),
+		string(ComplianceStandardISMAP),
+		string(ComplianceStandardHITRUST),
+		string(ComplianceStandardKFSI),
+		string(ComplianceStandardGERMANYC5),
+		string(ComplianceStandardGERMANYTISAX),
 	}
 }

--- a/website/docs/r/databricks_workspace.html.markdown
+++ b/website/docs/r/databricks_workspace.html.markdown
@@ -136,7 +136,7 @@ An `enhanced_security_compliance` block supports the following:
 
 ~> **Note:** The attributes `automatic_cluster_update_enabled` and `enhanced_security_monitoring_enabled` must be set to `true` in order to set `compliance_security_profile_enabled` to `true`.
 
-* `compliance_security_profile_standards` - (Optional) A list of standards to enforce on this workspace. Possible values include `HIPAA` and `PCI_DSS`.
+* `compliance_security_profile_standards` - (Optional) A list of standards to enforce on this workspace. Possible values include `HIPAA`, `PCI_DSS`, `FEDRAMP_MODERATE`, `IRAP_PROTECTED`, `FEDRAMP_HIGH`, `FEDRAMP_IL5`, `ITAR_EAR`, `CYBER_ESSENTIAL_PLUS`, `CANADA_PROTECTED_B`, `ISMAP`, `HITRUST`, `K_FSI`, `GERMANY_C5`, and `GERMANY_TISAX`
 
 ~> **Note:** `compliance_security_profile_enabled` must be set to `true` in order to use `compliance_security_profile_standards`.
 


### PR DESCRIPTION
<!--  All Submissions -->

This change adds support for all currently available compliance security profiles for Azure Databricks Workspaces. I pulled the list of all currently available compliance profiles from the REST docs [here](https://docs.databricks.com/api/account/cspenablementaccount/update), under `csp_enablement_account.compliance_standards`.

There have been a few issues and PRs that mention this problem in various places, including the following that I was able to find:

- https://github.com/hashicorp/terraform-provider-azurerm/pull/31654#discussion_r2825268532
- #30976 
- https://github.com/hashicorp/terraform-provider-azurerm/pull/31625
- https://github.com/databricks/terraform-provider-databricks/issues/5558
- https://github.com/hashicorp/terraform-provider-azurerm/pull/31480

I know there is likely quite a bit of nuance and background discussions around this that I am not privy to, so please let me know if this change is going to be resolved in an alternate way or if you'd prefer me to take a crack at changing how this is being handled.

Thank you!

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_databricks_workspace` - Add support for all currently available Compliance Security Profiles to the Databricks Workspace resource


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #30976


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
