### PR TITLE
service/storagemover: add list support for `azurerm_storage_mover`

### DIFF
--- a/internal/services/storagemover/registration.go
+++ b/internal/services/storagemover/registration.go
@@ -66,5 +66,7 @@ func (r Registration) EphemeralResources() []func() ephemeral.EphemeralResource 
 }
 
 func (r Registration) ListResources() []sdk.FrameworkListWrappedResource {
-	return []sdk.FrameworkListWrappedResource{}
+	return []sdk.FrameworkListWrappedResource{
+		StorageMoverListResource{},
+	}
 }

--- a/internal/services/storagemover/storage_mover_resource.go
+++ b/internal/services/storagemover/storage_mover_resource.go
@@ -11,11 +11,14 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2025-07-01/storagemovers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
+
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name storage_mover -service-package-name storagemover -properties "name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
 
 type StorageMoverModel struct {
 	Name              string            `tfschema:"name"`
@@ -27,7 +30,14 @@ type StorageMoverModel struct {
 
 type StorageMoverResource struct{}
 
-var _ sdk.ResourceWithUpdate = StorageMoverResource{}
+var (
+	_ sdk.ResourceWithIdentity = StorageMoverResource{}
+	_ sdk.ResourceWithUpdate   = StorageMoverResource{}
+)
+
+func (r StorageMoverResource) Identity() resourceids.ResourceId {
+	return &storagemovers.StorageMoverId{}
+}
 
 func (r StorageMoverResource) ResourceType() string {
 	return "azurerm_storage_mover"
@@ -106,6 +116,9 @@ func (r StorageMoverResource) Create() sdk.ResourceFunc {
 			}
 
 			metadata.SetID(id)
+			if err := pluginsdk.SetResourceIdentityData(metadata.ResourceData, &id); err != nil {
+				return err
+			}
 
 			return nil
 		},
@@ -180,27 +193,35 @@ func (r StorageMoverResource) Read() sdk.ResourceFunc {
 				return fmt.Errorf("retrieving %s: model was nil", *id)
 			}
 
-			state := StorageMoverModel{
-				Name:              id.StorageMoverName,
-				ResourceGroupName: id.ResourceGroupName,
-				Location:          location.Normalize(model.Location),
-			}
-
-			description := ""
-			if properties := model.Properties; properties != nil {
-				if properties.Description != nil {
-					description = *properties.Description
-				}
-			}
-			state.Description = description
-
-			if model.Tags != nil {
-				state.Tags = *model.Tags
-			}
-
-			return metadata.Encode(&state)
+			return r.flatten(metadata, id, model)
 		},
 	}
+}
+
+func (r StorageMoverResource) flatten(metadata sdk.ResourceMetaData, id *storagemovers.StorageMoverId, model *storagemovers.StorageMover) error {
+	state := StorageMoverModel{
+		Name:              id.StorageMoverName,
+		ResourceGroupName: id.ResourceGroupName,
+		Location:          location.Normalize(model.Location),
+	}
+
+	description := ""
+	if properties := model.Properties; properties != nil {
+		if properties.Description != nil {
+			description = *properties.Description
+		}
+	}
+	state.Description = description
+
+	if model.Tags != nil {
+		state.Tags = *model.Tags
+	}
+
+	if err := pluginsdk.SetResourceIdentityData(metadata.ResourceData, id); err != nil {
+		return err
+	}
+
+	return metadata.Encode(&state)
 }
 
 func (r StorageMoverResource) Delete() sdk.ResourceFunc {

--- a/internal/services/storagemover/storage_mover_resource_identity_gen_test.go
+++ b/internal/services/storagemover/storage_mover_resource_identity_gen_test.go
@@ -1,0 +1,39 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package storagemover_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
+)
+
+func TestAccStorageMover_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_mover", "test")
+	r := StorageMoverResource{}
+
+	checkedFields := map[string]struct{}{
+		"subscription_id":     {},
+		"name":                {},
+		"resource_group_name": {},
+	}
+
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				customstatecheck.ExpectAllIdentityFieldsAreChecked("azurerm_storage_mover.test", checkedFields),
+				statecheck.ExpectIdentityValue("azurerm_storage_mover.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_storage_mover.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_storage_mover.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
+			},
+		},
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
+}

--- a/internal/services/storagemover/storage_mover_resource_list.go
+++ b/internal/services/storagemover/storage_mover_resource_list.go
@@ -1,0 +1,98 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package storagemover
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2025-07-01/storagemovers"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type StorageMoverListResource struct{}
+
+var _ sdk.FrameworkListWrappedResource = new(StorageMoverListResource)
+
+func (StorageMoverListResource) Metadata(_ context.Context, _ resource.MetadataRequest, response *resource.MetadataResponse) {
+	response.TypeName = StorageMoverResource{}.ResourceType()
+}
+
+func (StorageMoverListResource) ResourceFunc() *pluginsdk.Resource {
+	return sdk.WrappedResource(StorageMoverResource{})
+}
+
+func (StorageMoverListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream, metadata sdk.ResourceMetadata) {
+	client := metadata.Client.StorageMover.StorageMoversClient
+
+	var data sdk.DefaultListModel
+	diags := request.Config.Get(ctx, &data)
+	if diags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	var results []storagemovers.StorageMover
+	subscriptionID := metadata.SubscriptionId
+	if !data.SubscriptionId.IsNull() {
+		subscriptionID = data.SubscriptionId.ValueString()
+	}
+
+	resource := StorageMoverResource{}
+
+	switch {
+	case !data.ResourceGroupName.IsNull():
+		resp, err := client.ListComplete(ctx, commonids.NewResourceGroupID(subscriptionID, data.ResourceGroupName.ValueString()))
+		if err != nil {
+			sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("listing `%s`", resource.ResourceType()), err)
+			return
+		}
+
+		results = resp.Items
+	default:
+		resp, err := client.ListBySubscriptionComplete(ctx, commonids.NewSubscriptionID(subscriptionID))
+		if err != nil {
+			sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("listing `%s`", resource.ResourceType()), err)
+			return
+		}
+
+		results = resp.Items
+	}
+
+	stream.Results = func(push func(list.ListResult) bool) {
+		for _, item := range results {
+			result := request.NewListResult(ctx)
+			result.DisplayName = pointer.From(item.Name)
+
+			id, err := storagemovers.ParseStorageMoverIDInsensitively(pointer.From(item.Id))
+			if err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, "parsing Storage Mover ID", err)
+				return
+			}
+
+			meta := sdk.NewResourceMetaData(metadata.Client, resource)
+			meta.SetID(id)
+
+			if err := resource.flatten(meta, id, &item); err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, fmt.Sprintf("encoding `%s` resource data", resource.ResourceType()), err)
+				return
+			}
+
+			sdk.EncodeListResult(ctx, meta.ResourceData, &result)
+			if result.Diagnostics.HasError() {
+				push(result)
+				return
+			}
+
+			if !push(result) {
+				return
+			}
+		}
+	}
+}

--- a/internal/services/storagemover/storage_mover_resource_list_test.go
+++ b/internal/services/storagemover/storage_mover_resource_list_test.go
@@ -1,0 +1,79 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package storagemover_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccStorageMover_list(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_mover", "testlist")
+	r := StorageMoverResource{}
+	resourceName := fmt.Sprintf("acctest-ssm-%d", data.RandomInteger)
+	resourceGroupName := fmt.Sprintf("acctest-rg-%d", data.RandomInteger)
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basic(data),
+			},
+			{
+				Query:  true,
+				Config: r.subscriptionListQuery(),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLengthAtLeast("azurerm_storage_mover.list", 1),
+					querycheck.ExpectIdentity("azurerm_storage_mover.list", map[string]knownvalue.Check{
+						"name":                knownvalue.StringExact(resourceName),
+						"resource_group_name": knownvalue.StringExact(resourceGroupName),
+						"subscription_id":     knownvalue.StringExact(data.Subscriptions.Primary),
+					}),
+				},
+			},
+			{
+				Query:  true,
+				Config: r.resourceGroupListQuery(),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLength("azurerm_storage_mover.list", 1),
+					querycheck.ExpectIdentity("azurerm_storage_mover.list", map[string]knownvalue.Check{
+						"name":                knownvalue.StringExact(resourceName),
+						"resource_group_name": knownvalue.StringExact(resourceGroupName),
+						"subscription_id":     knownvalue.StringExact(data.Subscriptions.Primary),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func (r StorageMoverResource) subscriptionListQuery() string {
+	return `
+list "azurerm_storage_mover" "list" {
+  provider = azurerm
+}
+`
+}
+
+func (r StorageMoverResource) resourceGroupListQuery() string {
+	return `
+list "azurerm_storage_mover" "list" {
+  provider = azurerm
+  config {
+    resource_group_name = azurerm_resource_group.test.name
+  }
+}
+`
+}

--- a/internal/services/storagemover/storage_mover_resource_test.go
+++ b/internal/services/storagemover/storage_mover_resource_test.go
@@ -17,11 +17,11 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
-type StorageMoverTestResource struct{}
+type StorageMoverResource struct{}
 
 func TestAccStorageMover_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_mover", "test")
-	r := StorageMoverTestResource{}
+	r := StorageMoverResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basic(data),
@@ -35,7 +35,7 @@ func TestAccStorageMover_basic(t *testing.T) {
 
 func TestAccStorageMover_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_mover", "test")
-	r := StorageMoverTestResource{}
+	r := StorageMoverResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basic(data),
@@ -49,7 +49,7 @@ func TestAccStorageMover_requiresImport(t *testing.T) {
 
 func TestAccStorageMover_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_mover", "test")
-	r := StorageMoverTestResource{}
+	r := StorageMoverResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.complete(data),
@@ -63,7 +63,7 @@ func TestAccStorageMover_complete(t *testing.T) {
 
 func TestAccStorageMover_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_mover", "test")
-	r := StorageMoverTestResource{}
+	r := StorageMoverResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.complete(data),
@@ -82,7 +82,7 @@ func TestAccStorageMover_update(t *testing.T) {
 	})
 }
 
-func (r StorageMoverTestResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (r StorageMoverResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := storagemovers.ParseStorageMoverID(state.ID)
 	if err != nil {
 		return nil, err
@@ -99,7 +99,7 @@ func (r StorageMoverTestResource) Exists(ctx context.Context, clients *clients.C
 	return pointer.To(resp.Model != nil), nil
 }
 
-func (r StorageMoverTestResource) template(data acceptance.TestData) string {
+func (r StorageMoverResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -112,7 +112,7 @@ resource "azurerm_resource_group" "test" {
 `, data.RandomInteger, data.Locations.Primary)
 }
 
-func (r StorageMoverTestResource) basic(data acceptance.TestData) string {
+func (r StorageMoverResource) basic(data acceptance.TestData) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
 				%s
@@ -125,7 +125,7 @@ resource "azurerm_storage_mover" "test" {
 `, template, data.RandomInteger, data.Locations.Primary)
 }
 
-func (r StorageMoverTestResource) requiresImport(data acceptance.TestData) string {
+func (r StorageMoverResource) requiresImport(data acceptance.TestData) string {
 	config := r.basic(data)
 	return fmt.Sprintf(`
 			%s
@@ -138,7 +138,7 @@ resource "azurerm_storage_mover" "import" {
 `, config, data.Locations.Primary)
 }
 
-func (r StorageMoverTestResource) complete(data acceptance.TestData) string {
+func (r StorageMoverResource) complete(data acceptance.TestData) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
 			%s
@@ -155,7 +155,7 @@ resource "azurerm_storage_mover" "test" {
 `, template, data.RandomInteger, data.Locations.Primary)
 }
 
-func (r StorageMoverTestResource) update(data acceptance.TestData) string {
+func (r StorageMoverResource) update(data acceptance.TestData) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
 			%s

--- a/website/docs/list-resources/storage_mover.html.markdown
+++ b/website/docs/list-resources/storage_mover.html.markdown
@@ -1,0 +1,41 @@
+---
+subcategory: "Storage Mover"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_storage_mover"
+description: |-
+  Lists Storage Mover resources.
+---
+
+# List resource: azurerm_storage_mover
+
+Lists Storage Mover resources.
+
+## Example Usage
+
+### List all Storage Movers in the subscription
+
+```hcl
+list "azurerm_storage_mover" "example" {
+  provider = azurerm
+  config {}
+}
+```
+
+### List all Storage Movers in a specific resource group
+
+```hcl
+list "azurerm_storage_mover" "example" {
+  provider = azurerm
+  config {
+    resource_group_name = "example-rg"
+  }
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `resource_group_name` - (Optional) The name of the resource group to query.
+
+* `subscription_id` - (Optional) The Subscription ID to query. Defaults to the value specified in the Provider Configuration.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
