### PR TITLE
Add state migration for federated_identity_credential parent_id deprecation

### DIFF
--- a/internal/services/managedidentity/federated_identity_credential_resource.go
+++ b/internal/services/managedidentity/federated_identity_credential_resource.go
@@ -15,15 +15,28 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/managedidentity/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
-var _ sdk.Resource = FederatedIdentityCredentialResource{}
+var (
+	_ sdk.Resource                   = FederatedIdentityCredentialResource{}
+	_ sdk.ResourceWithStateMigration = FederatedIdentityCredentialResource{}
+)
 
 type FederatedIdentityCredentialResource struct{}
 
 func (r FederatedIdentityCredentialResource) ModelObject() interface{} {
 	return &FederatedIdentityCredentialResourceSchema{}
+}
+
+func (r FederatedIdentityCredentialResource) StateUpgraders() sdk.StateUpgradeData {
+	return sdk.StateUpgradeData{
+		SchemaVersion: 1,
+		Upgraders: map[int]pluginsdk.StateUpgrade{
+			0: migration.FederatedIdentityCredentialV0ToV1{},
+		},
+	}
 }
 
 type FederatedIdentityCredentialResourceSchema struct {

--- a/internal/services/managedidentity/federated_identity_credential_resource_test.go
+++ b/internal/services/managedidentity/federated_identity_credential_resource_test.go
@@ -70,6 +70,33 @@ func TestAccFederatedIdentityCredential_deprecated(t *testing.T) {
 	})
 }
 
+func TestAccFederatedIdentityCredential_parentIdToUserAssignedIdentityId(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("this test is only valid in versions prior to 5.0")
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_federated_identity_credential", "test")
+	r := FederatedIdentityCredentialTestResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.deprecated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("parent_id").Exists(),
+			),
+		},
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("user_assigned_identity_id").Exists(),
+			),
+			PlanOnly: false,
+		},
+	})
+}
+
 func TestAccFederatedIdentityCredential_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_federated_identity_credential", "test")
 	r := FederatedIdentityCredentialTestResource{}

--- a/internal/services/managedidentity/migration/federated_identity_credential_v0_to_v1.go
+++ b/internal/services/managedidentity/migration/federated_identity_credential_v0_to_v1.go
@@ -1,0 +1,62 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package migration
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+var _ pluginsdk.StateUpgrade = FederatedIdentityCredentialV0ToV1{}
+
+type FederatedIdentityCredentialV0ToV1 struct{}
+
+func (FederatedIdentityCredentialV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"audience": {
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+			Required: true,
+			Type:     pluginsdk.TypeList,
+			MaxItems: 1,
+		},
+		"issuer": {
+			Required: true,
+			Type:     pluginsdk.TypeString,
+		},
+		"name": {
+			ForceNew: true,
+			Required: true,
+			Type:     pluginsdk.TypeString,
+		},
+		"parent_id": {
+			Type:     pluginsdk.TypeString,
+			ForceNew: true,
+			Required: true,
+		},
+		"resource_group_name": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+		"subject": {
+			Required: true,
+			Type:     pluginsdk.TypeString,
+		},
+	}
+}
+
+func (FederatedIdentityCredentialV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		if v, ok := rawState["user_assigned_identity_id"].(string); !ok || v == "" {
+			if parentId, ok := rawState["parent_id"].(string); ok && parentId != "" {
+				log.Printf("Copying `parent_id` to `user_assigned_identity_id`: %q", parentId)
+				rawState["user_assigned_identity_id"] = parentId
+			}
+		}
+		return rawState, nil
+	}
+}


### PR DESCRIPTION
Fixes #32074

## Description

The deprecation of `parent_id` in favor of `user_assigned_identity_id` was breaking for users with existing state. Added a state migration to handle the upgrade path so existing resources don't break when users upgrade the provider.

## PR Checklist

- [x] Followed Contributing Documentation
- [ ] Updated/added Documentation
- [x] Written new tests

## Changes to existing Resource / Data Source

Updated `FederatedIdentityCredentialResource` to implement `ResourceWithStateMigration` and added the `StateUpgraders()` method that registers the v0 to v1 migration. The migration logic copies the value from `parent_id` to `user_assigned_identity_id`.

## Testing

Added `TestAccFederatedIdentityCredential_parentIdToUserAssignedIdentityId` which verifies the migration works by creating a resource with the old config and upgrading to the new one. The test is gated with the feature flag so it only runs on pre-5.0 versions.

## Change Log

N/A

## Related Issue(s)

Closes #32074

## AI Assistance Disclosure

N/A