### PR TITLE
costmanagement: convert export resources to use typed models with Decode/Encode

### DIFF
--- a/internal/services/costmanagement/billing_account_cost_management_export_resource.go
+++ b/internal/services/costmanagement/billing_account_cost_management_export_resource.go
@@ -4,6 +4,14 @@
 package costmanagement
 
 import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2023-08-01/exports"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/costmanagement/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -12,6 +20,18 @@ import (
 
 type BillingAccountCostManagementExportResource struct {
 	base costManagementExportBaseResource
+}
+
+type BillingAccountCostManagementExportModel struct {
+	Name                      string                                         `tfschema:"name"`
+	BillingAccountId          string                                         `tfschema:"billing_account_id"`
+	Active                    bool                                           `tfschema:"active"`
+	RecurrenceType            string                                         `tfschema:"recurrence_type"`
+	RecurrencePeriodStartDate string                                         `tfschema:"recurrence_period_start_date"`
+	RecurrencePeriodEndDate   string                                         `tfschema:"recurrence_period_end_date"`
+	FileFormat                string                                         `tfschema:"file_format"`
+	ExportDataStorageLocation []CostManagementExportDataStorageLocationModel `tfschema:"export_data_storage_location"`
+	ExportDataOptions         []CostManagementExportDataOptionsModel         `tfschema:"export_data_options"`
 }
 
 var _ sdk.Resource = BillingAccountCostManagementExportResource{}
@@ -40,7 +60,7 @@ func (r BillingAccountCostManagementExportResource) Attributes() map[string]*plu
 }
 
 func (r BillingAccountCostManagementExportResource) ModelObject() interface{} {
-	return nil
+	return &BillingAccountCostManagementExportModel{}
 }
 
 func (r BillingAccountCostManagementExportResource) ResourceType() string {
@@ -52,11 +72,118 @@ func (r BillingAccountCostManagementExportResource) IDValidationFunc() pluginsdk
 }
 
 func (r BillingAccountCostManagementExportResource) Create() sdk.ResourceFunc {
-	return r.base.createFunc(r.ResourceType(), "billing_account_id")
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.CostManagement.ExportClient
+
+			var config BillingAccountCostManagementExportModel
+			if err := metadata.Decode(&config); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			id := exports.NewScopedExportID(config.BillingAccountId, config.Name)
+
+			var opts exports.GetOperationOptions
+			existing, err := client.Get(ctx, id, opts)
+			if err != nil {
+				if !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+				}
+			}
+
+			if !response.WasNotFound(existing.HttpResponse) {
+				return tf.ImportAsExistsError(r.ResourceType(), id.ID())
+			}
+
+			deliveryInfo, err := expandExportDataStorageLocationFromModel(config.ExportDataStorageLocation)
+			if err != nil {
+				return fmt.Errorf("expanding `export_data_storage_location`: %+v", err)
+			}
+
+			status := exports.StatusTypeActive
+			if !config.Active {
+				status = exports.StatusTypeInactive
+			}
+
+			format := exports.FormatType(config.FileFormat)
+			recurrenceType := exports.RecurrenceType(config.RecurrenceType)
+
+			props := exports.Export{
+				Properties: &exports.ExportProperties{
+					Schedule: &exports.ExportSchedule{
+						Recurrence: &recurrenceType,
+						RecurrencePeriod: &exports.ExportRecurrencePeriod{
+							From: config.RecurrencePeriodStartDate,
+							To:   pointer.To(config.RecurrencePeriodEndDate),
+						},
+						Status: &status,
+					},
+					DeliveryInfo: *deliveryInfo,
+					Format:       &format,
+					Definition:   *expandExportDataOptionsFromModel(config.ExportDataOptions),
+				},
+			}
+
+			if _, err = client.CreateOrUpdate(ctx, id, props); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+	}
 }
 
 func (r BillingAccountCostManagementExportResource) Read() sdk.ResourceFunc {
-	return r.base.readFunc("billing_account_id")
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.CostManagement.ExportClient
+
+			id, err := exports.ParseScopedExportID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			var opts exports.GetOperationOptions
+			resp, err := client.Get(ctx, *id, opts)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return metadata.MarkAsGone(id)
+				}
+				return fmt.Errorf("reading %s: %+v", *id, err)
+			}
+
+			state := BillingAccountCostManagementExportModel{
+				Name:             id.ExportName,
+				BillingAccountId: id.Scope,
+			}
+
+			if model := resp.Model; model != nil {
+				if props := model.Properties; props != nil {
+					if schedule := props.Schedule; schedule != nil {
+						if recurrencePeriod := schedule.RecurrencePeriod; recurrencePeriod != nil {
+							state.RecurrencePeriodStartDate = recurrencePeriod.From
+							state.RecurrencePeriodEndDate = pointer.From(recurrencePeriod.To)
+						}
+						state.Active = *schedule.Status == exports.StatusTypeActive
+						state.RecurrenceType = string(pointer.From(schedule.Recurrence))
+					}
+
+					storageLocation, err := flattenExportDataStorageLocationToModel(&props.DeliveryInfo)
+					if err != nil {
+						return fmt.Errorf("flattening `export_data_storage_location`: %+v", err)
+					}
+					state.ExportDataStorageLocation = storageLocation
+					state.ExportDataOptions = flattenExportDataOptionsToModel(&props.Definition)
+					state.FileFormat = string(pointer.From(props.Format))
+				}
+			}
+
+			return metadata.Encode(&state)
+		},
+	}
 }
 
 func (r BillingAccountCostManagementExportResource) Delete() sdk.ResourceFunc {
@@ -64,5 +191,69 @@ func (r BillingAccountCostManagementExportResource) Delete() sdk.ResourceFunc {
 }
 
 func (r BillingAccountCostManagementExportResource) Update() sdk.ResourceFunc {
-	return r.base.updateFunc()
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.CostManagement.ExportClient
+
+			id, err := exports.ParseScopedExportID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			var config BillingAccountCostManagementExportModel
+			if err := metadata.Decode(&config); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			// Update operation requires latest eTag to be set in the request.
+			var opts exports.GetOperationOptions
+			resp, err := client.Get(ctx, *id, opts)
+			if err != nil {
+				return fmt.Errorf("reading %s: %+v", *id, err)
+			}
+
+			if model := resp.Model; model != nil {
+				if model.ETag == nil {
+					return fmt.Errorf("add %s: etag was nil", *id)
+				}
+			}
+
+			deliveryInfo, err := expandExportDataStorageLocationFromModel(config.ExportDataStorageLocation)
+			if err != nil {
+				return fmt.Errorf("expanding `export_data_storage_location`: %+v", err)
+			}
+
+			status := exports.StatusTypeActive
+			if !config.Active {
+				status = exports.StatusTypeInactive
+			}
+
+			format := exports.FormatType(config.FileFormat)
+			recurrenceType := exports.RecurrenceType(config.RecurrenceType)
+
+			props := exports.Export{
+				ETag: resp.Model.ETag,
+				Properties: &exports.ExportProperties{
+					Schedule: &exports.ExportSchedule{
+						Recurrence: &recurrenceType,
+						RecurrencePeriod: &exports.ExportRecurrencePeriod{
+							From: config.RecurrencePeriodStartDate,
+							To:   pointer.To(config.RecurrencePeriodEndDate),
+						},
+						Status: &status,
+					},
+					DeliveryInfo: *deliveryInfo,
+					Format:       &format,
+					Definition:   *expandExportDataOptionsFromModel(config.ExportDataOptions),
+				},
+			}
+
+			if _, err = client.CreateOrUpdate(ctx, *id, props); err != nil {
+				return fmt.Errorf("updating %s: %+v", *id, err)
+			}
+
+			return nil
+		},
+	}
 }

--- a/internal/services/costmanagement/billing_account_cost_management_export_resource.go
+++ b/internal/services/costmanagement/billing_account_cost_management_export_resource.go
@@ -100,19 +100,24 @@ func (r BillingAccountCostManagementExportResource) Create() sdk.ResourceFunc {
 			if err != nil {
 				return fmt.Errorf("expanding `export_data_storage_location`: %+v", err)
 			}
+			if deliveryInfo == nil {
+				return fmt.Errorf("`export_data_storage_location` was empty")
+			}
+
+			definition := expandExportDataOptionsFromModel(config.ExportDataOptions)
+			if definition == nil {
+				return fmt.Errorf("`export_data_options` was empty")
+			}
 
 			status := exports.StatusTypeActive
 			if !config.Active {
 				status = exports.StatusTypeInactive
 			}
 
-			format := exports.FormatType(config.FileFormat)
-			recurrenceType := exports.RecurrenceType(config.RecurrenceType)
-
 			props := exports.Export{
 				Properties: &exports.ExportProperties{
 					Schedule: &exports.ExportSchedule{
-						Recurrence: &recurrenceType,
+						Recurrence: pointer.ToEnum[exports.RecurrenceType](config.RecurrenceType),
 						RecurrencePeriod: &exports.ExportRecurrencePeriod{
 							From: config.RecurrencePeriodStartDate,
 							To:   pointer.To(config.RecurrencePeriodEndDate),
@@ -120,8 +125,8 @@ func (r BillingAccountCostManagementExportResource) Create() sdk.ResourceFunc {
 						Status: &status,
 					},
 					DeliveryInfo: *deliveryInfo,
-					Format:       &format,
-					Definition:   *expandExportDataOptionsFromModel(config.ExportDataOptions),
+					Format:       pointer.ToEnum[exports.FormatType](config.FileFormat),
+					Definition:   *definition,
 				},
 			}
 
@@ -152,7 +157,7 @@ func (r BillingAccountCostManagementExportResource) Read() sdk.ResourceFunc {
 				if response.WasNotFound(resp.HttpResponse) {
 					return metadata.MarkAsGone(id)
 				}
-				return fmt.Errorf("reading %s: %+v", *id, err)
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
 			}
 
 			state := BillingAccountCostManagementExportModel{
@@ -167,16 +172,18 @@ func (r BillingAccountCostManagementExportResource) Read() sdk.ResourceFunc {
 							state.RecurrencePeriodStartDate = recurrencePeriod.From
 							state.RecurrencePeriodEndDate = pointer.From(recurrencePeriod.To)
 						}
-						state.Active = *schedule.Status == exports.StatusTypeActive
+						if schedule.Status != nil {
+							state.Active = *schedule.Status == exports.StatusTypeActive
+						}
 						state.RecurrenceType = string(pointer.From(schedule.Recurrence))
 					}
 
-					storageLocation, err := flattenExportDataStorageLocationToModel(&props.DeliveryInfo)
+					storageLocation, err := flattenExportDataStorageLocationToModel(props.DeliveryInfo)
 					if err != nil {
 						return fmt.Errorf("flattening `export_data_storage_location`: %+v", err)
 					}
 					state.ExportDataStorageLocation = storageLocation
-					state.ExportDataOptions = flattenExportDataOptionsToModel(&props.Definition)
+					state.ExportDataOptions = flattenExportDataOptionsToModel(props.Definition)
 					state.FileFormat = string(pointer.From(props.Format))
 				}
 			}
@@ -210,46 +217,78 @@ func (r BillingAccountCostManagementExportResource) Update() sdk.ResourceFunc {
 			var opts exports.GetOperationOptions
 			resp, err := client.Get(ctx, *id, opts)
 			if err != nil {
-				return fmt.Errorf("reading %s: %+v", *id, err)
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
 			}
 
-			if model := resp.Model; model != nil {
-				if model.ETag == nil {
-					return fmt.Errorf("add %s: etag was nil", *id)
+			if resp.Model == nil {
+				return fmt.Errorf("retrieving %s: model was nil", *id)
+			}
+
+			if resp.Model.ETag == nil {
+				return fmt.Errorf("retrieving %s: etag was nil", *id)
+			}
+
+			model := *resp.Model
+			if model.Properties == nil {
+				return fmt.Errorf("retrieving %s: properties was nil", *id)
+			}
+
+			props := model.Properties
+
+			if metadata.ResourceData.HasChange("active") {
+				status := exports.StatusTypeActive
+				if !config.Active {
+					status = exports.StatusTypeInactive
+				}
+				if props.Schedule == nil {
+					props.Schedule = &exports.ExportSchedule{}
+				}
+				props.Schedule.Status = &status
+			}
+
+			if metadata.ResourceData.HasChange("recurrence_type") {
+				if props.Schedule == nil {
+					props.Schedule = &exports.ExportSchedule{}
+				}
+				props.Schedule.Recurrence = pointer.ToEnum[exports.RecurrenceType](config.RecurrenceType)
+			}
+
+			if metadata.ResourceData.HasChanges("recurrence_period_start_date", "recurrence_period_end_date") {
+				if props.Schedule == nil {
+					props.Schedule = &exports.ExportSchedule{}
+				}
+				props.Schedule.RecurrencePeriod = &exports.ExportRecurrencePeriod{
+					From: config.RecurrencePeriodStartDate,
+					To:   pointer.To(config.RecurrencePeriodEndDate),
 				}
 			}
 
-			deliveryInfo, err := expandExportDataStorageLocationFromModel(config.ExportDataStorageLocation)
-			if err != nil {
-				return fmt.Errorf("expanding `export_data_storage_location`: %+v", err)
+			if metadata.ResourceData.HasChange("export_data_storage_location") {
+				deliveryInfo, err := expandExportDataStorageLocationFromModel(config.ExportDataStorageLocation)
+				if err != nil {
+					return fmt.Errorf("expanding `export_data_storage_location`: %+v", err)
+				}
+				if deliveryInfo == nil {
+					return fmt.Errorf("`export_data_storage_location` was empty")
+				}
+				props.DeliveryInfo = *deliveryInfo
 			}
 
-			status := exports.StatusTypeActive
-			if !config.Active {
-				status = exports.StatusTypeInactive
+			if metadata.ResourceData.HasChange("file_format") {
+				props.Format = pointer.ToEnum[exports.FormatType](config.FileFormat)
 			}
 
-			format := exports.FormatType(config.FileFormat)
-			recurrenceType := exports.RecurrenceType(config.RecurrenceType)
-
-			props := exports.Export{
-				ETag: resp.Model.ETag,
-				Properties: &exports.ExportProperties{
-					Schedule: &exports.ExportSchedule{
-						Recurrence: &recurrenceType,
-						RecurrencePeriod: &exports.ExportRecurrencePeriod{
-							From: config.RecurrencePeriodStartDate,
-							To:   pointer.To(config.RecurrencePeriodEndDate),
-						},
-						Status: &status,
-					},
-					DeliveryInfo: *deliveryInfo,
-					Format:       &format,
-					Definition:   *expandExportDataOptionsFromModel(config.ExportDataOptions),
-				},
+			if metadata.ResourceData.HasChange("export_data_options") {
+				definition := expandExportDataOptionsFromModel(config.ExportDataOptions)
+				if definition == nil {
+					return fmt.Errorf("`export_data_options` was empty")
+				}
+				props.Definition = *definition
 			}
 
-			if _, err = client.CreateOrUpdate(ctx, *id, props); err != nil {
+			model.Properties = props
+
+			if _, err = client.CreateOrUpdate(ctx, *id, model); err != nil {
 				return fmt.Errorf("updating %s: %+v", *id, err)
 			}
 

--- a/internal/services/costmanagement/export_resource_base.go
+++ b/internal/services/costmanagement/export_resource_base.go
@@ -9,14 +9,24 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2023-08-01/exports"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
+
+// Shared nested model structs for cost management export resources
+
+type CostManagementExportDataStorageLocationModel struct {
+	ContainerId    string `tfschema:"container_id"`
+	RootFolderPath string `tfschema:"root_folder_path"`
+}
+
+type CostManagementExportDataOptionsModel struct {
+	Type      string `tfschema:"type"`
+	TimeFrame string `tfschema:"time_frame"`
+}
 
 type costManagementExportBaseResource struct{}
 
@@ -129,90 +139,6 @@ func (br costManagementExportBaseResource) attributes() map[string]*pluginsdk.Sc
 	return map[string]*pluginsdk.Schema{}
 }
 
-func (br costManagementExportBaseResource) createFunc(resourceName, scopeFieldName string) sdk.ResourceFunc {
-	return sdk.ResourceFunc{
-		Timeout: 30 * time.Minute,
-		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
-			client := metadata.Client.CostManagement.ExportClient
-			id := exports.NewScopedExportID(metadata.ResourceData.Get(scopeFieldName).(string), metadata.ResourceData.Get("name").(string))
-			var opts exports.GetOperationOptions
-			existing, err := client.Get(ctx, id, opts)
-			if err != nil {
-				if !response.WasNotFound(existing.HttpResponse) {
-					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
-				}
-			}
-
-			if !response.WasNotFound(existing.HttpResponse) {
-				return tf.ImportAsExistsError(resourceName, id.ID())
-			}
-
-			if err := createOrUpdateCostManagementExport(ctx, client, metadata, id, nil); err != nil {
-				return fmt.Errorf("creating %s: %+v", id, err)
-			}
-
-			metadata.SetID(id)
-			return nil
-		},
-	}
-}
-
-func (br costManagementExportBaseResource) readFunc(scopeFieldName string) sdk.ResourceFunc {
-	return sdk.ResourceFunc{
-		Timeout: 5 * time.Minute,
-		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
-			client := metadata.Client.CostManagement.ExportClient
-
-			id, err := exports.ParseScopedExportID(metadata.ResourceData.Id())
-			if err != nil {
-				return err
-			}
-
-			var opts exports.GetOperationOptions
-			resp, err := client.Get(ctx, *id, opts)
-			if err != nil {
-				if response.WasNotFound(resp.HttpResponse) {
-					return metadata.MarkAsGone(id)
-				}
-				return fmt.Errorf("reading %s: %+v", *id, err)
-			}
-
-			metadata.ResourceData.Set("name", id.ExportName)
-			// lintignore:R001
-			metadata.ResourceData.Set(scopeFieldName, id.Scope)
-
-			if model := resp.Model; model != nil {
-				if props := model.Properties; props != nil {
-					if schedule := props.Schedule; schedule != nil {
-						if recurrencePeriod := schedule.RecurrencePeriod; recurrencePeriod != nil {
-							metadata.ResourceData.Set("recurrence_period_start_date", recurrencePeriod.From)
-							metadata.ResourceData.Set("recurrence_period_end_date", recurrencePeriod.To)
-						}
-						status := *schedule.Status == exports.StatusTypeActive
-
-						metadata.ResourceData.Set("active", status)
-						metadata.ResourceData.Set("recurrence_type", string(pointer.From(schedule.Recurrence)))
-					}
-
-					exportDeliveryInfo, err := flattenExportDataStorageLocation(&props.DeliveryInfo)
-					if err != nil {
-						return fmt.Errorf("flattening `export_data_storage_location`: %+v", err)
-					}
-					if err := metadata.ResourceData.Set("export_data_storage_location", exportDeliveryInfo); err != nil {
-						return fmt.Errorf("setting `export_data_storage_location`: %+v", err)
-					}
-					if err := metadata.ResourceData.Set("export_data_options", flattenExportDefinition(&props.Definition)); err != nil {
-						return fmt.Errorf("setting `export_data_options`: %+v", err)
-					}
-					metadata.ResourceData.Set("file_format", string(pointer.From(props.Format)))
-				}
-			}
-
-			return nil
-		},
-	}
-}
-
 func (br costManagementExportBaseResource) deleteFunc() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Timeout: 30 * time.Minute,
@@ -233,123 +159,41 @@ func (br costManagementExportBaseResource) deleteFunc() sdk.ResourceFunc {
 	}
 }
 
-func (br costManagementExportBaseResource) updateFunc() sdk.ResourceFunc {
-	return sdk.ResourceFunc{
-		Timeout: 30 * time.Minute,
-		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
-			client := metadata.Client.CostManagement.ExportClient
-
-			id, err := exports.ParseScopedExportID(metadata.ResourceData.Id())
-			if err != nil {
-				return err
-			}
-
-			// Update operation requires latest eTag to be set in the request.
-			var opts exports.GetOperationOptions
-			resp, err := client.Get(ctx, *id, opts)
-			if err != nil {
-				return fmt.Errorf("reading %s: %+v", *id, err)
-			}
-
-			if model := resp.Model; model != nil {
-				if model.ETag == nil {
-					return fmt.Errorf("add %s: etag was nil", *id)
-				}
-			}
-
-			if err := createOrUpdateCostManagementExport(ctx, client, metadata, *id, resp.Model.ETag); err != nil {
-				return fmt.Errorf("updating %s: %+v", *id, err)
-			}
-
-			return nil
-		},
-	}
-}
-
-func createOrUpdateCostManagementExport(ctx context.Context, client *exports.ExportsClient, metadata sdk.ResourceMetaData, id exports.ScopedExportId, etag *string) error {
-	status := exports.StatusTypeActive
-	if v := metadata.ResourceData.Get("active"); !v.(bool) {
-		status = exports.StatusTypeInactive
-	}
-
-	deliveryInfo, err := expandExportDataStorageLocation(metadata.ResourceData.Get("export_data_storage_location").([]interface{}))
-	if err != nil {
-		return fmt.Errorf("expanding `export_data_storage_location`: %+v", err)
-	}
-
-	format := exports.FormatType(metadata.ResourceData.Get("file_format").(string))
-
-	recurrenceType := exports.RecurrenceType(metadata.ResourceData.Get("recurrence_type").(string))
-	props := exports.Export{
-		ETag: etag,
-		Properties: &exports.ExportProperties{
-			Schedule: &exports.ExportSchedule{
-				Recurrence: &recurrenceType,
-				RecurrencePeriod: &exports.ExportRecurrencePeriod{
-					From: metadata.ResourceData.Get("recurrence_period_start_date").(string),
-					To:   pointer.To(metadata.ResourceData.Get("recurrence_period_end_date").(string)),
-				},
-				Status: &status,
-			},
-			DeliveryInfo: *deliveryInfo,
-			Format:       &format,
-			Definition:   *expandExportDefinition(metadata.ResourceData.Get("export_data_options").([]interface{})),
-		},
-	}
-
-	_, err = client.CreateOrUpdate(ctx, id, props)
-
-	return err
-}
-
-func expandExportDataStorageLocation(input []interface{}) (*exports.ExportDeliveryInfo, error) {
-	if len(input) == 0 || input[0] == nil {
+// expandExportDataStorageLocationFromModel converts the typed model to the SDK type
+func expandExportDataStorageLocationFromModel(input []CostManagementExportDataStorageLocationModel) (*exports.ExportDeliveryInfo, error) {
+	if len(input) == 0 {
 		return nil, nil
 	}
-	attrs := input[0].(map[string]interface{})
 
-	containerId, err := commonids.ParseStorageContainerID(attrs["container_id"].(string))
+	loc := input[0]
+
+	containerId, err := commonids.ParseStorageContainerID(loc.ContainerId)
 	if err != nil {
 		return nil, err
 	}
 
 	storageId := commonids.NewStorageAccountID(containerId.SubscriptionId, containerId.ResourceGroupName, containerId.StorageAccountName)
 
-	deliveryInfo := &exports.ExportDeliveryInfo{
+	return &exports.ExportDeliveryInfo{
 		Destination: exports.ExportDeliveryDestination{
 			ResourceId:     pointer.To(storageId.ID()),
 			Container:      containerId.ContainerName,
-			RootFolderPath: pointer.To(attrs["root_folder_path"].(string)),
+			RootFolderPath: pointer.To(loc.RootFolderPath),
 		},
-	}
-
-	return deliveryInfo, nil
+	}, nil
 }
 
-func expandExportDefinition(input []interface{}) *exports.ExportDefinition {
-	if len(input) == 0 || input[0] == nil {
-		return nil
-	}
-
-	attrs := input[0].(map[string]interface{})
-	definitionInfo := &exports.ExportDefinition{
-		Type:      exports.ExportType(attrs["type"].(string)),
-		Timeframe: exports.TimeframeType(attrs["time_frame"].(string)),
-	}
-
-	return definitionInfo
-}
-
-func flattenExportDataStorageLocation(input *exports.ExportDeliveryInfo) ([]interface{}, error) {
+// flattenExportDataStorageLocationToModel converts the SDK type to the typed model
+func flattenExportDataStorageLocationToModel(input *exports.ExportDeliveryInfo) ([]CostManagementExportDataStorageLocationModel, error) {
 	if input == nil {
-		return []interface{}{}, nil
+		return []CostManagementExportDataStorageLocationModel{}, nil
 	}
 
 	destination := input.Destination
-	var err error
 	var storageAccountId *commonids.StorageAccountId
 
 	if v := destination.ResourceId; v != nil {
+		var err error
 		storageAccountId, err = commonids.ParseStorageAccountIDInsensitively(*v)
 		if err != nil {
 			return nil, err
@@ -366,17 +210,31 @@ func flattenExportDataStorageLocation(input *exports.ExportDeliveryInfo) ([]inte
 		rootFolderPath = *v
 	}
 
-	return []interface{}{
-		map[string]interface{}{
-			"container_id":     containerId,
-			"root_folder_path": rootFolderPath,
+	return []CostManagementExportDataStorageLocationModel{
+		{
+			ContainerId:    containerId,
+			RootFolderPath: rootFolderPath,
 		},
 	}, nil
 }
 
-func flattenExportDefinition(input *exports.ExportDefinition) []interface{} {
+// expandExportDataOptionsFromModel converts the typed model to the SDK type
+func expandExportDataOptionsFromModel(input []CostManagementExportDataOptionsModel) *exports.ExportDefinition {
+	if len(input) == 0 {
+		return nil
+	}
+
+	opt := input[0]
+	return &exports.ExportDefinition{
+		Type:      exports.ExportType(opt.Type),
+		Timeframe: exports.TimeframeType(opt.TimeFrame),
+	}
+}
+
+// flattenExportDataOptionsToModel converts the SDK type to the typed model
+func flattenExportDataOptionsToModel(input *exports.ExportDefinition) []CostManagementExportDataOptionsModel {
 	if input == nil {
-		return []interface{}{}
+		return []CostManagementExportDataOptionsModel{}
 	}
 
 	queryType := ""
@@ -384,10 +242,10 @@ func flattenExportDefinition(input *exports.ExportDefinition) []interface{} {
 		queryType = string(input.Type)
 	}
 
-	return []interface{}{
-		map[string]interface{}{
-			"time_frame": string(input.Timeframe),
-			"type":       queryType,
+	return []CostManagementExportDataOptionsModel{
+		{
+			TimeFrame: string(input.Timeframe),
+			Type:      queryType,
 		},
 	}
 }

--- a/internal/services/costmanagement/export_resource_base.go
+++ b/internal/services/costmanagement/export_resource_base.go
@@ -185,7 +185,6 @@ func expandExportDataStorageLocationFromModel(input []CostManagementExportDataSt
 
 // flattenExportDataStorageLocationToModel converts the SDK type to the typed model
 func flattenExportDataStorageLocationToModel(input exports.ExportDeliveryInfo) ([]CostManagementExportDataStorageLocationModel, error) {
-
 	destination := input.Destination
 
 	var storageAccountId *commonids.StorageAccountId
@@ -231,7 +230,6 @@ func expandExportDataOptionsFromModel(input []CostManagementExportDataOptionsMod
 
 // flattenExportDataOptionsToModel converts the SDK type to the typed model
 func flattenExportDataOptionsToModel(input exports.ExportDefinition) []CostManagementExportDataOptionsModel {
-
 	queryType := ""
 	if v := input.Type; v != "" {
 		queryType = string(input.Type)

--- a/internal/services/costmanagement/export_resource_base.go
+++ b/internal/services/costmanagement/export_resource_base.go
@@ -184,12 +184,10 @@ func expandExportDataStorageLocationFromModel(input []CostManagementExportDataSt
 }
 
 // flattenExportDataStorageLocationToModel converts the SDK type to the typed model
-func flattenExportDataStorageLocationToModel(input *exports.ExportDeliveryInfo) ([]CostManagementExportDataStorageLocationModel, error) {
-	if input == nil {
-		return []CostManagementExportDataStorageLocationModel{}, nil
-	}
+func flattenExportDataStorageLocationToModel(input exports.ExportDeliveryInfo) ([]CostManagementExportDataStorageLocationModel, error) {
 
 	destination := input.Destination
+
 	var storageAccountId *commonids.StorageAccountId
 
 	if v := destination.ResourceId; v != nil {
@@ -232,10 +230,7 @@ func expandExportDataOptionsFromModel(input []CostManagementExportDataOptionsMod
 }
 
 // flattenExportDataOptionsToModel converts the SDK type to the typed model
-func flattenExportDataOptionsToModel(input *exports.ExportDefinition) []CostManagementExportDataOptionsModel {
-	if input == nil {
-		return []CostManagementExportDataOptionsModel{}
-	}
+func flattenExportDataOptionsToModel(input exports.ExportDefinition) []CostManagementExportDataOptionsModel {
 
 	queryType := ""
 	if v := input.Type; v != "" {

--- a/internal/services/costmanagement/resource_group_cost_management_export_resource.go
+++ b/internal/services/costmanagement/resource_group_cost_management_export_resource.go
@@ -4,6 +4,14 @@
 package costmanagement
 
 import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2023-08-01/exports"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/costmanagement/validate"
 	resourceValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/resource/validate"
@@ -13,6 +21,18 @@ import (
 
 type ResourceGroupCostManagementExportResource struct {
 	base costManagementExportBaseResource
+}
+
+type ResourceGroupCostManagementExportModel struct {
+	Name                      string                                         `tfschema:"name"`
+	ResourceGroupId           string                                         `tfschema:"resource_group_id"`
+	Active                    bool                                           `tfschema:"active"`
+	RecurrenceType            string                                         `tfschema:"recurrence_type"`
+	RecurrencePeriodStartDate string                                         `tfschema:"recurrence_period_start_date"`
+	RecurrencePeriodEndDate   string                                         `tfschema:"recurrence_period_end_date"`
+	FileFormat                string                                         `tfschema:"file_format"`
+	ExportDataStorageLocation []CostManagementExportDataStorageLocationModel `tfschema:"export_data_storage_location"`
+	ExportDataOptions         []CostManagementExportDataOptionsModel         `tfschema:"export_data_options"`
 }
 
 var _ sdk.Resource = ResourceGroupCostManagementExportResource{}
@@ -40,7 +60,7 @@ func (r ResourceGroupCostManagementExportResource) Attributes() map[string]*plug
 }
 
 func (r ResourceGroupCostManagementExportResource) ModelObject() interface{} {
-	return nil
+	return &ResourceGroupCostManagementExportModel{}
 }
 
 func (r ResourceGroupCostManagementExportResource) ResourceType() string {
@@ -52,11 +72,118 @@ func (r ResourceGroupCostManagementExportResource) IDValidationFunc() pluginsdk.
 }
 
 func (r ResourceGroupCostManagementExportResource) Create() sdk.ResourceFunc {
-	return r.base.createFunc(r.ResourceType(), "resource_group_id")
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.CostManagement.ExportClient
+
+			var config ResourceGroupCostManagementExportModel
+			if err := metadata.Decode(&config); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			id := exports.NewScopedExportID(config.ResourceGroupId, config.Name)
+
+			var opts exports.GetOperationOptions
+			existing, err := client.Get(ctx, id, opts)
+			if err != nil {
+				if !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+				}
+			}
+
+			if !response.WasNotFound(existing.HttpResponse) {
+				return tf.ImportAsExistsError(r.ResourceType(), id.ID())
+			}
+
+			deliveryInfo, err := expandExportDataStorageLocationFromModel(config.ExportDataStorageLocation)
+			if err != nil {
+				return fmt.Errorf("expanding `export_data_storage_location`: %+v", err)
+			}
+
+			status := exports.StatusTypeActive
+			if !config.Active {
+				status = exports.StatusTypeInactive
+			}
+
+			format := exports.FormatType(config.FileFormat)
+			recurrenceType := exports.RecurrenceType(config.RecurrenceType)
+
+			props := exports.Export{
+				Properties: &exports.ExportProperties{
+					Schedule: &exports.ExportSchedule{
+						Recurrence: &recurrenceType,
+						RecurrencePeriod: &exports.ExportRecurrencePeriod{
+							From: config.RecurrencePeriodStartDate,
+							To:   pointer.To(config.RecurrencePeriodEndDate),
+						},
+						Status: &status,
+					},
+					DeliveryInfo: *deliveryInfo,
+					Format:       &format,
+					Definition:   *expandExportDataOptionsFromModel(config.ExportDataOptions),
+				},
+			}
+
+			if _, err = client.CreateOrUpdate(ctx, id, props); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+	}
 }
 
 func (r ResourceGroupCostManagementExportResource) Read() sdk.ResourceFunc {
-	return r.base.readFunc("resource_group_id")
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.CostManagement.ExportClient
+
+			id, err := exports.ParseScopedExportID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			var opts exports.GetOperationOptions
+			resp, err := client.Get(ctx, *id, opts)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return metadata.MarkAsGone(id)
+				}
+				return fmt.Errorf("reading %s: %+v", *id, err)
+			}
+
+			state := ResourceGroupCostManagementExportModel{
+				Name:            id.ExportName,
+				ResourceGroupId: id.Scope,
+			}
+
+			if model := resp.Model; model != nil {
+				if props := model.Properties; props != nil {
+					if schedule := props.Schedule; schedule != nil {
+						if recurrencePeriod := schedule.RecurrencePeriod; recurrencePeriod != nil {
+							state.RecurrencePeriodStartDate = recurrencePeriod.From
+							state.RecurrencePeriodEndDate = pointer.From(recurrencePeriod.To)
+						}
+						state.Active = *schedule.Status == exports.StatusTypeActive
+						state.RecurrenceType = string(pointer.From(schedule.Recurrence))
+					}
+
+					storageLocation, err := flattenExportDataStorageLocationToModel(&props.DeliveryInfo)
+					if err != nil {
+						return fmt.Errorf("flattening `export_data_storage_location`: %+v", err)
+					}
+					state.ExportDataStorageLocation = storageLocation
+					state.ExportDataOptions = flattenExportDataOptionsToModel(&props.Definition)
+					state.FileFormat = string(pointer.From(props.Format))
+				}
+			}
+
+			return metadata.Encode(&state)
+		},
+	}
 }
 
 func (r ResourceGroupCostManagementExportResource) Delete() sdk.ResourceFunc {
@@ -64,5 +191,69 @@ func (r ResourceGroupCostManagementExportResource) Delete() sdk.ResourceFunc {
 }
 
 func (r ResourceGroupCostManagementExportResource) Update() sdk.ResourceFunc {
-	return r.base.updateFunc()
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.CostManagement.ExportClient
+
+			id, err := exports.ParseScopedExportID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			var config ResourceGroupCostManagementExportModel
+			if err := metadata.Decode(&config); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			// Update operation requires latest eTag to be set in the request.
+			var opts exports.GetOperationOptions
+			resp, err := client.Get(ctx, *id, opts)
+			if err != nil {
+				return fmt.Errorf("reading %s: %+v", *id, err)
+			}
+
+			if model := resp.Model; model != nil {
+				if model.ETag == nil {
+					return fmt.Errorf("add %s: etag was nil", *id)
+				}
+			}
+
+			deliveryInfo, err := expandExportDataStorageLocationFromModel(config.ExportDataStorageLocation)
+			if err != nil {
+				return fmt.Errorf("expanding `export_data_storage_location`: %+v", err)
+			}
+
+			status := exports.StatusTypeActive
+			if !config.Active {
+				status = exports.StatusTypeInactive
+			}
+
+			format := exports.FormatType(config.FileFormat)
+			recurrenceType := exports.RecurrenceType(config.RecurrenceType)
+
+			props := exports.Export{
+				ETag: resp.Model.ETag,
+				Properties: &exports.ExportProperties{
+					Schedule: &exports.ExportSchedule{
+						Recurrence: &recurrenceType,
+						RecurrencePeriod: &exports.ExportRecurrencePeriod{
+							From: config.RecurrencePeriodStartDate,
+							To:   pointer.To(config.RecurrencePeriodEndDate),
+						},
+						Status: &status,
+					},
+					DeliveryInfo: *deliveryInfo,
+					Format:       &format,
+					Definition:   *expandExportDataOptionsFromModel(config.ExportDataOptions),
+				},
+			}
+
+			if _, err = client.CreateOrUpdate(ctx, *id, props); err != nil {
+				return fmt.Errorf("updating %s: %+v", *id, err)
+			}
+
+			return nil
+		},
+	}
 }

--- a/internal/services/costmanagement/resource_group_cost_management_export_resource.go
+++ b/internal/services/costmanagement/resource_group_cost_management_export_resource.go
@@ -100,19 +100,24 @@ func (r ResourceGroupCostManagementExportResource) Create() sdk.ResourceFunc {
 			if err != nil {
 				return fmt.Errorf("expanding `export_data_storage_location`: %+v", err)
 			}
+			if deliveryInfo == nil {
+				return fmt.Errorf("`export_data_storage_location` was empty")
+			}
+
+			definition := expandExportDataOptionsFromModel(config.ExportDataOptions)
+			if definition == nil {
+				return fmt.Errorf("`export_data_options` was empty")
+			}
 
 			status := exports.StatusTypeActive
 			if !config.Active {
 				status = exports.StatusTypeInactive
 			}
 
-			format := exports.FormatType(config.FileFormat)
-			recurrenceType := exports.RecurrenceType(config.RecurrenceType)
-
 			props := exports.Export{
 				Properties: &exports.ExportProperties{
 					Schedule: &exports.ExportSchedule{
-						Recurrence: &recurrenceType,
+						Recurrence: pointer.ToEnum[exports.RecurrenceType](config.RecurrenceType),
 						RecurrencePeriod: &exports.ExportRecurrencePeriod{
 							From: config.RecurrencePeriodStartDate,
 							To:   pointer.To(config.RecurrencePeriodEndDate),
@@ -120,8 +125,8 @@ func (r ResourceGroupCostManagementExportResource) Create() sdk.ResourceFunc {
 						Status: &status,
 					},
 					DeliveryInfo: *deliveryInfo,
-					Format:       &format,
-					Definition:   *expandExportDataOptionsFromModel(config.ExportDataOptions),
+					Format:       pointer.ToEnum[exports.FormatType](config.FileFormat),
+					Definition:   *definition,
 				},
 			}
 
@@ -152,7 +157,7 @@ func (r ResourceGroupCostManagementExportResource) Read() sdk.ResourceFunc {
 				if response.WasNotFound(resp.HttpResponse) {
 					return metadata.MarkAsGone(id)
 				}
-				return fmt.Errorf("reading %s: %+v", *id, err)
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
 			}
 
 			state := ResourceGroupCostManagementExportModel{
@@ -167,16 +172,18 @@ func (r ResourceGroupCostManagementExportResource) Read() sdk.ResourceFunc {
 							state.RecurrencePeriodStartDate = recurrencePeriod.From
 							state.RecurrencePeriodEndDate = pointer.From(recurrencePeriod.To)
 						}
-						state.Active = *schedule.Status == exports.StatusTypeActive
+						if schedule.Status != nil {
+							state.Active = *schedule.Status == exports.StatusTypeActive
+						}
 						state.RecurrenceType = string(pointer.From(schedule.Recurrence))
 					}
 
-					storageLocation, err := flattenExportDataStorageLocationToModel(&props.DeliveryInfo)
+					storageLocation, err := flattenExportDataStorageLocationToModel(props.DeliveryInfo)
 					if err != nil {
 						return fmt.Errorf("flattening `export_data_storage_location`: %+v", err)
 					}
 					state.ExportDataStorageLocation = storageLocation
-					state.ExportDataOptions = flattenExportDataOptionsToModel(&props.Definition)
+					state.ExportDataOptions = flattenExportDataOptionsToModel(props.Definition)
 					state.FileFormat = string(pointer.From(props.Format))
 				}
 			}
@@ -210,46 +217,78 @@ func (r ResourceGroupCostManagementExportResource) Update() sdk.ResourceFunc {
 			var opts exports.GetOperationOptions
 			resp, err := client.Get(ctx, *id, opts)
 			if err != nil {
-				return fmt.Errorf("reading %s: %+v", *id, err)
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
 			}
 
-			if model := resp.Model; model != nil {
-				if model.ETag == nil {
-					return fmt.Errorf("add %s: etag was nil", *id)
+			if resp.Model == nil {
+				return fmt.Errorf("retrieving %s: model was nil", *id)
+			}
+
+			if resp.Model.ETag == nil {
+				return fmt.Errorf("retrieving %s: etag was nil", *id)
+			}
+
+			model := *resp.Model
+			if model.Properties == nil {
+				return fmt.Errorf("retrieving %s: properties was nil", *id)
+			}
+
+			props := model.Properties
+
+			if metadata.ResourceData.HasChange("active") {
+				status := exports.StatusTypeActive
+				if !config.Active {
+					status = exports.StatusTypeInactive
+				}
+				if props.Schedule == nil {
+					props.Schedule = &exports.ExportSchedule{}
+				}
+				props.Schedule.Status = &status
+			}
+
+			if metadata.ResourceData.HasChange("recurrence_type") {
+				if props.Schedule == nil {
+					props.Schedule = &exports.ExportSchedule{}
+				}
+				props.Schedule.Recurrence = pointer.ToEnum[exports.RecurrenceType](config.RecurrenceType)
+			}
+
+			if metadata.ResourceData.HasChanges("recurrence_period_start_date", "recurrence_period_end_date") {
+				if props.Schedule == nil {
+					props.Schedule = &exports.ExportSchedule{}
+				}
+				props.Schedule.RecurrencePeriod = &exports.ExportRecurrencePeriod{
+					From: config.RecurrencePeriodStartDate,
+					To:   pointer.To(config.RecurrencePeriodEndDate),
 				}
 			}
 
-			deliveryInfo, err := expandExportDataStorageLocationFromModel(config.ExportDataStorageLocation)
-			if err != nil {
-				return fmt.Errorf("expanding `export_data_storage_location`: %+v", err)
+			if metadata.ResourceData.HasChange("export_data_storage_location") {
+				deliveryInfo, err := expandExportDataStorageLocationFromModel(config.ExportDataStorageLocation)
+				if err != nil {
+					return fmt.Errorf("expanding `export_data_storage_location`: %+v", err)
+				}
+				if deliveryInfo == nil {
+					return fmt.Errorf("`export_data_storage_location` was empty")
+				}
+				props.DeliveryInfo = *deliveryInfo
 			}
 
-			status := exports.StatusTypeActive
-			if !config.Active {
-				status = exports.StatusTypeInactive
+			if metadata.ResourceData.HasChange("file_format") {
+				props.Format = pointer.ToEnum[exports.FormatType](config.FileFormat)
 			}
 
-			format := exports.FormatType(config.FileFormat)
-			recurrenceType := exports.RecurrenceType(config.RecurrenceType)
-
-			props := exports.Export{
-				ETag: resp.Model.ETag,
-				Properties: &exports.ExportProperties{
-					Schedule: &exports.ExportSchedule{
-						Recurrence: &recurrenceType,
-						RecurrencePeriod: &exports.ExportRecurrencePeriod{
-							From: config.RecurrencePeriodStartDate,
-							To:   pointer.To(config.RecurrencePeriodEndDate),
-						},
-						Status: &status,
-					},
-					DeliveryInfo: *deliveryInfo,
-					Format:       &format,
-					Definition:   *expandExportDataOptionsFromModel(config.ExportDataOptions),
-				},
+			if metadata.ResourceData.HasChange("export_data_options") {
+				definition := expandExportDataOptionsFromModel(config.ExportDataOptions)
+				if definition == nil {
+					return fmt.Errorf("`export_data_options` was empty")
+				}
+				props.Definition = *definition
 			}
 
-			if _, err = client.CreateOrUpdate(ctx, *id, props); err != nil {
+			model.Properties = props
+
+			if _, err = client.CreateOrUpdate(ctx, *id, model); err != nil {
 				return fmt.Errorf("updating %s: %+v", *id, err)
 			}
 

--- a/internal/services/costmanagement/subscription_cost_management_export_resource.go
+++ b/internal/services/costmanagement/subscription_cost_management_export_resource.go
@@ -4,7 +4,15 @@
 package costmanagement
 
 import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2023-08-01/exports"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/costmanagement/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -13,6 +21,18 @@ import (
 
 type SubscriptionCostManagementExportResource struct {
 	base costManagementExportBaseResource
+}
+
+type SubscriptionCostManagementExportModel struct {
+	Name                      string                                         `tfschema:"name"`
+	SubscriptionId            string                                         `tfschema:"subscription_id"`
+	Active                    bool                                           `tfschema:"active"`
+	RecurrenceType            string                                         `tfschema:"recurrence_type"`
+	RecurrencePeriodStartDate string                                         `tfschema:"recurrence_period_start_date"`
+	RecurrencePeriodEndDate   string                                         `tfschema:"recurrence_period_end_date"`
+	FileFormat                string                                         `tfschema:"file_format"`
+	ExportDataStorageLocation []CostManagementExportDataStorageLocationModel `tfschema:"export_data_storage_location"`
+	ExportDataOptions         []CostManagementExportDataOptionsModel         `tfschema:"export_data_options"`
 }
 
 var _ sdk.Resource = SubscriptionCostManagementExportResource{}
@@ -40,7 +60,7 @@ func (r SubscriptionCostManagementExportResource) Attributes() map[string]*plugi
 }
 
 func (r SubscriptionCostManagementExportResource) ModelObject() interface{} {
-	return nil
+	return &SubscriptionCostManagementExportModel{}
 }
 
 func (r SubscriptionCostManagementExportResource) ResourceType() string {
@@ -52,11 +72,118 @@ func (r SubscriptionCostManagementExportResource) IDValidationFunc() pluginsdk.S
 }
 
 func (r SubscriptionCostManagementExportResource) Create() sdk.ResourceFunc {
-	return r.base.createFunc(r.ResourceType(), "subscription_id")
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.CostManagement.ExportClient
+
+			var config SubscriptionCostManagementExportModel
+			if err := metadata.Decode(&config); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			id := exports.NewScopedExportID(config.SubscriptionId, config.Name)
+
+			var opts exports.GetOperationOptions
+			existing, err := client.Get(ctx, id, opts)
+			if err != nil {
+				if !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+				}
+			}
+
+			if !response.WasNotFound(existing.HttpResponse) {
+				return tf.ImportAsExistsError(r.ResourceType(), id.ID())
+			}
+
+			deliveryInfo, err := expandExportDataStorageLocationFromModel(config.ExportDataStorageLocation)
+			if err != nil {
+				return fmt.Errorf("expanding `export_data_storage_location`: %+v", err)
+			}
+
+			status := exports.StatusTypeActive
+			if !config.Active {
+				status = exports.StatusTypeInactive
+			}
+
+			format := exports.FormatType(config.FileFormat)
+			recurrenceType := exports.RecurrenceType(config.RecurrenceType)
+
+			props := exports.Export{
+				Properties: &exports.ExportProperties{
+					Schedule: &exports.ExportSchedule{
+						Recurrence: &recurrenceType,
+						RecurrencePeriod: &exports.ExportRecurrencePeriod{
+							From: config.RecurrencePeriodStartDate,
+							To:   pointer.To(config.RecurrencePeriodEndDate),
+						},
+						Status: &status,
+					},
+					DeliveryInfo: *deliveryInfo,
+					Format:       &format,
+					Definition:   *expandExportDataOptionsFromModel(config.ExportDataOptions),
+				},
+			}
+
+			if _, err = client.CreateOrUpdate(ctx, id, props); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+	}
 }
 
 func (r SubscriptionCostManagementExportResource) Read() sdk.ResourceFunc {
-	return r.base.readFunc("subscription_id")
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.CostManagement.ExportClient
+
+			id, err := exports.ParseScopedExportID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			var opts exports.GetOperationOptions
+			resp, err := client.Get(ctx, *id, opts)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return metadata.MarkAsGone(id)
+				}
+				return fmt.Errorf("reading %s: %+v", *id, err)
+			}
+
+			state := SubscriptionCostManagementExportModel{
+				Name:           id.ExportName,
+				SubscriptionId: id.Scope,
+			}
+
+			if model := resp.Model; model != nil {
+				if props := model.Properties; props != nil {
+					if schedule := props.Schedule; schedule != nil {
+						if recurrencePeriod := schedule.RecurrencePeriod; recurrencePeriod != nil {
+							state.RecurrencePeriodStartDate = recurrencePeriod.From
+							state.RecurrencePeriodEndDate = pointer.From(recurrencePeriod.To)
+						}
+						state.Active = *schedule.Status == exports.StatusTypeActive
+						state.RecurrenceType = string(pointer.From(schedule.Recurrence))
+					}
+
+					storageLocation, err := flattenExportDataStorageLocationToModel(&props.DeliveryInfo)
+					if err != nil {
+						return fmt.Errorf("flattening `export_data_storage_location`: %+v", err)
+					}
+					state.ExportDataStorageLocation = storageLocation
+					state.ExportDataOptions = flattenExportDataOptionsToModel(&props.Definition)
+					state.FileFormat = string(pointer.From(props.Format))
+				}
+			}
+
+			return metadata.Encode(&state)
+		},
+	}
 }
 
 func (r SubscriptionCostManagementExportResource) Delete() sdk.ResourceFunc {
@@ -64,5 +191,69 @@ func (r SubscriptionCostManagementExportResource) Delete() sdk.ResourceFunc {
 }
 
 func (r SubscriptionCostManagementExportResource) Update() sdk.ResourceFunc {
-	return r.base.updateFunc()
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.CostManagement.ExportClient
+
+			id, err := exports.ParseScopedExportID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			var config SubscriptionCostManagementExportModel
+			if err := metadata.Decode(&config); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			// Update operation requires latest eTag to be set in the request.
+			var opts exports.GetOperationOptions
+			resp, err := client.Get(ctx, *id, opts)
+			if err != nil {
+				return fmt.Errorf("reading %s: %+v", *id, err)
+			}
+
+			if model := resp.Model; model != nil {
+				if model.ETag == nil {
+					return fmt.Errorf("add %s: etag was nil", *id)
+				}
+			}
+
+			deliveryInfo, err := expandExportDataStorageLocationFromModel(config.ExportDataStorageLocation)
+			if err != nil {
+				return fmt.Errorf("expanding `export_data_storage_location`: %+v", err)
+			}
+
+			status := exports.StatusTypeActive
+			if !config.Active {
+				status = exports.StatusTypeInactive
+			}
+
+			format := exports.FormatType(config.FileFormat)
+			recurrenceType := exports.RecurrenceType(config.RecurrenceType)
+
+			props := exports.Export{
+				ETag: resp.Model.ETag,
+				Properties: &exports.ExportProperties{
+					Schedule: &exports.ExportSchedule{
+						Recurrence: &recurrenceType,
+						RecurrencePeriod: &exports.ExportRecurrencePeriod{
+							From: config.RecurrencePeriodStartDate,
+							To:   pointer.To(config.RecurrencePeriodEndDate),
+						},
+						Status: &status,
+					},
+					DeliveryInfo: *deliveryInfo,
+					Format:       &format,
+					Definition:   *expandExportDataOptionsFromModel(config.ExportDataOptions),
+				},
+			}
+
+			if _, err = client.CreateOrUpdate(ctx, *id, props); err != nil {
+				return fmt.Errorf("updating %s: %+v", *id, err)
+			}
+
+			return nil
+		},
+	}
 }

--- a/internal/services/costmanagement/subscription_cost_management_export_resource.go
+++ b/internal/services/costmanagement/subscription_cost_management_export_resource.go
@@ -100,19 +100,24 @@ func (r SubscriptionCostManagementExportResource) Create() sdk.ResourceFunc {
 			if err != nil {
 				return fmt.Errorf("expanding `export_data_storage_location`: %+v", err)
 			}
+			if deliveryInfo == nil {
+				return fmt.Errorf("`export_data_storage_location` was empty")
+			}
+
+			definition := expandExportDataOptionsFromModel(config.ExportDataOptions)
+			if definition == nil {
+				return fmt.Errorf("`export_data_options` was empty")
+			}
 
 			status := exports.StatusTypeActive
 			if !config.Active {
 				status = exports.StatusTypeInactive
 			}
 
-			format := exports.FormatType(config.FileFormat)
-			recurrenceType := exports.RecurrenceType(config.RecurrenceType)
-
 			props := exports.Export{
 				Properties: &exports.ExportProperties{
 					Schedule: &exports.ExportSchedule{
-						Recurrence: &recurrenceType,
+						Recurrence: pointer.ToEnum[exports.RecurrenceType](config.RecurrenceType),
 						RecurrencePeriod: &exports.ExportRecurrencePeriod{
 							From: config.RecurrencePeriodStartDate,
 							To:   pointer.To(config.RecurrencePeriodEndDate),
@@ -120,8 +125,8 @@ func (r SubscriptionCostManagementExportResource) Create() sdk.ResourceFunc {
 						Status: &status,
 					},
 					DeliveryInfo: *deliveryInfo,
-					Format:       &format,
-					Definition:   *expandExportDataOptionsFromModel(config.ExportDataOptions),
+					Format:       pointer.ToEnum[exports.FormatType](config.FileFormat),
+					Definition:   *definition,
 				},
 			}
 
@@ -152,7 +157,7 @@ func (r SubscriptionCostManagementExportResource) Read() sdk.ResourceFunc {
 				if response.WasNotFound(resp.HttpResponse) {
 					return metadata.MarkAsGone(id)
 				}
-				return fmt.Errorf("reading %s: %+v", *id, err)
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
 			}
 
 			state := SubscriptionCostManagementExportModel{
@@ -167,16 +172,18 @@ func (r SubscriptionCostManagementExportResource) Read() sdk.ResourceFunc {
 							state.RecurrencePeriodStartDate = recurrencePeriod.From
 							state.RecurrencePeriodEndDate = pointer.From(recurrencePeriod.To)
 						}
-						state.Active = *schedule.Status == exports.StatusTypeActive
+						if schedule.Status != nil {
+							state.Active = *schedule.Status == exports.StatusTypeActive
+						}
 						state.RecurrenceType = string(pointer.From(schedule.Recurrence))
 					}
 
-					storageLocation, err := flattenExportDataStorageLocationToModel(&props.DeliveryInfo)
+					storageLocation, err := flattenExportDataStorageLocationToModel(props.DeliveryInfo)
 					if err != nil {
 						return fmt.Errorf("flattening `export_data_storage_location`: %+v", err)
 					}
 					state.ExportDataStorageLocation = storageLocation
-					state.ExportDataOptions = flattenExportDataOptionsToModel(&props.Definition)
+					state.ExportDataOptions = flattenExportDataOptionsToModel(props.Definition)
 					state.FileFormat = string(pointer.From(props.Format))
 				}
 			}
@@ -210,46 +217,78 @@ func (r SubscriptionCostManagementExportResource) Update() sdk.ResourceFunc {
 			var opts exports.GetOperationOptions
 			resp, err := client.Get(ctx, *id, opts)
 			if err != nil {
-				return fmt.Errorf("reading %s: %+v", *id, err)
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
 			}
 
-			if model := resp.Model; model != nil {
-				if model.ETag == nil {
-					return fmt.Errorf("add %s: etag was nil", *id)
+			if resp.Model == nil {
+				return fmt.Errorf("retrieving %s: model was nil", *id)
+			}
+
+			if resp.Model.ETag == nil {
+				return fmt.Errorf("retrieving %s: etag was nil", *id)
+			}
+
+			model := *resp.Model
+			if model.Properties == nil {
+				return fmt.Errorf("retrieving %s: properties was nil", *id)
+			}
+
+			props := model.Properties
+
+			if metadata.ResourceData.HasChange("active") {
+				status := exports.StatusTypeActive
+				if !config.Active {
+					status = exports.StatusTypeInactive
+				}
+				if props.Schedule == nil {
+					props.Schedule = &exports.ExportSchedule{}
+				}
+				props.Schedule.Status = &status
+			}
+
+			if metadata.ResourceData.HasChange("recurrence_type") {
+				if props.Schedule == nil {
+					props.Schedule = &exports.ExportSchedule{}
+				}
+				props.Schedule.Recurrence = pointer.ToEnum[exports.RecurrenceType](config.RecurrenceType)
+			}
+
+			if metadata.ResourceData.HasChanges("recurrence_period_start_date", "recurrence_period_end_date") {
+				if props.Schedule == nil {
+					props.Schedule = &exports.ExportSchedule{}
+				}
+				props.Schedule.RecurrencePeriod = &exports.ExportRecurrencePeriod{
+					From: config.RecurrencePeriodStartDate,
+					To:   pointer.To(config.RecurrencePeriodEndDate),
 				}
 			}
 
-			deliveryInfo, err := expandExportDataStorageLocationFromModel(config.ExportDataStorageLocation)
-			if err != nil {
-				return fmt.Errorf("expanding `export_data_storage_location`: %+v", err)
+			if metadata.ResourceData.HasChange("export_data_storage_location") {
+				deliveryInfo, err := expandExportDataStorageLocationFromModel(config.ExportDataStorageLocation)
+				if err != nil {
+					return fmt.Errorf("expanding `export_data_storage_location`: %+v", err)
+				}
+				if deliveryInfo == nil {
+					return fmt.Errorf("`export_data_storage_location` was empty")
+				}
+				props.DeliveryInfo = *deliveryInfo
 			}
 
-			status := exports.StatusTypeActive
-			if !config.Active {
-				status = exports.StatusTypeInactive
+			if metadata.ResourceData.HasChange("file_format") {
+				props.Format = pointer.ToEnum[exports.FormatType](config.FileFormat)
 			}
 
-			format := exports.FormatType(config.FileFormat)
-			recurrenceType := exports.RecurrenceType(config.RecurrenceType)
-
-			props := exports.Export{
-				ETag: resp.Model.ETag,
-				Properties: &exports.ExportProperties{
-					Schedule: &exports.ExportSchedule{
-						Recurrence: &recurrenceType,
-						RecurrencePeriod: &exports.ExportRecurrencePeriod{
-							From: config.RecurrencePeriodStartDate,
-							To:   pointer.To(config.RecurrencePeriodEndDate),
-						},
-						Status: &status,
-					},
-					DeliveryInfo: *deliveryInfo,
-					Format:       &format,
-					Definition:   *expandExportDataOptionsFromModel(config.ExportDataOptions),
-				},
+			if metadata.ResourceData.HasChange("export_data_options") {
+				definition := expandExportDataOptionsFromModel(config.ExportDataOptions)
+				if definition == nil {
+					return fmt.Errorf("`export_data_options` was empty")
+				}
+				props.Definition = *definition
 			}
 
-			if _, err = client.CreateOrUpdate(ctx, *id, props); err != nil {
+			model.Properties = props
+
+			if _, err = client.CreateOrUpdate(ctx, *id, model); err != nil {
 				return fmt.Errorf("updating %s: %+v", *id, err)
 			}
 


### PR DESCRIPTION


## Community Note
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review
## Description
Convert the three cost management export resources (`azurerm_billing_account_cost_management_export`, `azurerm_resource_group_cost_management_export`, `azurerm_subscription_cost_management_export`) from returning `nil` in `ModelObject()` with raw `metadata.ResourceData.Get()`/`Set()` calls to using proper typed model structs with `metadata.Decode()`/`metadata.Encode()`.
This follows the same pattern applied to the consumption budget resources in #31929.
## PR Checklist
- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.
## Changes to existing Resource / Data Source
- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
## Testing
- `go build ./internal/services/costmanagement/...` — passes
- `go vet ./internal/services/costmanagement/...` — passes
- `make static-analysis` — passes
- Test registration (`go test -short`) — all cost management export tests discover and register without `ValidateModelObject` panics
No behavioral changes were made; existing acceptance tests cover the Create/Read/Update/Delete flows and will validate correctness when run with `TF_ACC`.
## Change Log
* `azurerm_billing_account_cost_management_export` - refactor to use typed model with Decode/Encode
* `azurerm_resource_group_cost_management_export` - refactor to use typed model with Decode/Encode
* `azurerm_subscription_cost_management_export` - refactor to use typed model with Decode/Encode
This is a (please select all that apply):
- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change
## Related Issue(s)
N/A — internal tech debt cleanup
## AI Assistance Disclosure
- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs
AI was used for code generation of the typed model structs, expand/flatten helpers, and inlined CRUD methods. All changes were reviewed and validated manually.
## Rollback Plan
If a change needs to be reverted, we will publish an updated version of the provider.
## Changes to Security Controls
No changes to security controls.