### PR TITLE
service/storagemover: add list support for `azurerm_storage_mover_project `

### DIFF
--- a/internal/services/storagemover/registration.go
+++ b/internal/services/storagemover/registration.go
@@ -69,6 +69,7 @@ func (r Registration) ListResources() []sdk.FrameworkListWrappedResource {
 	return []sdk.FrameworkListWrappedResource{
 		StorageMoverAgentListResource{},
 		StorageMoverListResource{},
+		StorageMoverProjectListResource{},
 		StorageMoverSourceEndpointListResource{},
 	}
 }

--- a/internal/services/storagemover/storage_mover_project_resource.go
+++ b/internal/services/storagemover/storage_mover_project_resource.go
@@ -11,12 +11,15 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2025-07-01/projects"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2025-07-01/storagemovers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
+
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name storage_mover_project -service-package-name storagemover -properties "name" -compare-values "subscription_id:storage_mover_id,resource_group_name:storage_mover_id,storage_mover_name:storage_mover_id"
 
 type StorageMoverProjectResourceModel struct {
 	Name           string `tfschema:"name"`
@@ -26,7 +29,14 @@ type StorageMoverProjectResourceModel struct {
 
 type StorageMoverProjectResource struct{}
 
-var _ sdk.ResourceWithUpdate = StorageMoverProjectResource{}
+var (
+	_ sdk.ResourceWithIdentity = StorageMoverProjectResource{}
+	_ sdk.ResourceWithUpdate   = StorageMoverProjectResource{}
+)
+
+func (r StorageMoverProjectResource) Identity() resourceids.ResourceId {
+	return &projects.ProjectId{}
+}
 
 func (r StorageMoverProjectResource) ResourceType() string {
 	return "azurerm_storage_mover_project"
@@ -109,6 +119,9 @@ func (r StorageMoverProjectResource) Create() sdk.ResourceFunc {
 			}
 
 			metadata.SetID(id)
+			if err := pluginsdk.SetResourceIdentityData(metadata.ResourceData, &id); err != nil {
+				return err
+			}
 			return nil
 		},
 	}
@@ -173,20 +186,28 @@ func (r StorageMoverProjectResource) Read() sdk.ResourceFunc {
 				return fmt.Errorf("retrieving %s: %+v", *id, err)
 			}
 
-			state := StorageMoverProjectResourceModel{
-				Name:           id.ProjectName,
-				StorageMoverId: storagemovers.NewStorageMoverID(id.SubscriptionId, id.ResourceGroupName, id.StorageMoverName).ID(),
-			}
-
-			if resp.Model != nil {
-				if properties := resp.Model.Properties; properties != nil {
-					state.Description = pointer.From(properties.Description)
-				}
-			}
-
-			return metadata.Encode(&state)
+			return r.flatten(metadata, id, resp.Model)
 		},
 	}
+}
+
+func (r StorageMoverProjectResource) flatten(metadata sdk.ResourceMetaData, id *projects.ProjectId, model *projects.Project) error {
+	state := StorageMoverProjectResourceModel{
+		Name:           id.ProjectName,
+		StorageMoverId: storagemovers.NewStorageMoverID(id.SubscriptionId, id.ResourceGroupName, id.StorageMoverName).ID(),
+	}
+
+	if model != nil {
+		if properties := model.Properties; properties != nil {
+			state.Description = pointer.From(properties.Description)
+		}
+	}
+
+	if err := pluginsdk.SetResourceIdentityData(metadata.ResourceData, id); err != nil {
+		return err
+	}
+
+	return metadata.Encode(&state)
 }
 
 func (r StorageMoverProjectResource) Delete() sdk.ResourceFunc {

--- a/internal/services/storagemover/storage_mover_project_resource_identity_gen_test.go
+++ b/internal/services/storagemover/storage_mover_project_resource_identity_gen_test.go
@@ -1,0 +1,40 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package storagemover_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
+)
+
+func TestAccStorageMoverProject_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_mover_project", "test")
+	r := StorageMoverProjectResource{}
+
+	checkedFields := map[string]struct{}{
+		"name":                {},
+		"resource_group_name": {},
+		"storage_mover_name":  {},
+		"subscription_id":     {},
+	}
+
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				customstatecheck.ExpectAllIdentityFieldsAreChecked("azurerm_storage_mover_project.test", checkedFields),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_storage_mover_project.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_mover_project.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("storage_mover_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_mover_project.test", tfjsonpath.New("storage_mover_name"), tfjsonpath.New("storage_mover_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_storage_mover_project.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("storage_mover_id")),
+			},
+		},
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
+}

--- a/internal/services/storagemover/storage_mover_project_resource_list.go
+++ b/internal/services/storagemover/storage_mover_project_resource_list.go
@@ -1,0 +1,105 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package storagemover
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-azure-helpers/framework/typehelpers"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2025-07-01/projects"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2025-07-01/storagemovers"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type StorageMoverProjectListResource struct{}
+
+type StorageMoverProjectListModel struct {
+	StorageMoverId types.String `tfsdk:"storage_mover_id"`
+}
+
+var _ sdk.FrameworkListWrappedResource = new(StorageMoverProjectListResource)
+
+func (StorageMoverProjectListResource) Metadata(_ context.Context, _ resource.MetadataRequest, response *resource.MetadataResponse) {
+	response.TypeName = StorageMoverProjectResource{}.ResourceType()
+}
+
+func (StorageMoverProjectListResource) ResourceFunc() *pluginsdk.Resource {
+	return sdk.WrappedResource(StorageMoverProjectResource{})
+}
+
+func (StorageMoverProjectListResource) ListResourceConfigSchema(_ context.Context, _ list.ListResourceSchemaRequest, response *list.ListResourceSchemaResponse) {
+	response.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"storage_mover_id": schema.StringAttribute{
+				Required: true,
+				Validators: []validator.String{
+					typehelpers.WrappedStringValidator{Func: storagemovers.ValidateStorageMoverID},
+				},
+			},
+		},
+	}
+}
+
+func (StorageMoverProjectListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream, metadata sdk.ResourceMetadata) {
+	client := metadata.Client.StorageMover.ProjectsClient
+
+	var data StorageMoverProjectListModel
+	diags := request.Config.Get(ctx, &data)
+	if diags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	storageMoverID, err := storagemovers.ParseStorageMoverID(data.StorageMoverId.ValueString())
+	if err != nil {
+		sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("parsing Storage Mover ID for `%s`", StorageMoverProjectResource{}.ResourceType()), err)
+		return
+	}
+
+	resp, err := client.ListComplete(ctx, projects.NewStorageMoverID(storageMoverID.SubscriptionId, storageMoverID.ResourceGroupName, storageMoverID.StorageMoverName))
+	if err != nil {
+		sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("listing `%s`", StorageMoverProjectResource{}.ResourceType()), err)
+		return
+	}
+
+	resource := StorageMoverProjectResource{}
+	stream.Results = func(push func(list.ListResult) bool) {
+		for _, item := range resp.Items {
+			result := request.NewListResult(ctx)
+			result.DisplayName = pointer.From(item.Name)
+
+			id, err := projects.ParseProjectIDInsensitively(pointer.From(item.Id))
+			if err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, "parsing Storage Mover Project ID", err)
+				return
+			}
+
+			meta := sdk.NewResourceMetaData(metadata.Client, resource)
+			meta.SetID(id)
+
+			if err := resource.flatten(meta, id, &item); err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, fmt.Sprintf("encoding `%s` resource data", resource.ResourceType()), err)
+				return
+			}
+
+			sdk.EncodeListResult(ctx, meta.ResourceData, &result)
+			if result.Diagnostics.HasError() {
+				push(result)
+				return
+			}
+
+			if !push(result) {
+				return
+			}
+		}
+	}
+}

--- a/internal/services/storagemover/storage_mover_project_resource_list_test.go
+++ b/internal/services/storagemover/storage_mover_project_resource_list_test.go
@@ -1,0 +1,59 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package storagemover_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccStorageMoverProject_list(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_mover_project", "testlist")
+	r := StorageMoverProjectResource{}
+	resourceName := fmt.Sprintf("acctest-sp-%d", data.RandomInteger)
+	storageMoverName := fmt.Sprintf("acctest-ssm-%d", data.RandomInteger)
+	resourceGroupName := fmt.Sprintf("acctest-rg-%d", data.RandomInteger)
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{Config: r.basic(data)},
+			{
+				Query:  true,
+				Config: r.listQuery(),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLength("azurerm_storage_mover_project.list", 1),
+					querycheck.ExpectIdentity("azurerm_storage_mover_project.list", map[string]knownvalue.Check{
+						"name":                knownvalue.StringExact(resourceName),
+						"resource_group_name": knownvalue.StringExact(resourceGroupName),
+						"storage_mover_name":  knownvalue.StringExact(storageMoverName),
+						"subscription_id":     knownvalue.StringExact(data.Subscriptions.Primary),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func (r StorageMoverProjectResource) listQuery() string {
+	return `
+list "azurerm_storage_mover_project" "list" {
+  provider = azurerm
+  config {
+    storage_mover_id = azurerm_storage_mover.test.id
+  }
+}
+`
+}

--- a/internal/services/storagemover/storage_mover_project_resource_test.go
+++ b/internal/services/storagemover/storage_mover_project_resource_test.go
@@ -17,11 +17,11 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
-type StorageMoverProjectTestResource struct{}
+type StorageMoverProjectResource struct{}
 
 func TestAccStorageMoverProject_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_mover_project", "test")
-	r := StorageMoverProjectTestResource{}
+	r := StorageMoverProjectResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basic(data),
@@ -35,7 +35,7 @@ func TestAccStorageMoverProject_basic(t *testing.T) {
 
 func TestAccStorageMoverProject_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_mover_project", "test")
-	r := StorageMoverProjectTestResource{}
+	r := StorageMoverProjectResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basic(data),
@@ -49,7 +49,7 @@ func TestAccStorageMoverProject_requiresImport(t *testing.T) {
 
 func TestAccStorageMoverProject_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_mover_project", "test")
-	r := StorageMoverProjectTestResource{}
+	r := StorageMoverProjectResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.complete(data),
@@ -63,7 +63,7 @@ func TestAccStorageMoverProject_complete(t *testing.T) {
 
 func TestAccStorageMoverProject_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_mover_project", "test")
-	r := StorageMoverProjectTestResource{}
+	r := StorageMoverProjectResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.complete(data),
@@ -82,7 +82,7 @@ func TestAccStorageMoverProject_update(t *testing.T) {
 	})
 }
 
-func (r StorageMoverProjectTestResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (r StorageMoverProjectResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := projects.ParseProjectID(state.ID)
 	if err != nil {
 		return nil, err
@@ -99,7 +99,7 @@ func (r StorageMoverProjectTestResource) Exists(ctx context.Context, clients *cl
 	return pointer.To(resp.Model != nil), nil
 }
 
-func (r StorageMoverProjectTestResource) template(data acceptance.TestData) string {
+func (r StorageMoverProjectResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctest-rg-%d"
@@ -114,7 +114,7 @@ resource "azurerm_storage_mover" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
-func (r StorageMoverProjectTestResource) basic(data acceptance.TestData) string {
+func (r StorageMoverProjectResource) basic(data acceptance.TestData) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -130,7 +130,7 @@ resource "azurerm_storage_mover_project" "test" {
 `, template, data.RandomInteger)
 }
 
-func (r StorageMoverProjectTestResource) requiresImport(data acceptance.TestData) string {
+func (r StorageMoverProjectResource) requiresImport(data acceptance.TestData) string {
 	config := r.basic(data)
 	return fmt.Sprintf(`
 %s
@@ -142,7 +142,7 @@ resource "azurerm_storage_mover_project" "import" {
 `, config)
 }
 
-func (r StorageMoverProjectTestResource) complete(data acceptance.TestData) string {
+func (r StorageMoverProjectResource) complete(data acceptance.TestData) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -159,7 +159,7 @@ resource "azurerm_storage_mover_project" "test" {
 `, template, data.RandomInteger)
 }
 
-func (r StorageMoverProjectTestResource) update(data acceptance.TestData) string {
+func (r StorageMoverProjectResource) update(data acceptance.TestData) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
 provider "azurerm" {

--- a/website/docs/list-resources/storage_mover_project.html.markdown
+++ b/website/docs/list-resources/storage_mover_project.html.markdown
@@ -1,0 +1,30 @@
+---
+subcategory: "Storage Mover"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_storage_mover_project"
+description: |-
+  Lists Storage Mover Project resources.
+---
+
+# List resource: azurerm_storage_mover_project
+
+Lists Storage Mover Project resources.
+
+## Example Usage
+
+### List Projects in a Storage Mover
+
+```hcl
+list "azurerm_storage_mover_project" "example" {
+  provider = azurerm
+  config {
+    storage_mover_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example-rg/providers/Microsoft.StorageMover/storageMovers/example-mover"
+  }
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `storage_mover_id` - (Required) The ID of the Storage Mover to query.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_STORAGEMOVER/649265?buildTab=tests

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
