### PR TITLE
New Data Source: azurerm_cdn_endpoint

### DIFF
--- a/internal/services/cdn/cdn_endpoint_data_source.go
+++ b/internal/services/cdn/cdn_endpoint_data_source.go
@@ -1,0 +1,211 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package cdn
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cdn/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+func dataSourceCdnEndpoint() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Read: dataSourceCdnEndpointRead,
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Read: pluginsdk.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*pluginsdk.Schema{
+			"name": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"profile_name": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"resource_group_name": commonschema.ResourceGroupNameForDataSource(),
+
+			"location": commonschema.LocationComputed(),
+
+			"origin_host_header": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"is_http_allowed": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
+
+			"is_https_allowed": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
+
+			"origin": {
+				Type:     pluginsdk.TypeSet,
+				Computed: true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"name": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
+						"host_name": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
+						"http_port": {
+							Type:     pluginsdk.TypeInt,
+							Computed: true,
+						},
+
+						"https_port": {
+							Type:     pluginsdk.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+
+			"origin_path": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"querystring_caching_behaviour": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"content_types_to_compress": {
+				Type:     pluginsdk.TypeSet,
+				Computed: true,
+				Elem: &pluginsdk.Schema{
+					Type: pluginsdk.TypeString,
+				},
+			},
+
+			"is_compression_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
+
+			"probe_path": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"geo_filter": {
+				Type:     pluginsdk.TypeList,
+				Computed: true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"relative_path": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+						"action": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+						"country_codes": {
+							Type:     pluginsdk.TypeList,
+							Computed: true,
+							Elem: &pluginsdk.Schema{
+								Type: pluginsdk.TypeString,
+							},
+						},
+					},
+				},
+			},
+
+			"optimization_type": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"fqdn": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"tags": commonschema.TagsDataSource(),
+		},
+	}
+}
+
+func dataSourceCdnEndpointRead(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Cdn.EndpointsClient
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id := parse.NewEndpointID(subscriptionId, d.Get("resource_group_name").(string), d.Get("profile_name").(string), d.Get("name").(string))
+	resp, err := client.Get(ctx, id.ResourceGroup, id.ProfileName, id.Name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return fmt.Errorf("%s was not found", id)
+		}
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	d.SetId(id.ID())
+
+	d.Set("name", id.Name)
+	d.Set("resource_group_name", id.ResourceGroup)
+	d.Set("profile_name", id.ProfileName)
+	d.Set("location", location.NormalizeNilable(resp.Location))
+
+	if props := resp.EndpointProperties; props != nil {
+		d.Set("fqdn", props.HostName)
+		d.Set("is_http_allowed", props.IsHTTPAllowed)
+		d.Set("is_https_allowed", props.IsHTTPSAllowed)
+		d.Set("querystring_caching_behaviour", props.QueryStringCachingBehavior)
+		d.Set("origin_host_header", props.OriginHostHeader)
+		d.Set("origin_path", props.OriginPath)
+		d.Set("probe_path", props.ProbePath)
+		d.Set("optimization_type", string(props.OptimizationType))
+
+		compressionEnabled := false
+		if v := props.IsCompressionEnabled; v != nil {
+			compressionEnabled = *v
+		}
+		d.Set("is_compression_enabled", compressionEnabled)
+
+		contentTypes := flattenAzureRMCdnEndpointContentTypes(props.ContentTypesToCompress)
+		if err := d.Set("content_types_to_compress", contentTypes); err != nil {
+			return fmt.Errorf("setting `content_types_to_compress`: %+v", err)
+		}
+
+		geoFilters := flattenCdnEndpointGeoFilters(props.GeoFilters)
+		if err := d.Set("geo_filter", geoFilters); err != nil {
+			return fmt.Errorf("setting `geo_filter`: %+v", err)
+		}
+
+		origins := flattenAzureRMCdnEndpointOrigin(props.Origins)
+		if err := d.Set("origin", origins); err != nil {
+			return fmt.Errorf("setting `origin`: %+v", err)
+		}
+	}
+
+	return tags.FlattenAndSet(d, resp.Tags)
+}

--- a/internal/services/cdn/cdn_endpoint_data_source_test.go
+++ b/internal/services/cdn/cdn_endpoint_data_source_test.go
@@ -1,0 +1,83 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package cdn_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cdn"
+)
+
+type CdnEndpointDataSource struct{}
+
+func TestAccCdnEndpointDataSource_basic(t *testing.T) {
+	if cdn.IsCdnDeprecatedForCreation() {
+		t.Skipf("skipping as CDN (Classic) endpoint creation is deprecated")
+	}
+
+	data := acceptance.BuildTestData(t, "data.azurerm_cdn_endpoint", "test")
+	d := CdnEndpointDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: d.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("location").Exists(),
+				check.That(data.ResourceName).Key("is_http_allowed").HasValue("true"),
+				check.That(data.ResourceName).Key("is_https_allowed").HasValue("true"),
+				check.That(data.ResourceName).Key("origin.#").HasValue("1"),
+				check.That(data.ResourceName).Key("fqdn").Exists(),
+				check.That(data.ResourceName).Key("tags.%").HasValue("2"),
+				check.That(data.ResourceName).Key("tags.environment").HasValue("Production"),
+				check.That(data.ResourceName).Key("tags.cost_center").HasValue("MSFT"),
+			),
+		},
+	})
+}
+
+func (d CdnEndpointDataSource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_cdn_profile" "test" {
+  name                = "acctestcdnprof%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard_Microsoft"
+}
+
+resource "azurerm_cdn_endpoint" "test" {
+  name                = "acctestcdnend%d"
+  profile_name        = azurerm_cdn_profile.test.name
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  origin {
+    name      = "acceptanceTestCdnOrigin1"
+    host_name = "www.contoso.com"
+  }
+
+  tags = {
+    environment = "Production"
+    cost_center = "MSFT"
+  }
+}
+
+data "azurerm_cdn_endpoint" "test" {
+  name                = azurerm_cdn_endpoint.test.name
+  profile_name        = azurerm_cdn_profile.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}

--- a/internal/services/cdn/registration.go
+++ b/internal/services/cdn/registration.go
@@ -36,7 +36,8 @@ func (r Registration) WebsiteCategories() []string {
 func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 	return map[string]*pluginsdk.Resource{
 		// CDN
-		"azurerm_cdn_profile": dataSourceCdnProfile(),
+		"azurerm_cdn_endpoint": dataSourceCdnEndpoint(),
+		"azurerm_cdn_profile":  dataSourceCdnProfile(),
 
 		// FrontDoor
 		"azurerm_cdn_frontdoor_custom_domain":   dataSourceCdnFrontDoorCustomDomain(),

--- a/website/docs/d/cdn_endpoint.html.markdown
+++ b/website/docs/d/cdn_endpoint.html.markdown
@@ -24,6 +24,24 @@ output "cdn_endpoint_fqdn" {
 }
 ```
 
+### Using with a DNS Record
+
+```hcl
+data "azurerm_cdn_endpoint" "app" {
+  name                = "app-cdn-endpoint"
+  profile_name        = "app-cdn-profile"
+  resource_group_name = "cdn-resources"
+}
+
+resource "azurerm_dns_cname_record" "cdn" {
+  name                = "cdn"
+  zone_name           = azurerm_dns_zone.example.name
+  resource_group_name = azurerm_dns_zone.example.resource_group_name
+  ttl                 = 300
+  record              = data.azurerm_cdn_endpoint.app.fqdn
+}
+```
+
 ## Arguments Reference
 
 * `name` - The name of the CDN Endpoint.

--- a/website/docs/d/cdn_endpoint.html.markdown
+++ b/website/docs/d/cdn_endpoint.html.markdown
@@ -1,0 +1,93 @@
+---
+subcategory: "CDN"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_cdn_endpoint"
+description: |-
+  Gets information about an existing CDN Endpoint.
+---
+
+# Data Source: azurerm_cdn_endpoint
+
+Use this data source to access information about an existing CDN Endpoint.
+
+## Example Usage
+
+```hcl
+data "azurerm_cdn_endpoint" "example" {
+  name                = "myfirstcdnendpoint"
+  profile_name        = "myfirstcdnprofile"
+  resource_group_name = "example-resources"
+}
+
+output "cdn_endpoint_fqdn" {
+  value = data.azurerm_cdn_endpoint.example.fqdn
+}
+```
+
+## Arguments Reference
+
+* `name` - The name of the CDN Endpoint.
+
+* `profile_name` - The name of the CDN Profile containing this CDN Endpoint.
+
+* `resource_group_name` - The name of the resource group in which the CDN Endpoint exists.
+
+## Attributes Reference
+
+* `id` - The ID of the CDN Endpoint.
+
+* `location` - The Azure Region where the CDN Endpoint exists.
+
+* `fqdn` - The Fully Qualified Domain Name of the CDN Endpoint.
+
+* `is_http_allowed` - Indicates whether HTTP traffic is allowed on the endpoint.
+
+* `is_https_allowed` - Indicates whether HTTPS traffic is allowed on the endpoint.
+
+* `origin_host_header` - The host header the CDN provider sends along with content requests to origins.
+
+* `origin_path` - The path used for origin requests.
+
+* `probe_path` - The path used for health probe requests.
+
+* `querystring_caching_behaviour` - The query string caching behaviour for requests.
+
+* `optimization_type` - The type of optimization used for this CDN Endpoint.
+
+* `is_compression_enabled` - Indicates whether content compression is enabled on the endpoint.
+
+* `content_types_to_compress` - A set of content types that are compressed when served by the CDN Endpoint.
+
+* `geo_filter` - A `geo_filter` block as defined below.
+
+* `origin` - An `origin` block as defined below.
+
+* `tags` - A mapping of tags assigned to the resource.
+
+---
+
+A `geo_filter` block exports the following:
+
+* `relative_path` - The relative path applicable to the geo filter.
+
+* `action` - The action of the geo filter, either `Allow` or `Block`.
+
+* `country_codes` - A list of two letter country codes that the filter applies to.
+
+---
+
+An `origin` block exports the following:
+
+* `name` - The name of the origin.
+
+* `host_name` - The hostname of the origin.
+
+* `http_port` - The HTTP port of the origin.
+
+* `https_port` - The HTTPS port of the origin.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/configure#define-operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the CDN Endpoint.


### PR DESCRIPTION
  Implements a read-only data source for existing CDN Endpoints,
  exposing origins, geo filters, compression settings, FQDN, and tags.

  Fixes #8243

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Adds a new azurerm_cdn_endpoint data source that enables reading existing CDN Endpoint configurations, exposing origins, geo filters, compression settings, FQDN, and tags. Follows the same untyped SDK      
  pattern as the existing azurerm_cdn_profile data source. Includes acceptance test with IsCdnDeprecatedForCreation() skip guard since CDN Classic creation is deprecated


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 



## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

Acceptance test compiles and correctly skips with `IsCdnDeprecatedForCreation()` guard (CDN Classic creation deprecated since Oct 2025), consistent with existing CDN endpoint resource tests which also skip.

  === RUN   TestAccCdnEndpointDataSource_basic
      cdn_endpoint_data_source_test.go:19: skipping as CDN (Classic) endpoint creation is deprecated
  --- SKIP: TestAccCdnEndpointDataSource_basic (0.00s)
  PASS



## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* New Data Source: azurerm_cdn_endpoint [GH-8243]   


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #8243 



## AI Assistance Disclosure


- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

Help with fixing issues, adding tests and docs

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
