### PR TITLE
costmanagement: convert view resources to use typed models with Decode/Encode

### DIFF
--- a/internal/services/costmanagement/resource_group_cost_management_view_resource.go
+++ b/internal/services/costmanagement/resource_group_cost_management_view_resource.go
@@ -4,6 +4,14 @@
 package costmanagement
 
 import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2023-08-01/views"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/costmanagement/validate"
 	resourceValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/resource/validate"
@@ -13,6 +21,19 @@ import (
 
 type ResourceGroupCostManagementViewResource struct {
 	base costManagementViewBaseResource
+}
+
+type ResourceGroupCostManagementViewModel struct {
+	Name            string                           `tfschema:"name"`
+	ResourceGroupId string                           `tfschema:"resource_group_id"`
+	DisplayName     string                           `tfschema:"display_name"`
+	ChartType       string                           `tfschema:"chart_type"`
+	Accumulated     bool                             `tfschema:"accumulated"`
+	ReportType      string                           `tfschema:"report_type"`
+	Timeframe       string                           `tfschema:"timeframe"`
+	Dataset         []CostManagementViewDatasetModel `tfschema:"dataset"`
+	Kpi             []CostManagementViewKpiModel     `tfschema:"kpi"`
+	Pivot           []CostManagementViewPivotModel   `tfschema:"pivot"`
 }
 
 var _ sdk.Resource = ResourceGroupCostManagementViewResource{}
@@ -40,7 +61,7 @@ func (r ResourceGroupCostManagementViewResource) Attributes() map[string]*plugin
 }
 
 func (r ResourceGroupCostManagementViewResource) ModelObject() interface{} {
-	return nil
+	return &ResourceGroupCostManagementViewModel{}
 }
 
 func (r ResourceGroupCostManagementViewResource) ResourceType() string {
@@ -52,11 +73,110 @@ func (r ResourceGroupCostManagementViewResource) IDValidationFunc() pluginsdk.Sc
 }
 
 func (r ResourceGroupCostManagementViewResource) Create() sdk.ResourceFunc {
-	return r.base.createFunc(r.ResourceType(), "resource_group_id")
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.CostManagement.ViewsClient
+
+			var config ResourceGroupCostManagementViewModel
+			if err := metadata.Decode(&config); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			id := views.NewScopedViewID(config.ResourceGroupId, config.Name)
+
+			existing, err := client.GetByScope(ctx, id)
+			if err != nil {
+				if !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+				}
+			}
+
+			if !response.WasNotFound(existing.HttpResponse) {
+				return tf.ImportAsExistsError(r.ResourceType(), id.ID())
+			}
+
+			accumulated := views.AccumulatedTypeFalse
+			if config.Accumulated {
+				accumulated = views.AccumulatedTypeTrue
+			}
+
+			props := views.View{
+				Properties: &views.ViewProperties{
+					Accumulated: pointer.To(accumulated),
+					DisplayName: pointer.To(config.DisplayName),
+					Chart:       pointer.To(views.ChartType(config.ChartType)),
+					Query: &views.ReportConfigDefinition{
+						DataSet:   expandDatasetFromModel(config.Dataset),
+						Timeframe: views.ReportTimeframeType(config.Timeframe),
+						Type:      views.ReportTypeUsage,
+					},
+					Kpis:   expandKpisFromModel(config.Kpi),
+					Pivots: expandPivotsFromModel(config.Pivot),
+				},
+			}
+
+			if _, err = client.CreateOrUpdateByScope(ctx, id, props); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+	}
 }
 
 func (r ResourceGroupCostManagementViewResource) Read() sdk.ResourceFunc {
-	return r.base.readFunc("resource_group_id")
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.CostManagement.ViewsClient
+
+			id, err := views.ParseScopedViewID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.GetByScope(ctx, *id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return metadata.MarkAsGone(id)
+				}
+				return fmt.Errorf("reading %s: %+v", *id, err)
+			}
+
+			state := ResourceGroupCostManagementViewModel{
+				Name:            id.ViewName,
+				ResourceGroupId: id.Scope,
+			}
+
+			if model := resp.Model; model != nil {
+				if props := model.Properties; props != nil {
+					state.ChartType = string(pointer.From(props.Chart))
+					state.DisplayName = pointer.From(props.DisplayName)
+
+					accumulated := false
+					if props.Accumulated != nil {
+						accumulated = views.AccumulatedTypeTrue == *props.Accumulated
+					}
+					state.Accumulated = accumulated
+
+					state.Kpi = flattenKpisToModel(props.Kpis)
+					state.Pivot = flattenPivotsToModel(props.Pivots)
+
+					if query := props.Query; query != nil {
+						state.Timeframe = string(query.Timeframe)
+						state.ReportType = string(query.Type)
+						if query.DataSet != nil {
+							state.Dataset = flattenDatasetToModel(query.DataSet)
+						}
+					}
+				}
+			}
+
+			return metadata.Encode(&state)
+		},
+	}
 }
 
 func (r ResourceGroupCostManagementViewResource) Delete() sdk.ResourceFunc {
@@ -64,5 +184,67 @@ func (r ResourceGroupCostManagementViewResource) Delete() sdk.ResourceFunc {
 }
 
 func (r ResourceGroupCostManagementViewResource) Update() sdk.ResourceFunc {
-	return r.base.updateFunc()
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.CostManagement.ViewsClient
+
+			id, err := views.ParseScopedViewID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			var config ResourceGroupCostManagementViewModel
+			if err := metadata.Decode(&config); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			// Update operation requires latest eTag to be set in the request.
+			existing, err := client.GetByScope(ctx, *id)
+			if err != nil {
+				return fmt.Errorf("reading %s: %+v", *id, err)
+			}
+			model := existing.Model
+
+			if model != nil {
+				if model.ETag == nil {
+					return fmt.Errorf("add %s: etag was nil", *id)
+				}
+			}
+
+			if model.Properties == nil {
+				return fmt.Errorf("retreiving properties for %s for update: %+v", *id, err)
+			}
+
+			if metadata.ResourceData.HasChange("display_name") {
+				model.Properties.DisplayName = pointer.To(config.DisplayName)
+			}
+
+			if metadata.ResourceData.HasChange("chart_type") {
+				model.Properties.Chart = pointer.To(views.ChartType(config.ChartType))
+			}
+
+			if metadata.ResourceData.HasChange("dataset") {
+				model.Properties.Query.DataSet = expandDatasetFromModel(config.Dataset)
+			}
+
+			if metadata.ResourceData.HasChange("timeframe") {
+				model.Properties.Query.Timeframe = views.ReportTimeframeType(config.Timeframe)
+			}
+
+			if metadata.ResourceData.HasChange("kpi") {
+				model.Properties.Kpis = expandKpisFromModel(config.Kpi)
+			}
+
+			if metadata.ResourceData.HasChange("pivot") {
+				model.Properties.Pivots = expandPivotsFromModel(config.Pivot)
+			}
+
+			if _, err = client.CreateOrUpdateByScope(ctx, *id, *model); err != nil {
+				return fmt.Errorf("updating %s: %+v", *id, err)
+			}
+
+			return nil
+		},
+	}
 }

--- a/internal/services/costmanagement/resource_group_cost_management_view_resource.go
+++ b/internal/services/costmanagement/resource_group_cost_management_view_resource.go
@@ -142,7 +142,7 @@ func (r ResourceGroupCostManagementViewResource) Read() sdk.ResourceFunc {
 				if response.WasNotFound(resp.HttpResponse) {
 					return metadata.MarkAsGone(id)
 				}
-				return fmt.Errorf("reading %s: %+v", *id, err)
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
 			}
 
 			state := ResourceGroupCostManagementViewModel{
@@ -152,14 +152,10 @@ func (r ResourceGroupCostManagementViewResource) Read() sdk.ResourceFunc {
 
 			if model := resp.Model; model != nil {
 				if props := model.Properties; props != nil {
-					state.ChartType = string(pointer.From(props.Chart))
+					state.ChartType = pointer.FromEnum(props.Chart)
 					state.DisplayName = pointer.From(props.DisplayName)
 
-					accumulated := false
-					if props.Accumulated != nil {
-						accumulated = views.AccumulatedTypeTrue == *props.Accumulated
-					}
-					state.Accumulated = accumulated
+					state.Accumulated = views.AccumulatedTypeTrue == pointer.From(props.Accumulated)
 
 					state.Kpi = flattenKpisToModel(props.Kpis)
 					state.Pivot = flattenPivotsToModel(props.Pivots)
@@ -202,7 +198,7 @@ func (r ResourceGroupCostManagementViewResource) Update() sdk.ResourceFunc {
 			// Update operation requires latest eTag to be set in the request.
 			existing, err := client.GetByScope(ctx, *id)
 			if err != nil {
-				return fmt.Errorf("reading %s: %+v", *id, err)
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
 			}
 			model := existing.Model
 
@@ -213,7 +209,7 @@ func (r ResourceGroupCostManagementViewResource) Update() sdk.ResourceFunc {
 			}
 
 			if model.Properties == nil {
-				return fmt.Errorf("retreiving properties for %s for update: %+v", *id, err)
+				return fmt.Errorf("retrieving %s: `properties` was nil", *id)
 			}
 
 			if metadata.ResourceData.HasChange("display_name") {

--- a/internal/services/costmanagement/subscription_cost_management_view_resource.go
+++ b/internal/services/costmanagement/subscription_cost_management_view_resource.go
@@ -4,7 +4,15 @@
 package costmanagement
 
 import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2023-08-01/views"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/costmanagement/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -13,6 +21,19 @@ import (
 
 type SubscriptionCostManagementViewResource struct {
 	base costManagementViewBaseResource
+}
+
+type SubscriptionCostManagementViewModel struct {
+	Name        string                           `tfschema:"name"`
+	SubId       string                           `tfschema:"subscription_id"`
+	DisplayName string                           `tfschema:"display_name"`
+	ChartType   string                           `tfschema:"chart_type"`
+	Accumulated bool                             `tfschema:"accumulated"`
+	ReportType  string                           `tfschema:"report_type"`
+	Timeframe   string                           `tfschema:"timeframe"`
+	Dataset     []CostManagementViewDatasetModel `tfschema:"dataset"`
+	Kpi         []CostManagementViewKpiModel     `tfschema:"kpi"`
+	Pivot       []CostManagementViewPivotModel   `tfschema:"pivot"`
 }
 
 var _ sdk.Resource = SubscriptionCostManagementViewResource{}
@@ -40,7 +61,7 @@ func (r SubscriptionCostManagementViewResource) Attributes() map[string]*plugins
 }
 
 func (r SubscriptionCostManagementViewResource) ModelObject() interface{} {
-	return nil
+	return &SubscriptionCostManagementViewModel{}
 }
 
 func (r SubscriptionCostManagementViewResource) ResourceType() string {
@@ -52,11 +73,110 @@ func (r SubscriptionCostManagementViewResource) IDValidationFunc() pluginsdk.Sch
 }
 
 func (r SubscriptionCostManagementViewResource) Create() sdk.ResourceFunc {
-	return r.base.createFunc(r.ResourceType(), "subscription_id")
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.CostManagement.ViewsClient
+
+			var config SubscriptionCostManagementViewModel
+			if err := metadata.Decode(&config); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			id := views.NewScopedViewID(config.SubId, config.Name)
+
+			existing, err := client.GetByScope(ctx, id)
+			if err != nil {
+				if !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+				}
+			}
+
+			if !response.WasNotFound(existing.HttpResponse) {
+				return tf.ImportAsExistsError(r.ResourceType(), id.ID())
+			}
+
+			accumulated := views.AccumulatedTypeFalse
+			if config.Accumulated {
+				accumulated = views.AccumulatedTypeTrue
+			}
+
+			props := views.View{
+				Properties: &views.ViewProperties{
+					Accumulated: pointer.To(accumulated),
+					DisplayName: pointer.To(config.DisplayName),
+					Chart:       pointer.To(views.ChartType(config.ChartType)),
+					Query: &views.ReportConfigDefinition{
+						DataSet:   expandDatasetFromModel(config.Dataset),
+						Timeframe: views.ReportTimeframeType(config.Timeframe),
+						Type:      views.ReportTypeUsage,
+					},
+					Kpis:   expandKpisFromModel(config.Kpi),
+					Pivots: expandPivotsFromModel(config.Pivot),
+				},
+			}
+
+			if _, err = client.CreateOrUpdateByScope(ctx, id, props); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+	}
 }
 
 func (r SubscriptionCostManagementViewResource) Read() sdk.ResourceFunc {
-	return r.base.readFunc("subscription_id")
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.CostManagement.ViewsClient
+
+			id, err := views.ParseScopedViewID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.GetByScope(ctx, *id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return metadata.MarkAsGone(id)
+				}
+				return fmt.Errorf("reading %s: %+v", *id, err)
+			}
+
+			state := SubscriptionCostManagementViewModel{
+				Name:  id.ViewName,
+				SubId: id.Scope,
+			}
+
+			if model := resp.Model; model != nil {
+				if props := model.Properties; props != nil {
+					state.ChartType = string(pointer.From(props.Chart))
+					state.DisplayName = pointer.From(props.DisplayName)
+
+					accumulated := false
+					if props.Accumulated != nil {
+						accumulated = views.AccumulatedTypeTrue == *props.Accumulated
+					}
+					state.Accumulated = accumulated
+
+					state.Kpi = flattenKpisToModel(props.Kpis)
+					state.Pivot = flattenPivotsToModel(props.Pivots)
+
+					if query := props.Query; query != nil {
+						state.Timeframe = string(query.Timeframe)
+						state.ReportType = string(query.Type)
+						if query.DataSet != nil {
+							state.Dataset = flattenDatasetToModel(query.DataSet)
+						}
+					}
+				}
+			}
+
+			return metadata.Encode(&state)
+		},
+	}
 }
 
 func (r SubscriptionCostManagementViewResource) Delete() sdk.ResourceFunc {
@@ -64,5 +184,67 @@ func (r SubscriptionCostManagementViewResource) Delete() sdk.ResourceFunc {
 }
 
 func (r SubscriptionCostManagementViewResource) Update() sdk.ResourceFunc {
-	return r.base.updateFunc()
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.CostManagement.ViewsClient
+
+			id, err := views.ParseScopedViewID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			var config SubscriptionCostManagementViewModel
+			if err := metadata.Decode(&config); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			// Update operation requires latest eTag to be set in the request.
+			existing, err := client.GetByScope(ctx, *id)
+			if err != nil {
+				return fmt.Errorf("reading %s: %+v", *id, err)
+			}
+			model := existing.Model
+
+			if model != nil {
+				if model.ETag == nil {
+					return fmt.Errorf("add %s: etag was nil", *id)
+				}
+			}
+
+			if model.Properties == nil {
+				return fmt.Errorf("retreiving properties for %s for update: %+v", *id, err)
+			}
+
+			if metadata.ResourceData.HasChange("display_name") {
+				model.Properties.DisplayName = pointer.To(config.DisplayName)
+			}
+
+			if metadata.ResourceData.HasChange("chart_type") {
+				model.Properties.Chart = pointer.To(views.ChartType(config.ChartType))
+			}
+
+			if metadata.ResourceData.HasChange("dataset") {
+				model.Properties.Query.DataSet = expandDatasetFromModel(config.Dataset)
+			}
+
+			if metadata.ResourceData.HasChange("timeframe") {
+				model.Properties.Query.Timeframe = views.ReportTimeframeType(config.Timeframe)
+			}
+
+			if metadata.ResourceData.HasChange("kpi") {
+				model.Properties.Kpis = expandKpisFromModel(config.Kpi)
+			}
+
+			if metadata.ResourceData.HasChange("pivot") {
+				model.Properties.Pivots = expandPivotsFromModel(config.Pivot)
+			}
+
+			if _, err = client.CreateOrUpdateByScope(ctx, *id, *model); err != nil {
+				return fmt.Errorf("updating %s: %+v", *id, err)
+			}
+
+			return nil
+		},
+	}
 }

--- a/internal/services/costmanagement/subscription_cost_management_view_resource.go
+++ b/internal/services/costmanagement/subscription_cost_management_view_resource.go
@@ -142,7 +142,7 @@ func (r SubscriptionCostManagementViewResource) Read() sdk.ResourceFunc {
 				if response.WasNotFound(resp.HttpResponse) {
 					return metadata.MarkAsGone(id)
 				}
-				return fmt.Errorf("reading %s: %+v", *id, err)
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
 			}
 
 			state := SubscriptionCostManagementViewModel{
@@ -152,14 +152,10 @@ func (r SubscriptionCostManagementViewResource) Read() sdk.ResourceFunc {
 
 			if model := resp.Model; model != nil {
 				if props := model.Properties; props != nil {
-					state.ChartType = string(pointer.From(props.Chart))
+					state.ChartType = pointer.FromEnum(props.Chart)
 					state.DisplayName = pointer.From(props.DisplayName)
 
-					accumulated := false
-					if props.Accumulated != nil {
-						accumulated = views.AccumulatedTypeTrue == *props.Accumulated
-					}
-					state.Accumulated = accumulated
+					state.Accumulated = views.AccumulatedTypeTrue == pointer.From(props.Accumulated)
 
 					state.Kpi = flattenKpisToModel(props.Kpis)
 					state.Pivot = flattenPivotsToModel(props.Pivots)
@@ -202,7 +198,7 @@ func (r SubscriptionCostManagementViewResource) Update() sdk.ResourceFunc {
 			// Update operation requires latest eTag to be set in the request.
 			existing, err := client.GetByScope(ctx, *id)
 			if err != nil {
-				return fmt.Errorf("reading %s: %+v", *id, err)
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
 			}
 			model := existing.Model
 
@@ -213,7 +209,7 @@ func (r SubscriptionCostManagementViewResource) Update() sdk.ResourceFunc {
 			}
 
 			if model.Properties == nil {
-				return fmt.Errorf("retreiving properties for %s for update: %+v", *id, err)
+				return fmt.Errorf("retrieving %s: `properties` was nil", *id)
 			}
 
 			if metadata.ResourceData.HasChange("display_name") {

--- a/internal/services/costmanagement/view_resource_base.go
+++ b/internal/services/costmanagement/view_resource_base.go
@@ -9,13 +9,44 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2023-08-01/views"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
+
+// Shared nested model structs for cost management view resources
+
+type CostManagementViewAggregationModel struct {
+	Name       string `tfschema:"name"`
+	ColumnName string `tfschema:"column_name"`
+}
+
+type CostManagementViewSortingModel struct {
+	Direction string `tfschema:"direction"`
+	Name      string `tfschema:"name"`
+}
+
+type CostManagementViewGroupingModel struct {
+	Type string `tfschema:"type"`
+	Name string `tfschema:"name"`
+}
+
+type CostManagementViewDatasetModel struct {
+	Granularity string                               `tfschema:"granularity"`
+	Aggregation []CostManagementViewAggregationModel `tfschema:"aggregation"`
+	Sorting     []CostManagementViewSortingModel     `tfschema:"sorting"`
+	Grouping    []CostManagementViewGroupingModel    `tfschema:"grouping"`
+}
+
+type CostManagementViewKpiModel struct {
+	Type string `tfschema:"type"`
+}
+
+type CostManagementViewPivotModel struct {
+	Name string `tfschema:"name"`
+	Type string `tfschema:"type"`
+}
 
 type costManagementViewBaseResource struct{}
 
@@ -166,106 +197,6 @@ func (br costManagementViewBaseResource) attributes() map[string]*pluginsdk.Sche
 	return map[string]*pluginsdk.Schema{}
 }
 
-func (br costManagementViewBaseResource) createFunc(resourceName, scopeFieldName string) sdk.ResourceFunc {
-	return sdk.ResourceFunc{
-		Timeout: 30 * time.Minute,
-		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
-			client := metadata.Client.CostManagement.ViewsClient
-			id := views.NewScopedViewID(metadata.ResourceData.Get(scopeFieldName).(string), metadata.ResourceData.Get("name").(string))
-
-			existing, err := client.GetByScope(ctx, id)
-			if err != nil {
-				if !response.WasNotFound(existing.HttpResponse) {
-					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
-				}
-			}
-
-			if !response.WasNotFound(existing.HttpResponse) {
-				return tf.ImportAsExistsError(resourceName, id.ID())
-			}
-
-			accumulated := views.AccumulatedTypeFalse
-			if accumulatedRaw := metadata.ResourceData.Get("accumulated").(bool); accumulatedRaw {
-				accumulated = views.AccumulatedTypeTrue
-			}
-
-			props := views.View{
-				Properties: &views.ViewProperties{
-					Accumulated: pointer.To(accumulated),
-					DisplayName: pointer.To(metadata.ResourceData.Get("display_name").(string)),
-					Chart:       pointer.To(views.ChartType(metadata.ResourceData.Get("chart_type").(string))),
-					Query: &views.ReportConfigDefinition{
-						DataSet:   expandDataset(metadata.ResourceData.Get("dataset").([]interface{})),
-						Timeframe: views.ReportTimeframeType(metadata.ResourceData.Get("timeframe").(string)),
-						Type:      views.ReportTypeUsage,
-					},
-					Kpis:   expandKpis(metadata.ResourceData.Get("kpi").([]interface{})),
-					Pivots: expandPivots(metadata.ResourceData.Get("pivot").([]interface{})),
-				},
-			}
-
-			if _, err = client.CreateOrUpdateByScope(ctx, id, props); err != nil {
-				return fmt.Errorf("creating %s: %+v", id, err)
-			}
-
-			metadata.SetID(id)
-			return nil
-		},
-	}
-}
-
-func (br costManagementViewBaseResource) readFunc(scopeFieldName string) sdk.ResourceFunc {
-	return sdk.ResourceFunc{
-		Timeout: 5 * time.Minute,
-		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
-			client := metadata.Client.CostManagement.ViewsClient
-
-			id, err := views.ParseScopedViewID(metadata.ResourceData.Id())
-			if err != nil {
-				return err
-			}
-
-			resp, err := client.GetByScope(ctx, *id)
-			if err != nil {
-				if response.WasNotFound(resp.HttpResponse) {
-					return metadata.MarkAsGone(id)
-				}
-				return fmt.Errorf("reading %s: %+v", *id, err)
-			}
-
-			metadata.ResourceData.Set("name", id.ViewName)
-			// lintignore:R001
-			metadata.ResourceData.Set(scopeFieldName, id.Scope)
-
-			if model := resp.Model; model != nil {
-				if props := model.Properties; props != nil {
-					metadata.ResourceData.Set("chart_type", string(pointer.From(props.Chart)))
-
-					accumulated := false
-					if props.Accumulated != nil {
-						accumulated = views.AccumulatedTypeTrue == *props.Accumulated
-					}
-					metadata.ResourceData.Set("accumulated", accumulated)
-
-					metadata.ResourceData.Set("display_name", props.DisplayName)
-					metadata.ResourceData.Set("kpi", flattenKpis(props.Kpis))
-					metadata.ResourceData.Set("pivot", flattenPivots(props.Pivots))
-
-					if query := props.Query; query != nil {
-						metadata.ResourceData.Set("timeframe", string(query.Timeframe))
-						metadata.ResourceData.Set("report_type", string(query.Type))
-						if query.DataSet != nil {
-							metadata.ResourceData.Set("dataset", flattenDataset(query.DataSet))
-						}
-					}
-				}
-			}
-
-			return nil
-		},
-	}
-}
-
 func (br costManagementViewBaseResource) deleteFunc() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Timeout: 30 * time.Minute,
@@ -286,284 +217,163 @@ func (br costManagementViewBaseResource) deleteFunc() sdk.ResourceFunc {
 	}
 }
 
-func (br costManagementViewBaseResource) updateFunc() sdk.ResourceFunc {
-	return sdk.ResourceFunc{
-		Timeout: 30 * time.Minute,
-		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
-			client := metadata.Client.CostManagement.ViewsClient
+// Typed model expand/flatten helpers
 
-			id, err := views.ParseScopedViewID(metadata.ResourceData.Id())
-			if err != nil {
-				return err
-			}
-
-			// Update operation requires latest eTag to be set in the request.
-			existing, err := client.GetByScope(ctx, *id)
-			if err != nil {
-				return fmt.Errorf("reading %s: %+v", *id, err)
-			}
-			model := existing.Model
-
-			if model != nil {
-				if model.ETag == nil {
-					return fmt.Errorf("add %s: etag was nil", *id)
-				}
-			}
-
-			if model.Properties == nil {
-				return fmt.Errorf("retreiving properties for %s for update: %+v", *id, err)
-			}
-
-			if metadata.ResourceData.HasChange("display_name") {
-				model.Properties.DisplayName = pointer.To(metadata.ResourceData.Get("display_name").(string))
-			}
-
-			if metadata.ResourceData.HasChange("chart_type") {
-				model.Properties.Chart = pointer.To(views.ChartType(metadata.ResourceData.Get("chart_type").(string)))
-			}
-
-			if metadata.ResourceData.HasChange("dataset") {
-				model.Properties.Query.DataSet = expandDataset(metadata.ResourceData.Get("dataset").([]interface{}))
-			}
-			if metadata.ResourceData.HasChange("timeframe") {
-				model.Properties.Query.Timeframe = views.ReportTimeframeType(metadata.ResourceData.Get("timeframe").(string))
-			}
-
-			if metadata.ResourceData.HasChange("kpi") {
-				model.Properties.Kpis = expandKpis(metadata.ResourceData.Get("kpi").([]interface{}))
-			}
-
-			if metadata.ResourceData.HasChange("pivot") {
-				model.Properties.Pivots = expandPivots(metadata.ResourceData.Get("pivot").([]interface{}))
-			}
-
-			if _, err = client.CreateOrUpdateByScope(ctx, *id, *model); err != nil {
-				return fmt.Errorf("updating %s: %+v", *id, err)
-			}
-
-			return nil
-		},
-	}
-}
-
-func expandDataset(input []interface{}) *views.ReportConfigDataset {
-	if len(input) == 0 || input[0] == nil {
+func expandDatasetFromModel(input []CostManagementViewDatasetModel) *views.ReportConfigDataset {
+	if len(input) == 0 {
 		return nil
 	}
 
-	attrs := input[0].(map[string]interface{})
+	ds := input[0]
 	dataset := &views.ReportConfigDataset{
-		Granularity: pointer.To(views.ReportGranularityType(attrs["granularity"].(string))),
+		Granularity: pointer.To(views.ReportGranularityType(ds.Granularity)),
 	}
 
-	if aggregation := attrs["aggregation"].(*pluginsdk.Set).List(); len(aggregation) > 0 {
-		dataset.Aggregation = expandAggregation(aggregation)
+	if len(ds.Aggregation) > 0 {
+		aggregation := map[string]views.ReportConfigAggregation{}
+		for _, a := range ds.Aggregation {
+			aggregation[a.Name] = views.ReportConfigAggregation{
+				Name:     a.ColumnName,
+				Function: views.FunctionTypeSum,
+			}
+		}
+		dataset.Aggregation = &aggregation
 	}
 
-	if sorting := attrs["sorting"].([]interface{}); len(sorting) > 0 {
-		dataset.Sorting = expandSorting(sorting)
+	if len(ds.Sorting) > 0 {
+		sorting := make([]views.ReportConfigSorting, 0)
+		for _, s := range ds.Sorting {
+			sorting = append(sorting, views.ReportConfigSorting{
+				Direction: pointer.To(views.ReportConfigSortingType(s.Direction)),
+				Name:      s.Name,
+			})
+		}
+		dataset.Sorting = &sorting
 	}
 
-	if grouping := attrs["grouping"].([]interface{}); len(grouping) > 0 {
-		dataset.Grouping = expandGrouping(grouping)
+	if len(ds.Grouping) > 0 {
+		grouping := make([]views.ReportConfigGrouping, 0)
+		for _, g := range ds.Grouping {
+			grouping = append(grouping, views.ReportConfigGrouping{
+				Type: views.QueryColumnType(g.Type),
+				Name: g.Name,
+			})
+		}
+		dataset.Grouping = &grouping
 	}
 
 	return dataset
 }
 
-func expandAggregation(input []interface{}) *map[string]views.ReportConfigAggregation {
-	outputSorting := map[string]views.ReportConfigAggregation{}
-	if len(input) == 0 || input[0] == nil {
-		return &outputSorting
+func flattenDatasetToModel(input *views.ReportConfigDataset) []CostManagementViewDatasetModel {
+	if input == nil {
+		return []CostManagementViewDatasetModel{}
 	}
 
-	for _, item := range input {
-		v := item.(map[string]interface{})
-		name := v["name"].(string)
-		outputSorting[name] = views.ReportConfigAggregation{
-			Name:     v["column_name"].(string),
-			Function: views.FunctionTypeSum,
+	ds := CostManagementViewDatasetModel{}
+
+	if input.Granularity != nil {
+		ds.Granularity = string(*input.Granularity)
+	}
+
+	if input.Aggregation != nil {
+		aggregation := make([]CostManagementViewAggregationModel, 0)
+		for name, item := range *input.Aggregation {
+			aggregation = append(aggregation, CostManagementViewAggregationModel{
+				Name:       name,
+				ColumnName: item.Name,
+			})
 		}
+		ds.Aggregation = aggregation
 	}
 
-	return &outputSorting
+	if input.Sorting != nil {
+		sorting := make([]CostManagementViewSortingModel, 0)
+		for _, item := range *input.Sorting {
+			if item.Direction == nil {
+				continue
+			}
+			sorting = append(sorting, CostManagementViewSortingModel{
+				Name:      item.Name,
+				Direction: string(*item.Direction),
+			})
+		}
+		ds.Sorting = sorting
+	}
+
+	if input.Grouping != nil {
+		grouping := make([]CostManagementViewGroupingModel, 0)
+		for _, item := range *input.Grouping {
+			grouping = append(grouping, CostManagementViewGroupingModel{
+				Name: item.Name,
+				Type: string(item.Type),
+			})
+		}
+		ds.Grouping = grouping
+	}
+
+	return []CostManagementViewDatasetModel{ds}
 }
 
-func expandGrouping(input []interface{}) *[]views.ReportConfigGrouping {
-	outputGrouping := []views.ReportConfigGrouping{}
-	if len(input) == 0 || input[0] == nil {
-		return &outputGrouping
-	}
-
-	for _, item := range input {
-		v := item.(map[string]interface{})
-		outputGrouping = append(outputGrouping, views.ReportConfigGrouping{
-			Type: views.QueryColumnType(v["type"].(string)),
-			Name: v["name"].(string),
-		})
-	}
-
-	return &outputGrouping
-}
-
-func expandSorting(input []interface{}) *[]views.ReportConfigSorting {
-	outputSorting := []views.ReportConfigSorting{}
-	if len(input) == 0 || input[0] == nil {
-		return &outputSorting
-	}
-
-	for _, item := range input {
-		v := item.(map[string]interface{})
-		outputSorting = append(outputSorting, views.ReportConfigSorting{
-			Direction: pointer.To(views.ReportConfigSortingType(v["direction"].(string))),
-			Name:      v["name"].(string),
-		})
-	}
-
-	return &outputSorting
-}
-
-func expandKpis(input []interface{}) *[]views.KpiProperties {
-	outputKpis := []views.KpiProperties{}
-	if len(input) == 0 || input[0] == nil {
-		return &outputKpis
-	}
-
-	for _, item := range input {
-		v := item.(map[string]interface{})
-		outputKpis = append(outputKpis, views.KpiProperties{
-			Type:    pointer.To(views.KpiTypeType(v["type"].(string))),
+func expandKpisFromModel(input []CostManagementViewKpiModel) *[]views.KpiProperties {
+	kpis := make([]views.KpiProperties, 0)
+	for _, k := range input {
+		kpis = append(kpis, views.KpiProperties{
+			Type:    pointer.To(views.KpiTypeType(k.Type)),
 			Enabled: pointer.To(true),
 		})
 	}
-
-	return &outputKpis
+	return &kpis
 }
 
-func expandPivots(input []interface{}) *[]views.PivotProperties {
-	outputPivots := []views.PivotProperties{}
-	if len(input) == 0 || input[0] == nil {
-		return &outputPivots
-	}
-
-	for _, item := range input {
-		v := item.(map[string]interface{})
-		outputPivots = append(outputPivots, views.PivotProperties{
-			Type: pointer.To(views.PivotTypeType(v["type"].(string))),
-			Name: pointer.To((v["name"].(string))),
-		})
-	}
-
-	return &outputPivots
-}
-
-func flattenKpis(input *[]views.KpiProperties) []interface{} {
-	outputKpis := []interface{}{}
+func flattenKpisToModel(input *[]views.KpiProperties) []CostManagementViewKpiModel {
 	if input == nil || len(*input) == 0 {
-		return outputKpis
+		return []CostManagementViewKpiModel{}
 	}
 
+	result := make([]CostManagementViewKpiModel, 0)
 	for _, item := range *input {
 		kpiType := ""
 		if v := item.Type; v != nil && item.Enabled != nil && *item.Enabled {
 			kpiType = string(*v)
 		}
-
-		outputKpis = append(outputKpis, map[string]interface{}{
-			"type": kpiType,
+		result = append(result, CostManagementViewKpiModel{
+			Type: kpiType,
 		})
 	}
-
-	return outputKpis
+	return result
 }
 
-func flattenPivots(input *[]views.PivotProperties) []interface{} {
-	outputPivots := []interface{}{}
+func expandPivotsFromModel(input []CostManagementViewPivotModel) *[]views.PivotProperties {
+	pivots := make([]views.PivotProperties, 0)
+	for _, p := range input {
+		pivots = append(pivots, views.PivotProperties{
+			Type: pointer.To(views.PivotTypeType(p.Type)),
+			Name: pointer.To(p.Name),
+		})
+	}
+	return &pivots
+}
+
+func flattenPivotsToModel(input *[]views.PivotProperties) []CostManagementViewPivotModel {
 	if input == nil || len(*input) == 0 {
-		return outputPivots
+		return []CostManagementViewPivotModel{}
 	}
 
+	result := make([]CostManagementViewPivotModel, 0)
 	for _, item := range *input {
 		pivotType := ""
 		if v := item.Type; v != nil {
 			pivotType = string(*v)
 		}
-
 		name := ""
 		if p := item.Name; p != nil {
 			name = *p
 		}
-
-		outputPivots = append(outputPivots, map[string]interface{}{
-			"name": name,
-			"type": pivotType,
+		result = append(result, CostManagementViewPivotModel{
+			Name: name,
+			Type: pivotType,
 		})
 	}
-
-	return outputPivots
-}
-
-func flattenDataset(input *views.ReportConfigDataset) []interface{} {
-	outputDataset := map[string]interface{}{
-		"aggregation": flattenAggregation(input.Aggregation),
-		"sorting":     flattenSorting(input.Sorting),
-		"grouping":    flattenGrouping(input.Grouping),
-	}
-
-	if input.Granularity != nil {
-		outputDataset["granularity"] = string(*input.Granularity)
-	}
-
-	return []interface{}{outputDataset}
-}
-
-func flattenAggregation(input *map[string]views.ReportConfigAggregation) []interface{} {
-	outputAggregations := []interface{}{}
-	if input == nil || len(*input) == 0 {
-		return outputAggregations
-	}
-
-	for name, item := range *input {
-		outputAggregations = append(outputAggregations, map[string]interface{}{
-			"name":        name,
-			"column_name": item.Name,
-		})
-	}
-
-	return outputAggregations
-}
-
-func flattenGrouping(input *[]views.ReportConfigGrouping) []interface{} {
-	outputGroupings := []interface{}{}
-	if input == nil || len(*input) == 0 {
-		return outputGroupings
-	}
-
-	for _, item := range *input {
-		outputGroupings = append(outputGroupings, map[string]interface{}{
-			"name": item.Name,
-			"type": string(item.Type),
-		})
-	}
-
-	return outputGroupings
-}
-
-func flattenSorting(input *[]views.ReportConfigSorting) []interface{} {
-	outputSortings := []interface{}{}
-	if input == nil || len(*input) == 0 {
-		return outputSortings
-	}
-
-	for _, item := range *input {
-		if item.Direction == nil {
-			continue
-		}
-		outputSortings = append(outputSortings, map[string]interface{}{
-			"name":      item.Name,
-			"direction": string(*item.Direction),
-		})
-	}
-
-	return outputSortings
+	return result
 }


### PR DESCRIPTION

## Community Note
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Convert `azurerm_subscription_cost_management_view` and `azurerm_resource_group_cost_management_view` from returning `nil` in `ModelObject()` with raw `metadata.ResourceData.Get()`/`Set()` calls to using proper typed model structs with `metadata.Decode()`/`metadata.Encode()`.

The `Update()` methods preserve the existing read-modify-write pattern with `HasChange` guards to ensure `lifecycle { ignore_changes }` continues to work correctly.

This follows the same pattern applied to the consumption budget resources in #31929, the cost management export resources in #31930, and the scheduled action/anomaly alert resources in #31931.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Testing

- `go build ./internal/services/costmanagement/...` — passes
- `go vet ./internal/services/costmanagement/...` — passes
- `make static-analysis` — passes
- Test registration (`go test -short`) — all cost management view tests discover and register without `ValidateModelObject` panics

No behavioral changes were made; existing acceptance tests cover the Create/Read/Update/Delete flows and will validate correctness when run with `TF_ACC`.


## Change Log

* `azurerm_subscription_cost_management_view` - refactor to use typed model with Decode/Encode
* `azurerm_resource_group_cost_management_view` - refactor to use typed model with Decode/Encode


This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

N/A — internal tech debt cleanup


## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

AI was used for code generation of the typed model structs, expand/flatten helpers, and refactored CRUD methods. All changes were reviewed and validated manually.


## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

No changes to security controls.
