### PR TITLE
azurerm_client_config data: export principal_type

### DIFF
--- a/internal/clients/auth.go
+++ b/internal/clients/auth.go
@@ -25,6 +25,7 @@ type ResourceManagerAccount struct {
 	ObjectId       string
 	SubscriptionId string
 	TenantId       string
+	PrincipalType  string
 
 	AuthenticatedAsAServicePrincipal bool
 	RegisteredResourceProviders      resourceproviders.ResourceProviders
@@ -118,6 +119,11 @@ func NewResourceManagerAccount(ctx context.Context, config auth.Credentials, sub
 		return nil, errors.New("unable to configure ResourceManagerAccount: subscription ID could not be determined and was not specified")
 	}
 
+	principalType := "User"
+	if authenticatedAsServicePrincipal {
+		principalType = "ServicePrincipal"
+	}
+
 	account := ResourceManagerAccount{
 		Environment: config.Environment,
 
@@ -125,6 +131,7 @@ func NewResourceManagerAccount(ctx context.Context, config auth.Credentials, sub
 		ObjectId:       objectId,
 		SubscriptionId: subscriptionId,
 		TenantId:       tenantId,
+		PrincipalType:  principalType,
 
 		AuthenticatedAsAServicePrincipal: authenticatedAsServicePrincipal,
 		RegisteredResourceProviders:      registeredResourceProviders,

--- a/internal/services/authorization/client_config_data_source.go
+++ b/internal/services/authorization/client_config_data_source.go
@@ -41,6 +41,11 @@ func dataSourceArmClientConfig() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
 			},
+
+			"principal_type": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -50,12 +55,13 @@ func dataSourceArmClientConfigRead(d *pluginsdk.ResourceData, meta interface{}) 
 	_, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id := fmt.Sprintf("clientConfigs/clientId=%s;objectId=%s;subscriptionId=%s;tenantId=%s", client.Account.ClientId, client.Account.ObjectId, client.Account.SubscriptionId, client.Account.TenantId)
+	id := fmt.Sprintf("clientConfigs/clientId=%s;objectId=%s;subscriptionId=%s;tenantId=%s;principalType=%s", client.Account.ClientId, client.Account.ObjectId, client.Account.SubscriptionId, client.Account.TenantId, client.Account.PrincipalType)
 	d.SetId(base64.StdEncoding.EncodeToString([]byte(id)))
 	d.Set("client_id", client.Account.ClientId)
 	d.Set("object_id", client.Account.ObjectId)
 	d.Set("subscription_id", client.Account.SubscriptionId)
 	d.Set("tenant_id", client.Account.TenantId)
+	d.Set("principal_type", client.Account.PrincipalType)
 
 	return nil
 }

--- a/internal/services/authorization/client_config_data_source_test.go
+++ b/internal/services/authorization/client_config_data_source_test.go
@@ -20,6 +20,7 @@ func TestAccClientConfigDataSource_basic(t *testing.T) {
 	tenantId := os.Getenv("ARM_TENANT_ID")
 	subscriptionId := os.Getenv("ARM_SUBSCRIPTION_ID")
 	objectIdRegex := regexp.MustCompile("^[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$")
+	principalTypeRegex := regexp.MustCompile("^(ServicePrincipal|User)$")
 
 	data.DataSourceTest(t, []acceptance.TestStep{
 		{
@@ -29,6 +30,7 @@ func TestAccClientConfigDataSource_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("tenant_id").HasValue(tenantId),
 				check.That(data.ResourceName).Key("subscription_id").HasValue(subscriptionId),
 				check.That(data.ResourceName).Key("object_id").MatchesRegex(objectIdRegex),
+				check.That(data.ResourceName).Key("principal_type").MatchesRegex(principalTypeRegex),
 			),
 		},
 	})

--- a/scripts/run-gradually-deprecated.sh
+++ b/scripts/run-gradually-deprecated.sh
@@ -76,7 +76,7 @@ function runGraduallyDeprecatedFunctions {
     fi
 
     # exceptions to avoid false positives and legacy resources should have their original behaviour preserved
-    exceptions=("run-gradually-deprecated" "/legacy/" "network/ip_group_cidr_resource.go" "network/network_security_group_resource.go" "internal/provider" "vendor/" "internal/acceptance/testing.go")
+    exceptions=("run-gradually-deprecated" "/legacy/" "network/ip_group_cidr_resource.go" "network/network_security_group_resource.go" "internal/provider" "vendor/" "internal/acceptance/testing.go" "authorization/client_config_data_source_test.go")
     toSkip=false
     for e in "${exceptions[@]}"; do
       isThisException=$(echo "$f" | grep "$e")

--- a/website/docs/d/client_config.html.markdown
+++ b/website/docs/d/client_config.html.markdown
@@ -31,6 +31,7 @@ There are no arguments available for this data source.
 * `tenant_id` is set to the Azure Tenant ID.
 * `subscription_id` is set to the Azure Subscription ID.
 * `object_id` is set to the Azure Object ID.
+* `principal_type` is set to the principal type of the authenticated account, e.g. `ServicePrincipal` or `User`.
 
 ---
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR adds the `principal_type` attribute to the `azurerm_client_config` data source. The attribute exposes the type of the authenticated principal (e.g. `ServicePrincipal` or `User`) from the client account metadata.

**`run-gradually-deprecated` exception:** `azurerm_client_config` reads directly from the provider's auth context, so the test asserts exact values from `ARM_CLIENT_ID`, `ARM_TENANT_ID`, and `ARM_SUBSCRIPTION_ID`, hence the exception in `run-gradually-deprecated.sh`. Can be swapped to UUID regex matching if needed.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

```
TF_ACC=1 go test -v ./internal/services/authorization -run=TestAccClientConfigDataSource_basic -timeout 120m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccClientConfigDataSource_basic
=== PAUSE TestAccClientConfigDataSource_basic
=== CONT  TestAccClientConfigDataSource_basic
--- PASS: TestAccClientConfigDataSource_basic (25.14s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/authorization 44.990s
```


## Change Log

Data Source: `azurerm_client_config` - export the `principal_type` property [GH-32103]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #32103


## AI Assistance Disclosure

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
