### PR TITLE
`azurerm_bot_web_app` - support for `microsoft_app_type`, `microsoft_app_tenant_id`, and `microsoft_app_user_assigned_identity_id` properties.

### DIFF
--- a/internal/services/bot/bot_web_app_resource.go
+++ b/internal/services/bot/bot_web_app_resource.go
@@ -208,9 +208,7 @@ func resourceBotWebApp() *pluginsdk.Resource {
 				string(botservice.MsaAppTypeUserAssignedMSI),
 			}, false),
 		}
-
 	}
-
 	return resource
 }
 

--- a/internal/services/bot/bot_web_app_resource.go
+++ b/internal/services/bot/bot_web_app_resource.go
@@ -11,10 +11,12 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/bot/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -25,7 +27,7 @@ import (
 )
 
 func resourceBotWebApp() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
+	resource := &pluginsdk.Resource{
 		Create: resourceBotWebAppCreate,
 		Read:   resourceBotWebAppRead,
 		Update: resourceBotWebAppUpdate,
@@ -92,6 +94,31 @@ func resourceBotWebApp() *pluginsdk.Resource {
 				ValidateFunc: validation.IsUUID,
 			},
 
+			"microsoft_app_type": {
+				Type:     pluginsdk.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(botservice.MsaAppTypeMultiTenant),
+					string(botservice.MsaAppTypeSingleTenant),
+					string(botservice.MsaAppTypeUserAssignedMSI),
+				}, false),
+			},
+
+			"microsoft_app_tenant_id": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IsUUID,
+			},
+
+			"microsoft_app_user_assigned_identity_id": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: commonids.ValidateUserAssignedIdentityID,
+			},
+
 			"display_name": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
@@ -143,6 +170,23 @@ func resourceBotWebApp() *pluginsdk.Resource {
 			"tags": commonschema.Tags(),
 		},
 	}
+
+	if !features.FivePointOh() {
+		resource.Schema["microsoft_app_type"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			// O+C because Azure sets a value for this if omitted
+			Computed: true,
+			ForceNew: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				string(botservice.MsaAppTypeMultiTenant),
+				string(botservice.MsaAppTypeSingleTenant),
+				string(botservice.MsaAppTypeUserAssignedMSI),
+			}, false),
+		}
+	}
+
+	return resource
 }
 
 func resourceBotWebAppCreate(d *pluginsdk.ResourceData, meta interface{}) error {
@@ -174,6 +218,7 @@ func resourceBotWebAppCreate(d *pluginsdk.ResourceData, meta interface{}) error 
 			DisplayName:                       pointer.To(displayName),
 			Endpoint:                          pointer.To(d.Get("endpoint").(string)),
 			MsaAppID:                          pointer.To(d.Get("microsoft_app_id").(string)),
+			MsaAppType:                        botservice.MsaAppType(d.Get("microsoft_app_type").(string)),
 			DeveloperAppInsightKey:            pointer.To(d.Get("developer_app_insights_key").(string)),
 			DeveloperAppInsightsAPIKey:        pointer.To(d.Get("developer_app_insights_api_key").(string)),
 			DeveloperAppInsightsApplicationID: pointer.To(d.Get("developer_app_insights_application_id").(string)),
@@ -186,6 +231,14 @@ func resourceBotWebAppCreate(d *pluginsdk.ResourceData, meta interface{}) error 
 		},
 		Kind: botservice.KindSdk,
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
+	}
+
+	if v, ok := d.GetOk("microsoft_app_tenant_id"); ok {
+		bot.Properties.MsaAppTenantID = pointer.To(v.(string))
+	}
+
+	if v, ok := d.GetOk("microsoft_app_user_assigned_identity_id"); ok {
+		bot.Properties.MsaAppMSIResourceID = pointer.To(v.(string))
 	}
 
 	if _, err := client.Create(ctx, resourceId.ResourceGroup, resourceId.Name, bot); err != nil {
@@ -232,6 +285,9 @@ func resourceBotWebAppRead(d *pluginsdk.ResourceData, meta interface{}) error {
 		d.Set("developer_app_insights_key", props.DeveloperAppInsightKey)
 		d.Set("developer_app_insights_application_id", props.DeveloperAppInsightsApplicationID)
 		d.Set("luis_app_ids", props.LuisAppIds)
+		d.Set("microsoft_app_type", string(props.MsaAppType))
+		d.Set("microsoft_app_tenant_id", pointer.From(props.MsaAppTenantID))
+		d.Set("microsoft_app_user_assigned_identity_id", pointer.From(props.MsaAppMSIResourceID))
 	}
 
 	return tags.FlattenAndSet(d, resp.Tags)
@@ -257,6 +313,7 @@ func resourceBotWebAppUpdate(d *pluginsdk.ResourceData, meta interface{}) error 
 			DisplayName:                       pointer.To(displayName),
 			Endpoint:                          pointer.To(d.Get("endpoint").(string)),
 			MsaAppID:                          pointer.To(d.Get("microsoft_app_id").(string)),
+			MsaAppType:                        botservice.MsaAppType(d.Get("microsoft_app_type").(string)),
 			DeveloperAppInsightKey:            pointer.To(d.Get("developer_app_insights_key").(string)),
 			DeveloperAppInsightsAPIKey:        pointer.To(d.Get("developer_app_insights_api_key").(string)),
 			DeveloperAppInsightsApplicationID: pointer.To(d.Get("developer_app_insights_application_id").(string)),
@@ -269,6 +326,14 @@ func resourceBotWebAppUpdate(d *pluginsdk.ResourceData, meta interface{}) error 
 		},
 		Kind: botservice.KindSdk,
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
+	}
+
+	if v, ok := d.GetOk("microsoft_app_tenant_id"); ok {
+		bot.Properties.MsaAppTenantID = pointer.To(v.(string))
+	}
+
+	if v, ok := d.GetOk("microsoft_app_user_assigned_identity_id"); ok {
+		bot.Properties.MsaAppMSIResourceID = pointer.To(v.(string))
 	}
 
 	if _, err := client.Update(ctx, id.ResourceGroup, id.Name, bot); err != nil {

--- a/internal/services/bot/bot_web_app_resource.go
+++ b/internal/services/bot/bot_web_app_resource.go
@@ -5,6 +5,7 @@ package bot
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"time"
@@ -169,6 +170,22 @@ func resourceBotWebApp() *pluginsdk.Resource {
 
 			"tags": commonschema.Tags(),
 		},
+
+		CustomizeDiff: pluginsdk.CustomizeDiffShim(func(ctx context.Context, d *pluginsdk.ResourceDiff, v interface{}) error {
+			// No state yet, a new resource being created.
+			if d.GetRawState().IsNull() {
+				if appType, ok := d.GetOk("microsoft_app_type"); !ok || appType == "MultiTenant" {
+					return errors.New("`microsoft_app_type` must be set to `SingleTenant` or `UserAssignedMSI` for new resources.")
+				}
+			}
+
+			if _, ok := d.GetOk("microsoft_app_tenant_id"); !ok {
+				if appType, ok := d.GetOk("microsoft_app_type"); ok && (appType == "SingleTenant" || appType == "UserAssignedMSI") {
+					return errors.New("`microsoft_app_tenant_id` must be set when app type is SingleTenant or UserAssignedMSI.")
+				}
+			}
+			return nil
+		}),
 	}
 
 	if !features.FivePointOh() {
@@ -184,6 +201,7 @@ func resourceBotWebApp() *pluginsdk.Resource {
 				string(botservice.MsaAppTypeUserAssignedMSI),
 			}, false),
 		}
+
 	}
 
 	return resource

--- a/internal/services/bot/bot_web_app_resource.go
+++ b/internal/services/bot/bot_web_app_resource.go
@@ -175,13 +175,20 @@ func resourceBotWebApp() *pluginsdk.Resource {
 			// No state yet, a new resource being created.
 			if d.GetRawState().IsNull() {
 				if appType, ok := d.GetOk("microsoft_app_type"); !ok || appType == "MultiTenant" {
-					return errors.New("`microsoft_app_type` must be set to `SingleTenant` or `UserAssignedMSI` for new resources.")
+					return errors.New("`microsoft_app_type` must be set to `SingleTenant` or `UserAssignedMSI` for new resources")
 				}
 			}
 
-			if _, ok := d.GetOk("microsoft_app_tenant_id"); !ok {
-				if appType, ok := d.GetOk("microsoft_app_type"); ok && (appType == "SingleTenant" || appType == "UserAssignedMSI") {
-					return errors.New("`microsoft_app_tenant_id` must be set when app type is SingleTenant or UserAssignedMSI.")
+			rawConfig := d.GetRawConfig()
+			if rawConfig.GetAttr("microsoft_app_tenant_id").IsNull() {
+				if appType := d.Get("microsoft_app_type"); appType == "SingleTenant" || appType == "UserAssignedMSI" {
+					return errors.New("`microsoft_app_tenant_id` must be set when app type is SingleTenant or UserAssignedMSI")
+				}
+			}
+
+			if rawConfig.GetAttr("microsoft_app_user_assigned_identity_id").IsNull() {
+				if d.Get("microsoft_app_type") == "UserAssignedMSI" {
+					return errors.New("`microsoft_app_user_assigned_identity_id` must be set when app type is UserAssignedMSI")
 				}
 			}
 			return nil

--- a/internal/services/bot/bot_web_app_resource_test.go
+++ b/internal/services/bot/bot_web_app_resource_test.go
@@ -6,6 +6,7 @@ package bot_test
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -92,6 +93,28 @@ func TestAccBotWebApp_msaAppType(t *testing.T) {
 	})
 }
 
+func TestAccBotWebApp_MsaAppTypeMultiTenantNotSupportedForNewResources(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_bot_web_app", "test")
+	r := BotWebAppResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:      r.withMsaAppTypeMultiTenant(data),
+			ExpectError: regexp.MustCompile("`microsoft_app_type` must be set to `SingleTenant` or `UserAssignedMSI` for new resources"),
+		},
+	})
+}
+
+func TestAccBotWebApp_MsaAppTenantIdMustNotBeNullOrEmpty(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_bot_web_app", "test")
+	r := BotWebAppResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:      r.withEmptyMsaAppTenantID(data),
+			ExpectError: regexp.MustCompile("`microsoft_app_tenant_id` must be set when app type is SingleTenant or UserAssignedMSI"),
+		},
+	})
+}
+
 func (t BotWebAppResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.BotServiceID(state.ID)
 	if err != nil {
@@ -106,7 +129,7 @@ func (t BotWebAppResource) Exists(ctx context.Context, clients *clients.Client, 
 	return pointer.To(resp.Properties != nil), nil
 }
 
-func (BotWebAppResource) basicConfig(data acceptance.TestData) string {
+func (BotWebAppResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -123,6 +146,12 @@ resource "azurerm_resource_group" "test" {
 resource "azuread_application_registration" "test" {
   display_name = "acctestReg-%d"
 }
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (r BotWebAppResource) basicConfig(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
 
 resource "azurerm_bot_web_app" "test" {
   name                    = "acctestdf%d"
@@ -137,22 +166,12 @@ resource "azurerm_bot_web_app" "test" {
     environment = "Test"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }
 
-func (BotWebAppResource) completeConfig(data acceptance.TestData) string {
+func (r BotWebAppResource) completeConfig(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-data "azurerm_client_config" "current" {
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
+%[1]s
 
 resource "azurerm_application_insights" "test" {
   name                = "acctestappinsights-%d"
@@ -165,10 +184,6 @@ resource "azurerm_application_insights_api_key" "test" {
   name                    = "acctestappinsightsapikey-%d"
   application_insights_id = azurerm_application_insights.test.id
   read_permissions        = ["aggregate", "api", "draft", "extendqueries", "search"]
-}
-
-resource "azuread_application_registration" "test" {
-  display_name = "acctestReg-%d"
 }
 
 resource "azurerm_bot_web_app" "test" {
@@ -189,31 +204,17 @@ resource "azurerm_bot_web_app" "test" {
     environment = "Test"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, r.template(data), data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
-func (BotWebAppResource) msaAppType(data acceptance.TestData) string {
+func (r BotWebAppResource) msaAppType(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-data "azurerm_client_config" "current" {
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
+%[1]s
 
 resource "azurerm_user_assigned_identity" "test" {
   name                = "acctestUAI-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-}
-
-resource "azuread_application_registration" "test" {
-  display_name = "acctestReg-%d"
 }
 
 resource "azurerm_bot_web_app" "test" {
@@ -230,5 +231,44 @@ resource "azurerm_bot_web_app" "test" {
     environment = "Test"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, r.template(data), data.RandomInteger, data.RandomInteger)
+}
+
+func (r BotWebAppResource) withMsaAppTypeMultiTenant(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_bot_web_app" "test" {
+  name                    = "acctestdf%d"
+  location                = "global"
+  resource_group_name     = azurerm_resource_group.test.name
+  sku                     = "F0"
+  microsoft_app_id        = azuread_application_registration.test.client_id
+  microsoft_app_type      = "MultiTenant"
+  microsoft_app_tenant_id = data.azurerm_client_config.current.tenant_id
+
+  tags = {
+    environment = "Test"
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r BotWebAppResource) withEmptyMsaAppTenantID(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_bot_web_app" "test" {
+  name                = "acctestdf%d"
+  location            = "global"
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "F0"
+  microsoft_app_id    = azuread_application_registration.test.client_id
+  microsoft_app_type  = "SingleTenant"
+
+  tags = {
+    environment = "Test"
+  }
+}
+`, r.template(data), data.RandomInteger)
 }

--- a/internal/services/bot/bot_web_app_resource_test.go
+++ b/internal/services/bot/bot_web_app_resource_test.go
@@ -110,11 +110,13 @@ resource "azuread_application_registration" "test" {
 }
 
 resource "azurerm_bot_web_app" "test" {
-  name                = "acctestdf%d"
-  location            = "global"
-  resource_group_name = azurerm_resource_group.test.name
-  sku                 = "F0"
-  microsoft_app_id    = azuread_application_registration.test.client_id
+  name                    = "acctestdf%d"
+  location                = "global"
+  resource_group_name     = azurerm_resource_group.test.name
+  sku                     = "F0"
+  microsoft_app_id        = azuread_application_registration.test.client_id
+  microsoft_app_type      = "SingleTenant"
+  microsoft_app_tenant_id = data.azurerm_client_config.current.tenant_id
 
   tags = {
     environment = "production"
@@ -142,11 +144,13 @@ resource "azuread_application_registration" "test" {
 }
 
 resource "azurerm_bot_web_app" "test" {
-  name                = "acctestdf%d"
-  location            = "global"
-  resource_group_name = azurerm_resource_group.test.name
-  sku                 = "F0"
-  microsoft_app_id    = azuread_application_registration.test.client_id
+  name                    = "acctestdf%d"
+  location                = "global"
+  resource_group_name     = azurerm_resource_group.test.name
+  sku                     = "F0"
+  microsoft_app_id        = azuread_application_registration.test.client_id
+  microsoft_app_type      = "SingleTenant"
+  microsoft_app_tenant_id = data.azurerm_client_config.current.tenant_id
 
   tags = {
     environment = "production"
@@ -187,11 +191,13 @@ resource "azuread_application_registration" "test" {
 }
 
 resource "azurerm_bot_web_app" "test" {
-  name                = "acctestdf%d"
-  location            = "global"
-  resource_group_name = azurerm_resource_group.test.name
-  microsoft_app_id    = azuread_application_registration.test.client_id
-  sku                 = "F0"
+  name                    = "acctestdf%d"
+  location                = "global"
+  resource_group_name     = azurerm_resource_group.test.name
+  microsoft_app_id        = azuread_application_registration.test.client_id
+  microsoft_app_type      = "SingleTenant"
+  microsoft_app_tenant_id = data.azurerm_client_config.current.tenant_id
+  sku                     = "F0"
 
   endpoint                              = "https://example.com"
   developer_app_insights_api_key        = azurerm_application_insights_api_key.test.api_key

--- a/internal/services/bot/bot_web_app_resource_test.go
+++ b/internal/services/bot/bot_web_app_resource_test.go
@@ -78,13 +78,35 @@ func TestAccBotWebApp_complete(t *testing.T) {
 	})
 }
 
-func TestAccBotWebApp_msaAppType(t *testing.T) {
+func TestAccBotWebApp_appTypeMultiTenantNotSupportedForNewResources(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_bot_web_app", "test")
+	r := BotWebAppResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:      r.withAppTypeMultiTenant(data),
+			ExpectError: regexp.MustCompile("`microsoft_app_type` must be set to `SingleTenant` or `UserAssignedMSI` for new resources"),
+		},
+	})
+}
+
+func TestAccBotWebApp_appTenantIdMustNotBeNullOrEmpty(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_bot_web_app", "test")
+	r := BotWebAppResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:      r.withEmptyAppTenantID(data),
+			ExpectError: regexp.MustCompile("`microsoft_app_tenant_id` must be set when app type is SingleTenant or UserAssignedMSI"),
+		},
+	})
+}
+
+func TestAccBotWebApp_appTypeUserAssignedMSI(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_bot_web_app", "test")
 	r := BotWebAppResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.msaAppType(data),
+			Config: r.withAppTypeUserAssignedMSI(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -93,24 +115,13 @@ func TestAccBotWebApp_msaAppType(t *testing.T) {
 	})
 }
 
-func TestAccBotWebApp_MsaAppTypeMultiTenantNotSupportedForNewResources(t *testing.T) {
+func TestAccBotWebApp_userAssignedMSIRequiresIdentityId(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_bot_web_app", "test")
 	r := BotWebAppResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config:      r.withMsaAppTypeMultiTenant(data),
-			ExpectError: regexp.MustCompile("`microsoft_app_type` must be set to `SingleTenant` or `UserAssignedMSI` for new resources"),
-		},
-	})
-}
-
-func TestAccBotWebApp_MsaAppTenantIdMustNotBeNullOrEmpty(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_bot_web_app", "test")
-	r := BotWebAppResource{}
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config:      r.withEmptyMsaAppTenantID(data),
-			ExpectError: regexp.MustCompile("`microsoft_app_tenant_id` must be set when app type is SingleTenant or UserAssignedMSI"),
+			Config:      r.withUserAssignedMSIMissingIdentityId(data),
+			ExpectError: regexp.MustCompile("`microsoft_app_user_assigned_identity_id` must be set when app type is UserAssignedMSI"),
 		},
 	})
 }
@@ -207,7 +218,7 @@ resource "azurerm_bot_web_app" "test" {
 `, r.template(data), data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
-func (r BotWebAppResource) msaAppType(data acceptance.TestData) string {
+func (r BotWebAppResource) withAppTypeUserAssignedMSI(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -234,7 +245,7 @@ resource "azurerm_bot_web_app" "test" {
 `, r.template(data), data.RandomInteger, data.RandomInteger)
 }
 
-func (r BotWebAppResource) withMsaAppTypeMultiTenant(data acceptance.TestData) string {
+func (r BotWebAppResource) withAppTypeMultiTenant(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -254,7 +265,7 @@ resource "azurerm_bot_web_app" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r BotWebAppResource) withEmptyMsaAppTenantID(data acceptance.TestData) string {
+func (r BotWebAppResource) withEmptyAppTenantID(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -265,6 +276,26 @@ resource "azurerm_bot_web_app" "test" {
   sku                 = "F0"
   microsoft_app_id    = azuread_application_registration.test.client_id
   microsoft_app_type  = "SingleTenant"
+
+  tags = {
+    environment = "Test"
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r BotWebAppResource) withUserAssignedMSIMissingIdentityId(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_bot_web_app" "test" {
+  name                    = "acctestdf%d"
+  location                = "global"
+  resource_group_name     = azurerm_resource_group.test.name
+  sku                     = "F0"
+  microsoft_app_id        = azuread_application_registration.test.client_id
+  microsoft_app_type      = "UserAssignedMSI"
+  microsoft_app_tenant_id = data.azurerm_client_config.current.tenant_id
 
   tags = {
     environment = "Test"

--- a/internal/services/bot/bot_web_app_resource_test.go
+++ b/internal/services/bot/bot_web_app_resource_test.go
@@ -53,7 +53,7 @@ func TestAccBotWebApp_update(t *testing.T) {
 		},
 		data.ImportStep("developer_app_insights_api_key"),
 		{
-			Config: r.updateConfig(data),
+			Config: r.basicConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -69,6 +69,21 @@ func TestAccBotWebApp_complete(t *testing.T) {
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.completeConfig(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("developer_app_insights_api_key"),
+	})
+}
+
+func TestAccBotWebApp_msaAppType(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_bot_web_app", "test")
+	r := BotWebAppResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.msaAppType(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -119,41 +134,7 @@ resource "azurerm_bot_web_app" "test" {
   microsoft_app_tenant_id = data.azurerm_client_config.current.tenant_id
 
   tags = {
-    environment = "production"
-  }
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
-}
-
-func (BotWebAppResource) updateConfig(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-data "azurerm_client_config" "current" {
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azuread_application_registration" "test" {
-  display_name = "acctestReg-%d"
-}
-
-resource "azurerm_bot_web_app" "test" {
-  name                    = "acctestdf%d"
-  location                = "global"
-  resource_group_name     = azurerm_resource_group.test.name
-  sku                     = "F0"
-  microsoft_app_id        = azuread_application_registration.test.client_id
-  microsoft_app_type      = "SingleTenant"
-  microsoft_app_tenant_id = data.azurerm_client_config.current.tenant_id
-
-  tags = {
-    environment = "production"
+    environment = "Test"
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
@@ -205,8 +186,49 @@ resource "azurerm_bot_web_app" "test" {
   developer_app_insights_key            = azurerm_application_insights.test.instrumentation_key
 
   tags = {
-    environment = "production"
+    environment = "Test"
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (BotWebAppResource) msaAppType(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctestUAI-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azuread_application_registration" "test" {
+  display_name = "acctestReg-%d"
+}
+
+resource "azurerm_bot_web_app" "test" {
+  name                                    = "acctestdf%d"
+  location                                = "global"
+  resource_group_name                     = azurerm_resource_group.test.name
+  sku                                     = "F0"
+  microsoft_app_id                        = azuread_application_registration.test.client_id
+  microsoft_app_type                      = "UserAssignedMSI"
+  microsoft_app_tenant_id                 = data.azurerm_client_config.current.tenant_id
+  microsoft_app_user_assigned_identity_id = azurerm_user_assigned_identity.test.id
+
+  tags = {
+    environment = "Test"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -312,6 +312,10 @@ Please follow the format in the example below for listing breaking changes in re
 
 * The `microsoft_app_type` property is now required.
 
+### `azurerm_bot_web_app`
+
+* The `microsoft_app_type` property is now required.
+
 ### `azurerm_cdn_endpoint_custom_domain`
 
 * The `cdn_managed_https.tls_version` property no longer accepts `None` or `TLS10` as a value.

--- a/website/docs/r/bot_web_app.html.markdown
+++ b/website/docs/r/bot_web_app.html.markdown
@@ -55,6 +55,8 @@ The following arguments are supported:
 
 * `microsoft_app_user_assigned_identity_id` - (Optional) The ID of Microsoft Application User Assigned Identity for the Web App Bot. Changing this forces a new resource to be created.
 
+~> **Note:** `microsoft_app_user_assigned_identity_id` must be set when `microsoft_app_type` is set to `UserAssignedMSI`.
+
 * `display_name` - (Optional) The name of the Web App Bot will be displayed as. This defaults to `name` if not specified.
 
 * `endpoint` - (Optional) The Web App Bot endpoint.

--- a/website/docs/r/bot_web_app.html.markdown
+++ b/website/docs/r/bot_web_app.html.markdown
@@ -21,11 +21,13 @@ resource "azurerm_resource_group" "example" {
 }
 
 resource "azurerm_bot_web_app" "example" {
-  name                = "example"
-  location            = "global"
-  resource_group_name = azurerm_resource_group.example.name
-  sku                 = "F0"
-  microsoft_app_id    = data.azurerm_client_config.current.client_id
+  name                    = "example"
+  location                = "global"
+  resource_group_name     = azurerm_resource_group.example.name
+  sku                     = "F0"
+  microsoft_app_id        = data.azurerm_client_config.current.client_id
+  microsoft_app_type      = "SingleTenant"
+  microsoft_app_tenant_id = data.azurerm_client_config.current.tenant_id
 }
 ```
 
@@ -48,6 +50,8 @@ The following arguments are supported:
 ~> **Note:** Creation of `azurerm_bot_web_app` resources using the `MultiTenant` type is no longer supported by Azure, existing resources can continue using this type.
 
 * `microsoft_app_tenant_id` - (Optional) The Microsoft Application Tenant ID for the Web App Bot. Changing this forces a new resource to be created.
+
+~> **Note:** `microsoft_app_tenant_id` must be set when `microsoft_app_type` is set to `SingleTenant` or `UserAssignedMSI`.
 
 * `microsoft_app_user_assigned_identity_id` - (Optional) The ID of Microsoft Application User Assigned Identity for the Web App Bot. Changing this forces a new resource to be created.
 

--- a/website/docs/r/bot_web_app.html.markdown
+++ b/website/docs/r/bot_web_app.html.markdown
@@ -43,6 +43,14 @@ The following arguments are supported:
 
 * `microsoft_app_id` - (Required) The Microsoft Application ID for the Web App Bot. Changing this forces a new resource to be created.
 
+* `microsoft_app_type` - (Optional) The Microsoft Application Type for the Web App Bot. Possible values are `MultiTenant`, `SingleTenant` and `UserAssignedMSI`. Changing this forces a new resource to be created.
+
+~> **Note:** Creation of `azurerm_bot_web_app` resources using the `MultiTenant` type is no longer supported by Azure, existing resources can continue using this type.
+
+* `microsoft_app_tenant_id` - (Optional) The Microsoft Application Tenant ID for the Web App Bot. Changing this forces a new resource to be created.
+
+* `microsoft_app_user_assigned_identity_id` - (Optional) The ID of Microsoft Application User Assigned Identity for the Web App Bot. Changing this forces a new resource to be created.
+
 * `display_name` - (Optional) The name of the Web App Bot will be displayed as. This defaults to `name` if not specified.
 
 * `endpoint` - (Optional) The Web App Bot endpoint.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Add the `microsoft_app_type`, `microsoft_app_tenant_id`, `microsoft_app_user_assigned_identity_id` as Multitenant app type is no longer supported for `azurerm_bot_web_app` creation. https://techcommunity.microsoft.com/discussions/teamsdeveloper/questions-about-alternatives-to-multi-tenant-bots-after-july-31-2025-deprecation/4423676
Similar to this PR https://github.com/hashicorp/terraform-provider-azurerm/pull/30457. 

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

<img width="597" height="507" alt="image" src="https://github.com/user-attachments/assets/f08a294d-bbcb-4266-8066-bb74b4b5847d" />

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_bot_web_app` - support for `microsoft_app_type`, `microsoft_app_tenant_id`, and `microsoft_app_user_assigned_identity_id` properties.


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
