### PR TITLE
`azurerm_postgresql_flexible_server` - add support for confidential virtual server type SKU

### DIFF
--- a/internal/services/postgres/postgresql_flexible_server_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource.go
@@ -536,6 +536,13 @@ func resourcePostgresqlFlexibleServer() *pluginsdk.Resource {
 			}
 
 			return nil
+		}, func(ctx context.Context, diff *pluginsdk.ResourceDiff, v interface{}) error {
+			if diff.HasChange("sku_name") {
+				skuOld, skuNew := diff.GetChange("sku_name")
+				return validate.FlexibleServerSkuNameChange(skuOld.(string), skuNew.(string))
+			}
+
+			return nil
 		},
 		),
 	}

--- a/internal/services/postgres/postgresql_flexible_server_resource_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource_test.go
@@ -733,6 +733,28 @@ func TestAccPostgresqlFlexibleServer_cluster(t *testing.T) {
 	})
 }
 
+func TestAccPostgresqlFlexibleServer_basicConfidential(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_postgresql_flexible_server", "test")
+	// @toddgiguere confidential type is only available in westeurope at time of this test creation
+	data.Locations.Primary = "westeurope"
+	data.Locations.Secondary = "westeurope"
+	data.Locations.Ternary = "westeurope"
+	r := PostgresqlFlexibleServerResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicConfidential(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("fqdn").Exists(),
+				check.That(data.ResourceName).Key("public_network_access_enabled").Exists(),
+				check.That(data.ResourceName).Key("storage_mb").HasValue("32768"),
+				check.That(data.ResourceName).Key("storage_tier").HasValue("P4"),
+			),
+		},
+		data.ImportStep("administrator_password", "create_mode"),
+	})
+}
+
 func (PostgresqlFlexibleServerResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := servers.ParseFlexibleServerID(state.ID)
 	if err != nil {
@@ -837,6 +859,23 @@ resource "azurerm_postgresql_flexible_server" "test" {
   administrator_password = "QAZwsx123"
   version                = "12"
   sku_name               = "GP_Standard_D2s_v3"
+  zone                   = "2"
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r PostgresqlFlexibleServerResource) basicConfidential(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_postgresql_flexible_server" "test" {
+  name                   = "acctest-fs-%d"
+  resource_group_name    = azurerm_resource_group.test.name
+  location               = azurerm_resource_group.test.location
+  administrator_login    = "adminTerraform"
+  administrator_password = "QAZwsx123"
+  version                = "12"
+  sku_name               = "GP_Standard_DC2ads_v5"
   zone                   = "2"
 }
 `, r.template(data), data.RandomInteger)

--- a/internal/services/postgres/validate/flexible_server_sku_name.go
+++ b/internal/services/postgres/validate/flexible_server_sku_name.go
@@ -15,7 +15,7 @@ func FlexibleServerSkuName(i interface{}, k string) (warnings []string, errors [
 		return
 	}
 
-	if !regexp.MustCompile(`^((B_Standard_B((1|2|4|8|12|16|20)ms|2s))|(GP_Standard_D(((2|4|8|16|32|48|64)s_v3)|((2|4|8|16|32|48|64)ds_v4)|((2|4|8|16|32|48|64|96)ds_v5)|((2|4|8|16|32|48|64|96)ads_v5)))|(MO_Standard_E((((2|4|8|16|20|32|48|64)s)_v3)|((2|4|6|8|16|20|32|48|64)ds_v4)|((2|4|8|16|20|32|48|64|96)ds_v5)|((2|4|8|16|32|48|64|96)ads_v5))))$`).MatchString(v) {
+	if !regexp.MustCompile(`^((B_Standard_B((1|2|4|8|12|16|20)ms|2s))|(GP_Standard_D(((2|4|8|16|32|48|64)s_v3)|((2|4|8|16|32|48|64)ds_v4)|((2|4|8|16|32|48|64|96)ds_v5)|((2|4|8|16|32|48|64|96)ads_v5)|(C(2|4|8|16|32|48|64|96)ads_v5)))|(MO_Standard_E((((2|4|8|16|20|32|48|64)s)_v3)|((2|4|6|8|16|20|32|48|64)ds_v4)|((2|4|8|16|20|32|48|64|96)ds_v5)|((2|4|8|16|32|48|64|96)ads_v5))))$`).MatchString(v) {
 		errors = append(errors, fmt.Errorf("%q is not a valid sku name, got %v", k, v))
 		return
 	}

--- a/internal/services/postgres/validate/flexible_server_sku_name.go
+++ b/internal/services/postgres/validate/flexible_server_sku_name.go
@@ -6,6 +6,7 @@ package validate
 import (
 	"fmt"
 	"regexp"
+	"strings"
 )
 
 func FlexibleServerSkuName(i interface{}, k string) (warnings []string, errors []error) {
@@ -20,4 +21,25 @@ func FlexibleServerSkuName(i interface{}, k string) (warnings []string, errors [
 		return
 	}
 	return
+}
+
+func FlexibleServerSkuNameChange(skuOld string, skuNew string) error {
+	if len(skuOld) == 0 || len(skuNew) == 0 {
+		return nil
+	}
+
+	// Migration from a non-confidential to confidential server is currently not supported by Azure.
+	// Manual migration process is required. Error and inform consumer.
+	skuOldParts := strings.Split(skuOld, "_")
+	skuNewParts := strings.Split(skuNew, "_")
+
+	confidentialComputeRegex := "^.C.*$"
+	isConfidentialOld := regexp.MustCompile(confidentialComputeRegex).MatchString(skuOldParts[2]) // index 2 is compute part
+	isConfidentialNew := regexp.MustCompile(confidentialComputeRegex).MatchString(skuNewParts[2])
+
+	if isConfidentialOld != isConfidentialNew {
+		return fmt.Errorf("migration of Postgres flexible server between `non-confidential` and `confidential` compute types requires manual intervention, suggestion is to deploy new server in parallel with old, consult official Azure documentation for migration then remove old server")
+	}
+
+	return nil
 }

--- a/internal/services/postgres/validate/flexible_server_sku_name.go
+++ b/internal/services/postgres/validate/flexible_server_sku_name.go
@@ -15,7 +15,7 @@ func FlexibleServerSkuName(i interface{}, k string) (warnings []string, errors [
 		return
 	}
 
-	if !regexp.MustCompile(`^((B_Standard_B((1|2|4|8|12|16|20)ms|2s))|(GP_Standard_D(((2|4|8|16|32|48|64)s_v3)|((2|4|8|16|32|48|64)ds_v4)|((2|4|8|16|32|48|64|96)ds_v5)|((2|4|8|16|32|48|64|96)ads_v5)|(C(2|4|8|16|32|48|64|96)ads_v5)))|(MO_Standard_E((((2|4|8|16|20|32|48|64)s)_v3)|((2|4|6|8|16|20|32|48|64)ds_v4)|((2|4|8|16|20|32|48|64|96)ds_v5)|((2|4|8|16|32|48|64|96)ads_v5))))$`).MatchString(v) {
+	if !regexp.MustCompile(`^((B_Standard_B((1|2|4|8|12|16|20)ms|2s))|(GP_Standard_D(((2|4|8|16|32|48|64)s_v3)|((2|4|8|16|32|48|64)ds_v4)|((2|4|8|16|32|48|64|96)ds_v5)|((2|4|8|16|32|48|64|96)ads_v5)|(C(2|4|8|16|32|48|64|96)ads_v5)))|(MO_Standard_E((((2|4|8|16|20|32|48|64)s)_v3)|((2|4|6|8|16|20|32|48|64)ds_v4)|((2|4|8|16|20|32|48|64|96)ds_v5)|((2|4|8|16|32|48|64|96)ads_v5)|(C(2|4|8|16|20|32|48|64|96)(ads|as)_v5))))$`).MatchString(v) {
 		errors = append(errors, fmt.Errorf("%q is not a valid sku name, got %v", k, v))
 		return
 	}

--- a/internal/services/postgres/validate/flexible_server_sku_name_test.go
+++ b/internal/services/postgres/validate/flexible_server_sku_name_test.go
@@ -3,7 +3,10 @@
 
 package validate
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 func TestFlexibleServerSkuName(t *testing.T) {
 	tests := []struct {
@@ -153,6 +156,62 @@ func TestFlexibleServerSkuName(t *testing.T) {
 			valid := err == nil
 			if valid != tt.valid {
 				t.Errorf("Expected valid status %t but got %t for input %s", tt.valid, valid, tt.input)
+			}
+		})
+	}
+}
+
+func TestFlexibleServerSkuNameChange(t *testing.T) {
+	tests := []struct {
+		name  string
+		sku1  string
+		sku2  string
+		valid bool
+	}{
+		{
+			name:  "Non-confidential identical",
+			sku1:  "GP_Standard_D16ds_v4",
+			sku2:  "GP_Standard_D16ds_v4",
+			valid: true,
+		},
+		{
+			name:  "Non-confidential update",
+			sku1:  "GP_Standard_D16ds_v4",
+			sku2:  "MO_Standard_E16ds_v5",
+			valid: true,
+		},
+		{
+			name:  "Confidential identical",
+			sku1:  "GP_Standard_DC96ads_v5",
+			sku2:  "GP_Standard_DC96ads_v5",
+			valid: true,
+		},
+		{
+			name:  "Confidential update",
+			sku1:  "GP_Standard_DC64ads_v5",
+			sku2:  "MO_Standard_EC96ads_v5",
+			valid: true,
+		},
+		{
+			name:  "Non-confidential to confidential",
+			sku1:  "GP_Standard_D16ds_v4",
+			sku2:  "MO_Standard_EC2ads_v5",
+			valid: false,
+		},
+		{
+			name:  "Confidential to non-confidential",
+			sku1:  "MO_Standard_EC20ads_v5",
+			sku2:  "MO_Standard_E16ads_v5",
+			valid: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := FlexibleServerSkuNameChange(tt.sku1, tt.sku2)
+			valid := err == nil
+			if valid != tt.valid {
+				t.Errorf("Expected valid status %t but got %t for input %s", tt.valid, valid, fmt.Sprintf("%s <-> %s", tt.sku1, tt.sku2))
 			}
 		})
 	}

--- a/internal/services/postgres/validate/flexible_server_sku_name_test.go
+++ b/internal/services/postgres/validate/flexible_server_sku_name_test.go
@@ -111,6 +111,41 @@ func TestFlexibleServerSkuName(t *testing.T) {
 			input: "MO_Standard_E96ds_v5",
 			valid: true,
 		},
+		{
+			name:  "GP_Standard_DC2ads_v5",
+			input: "GP_Standard_DC2ads_v5",
+			valid: true,
+		},
+		{
+			name:  "GP_Standard_DC64ads_v5",
+			input: "GP_Standard_DC64ads_v5",
+			valid: true,
+		},
+		{
+			name:  "GP_Standard_DC96ads_v5",
+			input: "GP_Standard_DC96ads_v5",
+			valid: true,
+		},
+		{
+			name:  "MO_Standard_EC2ads_v5",
+			input: "MO_Standard_EC2ads_v5",
+			valid: true,
+		},
+		{
+			name:  "MO_Standard_EC20ads_v5",
+			input: "MO_Standard_EC20ads_v5",
+			valid: true,
+		},
+		{
+			name:  "MO_Standard_EC96ads_v5",
+			input: "MO_Standard_EC96ads_v5",
+			valid: true,
+		},
+		{
+			name:  "MO_Standard_EC96as_v5",
+			input: "MO_Standard_EC96as_v5",
+			valid: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Add the ability for consumers to specify the new "confidential" flexible server types in the SKU input property.

Example: `GP_Standard_DC64ads_v5` - The upper-case "C" in the compute section denotes a "confidential" virtual server type.

This PR is an update to another [PR](https://github.com/hashicorp/terraform-provider-azurerm/pull/31004) submitted from a contributor, and enhances that PR with a validation to stop accidental migration to (or from) confidential servers, as this is not supported without manual intervention.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_postgresql_flexible_server` - add support for confidential virtual server SKU types [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
