### PR TITLE
list and identity implementation - azurerm_web_pubsub_socketio

### DIFF
--- a/internal/services/signalr/registration.go
+++ b/internal/services/signalr/registration.go
@@ -90,5 +90,6 @@ func (r Registration) EphemeralResources() []func() ephemeral.EphemeralResource 
 func (r Registration) ListResources() []sdk.FrameworkListWrappedResource {
 	return []sdk.FrameworkListWrappedResource{
 		WebPubSubListResource{},
+		WebPubSubSocketIOListResource{},
 	}
 }

--- a/internal/services/signalr/web_pubsub_socketio_resource.go
+++ b/internal/services/signalr/web_pubsub_socketio_resource.go
@@ -3,6 +3,8 @@
 
 package signalr
 
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name web_pubsub_socketio -service-package-name signalr -properties "name,resource_group_name"
+
 import (
 	"context"
 	"fmt"
@@ -14,6 +16,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/webpubsub/2024-03-01/webpubsub"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
@@ -57,10 +60,17 @@ type WebPubSubSocketIOSkuModel struct {
 	Capacity int64  `tfschema:"capacity"`
 }
 
+const webPubSubSocketIOResourceType = "azurerm_web_pubsub_socketio"
+
 var (
 	_ sdk.ResourceWithUpdate        = WebPubSubSocketIOResource{}
 	_ sdk.ResourceWithCustomizeDiff = WebPubSubSocketIOResource{}
+	_ sdk.ResourceWithIdentity      = WebPubSubSocketIOResource{}
 )
+
+func (w WebPubSubSocketIOResource) Identity() resourceids.ResourceId {
+	return &webpubsub.WebPubSubId{}
+}
 
 func (w WebPubSubSocketIOResource) Arguments() map[string]*pluginsdk.Schema {
 	return map[string]*pluginsdk.Schema{
@@ -260,7 +270,7 @@ func (w WebPubSubSocketIOResource) ModelObject() interface{} {
 }
 
 func (w WebPubSubSocketIOResource) ResourceType() string {
-	return "azurerm_web_pubsub_socketio"
+	return webPubSubSocketIOResourceType
 }
 
 func (w WebPubSubSocketIOResource) Create() sdk.ResourceFunc {
@@ -286,7 +296,7 @@ func (w WebPubSubSocketIOResource) Create() sdk.ResourceFunc {
 			}
 
 			if !response.WasNotFound(existing.HttpResponse) {
-				return tf.ImportAsExistsError("azurerm_web_pubsub_socketio", id.ID())
+				return tf.ImportAsExistsError(webPubSubSocketIOResourceType, id.ID())
 			}
 
 			expandedIdentity, err := identity.ExpandSystemOrUserAssignedMapFromModel(config.Identity)
@@ -319,6 +329,9 @@ func (w WebPubSubSocketIOResource) Create() sdk.ResourceFunc {
 			}
 
 			metadata.SetID(id)
+			if err := pluginsdk.SetResourceIdentityData(metadata.ResourceData, &id); err != nil {
+				return err
+			}
 			return nil
 		},
 	}
@@ -349,62 +362,70 @@ func (w WebPubSubSocketIOResource) Read() sdk.ResourceFunc {
 				return fmt.Errorf("listing keys for %s: %+v", *id, err)
 			}
 
-			state := WebPubSubSocketIOResourceModel{
-				Name:              id.WebPubSubName,
-				ResourceGroupName: id.ResourceGroupName,
-			}
-
-			if model := resp.Model; model != nil {
-				state.Location = location.Normalize(model.Location)
-				state.Tags = pointer.From(model.Tags)
-
-				flattenedIdentity, err := identity.FlattenSystemOrUserAssignedMapToModel(model.Identity)
-				if err != nil {
-					return fmt.Errorf("flattening `identity`: %+v", err)
-				}
-				state.Identity = pointer.From(flattenedIdentity)
-
-				if sku := model.Sku; sku != nil {
-					state.Sku = flattenWebPubSubSocketIOSkuToModel(sku)
-				}
-
-				if props := model.Properties; props != nil {
-					liveTrace := flattenLiveTraceConfigToMap(props.LiveTraceConfiguration)
-
-					state.AADAuthEnabled = !pointer.From(props.DisableAadAuth)
-					state.ExternalIP = pointer.From(props.ExternalIP)
-					state.HostName = pointer.From(props.HostName)
-					state.PublicPort = pointer.From(props.PublicPort)
-					state.ServerPort = pointer.From(props.ServerPort)
-
-					state.LiveTraceEnabled = liveTrace["enabled"]
-					state.LiveTraceConnectivityLogsEnabled = liveTrace["connectivityLogsEnabled"]
-					state.LiveTraceHttpRequestLogsEnabled = liveTrace["httpLogsEnabled"]
-					state.LiveTraceMessagingLogsEnabled = liveTrace["messagingLogsEnabled"]
-
-					state.LocalAuthEnabled = !pointer.From(props.DisableLocalAuth)
-					state.PublicNetworkAccess = pointer.From(props.PublicNetworkAccess)
-
-					if socketio := props.SocketIO; socketio != nil {
-						state.ServiceMode = pointer.From(socketio.ServiceMode)
-					}
-
-					if tls := props.Tls; tls != nil {
-						state.TlsClientCertEnabled = pointer.From(tls.ClientCertEnabled)
-					}
-				}
-			}
-
-			if keyModel := keys.Model; keyModel != nil {
-				state.PrimaryAccessKey = pointer.From(keyModel.PrimaryKey)
-				state.PrimaryConnectionString = pointer.From(keyModel.PrimaryConnectionString)
-				state.SecondaryAccessKey = pointer.From(keyModel.SecondaryKey)
-				state.SecondaryConnectionString = pointer.From(keyModel.SecondaryConnectionString)
-			}
-
-			return metadata.Encode(&state)
+			return w.flatten(metadata, id, resp.Model, keys.Model)
 		},
 	}
+}
+
+func (w WebPubSubSocketIOResource) flatten(metadata sdk.ResourceMetaData, id *webpubsub.WebPubSubId, model *webpubsub.WebPubSubResource, keyModel *webpubsub.WebPubSubKeys) error {
+	state := WebPubSubSocketIOResourceModel{
+		Name:              id.WebPubSubName,
+		ResourceGroupName: id.ResourceGroupName,
+	}
+
+	if model != nil {
+		state.Location = location.Normalize(model.Location)
+		state.Tags = pointer.From(model.Tags)
+
+		flattenedIdentity, err := identity.FlattenSystemOrUserAssignedMapToModel(model.Identity)
+		if err != nil {
+			return fmt.Errorf("flattening `identity`: %+v", err)
+		}
+		state.Identity = pointer.From(flattenedIdentity)
+
+		if sku := model.Sku; sku != nil {
+			state.Sku = flattenWebPubSubSocketIOSkuToModel(sku)
+		}
+
+		if props := model.Properties; props != nil {
+			liveTrace := flattenLiveTraceConfigToMap(props.LiveTraceConfiguration)
+
+			state.AADAuthEnabled = !pointer.From(props.DisableAadAuth)
+			state.ExternalIP = pointer.From(props.ExternalIP)
+			state.HostName = pointer.From(props.HostName)
+			state.PublicPort = pointer.From(props.PublicPort)
+			state.ServerPort = pointer.From(props.ServerPort)
+
+			state.LiveTraceEnabled = liveTrace["enabled"]
+			state.LiveTraceConnectivityLogsEnabled = liveTrace["connectivityLogsEnabled"]
+			state.LiveTraceHttpRequestLogsEnabled = liveTrace["httpLogsEnabled"]
+			state.LiveTraceMessagingLogsEnabled = liveTrace["messagingLogsEnabled"]
+
+			state.LocalAuthEnabled = !pointer.From(props.DisableLocalAuth)
+			state.PublicNetworkAccess = pointer.From(props.PublicNetworkAccess)
+
+			if socketio := props.SocketIO; socketio != nil {
+				state.ServiceMode = pointer.From(socketio.ServiceMode)
+			}
+
+			if tls := props.Tls; tls != nil {
+				state.TlsClientCertEnabled = pointer.From(tls.ClientCertEnabled)
+			}
+		}
+	}
+
+	if keyModel != nil {
+		state.PrimaryAccessKey = pointer.From(keyModel.PrimaryKey)
+		state.PrimaryConnectionString = pointer.From(keyModel.PrimaryConnectionString)
+		state.SecondaryAccessKey = pointer.From(keyModel.SecondaryKey)
+		state.SecondaryConnectionString = pointer.From(keyModel.SecondaryConnectionString)
+	}
+
+	if err := pluginsdk.SetResourceIdentityData(metadata.ResourceData, id); err != nil {
+		return err
+	}
+
+	return metadata.Encode(&state)
 }
 
 func (w WebPubSubSocketIOResource) Update() sdk.ResourceFunc {

--- a/internal/services/signalr/web_pubsub_socketio_resource.go
+++ b/internal/services/signalr/web_pubsub_socketio_resource.go
@@ -60,8 +60,6 @@ type WebPubSubSocketIOSkuModel struct {
 	Capacity int64  `tfschema:"capacity"`
 }
 
-const webPubSubSocketIOResourceType = "azurerm_web_pubsub_socketio"
-
 var (
 	_ sdk.ResourceWithUpdate        = WebPubSubSocketIOResource{}
 	_ sdk.ResourceWithCustomizeDiff = WebPubSubSocketIOResource{}
@@ -270,7 +268,7 @@ func (w WebPubSubSocketIOResource) ModelObject() interface{} {
 }
 
 func (w WebPubSubSocketIOResource) ResourceType() string {
-	return webPubSubSocketIOResourceType
+	return "azurerm_web_pubsub_socketio"
 }
 
 func (w WebPubSubSocketIOResource) Create() sdk.ResourceFunc {
@@ -296,7 +294,7 @@ func (w WebPubSubSocketIOResource) Create() sdk.ResourceFunc {
 			}
 
 			if !response.WasNotFound(existing.HttpResponse) {
-				return tf.ImportAsExistsError(webPubSubSocketIOResourceType, id.ID())
+				return tf.ImportAsExistsError(w.ResourceType(), id.ID())
 			}
 
 			expandedIdentity, err := identity.ExpandSystemOrUserAssignedMapFromModel(config.Identity)
@@ -546,7 +544,7 @@ func (w WebPubSubSocketIOResource) IDValidationFunc() pluginsdk.SchemaValidateFu
 }
 
 func expandLiveTraceConfigFromModel(input WebPubSubSocketIOResourceModel) *webpubsub.LiveTraceConfiguration {
-	resourceCategories := make([]webpubsub.LiveTraceCategory, 0)
+	resourceCategories := make([]webpubsub.LiveTraceCategory, 0, 3)
 
 	enabled := pointer.To("false")
 	if input.LiveTraceEnabled {
@@ -629,7 +627,7 @@ func expandWebPubSubSocketIOSkuFromModel(input []WebPubSubSocketIOSkuModel) *web
 }
 
 func flattenWebPubSubSocketIOSkuToModel(input *webpubsub.ResourceSku) []WebPubSubSocketIOSkuModel {
-	result := make([]WebPubSubSocketIOSkuModel, 0)
+	result := make([]WebPubSubSocketIOSkuModel, 0, 1)
 	if input == nil {
 		return result
 	}

--- a/internal/services/signalr/web_pubsub_socketio_resource_identity_gen_test.go
+++ b/internal/services/signalr/web_pubsub_socketio_resource_identity_gen_test.go
@@ -1,0 +1,39 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package signalr_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
+)
+
+func TestAccWebPubSubSocketIO_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_web_pubsub_socketio", "test")
+	r := WebPubSubSocketIOTestResource{}
+
+	checkedFields := map[string]struct{}{
+		"subscription_id":     {},
+		"name":                {},
+		"resource_group_name": {},
+	}
+
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data, "Standard_S1", 1),
+			ConfigStateChecks: []statecheck.StateCheck{
+				customstatecheck.ExpectAllIdentityFieldsAreChecked("azurerm_web_pubsub_socketio.test", checkedFields),
+				statecheck.ExpectIdentityValue("azurerm_web_pubsub_socketio.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_web_pubsub_socketio.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_web_pubsub_socketio.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
+			},
+		},
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
+}

--- a/internal/services/signalr/web_pubsub_socketio_resource_identity_gen_test.go
+++ b/internal/services/signalr/web_pubsub_socketio_resource_identity_gen_test.go
@@ -13,9 +13,9 @@ import (
 	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
 )
 
-func TestAccWebPubSubSocketIO_resourceIdentity(t *testing.T) {
+func TestAccWebPubsubSocketio_resourceIdentity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_web_pubsub_socketio", "test")
-	r := WebPubSubSocketIOTestResource{}
+	r := WebPubsubSocketioResource{}
 
 	checkedFields := map[string]struct{}{
 		"subscription_id":     {},
@@ -25,7 +25,7 @@ func TestAccWebPubSubSocketIO_resourceIdentity(t *testing.T) {
 
 	data.ResourceIdentityTest(t, []acceptance.TestStep{
 		{
-			Config: r.basic(data, "Standard_S1", 1),
+			Config: r.basic(data),
 			ConfigStateChecks: []statecheck.StateCheck{
 				customstatecheck.ExpectAllIdentityFieldsAreChecked("azurerm_web_pubsub_socketio.test", checkedFields),
 				statecheck.ExpectIdentityValue("azurerm_web_pubsub_socketio.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),

--- a/internal/services/signalr/web_pubsub_socketio_resource_list.go
+++ b/internal/services/signalr/web_pubsub_socketio_resource_list.go
@@ -1,0 +1,98 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package signalr
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/webpubsub/2024-03-01/webpubsub"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type WebPubSubSocketIOListResource struct{}
+
+var _ sdk.FrameworkListWrappedResource = new(WebPubSubSocketIOListResource)
+
+func (r WebPubSubSocketIOListResource) ResourceFunc() *pluginsdk.Resource {
+	return sdk.WrappedResource(WebPubSubSocketIOResource{})
+}
+
+func (r WebPubSubSocketIOListResource) Metadata(_ context.Context, _ resource.MetadataRequest, response *resource.MetadataResponse) {
+	response.TypeName = webPubSubSocketIOResourceType
+}
+
+func (r WebPubSubSocketIOListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream, metadata sdk.ResourceMetadata) {
+	client := metadata.Client.SignalR.WebPubSubClient.WebPubSub
+	resource := WebPubSubSocketIOResource{}
+
+	var data sdk.DefaultListModel
+	if diags := request.Config.Get(ctx, &data); diags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	subscriptionID := metadata.SubscriptionId
+	if !data.SubscriptionId.IsNull() {
+		subscriptionID = data.SubscriptionId.ValueString()
+	}
+
+	results := make([]webpubsub.WebPubSubResource, 0)
+
+	switch {
+	case !data.ResourceGroupName.IsNull():
+		resp, err := client.ListByResourceGroupComplete(ctx, commonids.NewResourceGroupID(subscriptionID, data.ResourceGroupName.ValueString()))
+		if err != nil {
+			sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("listing `%s`", webPubSubSocketIOResourceType), err)
+			return
+		}
+		results = resp.Items
+	default:
+		resp, err := client.ListBySubscriptionComplete(ctx, commonids.NewSubscriptionID(subscriptionID))
+		if err != nil {
+			sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("listing `%s`", webPubSubSocketIOResourceType), err)
+			return
+		}
+		results = resp.Items
+	}
+
+	stream.Results = func(push func(list.ListResult) bool) {
+		for _, item := range results {
+			if item.Kind == nil || *item.Kind != webpubsub.ServiceKindSocketIO {
+				continue
+			}
+
+			result := request.NewListResult(ctx)
+			result.DisplayName = pointer.From(item.Name)
+
+			id, err := webpubsub.ParseWebPubSubIDInsensitively(pointer.From(item.Id))
+			if err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, "parsing Web PubSub Socket.IO ID", err)
+				return
+			}
+
+			rmd := sdk.NewResourceMetaData(metadata.Client, resource)
+			rmd.SetID(id)
+
+			if err := resource.flatten(rmd, id, &item, nil); err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, fmt.Sprintf("encoding `%s` resource data", resource.ResourceType()), err)
+				return
+			}
+
+			sdk.EncodeListResult(ctx, rmd.ResourceData, &result)
+			if result.Diagnostics.HasError() {
+				push(result)
+				return
+			}
+			if !push(result) {
+				return
+			}
+		}
+	}
+}

--- a/internal/services/signalr/web_pubsub_socketio_resource_list.go
+++ b/internal/services/signalr/web_pubsub_socketio_resource_list.go
@@ -71,7 +71,7 @@ func (r WebPubSubSocketIOListResource) List(ctx context.Context, request list.Li
 			result := request.NewListResult(ctx)
 			result.DisplayName = pointer.From(item.Name)
 
-			id, err := webpubsub.ParseWebPubSubID(pointer.From(item.Id))
+			id, err := webpubsub.ParseWebPubSubIDInsensitively(pointer.From(item.Id))
 			if err != nil {
 				sdk.SetErrorDiagnosticAndPushListResult(result, push, "parsing Web PubSub Socket.IO ID", err)
 				return

--- a/internal/services/signalr/web_pubsub_socketio_resource_list.go
+++ b/internal/services/signalr/web_pubsub_socketio_resource_list.go
@@ -25,7 +25,7 @@ func (r WebPubSubSocketIOListResource) ResourceFunc() *pluginsdk.Resource {
 }
 
 func (r WebPubSubSocketIOListResource) Metadata(_ context.Context, _ resource.MetadataRequest, response *resource.MetadataResponse) {
-	response.TypeName = webPubSubSocketIOResourceType
+	response.TypeName = WebPubSubSocketIOResource{}.ResourceType()
 }
 
 func (r WebPubSubSocketIOListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream, metadata sdk.ResourceMetadata) {
@@ -49,14 +49,14 @@ func (r WebPubSubSocketIOListResource) List(ctx context.Context, request list.Li
 	case !data.ResourceGroupName.IsNull():
 		resp, err := client.ListByResourceGroupComplete(ctx, commonids.NewResourceGroupID(subscriptionID, data.ResourceGroupName.ValueString()))
 		if err != nil {
-			sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("listing `%s`", webPubSubSocketIOResourceType), err)
+			sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("listing `%s`", WebPubSubSocketIOResource{}.ResourceType()), err)
 			return
 		}
 		results = resp.Items
 	default:
 		resp, err := client.ListBySubscriptionComplete(ctx, commonids.NewSubscriptionID(subscriptionID))
 		if err != nil {
-			sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("listing `%s`", webPubSubSocketIOResourceType), err)
+			sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("listing `%s`", WebPubSubSocketIOResource{}.ResourceType()), err)
 			return
 		}
 		results = resp.Items
@@ -71,7 +71,7 @@ func (r WebPubSubSocketIOListResource) List(ctx context.Context, request list.Li
 			result := request.NewListResult(ctx)
 			result.DisplayName = pointer.From(item.Name)
 
-			id, err := webpubsub.ParseWebPubSubIDInsensitively(pointer.From(item.Id))
+			id, err := webpubsub.ParseWebPubSubID(pointer.From(item.Id))
 			if err != nil {
 				sdk.SetErrorDiagnosticAndPushListResult(result, push, "parsing Web PubSub Socket.IO ID", err)
 				return

--- a/internal/services/signalr/web_pubsub_socketio_resource_list_test.go
+++ b/internal/services/signalr/web_pubsub_socketio_resource_list_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestAccWebPubSubSocketIO_list(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_web_pubsub_socketio", "test")
-	r := WebPubSubSocketIOTestResource{}
+	r := WebPubsubSocketioResource{}
 
 	resource.Test(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -25,7 +25,7 @@ func TestAccWebPubSubSocketIO_list(t *testing.T) {
 		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
 		Steps: []resource.TestStep{
 			{
-				Config: r.basic(data, "Standard_S1", 1),
+				Config: r.basic(data),
 			},
 			{
 				Query:  true,
@@ -61,7 +61,7 @@ func TestAccWebPubSubSocketIO_list(t *testing.T) {
 	})
 }
 
-func (WebPubSubSocketIOTestResource) basicListQuery() string {
+func (WebPubsubSocketioResource) basicListQuery() string {
 	return `
 list "azurerm_web_pubsub_socketio" "list" {
   provider = azurerm
@@ -70,7 +70,7 @@ list "azurerm_web_pubsub_socketio" "list" {
 `
 }
 
-func (WebPubSubSocketIOTestResource) basicListQueryByResourceGroupName() string {
+func (WebPubsubSocketioResource) basicListQueryByResourceGroupName() string {
 	return `
 list "azurerm_web_pubsub_socketio" "list" {
   provider = azurerm

--- a/internal/services/signalr/web_pubsub_socketio_resource_list_test.go
+++ b/internal/services/signalr/web_pubsub_socketio_resource_list_test.go
@@ -1,0 +1,82 @@
+package signalr_test
+
+import (
+	"context"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccWebPubSubSocketIO_list(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_web_pubsub_socketio", "test")
+	r := WebPubSubSocketIOTestResource{}
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basic(data, "Standard_S1", 1),
+			},
+			{
+				Query:  true,
+				Config: r.basicListQuery(),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLengthAtLeast("azurerm_web_pubsub_socketio.list", 1),
+					querycheck.ExpectIdentity(
+						"azurerm_web_pubsub_socketio.list",
+						map[string]knownvalue.Check{
+							"name":                knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"resource_group_name": knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"subscription_id":     knownvalue.StringExact(data.Subscriptions.Primary),
+						},
+					),
+				},
+			},
+			{
+				Query:  true,
+				Config: r.basicListQueryByResourceGroupName(),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLength("azurerm_web_pubsub_socketio.list", 1),
+					querycheck.ExpectIdentity(
+						"azurerm_web_pubsub_socketio.list",
+						map[string]knownvalue.Check{
+							"name":                knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"resource_group_name": knownvalue.StringRegexp(regexp.MustCompile(strconv.Itoa(data.RandomInteger))),
+							"subscription_id":     knownvalue.StringExact(data.Subscriptions.Primary),
+						},
+					),
+				},
+			},
+		},
+	})
+}
+
+func (WebPubSubSocketIOTestResource) basicListQuery() string {
+	return `
+list "azurerm_web_pubsub_socketio" "list" {
+  provider = azurerm
+  config {}
+}
+`
+}
+
+func (WebPubSubSocketIOTestResource) basicListQueryByResourceGroupName() string {
+	return `
+list "azurerm_web_pubsub_socketio" "list" {
+  provider = azurerm
+  config {
+    resource_group_name = azurerm_resource_group.test.name
+  }
+}
+`
+}

--- a/internal/services/signalr/web_pubsub_socketio_resource_list_test.go
+++ b/internal/services/signalr/web_pubsub_socketio_resource_list_test.go
@@ -2,6 +2,7 @@ package signalr_test
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strconv"
 	"testing"
@@ -25,7 +26,7 @@ func TestAccWebPubSubSocketIO_list(t *testing.T) {
 		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
 		Steps: []resource.TestStep{
 			{
-				Config: r.basic(data),
+				Config: r.basicList(data),
 			},
 			{
 				Query:  true,
@@ -46,7 +47,7 @@ func TestAccWebPubSubSocketIO_list(t *testing.T) {
 				Query:  true,
 				Config: r.basicListQueryByResourceGroupName(),
 				QueryResultChecks: []querycheck.QueryResultCheck{
-					querycheck.ExpectLength("azurerm_web_pubsub_socketio.list", 1),
+					querycheck.ExpectLength("azurerm_web_pubsub_socketio.list", 2),
 					querycheck.ExpectIdentity(
 						"azurerm_web_pubsub_socketio.list",
 						map[string]knownvalue.Check{
@@ -61,7 +62,7 @@ func TestAccWebPubSubSocketIO_list(t *testing.T) {
 	})
 }
 
-func (WebPubsubSocketioResource) basicListQuery() string {
+func (r WebPubsubSocketioResource) basicListQuery() string {
 	return `
 list "azurerm_web_pubsub_socketio" "list" {
   provider = azurerm
@@ -70,7 +71,7 @@ list "azurerm_web_pubsub_socketio" "list" {
 `
 }
 
-func (WebPubsubSocketioResource) basicListQueryByResourceGroupName() string {
+func (r WebPubsubSocketioResource) basicListQueryByResourceGroupName() string {
 	return `
 list "azurerm_web_pubsub_socketio" "list" {
   provider = azurerm
@@ -79,4 +80,32 @@ list "azurerm_web_pubsub_socketio" "list" {
   }
 }
 `
+}
+
+func (r WebPubsubSocketioResource) basicList(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_web_pubsub_socketio" "test" {
+  name                = "acctestWebPubsubSocketIO-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku {
+    name     = "Standard_S1"
+    capacity = 1
+  }
+}
+
+resource "azurerm_web_pubsub_socketio" "test2" {
+  name                = "acctestWebPubsubSocketIO2-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku {
+    name     = "Standard_S1"
+    capacity = 1
+  }
+}
+`, r.template(data), data.RandomInteger, data.RandomInteger)
 }

--- a/internal/services/signalr/web_pubsub_socketio_resource_test.go
+++ b/internal/services/signalr/web_pubsub_socketio_resource_test.go
@@ -17,15 +17,15 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
-type WebPubSubSocketIOTestResource struct{}
+type WebPubsubSocketioResource struct{}
 
 func TestAccWebPubSubSocketIO_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_web_pubsub_socketio", "test")
-	r := WebPubSubSocketIOTestResource{}
+	r := WebPubsubSocketioResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data, "Standard_S1", 1),
+			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -36,11 +36,11 @@ func TestAccWebPubSubSocketIO_basic(t *testing.T) {
 
 func TestAccWebPubSubSocketIO_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_web_pubsub_socketio", "test")
-	r := WebPubSubSocketIOTestResource{}
+	r := WebPubsubSocketioResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data, "Standard_S1", 1),
+			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -51,11 +51,11 @@ func TestAccWebPubSubSocketIO_requiresImport(t *testing.T) {
 
 func TestAccWebPubSubSocketIO_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_web_pubsub_socketio", "test")
-	r := WebPubSubSocketIOTestResource{}
+	r := WebPubsubSocketioResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data, "Standard_S1", 1),
+			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -69,7 +69,7 @@ func TestAccWebPubSubSocketIO_complete(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.basic(data, "Standard_S1", 1),
+			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -80,7 +80,7 @@ func TestAccWebPubSubSocketIO_complete(t *testing.T) {
 
 func TestAccWebPubSubSocketIO_identity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_web_pubsub_socketio", "test")
-	r := WebPubSubSocketIOTestResource{}
+	r := WebPubsubSocketioResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -109,32 +109,32 @@ func TestAccWebPubSubSocketIO_identity(t *testing.T) {
 
 func TestAccWebPubSubSocketIO_skus(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_web_pubsub_socketio", "test")
-	r := WebPubSubSocketIOTestResource{}
+	r := WebPubsubSocketioResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data, "Free_F1", 1),
+			Config: r.basicWithSku(data, "Free_F1", 1),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.basic(data, "Standard_S1", 1),
+			Config: r.basicWithSku(data, "Standard_S1", 1),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.basic(data, "Premium_P1", 1),
+			Config: r.basicWithSku(data, "Premium_P1", 1),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.basic(data, "Premium_P2", 100),
+			Config: r.basicWithSku(data, "Premium_P2", 100),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -143,7 +143,7 @@ func TestAccWebPubSubSocketIO_skus(t *testing.T) {
 	})
 }
 
-func (WebPubSubSocketIOTestResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (WebPubsubSocketioResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := webpubsub.ParseWebPubSubID(state.ID)
 	if err != nil {
 		return nil, err
@@ -160,7 +160,11 @@ func (WebPubSubSocketIOTestResource) Exists(ctx context.Context, client *clients
 	return pointer.To(resp.Model != nil), nil
 }
 
-func (r WebPubSubSocketIOTestResource) basic(data acceptance.TestData, sku string, capacity int) string {
+func (r WebPubsubSocketioResource) basic(data acceptance.TestData) string {
+	return r.basicWithSku(data, "Standard_S1", 1)
+}
+
+func (r WebPubsubSocketioResource) basicWithSku(data acceptance.TestData, sku string, capacity int) string {
 	return fmt.Sprintf(`
 %s
 
@@ -177,7 +181,7 @@ resource "azurerm_web_pubsub_socketio" "test" {
 `, r.template(data), data.RandomInteger, sku, capacity)
 }
 
-func (r WebPubSubSocketIOTestResource) requiresImport(data acceptance.TestData) string {
+func (r WebPubsubSocketioResource) requiresImport(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -190,10 +194,10 @@ resource "azurerm_web_pubsub_socketio" "import" {
     name     = azurerm_web_pubsub_socketio.test.sku.0.name
     capacity = azurerm_web_pubsub_socketio.test.sku.0.capacity
   }
-}`, r.basic(data, "Standard_S1", 1))
+}`, r.basic(data))
 }
 
-func (r WebPubSubSocketIOTestResource) complete(data acceptance.TestData) string {
+func (r WebPubsubSocketioResource) complete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -230,7 +234,7 @@ resource "azurerm_web_pubsub_socketio" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r WebPubSubSocketIOTestResource) userAssignedIdentity(data acceptance.TestData) string {
+func (r WebPubsubSocketioResource) userAssignedIdentity(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -257,7 +261,7 @@ resource "azurerm_web_pubsub_socketio" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (WebPubSubSocketIOTestResource) template(data acceptance.TestData) string {
+func (WebPubsubSocketioResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/website/docs/list-resources/web_pubsub_socketio.html.markdown
+++ b/website/docs/list-resources/web_pubsub_socketio.html.markdown
@@ -1,0 +1,41 @@
+---
+subcategory: "Messaging"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_web_pubsub_socketio"
+description: |-
+  Lists Web PubSub Service for Socket.IO resources.
+---
+
+# List resource: azurerm_web_pubsub_socketio
+
+Lists Web PubSub Service for Socket.IO resources.
+
+## Example Usage
+
+### List all Web PubSub Service for Socket.IO resources in a Subscription
+
+```hcl
+list "azurerm_web_pubsub_socketio" "example" {
+  provider = azurerm
+  config {}
+}
+```
+
+### List all Web PubSub Service for Socket.IO resources in a Resource Group
+
+```hcl
+list "azurerm_web_pubsub_socketio" "example" {
+  provider = azurerm
+  config {
+    resource_group_name = azurerm_resource_group.example.name
+  }
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `subscription_id` - (Optional) The Subscription ID in which to list resources. Defaults to the current subscription.
+
+* `resource_group_name` - (Optional) The Resource Group name in which to list resources.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

List and identity implementation for azurerm_web_pubsub_socketio

Teamcity run link: https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_SIGNALR/651813?buildTab=overview

I have made changes in the basic function and added a new function called basicwithsku for the following reason:
This change was made to keep generated tests and hand-written tests aligned without losing SKU test coverage.

- The resource identity test for this resource is generated by the go:generate directive.
- The generator now produces a test that calls basic with a single argument (the test data object).
- Our hand-written helpers previously defined basic with three arguments (data, sku, capacity).
- That signature mismatch causes generated output drift and makes gencheck fail, because generated code no longer matches committed helper usage.

To fix this cleanly, we split responsibilities:

- basic(data) was kept as the canonical default helper expected by generated tests.
- basicWithSku(data, sku, capacity) was introduced as the parameterized helper for SKU matrix scenarios (Free/Standard/Premium).
- SKU-focused tests were switched to basicWithSku, while generated identity tests and default-path tests continue to use basic(data).


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
