### PR TITLE
kubernetes_cluster_resource/kubernetes_cluster_node_pool_resource - fix provider deleting original node pools when temp pool isn't ready …

### DIFF
--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -1049,9 +1049,16 @@ func resourceKubernetesClusterNodePoolUpdate(d *pluginsdk.ResourceData, meta int
 			existing.Model.Properties.NodeImageVersion = nil
 		}
 
-		// if the temp node pool already exists due to a previous failure, don't bother spinning it up.
-		// the temporary nodepool is created with the new values
+		// if the temp node pool doesn't exist, create it. if it is in a failed state, then delete and recreate it.
 		if tempExisting.Model == nil {
+			if err := retryNodePoolCreation(ctx, client, tempNodePoolId, tempAgentProfile); err != nil {
+				return fmt.Errorf("creating temporary %s: %+v", tempNodePoolId, err)
+			}
+		} else if *tempExisting.Model.Properties.ProvisioningState != "Succeeded" {
+			if err := client.DeleteThenPoll(ctx, tempNodePoolId, agentpools.DefaultDeleteOperationOptions()); err != nil {
+				return fmt.Errorf("deleting temporary %s: %+v", tempNodePoolId, err)
+			}
+
 			if err := retryNodePoolCreation(ctx, client, tempNodePoolId, tempAgentProfile); err != nil {
 				return fmt.Errorf("creating temporary %s: %+v", tempNodePoolId, err)
 			}

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -2773,8 +2773,16 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 				agentProfile.Properties.NodeImageVersion = nil
 			}
 
-			// if the temp node pool already exists due to a previous failure, don't bother spinning it up
+			// if the temp node pool doesn't exist, create it. if it is in a failed state, then delete and recreate it.
 			if tempExisting.Model == nil {
+				if err := retryNodePoolCreation(ctx, nodePoolsClient, tempNodePoolId, tempAgentProfile); err != nil {
+					return fmt.Errorf("creating temporary %s: %+v", tempNodePoolId, err)
+				}
+			} else if *tempExisting.Model.Properties.ProvisioningState != "Succeeded" {
+				if err := nodePoolsClient.DeleteThenPoll(ctx, tempNodePoolId, agentpools.DefaultDeleteOperationOptions()); err != nil {
+					return fmt.Errorf("deleting temporary %s: %+v", tempNodePoolId, err)
+				}
+
 				if err := retryNodePoolCreation(ctx, nodePoolsClient, tempNodePoolId, tempAgentProfile); err != nil {
 					return fmt.Errorf("creating temporary %s: %+v", tempNodePoolId, err)
 				}


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

If provider fails while provisioning the temp node pool, on the next run it will ignore the temp pool, and attempt to delete/recreate the original pool, regardless of the state of the temp pool. these changes should fix that.


## PR Checklist

- [ x ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ x ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ x ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ x ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [  x ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”

## Testing 

- [ x ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).


* `kubernetes_cluster_resource` - fix bug where node pool is deleted regardless of the whether temp node pool is ready, when 'temporary_name_for_rotation' is set.

* `kubernetes_cluster_node_pool_resource` - fix bug where node pool is deleted regardless of the whether temp node pool is ready, when 'temporary_name_for_rotation' is set.

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ x ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change

## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
