### PR TITLE
fix: allow empty `request_message` when `is_manual_connection = true` in azurerm_private_endpoint (closes #32206)

### DIFF
--- a/internal/services/network/private_endpoint_resource.go
+++ b/internal/services/network/private_endpoint_resource.go
@@ -175,7 +175,7 @@ func resourcePrivateEndpoint() *pluginsdk.Resource {
 						"request_message": {
 							Type:         pluginsdk.TypeString,
 							Optional:     true,
-							ValidateFunc: validation.StringLenBetween(1, 140),
+							ValidateFunc: validation.StringLenBetween(0, 140),
 						},
 						"private_ip_address": {
 							Type:     pluginsdk.TypeString,
@@ -304,11 +304,6 @@ func resourcePrivateEndpoint() *pluginsdk.Resource {
 				// If this is not a manual connection and the message is set return an error since this does not make sense.
 				if !privateServiceConnection["is_manual_connection"].(bool) && privateServiceConnection["request_message"].(string) != "" {
 					return fmt.Errorf(`"private_service_connection":%q is invalid, the "request_message" attribute cannot be set if the "is_manual_connection" attribute is "false"`, name)
-				}
-
-				// If this is a manual connection and the message isn't set return an error.
-				if privateServiceConnection["is_manual_connection"].(bool) && strings.TrimSpace(privateServiceConnection["request_message"].(string)) == "" {
-					return fmt.Errorf(`"private_service_connection":%q is invalid, the "request_message" attribute must not be empty`, name)
 				}
 			}
 			return nil


### PR DESCRIPTION
## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

This PR fixes a regression introduced in #31705 for the `azurerm_private_endpoint` resource.

**Problem**  
After PR #31705 moved validation to plan-time, setting `request_message = ""` (empty string) when `is_manual_connection = true` started failing during `terraform plan` with:
- `expected length of private_service_connection.0.request_message to be in the range (1 - 140), got`
- or `"request_message" attribute must not be empty`

This broke existing configurations and imported resources.

**Changes**  
- Updated `ValidateFunc` for `request_message` from `validation.StringLenBetween(1, 140)` to `validation.StringLenBetween(0, 140)`.
- Removed the overly strict empty-string check in `CustomizeDiff` (the check that prevents setting `request_message` when `is_manual_connection = false` remains intact).

This restores the documented “Optional” behavior for `request_message`.

**Testing**  
- Reproduced the exact config from issue #32206 (`request_message = ""` + `is_manual_connection = true`).
- Verified `terraform plan` now succeeds cleanly using local development override.

## PR Checklist
- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.

## Changes to existing Resource / Data Source
- [x] I have added an explanation of what my changes do and why I'd like you to include them.

## Testing
- Validation-only change. No new tests were added in this PR (existing tests remain unaffected).
- Tested manually with the reproduction case from the issue.

## Change Log
* `azurerm_private_endpoint` - allow empty `request_message` when `is_manual_connection = true` [GH-32206]

<!-- What type of PR is this? -->
This is a (please select all that apply):
- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change

## Related Issue(s)
Closes #32206

## AI Assistance Disclosure
- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs  
  (Grok assisted with debugging the local development setup, code suggestions, and PR description. All changes were reviewed and applied manually by the contributor.)

## Rollback Plan
If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls
No changes to security controls.