### PR TITLE
`azurerm_firewall` - support virtual hub deployment with customer managed public IPs

### DIFF
--- a/internal/services/firewall/firewall_resource.go
+++ b/internal/services/firewall/firewall_resource.go
@@ -207,8 +207,8 @@ func resourceFirewall() *pluginsdk.Resource {
 						"public_ip_count": {
 							Type:         pluginsdk.TypeInt,
 							Optional:     true,
+							Computed:     true,
 							ValidateFunc: validation.IntAtLeast(1),
-							Default:      1,
 						},
 						"public_ip_addresses": {
 							Type:     pluginsdk.TypeList,
@@ -253,7 +253,7 @@ func resourceFirewallCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 		return tf.ImportAsExistsError("azurerm_firewall", id.ID())
 	}
 
-	if err := validateFirewallIPConfigurationSettings(d.Get("ip_configuration").([]interface{})); err != nil {
+	if err := validateFirewallIPConfigurationSettings(d.Get("ip_configuration").([]interface{}), d.Get("virtual_hub").([]interface{})); err != nil {
 		return fmt.Errorf("validating %s: %+v", id, err)
 	}
 
@@ -315,7 +315,7 @@ func resourceFirewallCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 		parameters.Properties.FirewallPolicy = &azurefirewalls.SubResource{Id: &policyId}
 	}
 
-	vhub, hubIpAddresses, ok := expandFirewallVirtualHubSetting(existing.Model, d.Get("virtual_hub").([]interface{}))
+	vhub, hubIpAddresses, ok := expandFirewallVirtualHubSetting(existing.Model, d.Get("virtual_hub").([]interface{}), firewallVirtualHubPublicIPCount(d))
 	if ok {
 		parameters.Properties.VirtualHub = vhub
 		parameters.Properties.HubIPAddresses = hubIpAddresses
@@ -730,12 +730,37 @@ func flattenFirewallPrivateIpRange(input *map[string]string) []interface{} {
 	return utils.FlattenStringSlice(&rangeSlice)
 }
 
-func expandFirewallVirtualHubSetting(existing *azurefirewalls.AzureFirewall, input []interface{}) (vhub *azurefirewalls.SubResource, ipAddresses *azurefirewalls.HubIPAddresses, ok bool) {
+func firewallVirtualHubPublicIPCount(d *pluginsdk.ResourceData) *int64 {
+	rawVirtualHub := d.GetRawConfig().AsValueMap()["virtual_hub"]
+	if rawVirtualHub.IsNull() || !rawVirtualHub.IsKnown() {
+		return nil
+	}
+
+	rawVirtualHubConfig := rawVirtualHub.AsValueSlice()
+	if len(rawVirtualHubConfig) == 0 {
+		return nil
+	}
+
+	rawPublicIPCount := rawVirtualHubConfig[0].AsValueMap()["public_ip_count"]
+	if rawPublicIPCount.IsNull() || !rawPublicIPCount.IsKnown() {
+		return nil
+	}
+
+	publicIPCount := int64(d.Get("virtual_hub.0.public_ip_count").(int))
+	return &publicIPCount
+}
+
+func expandFirewallVirtualHubSetting(existing *azurefirewalls.AzureFirewall, input []interface{}, publicIPCount *int64) (vhub *azurefirewalls.SubResource, ipAddresses *azurefirewalls.HubIPAddresses, ok bool) {
 	if len(input) == 0 {
 		return nil, nil, false
 	}
 
 	b := input[0].(map[string]interface{})
+	vhub = &azurefirewalls.SubResource{Id: pointer.To(b["virtual_hub_id"].(string))}
+
+	if publicIPCount == nil {
+		return vhub, nil, true
+	}
 
 	// The API requires both "Count" and "Addresses" for the "PublicIPs" setting.
 	// The "Count" means how many PIP to provision.
@@ -744,7 +769,7 @@ func expandFirewallVirtualHubSetting(existing *azurefirewalls.AzureFirewall, inp
 	// - Update: both "Count" and "Addresses" are needed:
 	//     Scale up: "Addresses" should remain same as before scaling up
 	//     Scale down: "Addresses" should indicate the addresses to be retained (in this case we retain the first new "Count" ones)
-	newCount := b["public_ip_count"].(int)
+	newCount := int(*publicIPCount)
 	var addresses *[]azurefirewalls.AzureFirewallPublicIPAddress
 	if existing != nil {
 		if prop := existing.Properties; prop != nil {
@@ -768,10 +793,9 @@ func expandFirewallVirtualHubSetting(existing *azurefirewalls.AzureFirewall, inp
 		}
 	}
 
-	vhub = &azurefirewalls.SubResource{Id: pointer.To(b["virtual_hub_id"].(string))}
 	ipAddresses = &azurefirewalls.HubIPAddresses{
 		PublicIPs: &azurefirewalls.HubPublicIPAddresses{
-			Count:     pointer.To(int64(b["public_ip_count"].(int))),
+			Count:     publicIPCount,
 			Addresses: addresses,
 		},
 	}
@@ -784,15 +808,17 @@ func flattenFirewallVirtualHubSetting(props *azurefirewalls.AzureFirewallPropert
 		return nil
 	}
 
+	vhubSetting := map[string]interface{}{}
+
 	var vhubId string
 	if props.VirtualHub.Id != nil {
 		vhubId = *props.VirtualHub.Id
 	}
+	vhubSetting["virtual_hub_id"] = vhubId
 
 	var (
-		publicIpCount int
-		publicIps     []string
-		privateIp     string
+		publicIps []string
+		privateIp string
 	)
 	if hubIP := props.HubIPAddresses; hubIP != nil {
 		if hubIP.PrivateIPAddress != nil {
@@ -800,7 +826,7 @@ func flattenFirewallVirtualHubSetting(props *azurefirewalls.AzureFirewallPropert
 		}
 		if pubIPs := hubIP.PublicIPs; pubIPs != nil {
 			if pubIPs.Count != nil {
-				publicIpCount = int(*pubIPs.Count)
+				vhubSetting["public_ip_count"] = int(*pubIPs.Count)
 			}
 			if pubIPs.Addresses != nil {
 				for _, addr := range *pubIPs.Addresses {
@@ -811,18 +837,15 @@ func flattenFirewallVirtualHubSetting(props *azurefirewalls.AzureFirewallPropert
 			}
 		}
 	}
+	vhubSetting["public_ip_addresses"] = publicIps
+	vhubSetting["private_ip_address"] = privateIp
 
 	return []interface{}{
-		map[string]interface{}{
-			"virtual_hub_id":      vhubId,
-			"public_ip_count":     publicIpCount,
-			"public_ip_addresses": publicIps,
-			"private_ip_address":  privateIp,
-		},
+		vhubSetting,
 	}
 }
 
-func validateFirewallIPConfigurationSettings(configs []interface{}) error {
+func validateFirewallIPConfigurationSettings(configs []interface{}, virtualHub []interface{}) error {
 	if len(configs) == 0 {
 		return nil
 	}
@@ -834,6 +857,10 @@ func validateFirewallIPConfigurationSettings(configs []interface{}) error {
 		if subnet, exist := data["subnet_id"].(string); exist && subnet != "" {
 			subnetNumber++
 		}
+	}
+
+	if subnetNumber == 0 && len(virtualHub) > 0 {
+		return nil
 	}
 
 	if subnetNumber != 1 {

--- a/internal/services/firewall/firewall_resource_test.go
+++ b/internal/services/firewall/firewall_resource_test.go
@@ -339,6 +339,24 @@ func TestAccFirewall_inVirtualHub(t *testing.T) {
 	})
 }
 
+func TestAccFirewall_inVirtualHubWithIPConfigurationWithoutSubnet(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_firewall", "test")
+	r := FirewallResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.inVirtualHubWithIPConfigurationWithoutSubnet(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("ip_configuration.0.name").HasValue("configuration"),
+				check.That(data.ResourceName).Key("ip_configuration.0.public_ip_address_id").Exists(),
+				check.That(data.ResourceName).Key("virtual_hub.0.private_ip_address").Exists(),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccFirewall_privateRanges(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_firewall", "test")
 	r := FirewallResource{}
@@ -1228,6 +1246,66 @@ resource "azurerm_firewall" "test" {
   firewall_policy_id = azurerm_firewall_policy.test.id
 }
 `, data.RandomInteger, data.Locations.Primary, pipCount)
+}
+
+func (FirewallResource) inVirtualHubWithIPConfigurationWithoutSubnet(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-fw-%[1]d"
+  location = "%s"
+}
+
+resource "azurerm_firewall_policy" "test" {
+  name                = "acctest-firewallpolicy-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_virtual_wan" "test" {
+  name                = "acctest-virtualwan-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_virtual_hub" "test" {
+  name                = "acctest-virtualhub-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  virtual_wan_id      = azurerm_virtual_wan.test.id
+  address_prefix      = "10.0.1.0/24"
+}
+
+resource "azurerm_public_ip" "test" {
+  name                = "acctestpip-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
+
+resource "azurerm_firewall" "test" {
+  name                = "acctest-firewall-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku_name            = "AZFW_Hub"
+  sku_tier            = "Standard"
+
+  ip_configuration {
+    name                 = "configuration"
+    public_ip_address_id = azurerm_public_ip.test.id
+  }
+
+  virtual_hub {
+    virtual_hub_id = azurerm_virtual_hub.test.id
+  }
+
+  firewall_policy_id = azurerm_firewall_policy.test.id
+}
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (FirewallResource) privateRanges(data acceptance.TestData) string {

--- a/website/docs/r/firewall.html.markdown
+++ b/website/docs/r/firewall.html.markdown
@@ -104,6 +104,8 @@ An `ip_configuration` block supports the following:
 
 -> **Note:** At least one and only one `ip_configuration` block may contain a `subnet_id`.
 
+-> **Note:** When the Firewall is deployed in a `virtual_hub`, the `subnet_id` may be omitted from all `ip_configuration` blocks.
+
 * `public_ip_address_id` - (Optional) The ID of the Public IP Address associated with the firewall.
 
 -> **Note:** A public ip address is required unless a `management_ip_configuration` block is specified.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->
When deploying azure firewall to a virtual hub, it's possible to specify custom public IP's via ip_configuration blocks as an alternative to `public_ip_count` which randomly allocates IP addresses.

The provider previously required at least one instance of `subnet_id` in ip_configuration blocks, which is not required by ARM when deploying to a virtual hub. This PR modifies the check to allow this scenario.

This should enable the scenario described in #30415 

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_firewall` - support virtual hub deployment without `subnet_id` in IP configuration [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #30415


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->
Code changes and tests carefully made with the assistance of copilot. All testing and code review done by me.
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
