### PR TITLE
mysql/postgres: fix `backup_retention_days` being ignored on update

### DIFF
--- a/internal/services/mysql/mysql_flexible_server_resource.go
+++ b/internal/services/mysql/mysql_flexible_server_resource.go
@@ -615,7 +615,7 @@ func resourceMysqlFlexibleServerFlatten(d *pluginsdk.ResourceData, id *servers.F
 			}
 
 			if backup := props.Backup; backup != nil {
-				d.Set("backup_retention_days", backup.BackupRetentionDays)
+				d.Set("backup_retention_days", int(pointer.From(backup.BackupRetentionDays)))
 				d.Set("geo_redundant_backup_enabled", *backup.GeoRedundantBackup == servers.EnableStatusEnumEnabled)
 			}
 
@@ -975,9 +975,7 @@ func expandArmServerBackup(d *pluginsdk.ResourceData) *servers.Backup {
 		GeoRedundantBackup: &geoRedundantBackup,
 	}
 
-	if v, ok := d.GetOk("backup_retention_days"); ok {
-		backup.BackupRetentionDays = pointer.To(int64(v.(int)))
-	}
+	backup.BackupRetentionDays = pointer.To(int64(d.Get("backup_retention_days").(int)))
 
 	return &backup
 }

--- a/internal/services/postgres/postgresql_flexible_server_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource.go
@@ -849,7 +849,7 @@ func resourcePostgresqlFlexibleServerRead(d *pluginsdk.ResourceData, meta interf
 			}
 
 			if backup := props.Backup; backup != nil {
-				d.Set("backup_retention_days", backup.BackupRetentionDays)
+				d.Set("backup_retention_days", int(pointer.From(backup.BackupRetentionDays)))
 
 				geoRedundantBackup := false
 				if backup.GeoRedundantBackup != nil {
@@ -1231,8 +1231,8 @@ func expandArmServerBackup(d *pluginsdk.ResourceData) *servers.Backup {
 func expandArmServerBackupForPatch(d *pluginsdk.ResourceData) *servers.BackupForPatch {
 	backup := servers.BackupForPatch{}
 
-	if v, ok := d.GetOk("backup_retention_days"); ok {
-		backup.BackupRetentionDays = pointer.To(int64(v.(int)))
+	if v := d.Get("backup_retention_days").(int); v > 0 {
+		backup.BackupRetentionDays = pointer.To(int64(v))
 	}
 
 	geoRedundantEnabled := servers.GeographicallyRedundantBackupDisabled

--- a/internal/services/postgres/postgresql_server_resource.go
+++ b/internal/services/postgres/postgresql_server_resource.go
@@ -815,7 +815,7 @@ func resourcePostgreSQLServerRead(d *pluginsdk.ResourceData, meta interface{}) e
 
 			if storage := props.StorageProfile; storage != nil {
 				d.Set("storage_mb", storage.StorageMB)
-				d.Set("backup_retention_days", storage.BackupRetentionDays)
+				d.Set("backup_retention_days", int(pointer.From(storage.BackupRetentionDays)))
 
 				autoGrow := false
 				if storage.StorageAutogrow != nil {


### PR DESCRIPTION
## Description

`backup_retention_days` was silently ignored during updates on `azurerm_mysql_flexible_server`, `azurerm_postgresql_flexible_server`, and `azurerm_postgresql_server`.

### Root cause

`expandArmServerBackup` / `expandArmServerBackupForPatch` used `d.GetOk` to gate setting `BackupRetentionDays` in the API payload:

```go
if v, ok := d.GetOk("backup_retention_days"); ok {
    backup.BackupRetentionDays = pointer.To(int64(v.(int)))
}
```

For `azurerm_mysql_flexible_server`, the schema declares `Default: 7`. The Terraform SDK's `GetOk` returns `ok=false` when the value is sourced from the schema default rather than being explicitly set in config. This caused `BackupRetentionDays` to be silently omitted from the PATCH request whenever a user relied on the default value or reset the field to `7`, leaving Azure with the previous retention period.

The Read functions also passed `*int64` directly to `d.Set` for a `TypeInt` field, which can silently zero out the state when the API returns `nil`.

### Fix

- **MySQL flexible** (`expandArmServerBackup`): replace `d.GetOk` with unconditional `d.Get` — safe because `Default: 7` guarantees a valid value (1–35) is always present.
- **PostgreSQL flexible** (`expandArmServerBackupForPatch`): replace `d.GetOk` with `d.Get` + explicit `> 0` guard — the function is only called when `d.HasChange("backup_retention_days")` is true, so the value is always a valid user-supplied integer.
- **All three Read functions**: dereference the `*int64` pointer explicitly via `pointer.From` before calling `d.Set`, avoiding implicit conversion issues when the API returns `nil`.

## Affected Resources

- `azurerm_mysql_flexible_server`
- `azurerm_postgresql_flexible_server`
- `azurerm_postgresql_server`

## Testing

- Existing acceptance test `TestAccMySqlFlexibleServer_completeUpdate` covers `backup_retention_days` change (7 → 10).
- Manually verified with a local build against Azure that changing `backup_retention_days` is now correctly reflected in the PATCH request and persisted by the API.