### PR TITLE
workflow: mark CI failure comments outdated on pass

### DIFF
--- a/.github/workflows/comment-cleanup.yaml
+++ b/.github/workflows/comment-cleanup.yaml
@@ -1,0 +1,51 @@
+name: Comment Cleanup
+
+on:
+  # This file is reused, and called from other workflows
+  workflow_call:
+
+permissions:
+  pull-requests: write
+
+jobs:
+  comment-cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Minimize outdated failure comments
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          result-encoding: string
+          script: |
+            const workflowName = '${{ github.workflow }}';
+            const marker = `<b>Build failure: ${workflowName}</b>`;
+
+            // Find all comments on this PR
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ github.event.number }},
+              per_page: 100
+            });
+
+            for (const comment of comments.data) {
+              // Only target comments left by the github-actions bot
+              if (comment.user.login !== 'github-actions[bot]') continue;
+
+              if (comment.body && comment.body.includes(marker)) {
+                // Use GraphQL to minimize the comment as OUTDATED
+                await github.graphql(`
+                  mutation($id: ID!) {
+                    minimizeComment(input: {
+                      subjectId: $id,
+                      classifier: OUTDATED
+                    }) {
+                      minimizedComment {
+                        isMinimized
+                      }
+                    }
+                  }
+                `, { id: comment.node_id });
+
+                console.log(`Minimized outdated failure comment ${comment.id} for workflow "${workflowName}"`);
+              }
+            }

--- a/.github/workflows/comment-cleanup.yaml
+++ b/.github/workflows/comment-cleanup.yaml
@@ -19,33 +19,65 @@ jobs:
             const workflowName = '${{ github.workflow }}';
             const marker = `<b>Build failure: ${workflowName}</b>`;
 
-            // Find all comments on this PR
-            const comments = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: ${{ github.event.number }},
-              per_page: 100
-            });
-
-            for (const comment of comments.data) {
-              // Only target comments left by the github-actions bot
-              if (comment.user.login !== 'github-actions[bot]') continue;
-
-              if (comment.body && comment.body.includes(marker)) {
-                // Use GraphQL to minimize the comment as OUTDATED
-                await github.graphql(`
-                  mutation($id: ID!) {
-                    minimizeComment(input: {
-                      subjectId: $id,
-                      classifier: OUTDATED
-                    }) {
-                      minimizedComment {
+            // Use GraphQL to fetch comments with isMinimized status, paginating through all
+            const query = `
+              query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $number) {
+                    comments(first: 100, after: $cursor) {
+                      pageInfo {
+                        hasNextPage
+                        endCursor
+                      }
+                      nodes {
+                        id
+                        body
                         isMinimized
+                        author { login }
                       }
                     }
                   }
-                `, { id: comment.node_id });
+                }
+              }
+            `;
 
-                console.log(`Minimized outdated failure comment ${comment.id} for workflow "${workflowName}"`);
+            let cursor = null;
+            let hasNextPage = true;
+
+            while (hasNextPage) {
+              const result = await github.graphql(query, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                number: ${{ github.event.number }},
+                cursor: cursor
+              });
+
+              const { nodes, pageInfo } = result.repository.pullRequest.comments;
+              hasNextPage = pageInfo.hasNextPage;
+              cursor = pageInfo.endCursor;
+
+              for (const comment of nodes) {
+                // Only target comments left by the github-actions bot
+                if (comment.author.login !== 'github-actions[bot]') continue;
+
+                // Skip comments that are already minimized
+                if (comment.isMinimized) continue;
+
+                if (comment.body && comment.body.includes(marker)) {
+                  await github.graphql(`
+                    mutation($id: ID!) {
+                      minimizeComment(input: {
+                        subjectId: $id,
+                        classifier: OUTDATED
+                      }) {
+                        minimizedComment {
+                          isMinimized
+                        }
+                      }
+                    }
+                  `, { id: comment.id });
+
+                  console.log(`Minimized outdated failure comment for workflow "${workflowName}"`);
+                }
               }
             }

--- a/.github/workflows/depscheck.yaml
+++ b/.github/workflows/depscheck.yaml
@@ -39,3 +39,7 @@ jobs:
     needs: depscheck
     if: ${{ failure() }}
     uses: ./.github/workflows/comment-failure.yaml
+  comment-outdated-on-pass:
+    needs: depscheck
+    if: ${{ success() }}
+    uses: ./.github/workflows/comment-cleanup.yaml

--- a/.github/workflows/gencheck.yaml
+++ b/.github/workflows/gencheck.yaml
@@ -41,3 +41,7 @@ jobs:
     needs: gencheck
     if: ${{ failure() }}
     uses: ./.github/workflows/comment-failure.yaml
+  comment-outdated-on-pass:
+    needs: gencheck
+    if: ${{ success() }}
+    uses: ./.github/workflows/comment-cleanup.yaml

--- a/.github/workflows/golint.yaml
+++ b/.github/workflows/golint.yaml
@@ -47,3 +47,7 @@ jobs:
     needs: golint
     if: ${{ failure() }}
     uses: ./.github/workflows/comment-failure.yaml
+  comment-outdated-on-pass:
+    needs: golint
+    if: ${{ success() }}
+    uses: ./.github/workflows/comment-cleanup.yaml

--- a/.github/workflows/gradually-deprecated.yaml
+++ b/.github/workflows/gradually-deprecated.yaml
@@ -40,3 +40,7 @@ jobs:
     needs: test
     if: ${{ failure() }}
     uses: ./.github/workflows/comment-failure.yaml
+  comment-outdated-on-pass:
+    needs: test
+    if: ${{ success() }}
+    uses: ./.github/workflows/comment-cleanup.yaml

--- a/.github/workflows/preview-api-version-linter.yaml
+++ b/.github/workflows/preview-api-version-linter.yaml
@@ -34,3 +34,7 @@ jobs:
     needs: preview-api-version-linter
     if: ${{ failure() }}
     uses: ./.github/workflows/comment-failure.yaml
+  comment-outdated-on-pass:
+    needs: preview-api-version-linter
+    if: ${{ success() }}
+    uses: ./.github/workflows/comment-cleanup.yaml

--- a/.github/workflows/provider-test.yaml
+++ b/.github/workflows/provider-test.yaml
@@ -93,3 +93,7 @@ jobs:
     needs: provider-tests
     if: ${{ failure() }}
     uses: ./.github/workflows/comment-failure.yaml
+  comment-outdated-on-pass:
+    needs: provider-tests
+    if: ${{ success() }}
+    uses: ./.github/workflows/comment-cleanup.yaml

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -39,3 +39,7 @@ jobs:
     needs: shellcheck
     if: ${{ failure() }}
     uses: ./.github/workflows/comment-failure.yaml
+  comment-outdated-on-pass:
+    needs: shellcheck
+    if: ${{ success() }}
+    uses: ./.github/workflows/comment-cleanup.yaml

--- a/.github/workflows/tflint.yaml
+++ b/.github/workflows/tflint.yaml
@@ -45,3 +45,7 @@ jobs:
     needs: tflint
     if: ${{ failure() }}
     uses: ./.github/workflows/comment-failure.yaml
+  comment-outdated-on-pass:
+    needs: tflint
+    if: ${{ success() }}
+    uses: ./.github/workflows/comment-cleanup.yaml

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -84,3 +84,7 @@ jobs:
     needs: test
     if: ${{ failure() }}
     uses: ./.github/workflows/comment-failure.yaml
+  comment-outdated-on-pass:
+    needs: test
+    if: ${{ success() }}
+    uses: ./.github/workflows/comment-cleanup.yaml

--- a/.github/workflows/validate-examples.yaml
+++ b/.github/workflows/validate-examples.yaml
@@ -43,3 +43,7 @@ jobs:
     needs: website-lint
     if: ${{ failure() }}
     uses: ./.github/workflows/comment-failure.yaml
+  comment-outdated-on-pass:
+    needs: website-lint
+    if: ${{ success() }}
+    uses: ./.github/workflows/comment-cleanup.yaml

--- a/.github/workflows/website-lint.yaml
+++ b/.github/workflows/website-lint.yaml
@@ -42,3 +42,7 @@ jobs:
     needs: website-lint
     if: ${{ failure() }}
     uses: ./.github/workflows/comment-failure.yaml
+  comment-outdated-on-pass:
+    needs: website-lint
+    if: ${{ success() }}
+    uses: ./.github/workflows/comment-cleanup.yaml


### PR DESCRIPTION
## Community Note
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

When CI checks fail, the `comment-failure` workflow leaves a comment on the PR with instructions on how to fix the issue. Previously these comments would accumulate and remain visible even after the contributor fixes the issue and the check starts passing.

This PR adds a `comment-cleanup.yaml` reusable workflow that automatically marks these failure comments as **outdated** (collapsed/minimized) when the corresponding CI check passes. Each workflow only cleans up its own comments — if 3 out of 5 checks pass, only those 3 get their comments collapsed while the other 2 remain visible.

The cleanup matches on both:
- **Author**: `github-actions[bot]` (won't accidentally hide human comments)
- **Body**: `Build failure: {workflow name}` (scoped per-workflow)


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.


## Changes to existing Resource / Data Source

N/A - Workflow changes only.


## Testing

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass.

This is a workflow-only change. The cleanup logic uses the GitHub GraphQL `minimizeComment` mutation with `OUTDATED` classifier. Testing will be validated by CI runs on this PR itself.


## Change Log

* workflows - automatically mark CI failure comments as outdated when checks start passing


This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

N/A


## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

AI was used to generate the `comment-cleanup.yaml` workflow and add the `comment-outdated-on-pass` job to all 11 caller workflows.


## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

No changes to security controls.