### PR TITLE
fix for azurerm_local_network_gateway - all address spaces are removed when modifying a single one #16327

### DIFF
--- a/internal/services/network/local_network_gateway_resource.go
+++ b/internal/services/network/local_network_gateway_resource.go
@@ -205,26 +205,6 @@ func resourceLocalNetworkGatewayUpdate(d *pluginsdk.ResourceData, meta interface
 	pollerType := custompollers.NewLocalNetworkGatewayPoller(client, *id)
 	poller := pollers.NewPoller(pollerType, 10*time.Second, pollers.DefaultNumberOfDroppedConnectionsToAllow)
 
-	// There is a bug in the provider where the address space ordering doesn't change as expected.
-	// In the UI we have to remove the current list of addresses in the address space and re-add them in the new order and we'll copy that here.
-	if d.HasChange("address_space") {
-		// since the local network gateway cannot have both empty address prefix and empty BGP setting(confirmed with service team, it is by design),
-		// replace the empty address prefix with the first address prefix in the "address_space" list to avoid error.
-		if v := d.Get("address_space").([]interface{}); len(v) > 0 {
-			payload.Properties.LocalNetworkAddressSpace = &localnetworkgateways.AddressSpace{
-				AddressPrefixes: &[]string{v[0].(string)},
-			}
-		}
-
-		// This can be switched back over to CreateOrUpdateThenPoll once https://github.com/hashicorp/go-azure-sdk/issues/989 has been fixed
-		if _, err := client.CreateOrUpdate(ctx, *id, *payload); err != nil {
-			return fmt.Errorf("removing %s: %+v", id, err)
-		}
-		if err := poller.PollUntilDone(ctx); err != nil {
-			return err
-		}
-	}
-
 	payload.Properties.LocalNetworkAddressSpace = expandLocalNetworkGatewayAddressSpaces(d)
 
 	if _, err := client.CreateOrUpdate(ctx, *id, *payload); err != nil {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
When making changes to the local_network_gateway resource's address_space I found that, internally, the azurerm provider was removing all but the first prefixes from resource and waiting for that to complete and then making a second API call to all  the intended prefixes.

This behaviour was intentionally introduced in this commit: https://github.com/hashicorp/terraform-provider-azurerm/commit/f0d33383d1133a375fa53e684cfca78161bfe91b back in Jul 2020

A bug was subsequently filed for this issue here https://github.com/hashicorp/terraform-provider-azurerm/issues/16327

I encountered this issue when one of my customers raised it with us noting an (application) outage of approximately 20 minutes was occurring when we pushed network changes to the VPN configuration. I'm hoping (expecting) this PR to resolve this issue.

This PR simply removes the initial api call to erase all but the first CIDR. In testing I see Azure accepts just programming the local_network_gateway with all the desired prefixes directly.


## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [X] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [X] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [X] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [X] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_local_network_gateway_resource` - directly program local_network_gateway with all desired prefixes [#16327]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [X] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #16327


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [X] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

VSCode Copilot chat used to analyse my forked terraform-provider-azurerm repo and remove the section of code causing the initial removal of the address_space prefixes based on my prompt to it describing the error.
I subsequently manually reviewed the change and allowed AI to run the go tests locally for this resource.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
