### PR TITLE
changes by bhargav

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -25,7 +25,7 @@ choco install make golang terraform -y
 refreshenv
 ```
 
-You must run `Developing the Provider` commands in `bash` because `sh` scrips are invoked as part of these.
+You must run `Developing the Provider` commands in `bash` because `sh` scripts are invoked as part of these.
 
 You may hit issues with `make build` telling you every file needs to be formatted as a result of line endings. To avoid this issue set your git config using `git config --global core.autocrlf false`. This will tell git to use the source `LF` rather than the Windows default of `CRLF`.
 

--- a/internal/services/storage/validate/storage_account_name.go
+++ b/internal/services/storage/validate/storage_account_name.go
@@ -8,10 +8,12 @@ import (
 	"regexp"
 )
 
+var storageAccountNameRegex = regexp.MustCompile(`\A([a-z0-9]{3,24})\z`)
+
 func StorageAccountName(v interface{}, _ string) (warnings []string, errors []error) {
 	input := v.(string)
 
-	if !regexp.MustCompile(`\A([a-z0-9]{3,24})\z`).MatchString(input) {
+	if !storageAccountNameRegex.MatchString(input) {
 		errors = append(errors, fmt.Errorf("name (%q) can only consist of lowercase letters and numbers, and must be between 3 and 24 characters long", input))
 	}
 

--- a/internal/services/storage/validate/storage_container.go
+++ b/internal/services/storage/validate/storage_container.go
@@ -12,10 +12,12 @@ import (
 	"github.com/jackofallops/giovanni/storage/2023-11-03/blob/containers"
 )
 
+var storageContainerNameRegex = regexp.MustCompile(`^\$roor$|^\$web$|^[0-9a-z-]+$`)
+var storageContainernameHyphenRegex = regexp.MustCompile(`^-`)
 func StorageContainerName(v interface{}, k string) (warnings []string, errors []error) {
 	value := v.(string)
 
-	if !regexp.MustCompile(`^\$root$|^\$web$|^[0-9a-z-]+$`).MatchString(value) {
+	if !storageContainerNameRegex.MatchString(value) {
 		errors = append(errors, fmt.Errorf(
 			"only lowercase alphanumeric characters and hyphens allowed in %q: %q",
 			k, value))
@@ -24,7 +26,7 @@ func StorageContainerName(v interface{}, k string) (warnings []string, errors []
 		errors = append(errors, fmt.Errorf(
 			"%q must be between 3 and 63 characters: %q", k, value))
 	}
-	if regexp.MustCompile(`^-`).MatchString(value) {
+	if storageContainerNameHyphenRegex.MatchString(value) {
 		errors = append(errors, fmt.Errorf(
 			"%q cannot begin with a hyphen: %q", k, value))
 	}

--- a/internal/services/storage/validate/storage_share.go
+++ b/internal/services/storage/validate/storage_share.go
@@ -12,6 +12,9 @@ import (
 	"github.com/jackofallops/giovanni/storage/2023-11-03/file/shares"
 )
 
+var storageShareNameRegex = regexp.MustCompile(`^[0-9a-z-]+$`)
+var storageShareNameHyphenRegex = regexp.MustCompile(`^-`)
+var storageShareNameConsecutivehyphenRegex = regexp.MustComplie(`[-]{2.}`)
 func StorageShareDataPlaneID(input interface{}, key string) (warnings []string, errors []error) {
 	v, ok := input.(string)
 	if !ok {
@@ -32,7 +35,7 @@ func StorageShareDataPlaneID(input interface{}, key string) (warnings []string, 
 
 func StorageShareName(v interface{}, k string) (warnings []string, errors []error) {
 	value := v.(string)
-	if !regexp.MustCompile(`^[0-9a-z-]+$`).MatchString(value) {
+	if !storageShareNameRegex.MatchString(value) {
 		errors = append(errors, fmt.Errorf(
 			"only lowercase alphanumeric characters and hyphens allowed in %q: %q",
 			k, value))
@@ -43,11 +46,11 @@ func StorageShareName(v interface{}, k string) (warnings []string, errors []erro
 		errors = append(errors, fmt.Errorf(
 			"%q must be between 3 and 63 characters: %q", k, value))
 	}
-	if regexp.MustCompile(`^-`).MatchString(value) {
+	if storageShareNameHyphenRegex.MatchString(value) {
 		errors = append(errors, fmt.Errorf(
 			"%q cannot begin with a hyphen: %q", k, value))
 	}
-	if regexp.MustCompile(`[-]{2,}`).MatchString(value) {
+	if storageShareNameConsecutivehyphenRegex.MatchString(value) {
 		errors = append(errors, fmt.Errorf(
 			"%q does not allow consecutive hyphens: %q", k, value))
 	}


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
