### PR TITLE
`azurerm_disk_encryption_set` - Nested item ID migration

### DIFF
--- a/internal/services/compute/disk_encryption_set_resource.go
+++ b/internal/services/compute/disk_encryption_set_resource.go
@@ -5,6 +5,7 @@ package compute
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"time"
@@ -14,28 +15,22 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/keyvault"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-02/diskencryptionsets"
-	"github.com/hashicorp/go-azure-sdk/sdk/environments"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/validate"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/client"
-	keyVaultParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/parse"
-	keyVaultValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/validate"
-	managedHsmHelpers "github.com/hashicorp/terraform-provider-azurerm/internal/services/managedhsm/helpers"
-	managedHsmParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/managedhsm/parse"
-	managedHsmValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/managedhsm/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/jackofallops/kermit/sdk/keyvault/7.4/keyvault"
 )
 
 func resourceDiskEncryptionSet() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
+	r := &pluginsdk.Resource{
 		Create: resourceDiskEncryptionSetCreate,
 		Read:   resourceDiskEncryptionSetRead,
 		Update: resourceDiskEncryptionSetUpdate,
@@ -65,19 +60,10 @@ func resourceDiskEncryptionSet() *pluginsdk.Resource {
 
 			"resource_group_name": commonschema.ResourceGroupName(),
 
-			// Issue #22864
 			"key_vault_key_id": {
 				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				ValidateFunc: keyVaultValidate.NestedItemIdWithOptionalVersion,
-				ExactlyOneOf: []string{"managed_hsm_key_id", "key_vault_key_id"},
-			},
-
-			"managed_hsm_key_id": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.Any(managedHsmValidate.ManagedHSMDataPlaneVersionedKeyID, managedHsmValidate.ManagedHSMDataPlaneVersionlessKeyID),
-				ExactlyOneOf: []string{"managed_hsm_key_id", "key_vault_key_id"},
+				Required:     true,
+				ValidateFunc: keyvault.ValidateNestedItemID(keyvault.VersionTypeAny, keyvault.NestedItemTypeKey),
 			},
 
 			"auto_key_rotation_enabled": {
@@ -121,14 +107,31 @@ func resourceDiskEncryptionSet() *pluginsdk.Resource {
 			}),
 		),
 	}
+
+	if !features.FivePointOh() {
+		r.Schema["key_vault_key_id"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			Computed:     true,
+			ValidateFunc: keyvault.ValidateNestedItemID(keyvault.VersionTypeAny, keyvault.NestedItemTypeAny),
+			ExactlyOneOf: []string{"managed_hsm_key_id", "key_vault_key_id"},
+		}
+
+		r.Schema["managed_hsm_key_id"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			Computed:     true,
+			ValidateFunc: keyvault.ValidateNestedItemID(keyvault.VersionTypeAny, keyvault.NestedItemTypeAny),
+			ExactlyOneOf: []string{"managed_hsm_key_id", "key_vault_key_id"},
+			Deprecated:   "`managed_hsm_key_id` has been deprecated in favour of `key_vault_key_id` and will be removed in v5.0 of the AzureRM Provider",
+		}
+	}
+
+	return r
 }
 
 func resourceDiskEncryptionSetCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Compute.DiskEncryptionSetsClient
-	keyVaultsClient := meta.(*clients.Client).KeyVault
-	keyVaultKeyClient := meta.(*clients.Client).KeyVault.ManagementClient
-	managedkeyBundleClient := meta.(*clients.Client).ManagedHSMs.DataPlaneKeysClient
-	env := meta.(*clients.Client).Account.Environment
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -141,6 +144,7 @@ func resourceDiskEncryptionSetCreate(d *pluginsdk.ResourceData, meta interface{}
 			return fmt.Errorf("checking for present of existing %s: %+v", id, err)
 		}
 	}
+
 	if !response.WasNotFound(existing.HttpResponse) {
 		return tf.ImportAsExistsError("azurerm_disk_encryption_set", id.ID())
 	}
@@ -148,60 +152,34 @@ func resourceDiskEncryptionSetCreate(d *pluginsdk.ResourceData, meta interface{}
 	rotationToLatestKeyVersionEnabled := d.Get("auto_key_rotation_enabled").(bool)
 	activeKey := &diskencryptionsets.KeyForDiskEncryptionSet{}
 
-	if keyVaultKeyId, ok := d.GetOk("key_vault_key_id"); ok {
-		keyVaultKey, err := keyVaultParse.ParseOptionallyVersionedNestedItemID(keyVaultKeyId.(string))
+	if !features.FivePointOh() && !d.GetRawConfig().AsValueMap()["managed_hsm_key_id"].IsNull() {
+		key, err := keyvault.ParseNestedItemID(d.Get("managed_hsm_key_id").(string), keyvault.VersionTypeAny, keyvault.NestedItemTypeAny)
 		if err != nil {
 			return err
 		}
 
-		err = validateKeyAndRotationEnabled(rotationToLatestKeyVersionEnabled, keyVaultKey.Version != "", keyVaultKey.ID())
+		keyURL, err := getKeyURL(ctx, key, rotationToLatestKeyVersionEnabled, meta)
+		if err != nil {
+			return err
+		}
+		activeKey.KeyURL = keyURL
+	} else {
+		nestedItemType := keyvault.NestedItemTypeKey
+		if !features.FivePointOh() {
+			nestedItemType = keyvault.NestedItemTypeAny
+		}
+
+		key, err := keyvault.ParseNestedItemID(d.Get("key_vault_key_id").(string), keyvault.VersionTypeAny, nestedItemType)
 		if err != nil {
 			return err
 		}
 
-		keyVaultDetails, err := diskEncryptionSetRetrieveKeyVault(ctx, keyVaultsClient, subscriptionId, *keyVaultKey)
-		if err != nil {
-			return fmt.Errorf("validating Key Vault Key %q for Disk Encryption Set: %+v", keyVaultKey.ID(), err)
-		}
-
-		if keyVaultDetails != nil {
-			err = validateKeyVaultDetails(keyVaultDetails)
-			if err != nil {
-				return err
-			}
-
-			activeKey.SourceVault = &diskencryptionsets.SourceVault{
-				Id: pointer.To(keyVaultDetails.keyVaultId),
-			}
-		}
-
-		// NOTE: The API requires a versioned key to be sent however if rotationToLatestKeyVersion is enabled this will cause
-		// terraform to revert the rotated key to the previous version that is defined in the configuration file...
-		// Issue #22864
-		if rotationToLatestKeyVersionEnabled {
-			// Get the latest version of the key...
-			keyBundle, err := keyVaultKeyClient.GetKey(ctx, keyVaultKey.KeyVaultBaseUrl, keyVaultKey.Name, "")
-			if err != nil {
-				return err
-			}
-
-			if keyBundle.Key != nil {
-				activeKey.KeyURL = pointer.From(keyBundle.Key.Kid)
-			}
-		} else {
-			// Use the passed version of the key...
-			activeKey.KeyURL = keyVaultKey.ID()
-		}
-	} else if managedHsmKeyId, ok := d.GetOk("managed_hsm_key_id"); ok {
-		keyUrl, err := getManagedHsmKeyURL(ctx, managedkeyBundleClient, managedHsmKeyId.(string), rotationToLatestKeyVersionEnabled, env)
+		keyURL, err := getKeyURL(ctx, key, rotationToLatestKeyVersionEnabled, meta)
 		if err != nil {
 			return err
 		}
-		activeKey.KeyURL = keyUrl
+		activeKey.KeyURL = keyURL
 	}
-
-	encryptionType := diskencryptionsets.DiskEncryptionSetType(d.Get("encryption_type").(string))
-	t := d.Get("tags").(map[string]interface{})
 
 	expandedIdentity, err := expandDiskEncryptionSetIdentity(d.Get("identity").([]interface{}))
 	if err != nil {
@@ -213,18 +191,17 @@ func resourceDiskEncryptionSetCreate(d *pluginsdk.ResourceData, meta interface{}
 		Properties: &diskencryptionsets.EncryptionSetProperties{
 			ActiveKey:                         activeKey,
 			RotationToLatestKeyVersionEnabled: pointer.To(rotationToLatestKeyVersionEnabled),
-			EncryptionType:                    &encryptionType,
+			EncryptionType:                    pointer.ToEnum[diskencryptionsets.DiskEncryptionSetType](d.Get("encryption_type").(string)),
 		},
 		Identity: expandedIdentity,
-		Tags:     tags.Expand(t),
+		Tags:     tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
 
 	if v, ok := d.GetOk("federated_client_id"); ok {
 		params.Properties.FederatedClientId = pointer.To(v.(string))
 	}
 
-	err = client.CreateOrUpdateThenPoll(ctx, id, params)
-	if err != nil {
+	if err := client.CreateOrUpdateThenPoll(ctx, id, params); err != nil {
 		return fmt.Errorf("creating %s: %+v", id, err)
 	}
 
@@ -233,22 +210,8 @@ func resourceDiskEncryptionSetCreate(d *pluginsdk.ResourceData, meta interface{}
 	return resourceDiskEncryptionSetRead(d, meta)
 }
 
-func validateKeyAndRotationEnabled(rotationToLatestKeyVersionEnabled bool, hasVersion bool, keyVaultKeyId string) error {
-	if rotationToLatestKeyVersionEnabled {
-		if hasVersion {
-			return fmt.Errorf("'auto_key_rotation_enabled' field is set to 'true' expected a key vault key with a versionless ID but version information was found: %s", keyVaultKeyId)
-		}
-	} else {
-		if !hasVersion {
-			return fmt.Errorf("'auto_key_rotation_enabled' field is set to 'false' expected a key vault key with a versioned ID but no version information was found: %s", keyVaultKeyId)
-		}
-	}
-	return nil
-}
-
 func resourceDiskEncryptionSetRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Compute.DiskEncryptionSetsClient
-	env := meta.(*clients.Client).Account.Environment
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -264,111 +227,72 @@ func resourceDiskEncryptionSetRead(d *pluginsdk.ResourceData, meta interface{}) 
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("reading Disk Encryption Set %q (Resource Group %q): %+v", id.DiskEncryptionSetName, id.ResourceGroupName, err)
+		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
 	d.Set("name", id.DiskEncryptionSetName)
 	d.Set("resource_group_name", id.ResourceGroupName)
 
-	model := resp.Model
-	if model == nil {
-		return fmt.Errorf("reading Disk Encryption Set : %+v", err)
-	}
+	if model := resp.Model; model != nil {
+		d.Set("location", location.Normalize(model.Location))
 
-	if l := model.Location; l != "" {
-		d.Set("location", location.Normalize(l))
-	}
+		if props := model.Properties; props != nil {
+			rotationToLatestKeyVersionEnabled := pointer.From(props.RotationToLatestKeyVersionEnabled)
+			d.Set("auto_key_rotation_enabled", rotationToLatestKeyVersionEnabled)
 
-	if props := model.Properties; props != nil {
-		var keyVaultKey *keyVaultParse.NestedItemId
-
-		RotationToLatestKeyVersionEnabled := pointer.From(props.RotationToLatestKeyVersionEnabled)
-		d.Set("auto_key_rotation_enabled", RotationToLatestKeyVersionEnabled)
-
-		if props.ActiveKey != nil && props.ActiveKey.KeyURL != "" {
-			keyVaultURI := props.ActiveKey.KeyURL
-
-			isHSMURI, instanceName, domainSuffix, err := managedHsmHelpers.IsManagedHSMURI(env, keyVaultURI)
-			if err != nil {
-				return err
+			encryptionType := string(diskencryptionsets.DiskEncryptionSetTypeEncryptionAtRestWithCustomerKey)
+			if props.EncryptionType != nil {
+				encryptionType = string(*props.EncryptionType)
 			}
+			d.Set("encryption_type", encryptionType)
+			d.Set("federated_client_id", pointer.From(props.FederatedClientId))
 
-			switch {
-			case !isHSMURI:
-				{
-					keyVaultKey, err = keyVaultParse.ParseOptionallyVersionedNestedItemID(props.ActiveKey.KeyURL)
-					if err != nil {
-						return err
-					}
-
-					// This "should" never happen, but if keyVaultKey does not get assigned above it
-					// would cause a panic when referenced below, so check to make sure it was
-					// assigned or not...
-					if keyVaultKey == nil {
-						return fmt.Errorf("`KeyForDiskEncryptionSet.ActiveKey` was nil")
-					}
-					d.Set("key_vault_key_url", keyVaultKey.ID())
-
-					// NOTE: Since the auto rotation changes the version information when the key is rotated
-					// we need to persist the versionless key ID to the state file else terraform will always
-					// try to revert to the original version of the key once it has been rotated...
-					// Issue #22864
-					if RotationToLatestKeyVersionEnabled {
-						d.Set("key_vault_key_id", keyVaultKey.VersionlessID())
-					} else {
-						d.Set("key_vault_key_id", keyVaultKey.ID())
-					}
+			if props.ActiveKey != nil && props.ActiveKey.KeyURL != "" {
+				nestedItemType := keyvault.NestedItemTypeKey
+				if !features.FivePointOh() {
+					nestedItemType = keyvault.NestedItemTypeAny
 				}
 
-			case isHSMURI:
-				{
-					keyId, err := managedHsmParse.ManagedHSMDataPlaneVersionedKeyID(keyVaultURI, &domainSuffix)
-					if err != nil {
-						return err
-					}
+				key, err := keyvault.ParseNestedItemID(props.ActiveKey.KeyURL, keyvault.VersionTypeAny, nestedItemType)
+				if err != nil {
+					return err
+				}
+				d.Set("key_vault_key_url", key.ID())
 
-					// See comment above and issue #22864
-					if RotationToLatestKeyVersionEnabled {
-						versionlessKeyId := managedHsmParse.NewManagedHSMDataPlaneVersionlessKeyID(instanceName, domainSuffix, keyId.KeyName)
-						d.Set("managed_hsm_key_id", versionlessKeyId.ID())
+				if rotationToLatestKeyVersionEnabled {
+					key.Version = ""
+				}
+
+				d.Set("key_vault_key_id", key.ID())
+				if !features.FivePointOh() {
+					if key.IsManagedHSM() {
+						d.Set("managed_hsm_key_id", key.ID())
 					} else {
-						d.Set("managed_hsm_key_id", keyId.ID())
+						d.Set("managed_hsm_key_id", "")
 					}
 				}
 			}
 		}
 
-		encryptionType := string(diskencryptionsets.DiskEncryptionSetTypeEncryptionAtRestWithCustomerKey)
-		if props.EncryptionType != nil {
-			encryptionType = string(*props.EncryptionType)
+		flattenedIdentity, err := identity.FlattenSystemAndUserAssignedMap(model.Identity)
+		if err != nil {
+			return fmt.Errorf("flattening `identity`: %+v", err)
 		}
-		d.Set("encryption_type", encryptionType)
 
-		federatedClientId := ""
-		if props.FederatedClientId != nil {
-			federatedClientId = *props.FederatedClientId
+		if err := d.Set("identity", flattenedIdentity); err != nil {
+			return fmt.Errorf("setting `identity`: %+v", err)
 		}
-		d.Set("federated_client_id", federatedClientId)
+
+		if err := tags.FlattenAndSet(d, model.Tags); err != nil {
+			return err
+		}
 	}
 
-	flattenedIdentity, err := identity.FlattenSystemAndUserAssignedMap(model.Identity)
-	if err != nil {
-		return fmt.Errorf("flattening `identity`: %+v", err)
-	}
-
-	if err := d.Set("identity", flattenedIdentity); err != nil {
-		return fmt.Errorf("setting `identity`: %+v", err)
-	}
-
-	return tags.FlattenAndSet(d, model.Tags)
+	return nil
 }
 
 func resourceDiskEncryptionSetUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Compute.DiskEncryptionSetsClient
-	keyVaultsClient := meta.(*clients.Client).KeyVault
-	keyVaultKeyClient := meta.(*clients.Client).KeyVault.ManagementClient
-	managedkeyBundleClient := meta.(*clients.Client).ManagedHSMs.DataPlaneKeysClient
-	env := meta.(*clients.Client).Account.Environment
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -384,7 +308,6 @@ func resourceDiskEncryptionSetUpdate(d *pluginsdk.ResourceData, meta interface{}
 		if err != nil {
 			return fmt.Errorf("expanding `identity`: %+v", err)
 		}
-
 		update.Identity = expandedIdentity
 	}
 
@@ -394,62 +317,47 @@ func resourceDiskEncryptionSetUpdate(d *pluginsdk.ResourceData, meta interface{}
 
 	rotationToLatestKeyVersionEnabled := d.Get("auto_key_rotation_enabled").(bool)
 
-	if keyVaultKeyId, ok := d.GetOk("key_vault_key_id"); ok && d.HasChange("key_vault_key_id") {
-		keyVaultKey, err := keyVaultParse.ParseOptionallyVersionedNestedItemID(keyVaultKeyId.(string))
-		if err != nil {
-			return err
-		}
-
-		err = validateKeyAndRotationEnabled(rotationToLatestKeyVersionEnabled, keyVaultKey.Version != "", keyVaultKey.ID())
-		if err != nil {
-			return err
-		}
-
+	if !features.FivePointOh() && d.HasChange("managed_hsm_key_id") {
 		if update.Properties == nil {
 			update.Properties = &diskencryptionsets.DiskEncryptionSetUpdateProperties{
 				ActiveKey: &diskencryptionsets.KeyForDiskEncryptionSet{},
 			}
 		}
 
-		// NOTE: The API requires a versioned key to be sent however if rotationToLatestKeyVersion is enabled this will cause
-		// terraform to revert the rotated key to the previous version that is defined in the configuration file...
-		// Issue #22864
-		if rotationToLatestKeyVersionEnabled {
-			// Get the latest version of the key...
-			keyBundle, err := keyVaultKeyClient.GetKey(ctx, keyVaultKey.KeyVaultBaseUrl, keyVaultKey.Name, "")
-			if err != nil {
-				return err
-			}
-
-			if keyBundle.Key != nil {
-				update.Properties.ActiveKey.KeyURL = pointer.From(keyBundle.Key.Kid)
-			}
-		} else {
-			// Use the passed version of the key...
-			update.Properties.ActiveKey.KeyURL = keyVaultKey.ID()
-		}
-
-		keyVaultDetails, err := diskEncryptionSetRetrieveKeyVault(ctx, keyVaultsClient, id.SubscriptionId, *keyVaultKey)
-		if err != nil {
-			return fmt.Errorf("validating Key Vault Key %q for Disk Encryption Set: %+v", keyVaultKey.ID(), err)
-		}
-
-		if keyVaultDetails != nil {
-			err = validateKeyVaultDetails(keyVaultDetails)
-			if err != nil {
-				return err
-			}
-
-			update.Properties.ActiveKey.SourceVault = &diskencryptionsets.SourceVault{
-				Id: pointer.To(keyVaultDetails.keyVaultId),
-			}
-		}
-	} else if managedHsmKeyId, ok := d.GetOk("managed_hsm_key_id"); ok && d.HasChange("managed_hsm_key_id") {
-		keyUrl, err := getManagedHsmKeyURL(ctx, managedkeyBundleClient, managedHsmKeyId.(string), rotationToLatestKeyVersionEnabled, env)
+		key, err := keyvault.ParseNestedItemID(d.Get("managed_hsm_key_id").(string), keyvault.VersionTypeAny, keyvault.NestedItemTypeAny)
 		if err != nil {
 			return err
 		}
-		update.Properties.ActiveKey.KeyURL = keyUrl
+
+		keyURL, err := getKeyURL(ctx, key, rotationToLatestKeyVersionEnabled, meta)
+		if err != nil {
+			return err
+		}
+		update.Properties.ActiveKey.KeyURL = keyURL
+	}
+
+	if d.HasChange("key_vault_key_id") {
+		if update.Properties == nil {
+			update.Properties = &diskencryptionsets.DiskEncryptionSetUpdateProperties{
+				ActiveKey: &diskencryptionsets.KeyForDiskEncryptionSet{},
+			}
+		}
+
+		nestedItemType := keyvault.NestedItemTypeKey
+		if !features.FivePointOh() {
+			nestedItemType = keyvault.NestedItemTypeAny
+		}
+
+		key, err := keyvault.ParseNestedItemID(d.Get("key_vault_key_id").(string), keyvault.VersionTypeAny, nestedItemType)
+		if err != nil {
+			return err
+		}
+
+		keyURL, err := getKeyURL(ctx, key, rotationToLatestKeyVersionEnabled, meta)
+		if err != nil {
+			return err
+		}
+		update.Properties.ActiveKey.KeyURL = keyURL
 	}
 
 	if d.HasChange("auto_key_rotation_enabled") {
@@ -465,61 +373,17 @@ func resourceDiskEncryptionSetUpdate(d *pluginsdk.ResourceData, meta interface{}
 			update.Properties = &diskencryptionsets.DiskEncryptionSetUpdateProperties{}
 		}
 
-		v, ok := d.GetOk("federated_client_id")
-		if ok {
+		update.Properties.FederatedClientId = pointer.To("None")
+		if v, ok := d.GetOk("federated_client_id"); ok {
 			update.Properties.FederatedClientId = pointer.To(v.(string))
-		} else {
-			update.Properties.FederatedClientId = pointer.To("None") // this is the only way to remove the federated client id
 		}
 	}
 
-	err = client.UpdateThenPoll(ctx, *id, update)
-	if err != nil {
-		return fmt.Errorf("updating Disk Encryption Set %q (Resource Group %q): %+v", id.DiskEncryptionSetName, id.ResourceGroupName, err)
+	if err := client.UpdateThenPoll(ctx, *id, update); err != nil {
+		return fmt.Errorf("updating %s: %+v", id, err)
 	}
 
 	return resourceDiskEncryptionSetRead(d, meta)
-}
-
-func getManagedHsmKeyURL(ctx context.Context, managedkeyBundleClient *keyvault.BaseClient, managedHsmKeyId string, rotationToLatestKeyVersionEnabled bool, env environments.Environment) (string, error) {
-	domainSuffix, ok := env.ManagedHSM.DomainSuffix()
-	if !ok {
-		return "", fmt.Errorf("managed HSM is not supported in this Environment")
-	}
-	managedHsmVersionedKey, err := managedHsmParse.ManagedHSMDataPlaneVersionedKeyID(managedHsmKeyId, domainSuffix)
-	if err == nil {
-		err = validateKeyAndRotationEnabled(rotationToLatestKeyVersionEnabled, true, managedHsmVersionedKey.ID())
-		if err != nil {
-			return "", err
-		}
-		return managedHsmVersionedKey.ID(), nil
-	} else {
-		managedHsmVersionlessKey, err := managedHsmParse.ManagedHSMDataPlaneVersionlessKeyID(managedHsmKeyId, domainSuffix)
-		if err != nil {
-			return "", err
-		}
-		err = validateKeyAndRotationEnabled(rotationToLatestKeyVersionEnabled, false, managedHsmVersionlessKey.ID())
-		if err != nil {
-			return "", err
-		}
-		keyBundle, err := managedkeyBundleClient.GetKey(ctx, managedHsmVersionlessKey.BaseUri(), managedHsmVersionlessKey.KeyName, "")
-		if err != nil {
-			return "", err
-		}
-
-		if keyBundle.Key.Kid != nil {
-			return pointer.From(keyBundle.Key.Kid), nil
-		}
-		return "", fmt.Errorf("retrieving key version for key %s: Key Vault did not return a version", managedHsmKeyId)
-	}
-}
-
-func validateKeyVaultDetails(keyVaultDetails *diskEncryptionSetKeyVault) error {
-	if !keyVaultDetails.softDeleteEnabled {
-		return fmt.Errorf("validating Key Vault %q (Resource Group %q) for Disk Encryption Set: Soft Delete must be enabled", keyVaultDetails.keyVaultName, keyVaultDetails.resourceGroupName)
-	}
-
-	return nil
 }
 
 func resourceDiskEncryptionSetDelete(d *pluginsdk.ResourceData, meta interface{}) error {
@@ -532,12 +396,55 @@ func resourceDiskEncryptionSetDelete(d *pluginsdk.ResourceData, meta interface{}
 		return err
 	}
 
-	err = client.DeleteThenPoll(ctx, *id)
-	if err != nil {
-		return fmt.Errorf("deleting Disk Encryption Set %q (Resource Group %q): %+v", id.DiskEncryptionSetName, id.ResourceGroupName, err)
+	if err := client.DeleteThenPoll(ctx, *id); err != nil {
+		return fmt.Errorf("deleting %s: %+v", id, err)
 	}
 
 	return nil
+}
+
+func getKeyURL(ctx context.Context, id *keyvault.NestedItemID, rotationToLatestKeyVersionEnabled bool, meta any) (string, error) {
+	keyVaultClient := meta.(*clients.Client).KeyVault.ManagementClient
+	managedHSMClient := meta.(*clients.Client).ManagedHSMs.DataPlaneKeysClient
+
+	keyURL := ""
+
+	if rotationToLatestKeyVersionEnabled {
+		if id.Version != "" {
+			return keyURL, fmt.Errorf("`auto_key_rotation_enabled` field is set to `true` expected a key vault key with a versionless ID but version information was found: %s", id)
+		}
+
+		if id.IsManagedHSM() {
+			keyBundle, err := managedHSMClient.GetKey(ctx, id.KeyVaultBaseURL, id.Name, "")
+			if err != nil {
+				return keyURL, err
+			}
+
+			if keyBundle.Key != nil {
+				keyURL = pointer.From(keyBundle.Key.Kid)
+			}
+		} else {
+			keyBundle, err := keyVaultClient.GetKey(ctx, id.KeyVaultBaseURL, id.Name, "")
+			if err != nil {
+				return keyURL, err
+			}
+
+			if keyBundle.Key != nil {
+				keyURL = pointer.From(keyBundle.Key.Kid)
+			}
+		}
+	} else {
+		if id.Version == "" {
+			return keyURL, fmt.Errorf("`auto_key_rotation_enabled` field is set to `false` expected a key vault key with a versioned ID but no version information was found: %s", id)
+		}
+		keyURL = id.ID()
+	}
+
+	if keyURL == "" {
+		return keyURL, errors.New("internal-error: received an unexpected empty key URL")
+	}
+
+	return keyURL, nil
 }
 
 func expandDiskEncryptionSetIdentity(input []interface{}) (*identity.SystemAndUserAssignedMap, error) {
@@ -547,53 +454,4 @@ func expandDiskEncryptionSetIdentity(input []interface{}) (*identity.SystemAndUs
 	}
 
 	return expanded, nil
-}
-
-type diskEncryptionSetKeyVault struct {
-	keyVaultId             string
-	resourceGroupName      string
-	keyVaultName           string
-	purgeProtectionEnabled bool
-	softDeleteEnabled      bool
-}
-
-func diskEncryptionSetRetrieveKeyVault(ctx context.Context, keyVaultsClient *client.Client, subscriptionId string, keyVaultKeyId keyVaultParse.NestedItemId) (*diskEncryptionSetKeyVault, error) {
-	subscriptionResourceId := commonids.NewSubscriptionID(subscriptionId)
-	keyVaultID, err := keyVaultsClient.KeyVaultIDFromBaseUrl(ctx, subscriptionResourceId, keyVaultKeyId.KeyVaultBaseUrl)
-	if err != nil {
-		return nil, fmt.Errorf("retrieving the Resource ID the Key Vault at URL %q: %s", keyVaultKeyId.KeyVaultBaseUrl, err)
-	}
-	if keyVaultID == nil {
-		return nil, nil
-	}
-
-	parsedKeyVaultID, err := commonids.ParseKeyVaultID(*keyVaultID)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := keyVaultsClient.VaultsClient.Get(ctx, *parsedKeyVaultID)
-	if err != nil {
-		return nil, fmt.Errorf("retrieving %s: %+v", *parsedKeyVaultID, err)
-	}
-
-	purgeProtectionEnabled := false
-	softDeleteEnabled := false
-	if model := resp.Model; model != nil {
-		if model.Properties.EnableSoftDelete != nil {
-			softDeleteEnabled = *model.Properties.EnableSoftDelete
-		}
-
-		if model.Properties.EnablePurgeProtection != nil {
-			purgeProtectionEnabled = *model.Properties.EnablePurgeProtection
-		}
-	}
-
-	return &diskEncryptionSetKeyVault{
-		keyVaultId:             *keyVaultID,
-		resourceGroupName:      parsedKeyVaultID.ResourceGroupName,
-		keyVaultName:           parsedKeyVaultID.VaultName,
-		purgeProtectionEnabled: purgeProtectionEnabled,
-		softDeleteEnabled:      softDeleteEnabled,
-	}, nil
 }

--- a/internal/services/compute/disk_encryption_set_resource_test.go
+++ b/internal/services/compute/disk_encryption_set_resource_test.go
@@ -133,7 +133,7 @@ func TestAccDiskEncryptionSet_keyRotateInvalid(t *testing.T) {
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config:      r.keyRotateInvalid(data),
-			ExpectError: regexp.MustCompile("'auto_key_rotation_enabled' field is set to 'true' expected a key vault key with a versionless ID but version information was found"),
+			ExpectError: regexp.MustCompile("`auto_key_rotation_enabled` field is set to `true` expected a key vault key with a versionless ID but version information was found"),
 		},
 	})
 }
@@ -146,7 +146,7 @@ func TestAccDiskEncryptionSet_keyRotateFalseInvalid(t *testing.T) {
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config:      r.keyRotateFalseInvalid(data),
-			ExpectError: regexp.MustCompile("'auto_key_rotation_enabled' field is set to 'false' expected a key vault key with a versioned ID but no version information was found"),
+			ExpectError: regexp.MustCompile("`auto_key_rotation_enabled` field is set to `false` expected a key vault key with a versioned ID but no version information was found"),
 		},
 	})
 }

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -258,11 +258,11 @@ Please follow the format in the example below for listing breaking changes in re
 
 ### `azurerm_api_management`
 
-* The deprecated `hostname_configuration.developer_portal.key_vault_id` property has been removed in favour of the ``hostname_configuration.developer_portal.key_vault_certificate_id`` property. 
-* The deprecated `hostname_configuration.management.key_vault_id` property has been removed in favour of the ``hostname_configuration.management.key_vault_certificate_id`` property. 
-* The deprecated `hostname_configuration.portal.key_vault_id` property has been removed in favour of the ``hostname_configuration.portal.key_vault_certificate_id`` property. 
-* The deprecated `hostname_configuration.proxy.key_vault_id` property has been removed in favour of the ``hostname_configuration.proxy.key_vault_certificate_id`` property. 
-* The deprecated `hostname_configuration.scm.key_vault_id` property has been removed in favour of the ``hostname_configuration.scm.key_vault_certificate_id`` property.
+* The deprecated `hostname_configuration.developer_portal.key_vault_id` property has been removed in favour of the `hostname_configuration.developer_portal.key_vault_certificate_id` property. 
+* The deprecated `hostname_configuration.management.key_vault_id` property has been removed in favour of the `hostname_configuration.management.key_vault_certificate_id` property. 
+* The deprecated `hostname_configuration.portal.key_vault_id` property has been removed in favour of the `hostname_configuration.portal.key_vault_certificate_id` property. 
+* The deprecated `hostname_configuration.proxy.key_vault_id` property has been removed in favour of the `hostname_configuration.proxy.key_vault_certificate_id` property. 
+* The deprecated `hostname_configuration.scm.key_vault_id` property has been removed in favour of the `hostname_configuration.scm.key_vault_certificate_id` property.
 * The deprecated `protocols.enable_http2` property has been removed in favour of the `protocols.http2_enabled` property.
 * The deprecated `security.enable_backend_ssl30` property has been removed in favour of the `security.backend_ssl30_enabled` property.
 * The deprecated `security.enable_backend_tls10` property has been removed in favour of the `security.backend_tls10_enabled` property.
@@ -363,6 +363,10 @@ Please follow the format in the example below for listing breaking changes in re
 ### `azurerm_data_factory_integration_runtime_self_hosted`
 
 * Validation for `rbac_authorization.resource_id` has been changed to validate for an integration runtime resource ID (case-sensitive) rather than validating for a non-empty string.
+
+### `azurerm_disk_encryption_set`
+
+* The deprecated `managed_hsm_key_id` property has been removed in favour of the `key_vault_key_id` property.
 
 ### `azurerm_eventgrid_event_subscription`
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

- Migrates to updated nested item IDs
- deprecates `managed_hsm_key_id` in favour of `key_vault_key_id`

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
