### PR TITLE
`azurerm_mysql_flexible_server` - migrate nested item funcs and deprecate `managed_hsm_key_id`

### DIFF
--- a/internal/services/cognitive/ai_services_resource.go
+++ b/internal/services/cognitive/ai_services_resource.go
@@ -15,19 +15,15 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/keyvault"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2025-06-01/cognitiveservicesaccounts"
-	"github.com/hashicorp/go-azure-sdk/sdk/environments"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	commonValidate "github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	cognitiveValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/cognitive/validate"
-	keyVaultParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/parse"
-	keyVaultValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/validate"
-	managedHsmHelpers "github.com/hashicorp/terraform-provider-azurerm/internal/services/managedhsm/helpers"
-	managedHsmParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/managedhsm/parse"
-	managedHsmValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/managedhsm/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/set"
@@ -77,7 +73,7 @@ type NetworkACLs struct {
 type CustomerManagedKey struct {
 	IdentityClientID string `tfschema:"identity_client_id"`
 	KeyVaultKeyID    string `tfschema:"key_vault_key_id"`
-	ManagedHsmKeyID  string `tfschema:"managed_hsm_key_id"`
+	ManagedHsmKeyID  string `tfschema:"managed_hsm_key_id,removedInNextMajorVersion"`
 }
 
 type AIServicesModel struct {
@@ -100,7 +96,7 @@ type AIServicesModel struct {
 }
 
 func (AIServices) Arguments() map[string]*pluginsdk.Schema {
-	return map[string]*pluginsdk.Schema{
+	args := map[string]*pluginsdk.Schema{
 		"name": {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
@@ -135,16 +131,8 @@ func (AIServices) Arguments() map[string]*pluginsdk.Schema {
 				Schema: map[string]*pluginsdk.Schema{
 					"key_vault_key_id": {
 						Type:         pluginsdk.TypeString,
-						Optional:     true,
-						ValidateFunc: keyVaultValidate.NestedItemIdWithOptionalVersion,
-						ExactlyOneOf: []string{"customer_managed_key.0.managed_hsm_key_id", "customer_managed_key.0.key_vault_key_id"},
-					},
-
-					"managed_hsm_key_id": {
-						Type:         pluginsdk.TypeString,
-						Optional:     true,
-						ValidateFunc: validation.Any(managedHsmValidate.ManagedHSMDataPlaneVersionedKeyID, managedHsmValidate.ManagedHSMDataPlaneVersionlessKeyID),
-						ExactlyOneOf: []string{"customer_managed_key.0.managed_hsm_key_id", "customer_managed_key.0.key_vault_key_id"},
+						Required:     true,
+						ValidateFunc: keyvault.ValidateNestedItemID(keyvault.VersionTypeVersioned, keyvault.NestedItemTypeKey),
 					},
 
 					"identity_client_id": {
@@ -270,6 +258,26 @@ func (AIServices) Arguments() map[string]*pluginsdk.Schema {
 
 		"tags": commonschema.Tags(),
 	}
+
+	if !features.FivePointOh() {
+		cmkSchema := args["customer_managed_key"].Elem.(*pluginsdk.Resource).Schema
+		cmkSchema["key_vault_key_id"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: keyvault.ValidateNestedItemID(keyvault.VersionTypeVersioned, keyvault.NestedItemTypeKey),
+			ExactlyOneOf: []string{"customer_managed_key.0.managed_hsm_key_id", "customer_managed_key.0.key_vault_key_id"},
+		}
+
+		cmkSchema["managed_hsm_key_id"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: keyvault.ValidateNestedItemID(keyvault.VersionTypeVersioned, keyvault.NestedItemTypeKey),
+			ExactlyOneOf: []string{"customer_managed_key.0.managed_hsm_key_id", "customer_managed_key.0.key_vault_key_id"},
+			Deprecated:   "`managed_hsm_key_id` has been deprecated in favour of `key_vault_key_id` and will be removed in v5.0 of the AzureRM provider",
+		}
+	}
+
+	return args
 }
 
 func (AIServices) Attributes() map[string]*pluginsdk.Schema {
@@ -369,9 +377,11 @@ func (AIServices) Create() sdk.ResourceFunc {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
 
+			metadata.SetID(id)
+
 			// creating with KV HSM takes more time than expected, at least hours in most cases and eventually terminated by service
 			if len(model.CustomerManagedKey) > 0 {
-				customerManagedKey, err := expandCustomerManagedKey(model.CustomerManagedKey)
+				customerManagedKey, err := expandCustomerManagedKey(model.CustomerManagedKey, metadata)
 				if err != nil {
 					return fmt.Errorf("expanding `customer_managed_key`: %+v", err)
 				}
@@ -384,8 +394,6 @@ func (AIServices) Create() sdk.ResourceFunc {
 				}
 			}
 
-			metadata.SetID(id)
-
 			return nil
 		},
 	}
@@ -396,7 +404,6 @@ func (AIServices) Read() sdk.ResourceFunc {
 		Timeout: 5 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
 			client := metadata.Client.Cognitive.AccountsClient
-			env := metadata.Client.Account.Environment
 
 			state := AIServicesModel{}
 			id, err := cognitiveservicesaccounts.ParseAccountID(metadata.ResourceData.Id())
@@ -454,7 +461,7 @@ func (AIServices) Read() sdk.ResourceFunc {
 					}
 					state.LocalAuthorizationEnabled = localAuthEnabled
 
-					customerManagedKey, err := flattenCustomerManagedKey(props.Encryption, env)
+					customerManagedKey, err := flattenCustomerManagedKey(props.Encryption)
 					if err != nil {
 						return fmt.Errorf("flattening `customer_managed_key`: %+v", err)
 					}
@@ -549,7 +556,7 @@ func (AIServices) Update() sdk.ResourceFunc {
 			}
 
 			if metadata.ResourceData.HasChange("customer_managed_key") {
-				customerManagedKey, err := expandCustomerManagedKey(model.CustomerManagedKey)
+				customerManagedKey, err := expandCustomerManagedKey(model.CustomerManagedKey, metadata)
 				if err != nil {
 					return fmt.Errorf("expanding `customer_managed_key`: %+v", err)
 				}
@@ -617,7 +624,7 @@ func (AIServices) IDValidationFunc() pluginsdk.SchemaValidateFunc {
 	return cognitiveservicesaccounts.ValidateAccountID
 }
 
-func expandCustomerManagedKey(input []CustomerManagedKey) (*cognitiveservicesaccounts.Encryption, error) {
+func expandCustomerManagedKey(input []CustomerManagedKey, rmd sdk.ResourceMetaData) (*cognitiveservicesaccounts.Encryption, error) {
 	if len(input) == 0 {
 		return &cognitiveservicesaccounts.Encryption{
 			KeySource: pointer.To(cognitiveservicesaccounts.KeySourceMicrosoftPointCognitiveServices),
@@ -631,87 +638,63 @@ func expandCustomerManagedKey(input []CustomerManagedKey) (*cognitiveservicesacc
 		identityClientId = value
 	}
 
-	encryption := &cognitiveservicesaccounts.Encryption{
+	setInConfig := func(rmd sdk.ResourceMetaData) bool {
+		raw, err := rmd.GetRawConfigAt("customer_managed_key.0.managed_hsm_key_id")
+		return err == nil && !raw.IsNull()
+	}
+
+	key := keyvault.NestedItemID{}
+	if !features.FivePointOh() && setInConfig(rmd) {
+		hsmKeyId, err := keyvault.ParseNestedItemID(v.ManagedHsmKeyID, keyvault.VersionTypeVersioned, keyvault.NestedItemTypeKey)
+		if err != nil {
+			return nil, err
+		}
+		key = *hsmKeyId
+	} else {
+		keyId, err := keyvault.ParseNestedItemID(v.KeyVaultKeyID, keyvault.VersionTypeVersioned, keyvault.NestedItemTypeKey)
+		if err != nil {
+			return nil, err
+		}
+		key = *keyId
+	}
+
+	return &cognitiveservicesaccounts.Encryption{
 		KeySource: pointer.To(cognitiveservicesaccounts.KeySourceMicrosoftPointKeyVault),
 		KeyVaultProperties: &cognitiveservicesaccounts.KeyVaultProperties{
 			IdentityClientId: pointer.To(identityClientId),
+			KeyName:          pointer.To(key.Name),
+			KeyVaultUri:      pointer.To(key.KeyVaultBaseURL),
+			KeyVersion:       pointer.To(key.Version),
 		},
-	}
-
-	if v.KeyVaultKeyID != "" {
-		keyId, err := keyVaultParse.ParseOptionallyVersionedNestedItemID(v.KeyVaultKeyID)
-		if err != nil {
-			return nil, err
-		}
-		encryption.KeyVaultProperties.KeyName = pointer.To(keyId.Name)
-		encryption.KeyVaultProperties.KeyVersion = pointer.To(keyId.Version)
-		encryption.KeyVaultProperties.KeyVaultUri = pointer.To(keyId.KeyVaultBaseUrl)
-	} else {
-		hsmKyId, err := managedHsmParse.ManagedHSMDataPlaneVersionedKeyID(v.ManagedHsmKeyID, nil)
-		if err != nil {
-			return nil, err
-		}
-
-		encryption.KeyVaultProperties.KeyName = pointer.To(hsmKyId.KeyName)
-		encryption.KeyVaultProperties.KeyVersion = pointer.To(hsmKyId.KeyVersion)
-		encryption.KeyVaultProperties.KeyVaultUri = pointer.To(hsmKyId.BaseUri())
-	}
-	return encryption, nil
+	}, nil
 }
 
-func flattenCustomerManagedKey(input *cognitiveservicesaccounts.Encryption, env environments.Environment) ([]CustomerManagedKey, error) {
-	if input == nil || *input.KeySource == cognitiveservicesaccounts.KeySourceMicrosoftPointCognitiveServices {
+func flattenCustomerManagedKey(input *cognitiveservicesaccounts.Encryption) ([]CustomerManagedKey, error) {
+	result := make([]CustomerManagedKey, 0)
+
+	if input == nil || pointer.From(input.KeySource) == cognitiveservicesaccounts.KeySourceMicrosoftPointCognitiveServices {
 		return []CustomerManagedKey{}, nil
 	}
 
-	keyName := ""
-	keyVaultURI := ""
-	keyVersion := ""
-	customerManagerKey := CustomerManagedKey{}
-
 	if props := input.KeyVaultProperties; props != nil {
-		if props.KeyName != nil {
-			keyName = *props.KeyName
-		}
-		if props.KeyVaultUri != nil {
-			keyVaultURI = *props.KeyVaultUri
-		}
-		if props.KeyVersion != nil {
-			keyVersion = *props.KeyVersion
-		}
-
-		isHsmURI, instanceName, domainSuffix, err := managedHsmHelpers.IsManagedHSMURI(env, keyVaultURI)
+		keyId, err := keyvault.NewNestedItemID(pointer.From(props.KeyVaultUri), keyvault.NestedItemTypeKey, pointer.From(props.KeyName), pointer.From(props.KeyVersion))
 		if err != nil {
 			return nil, err
 		}
 
-		if props.IdentityClientId != nil {
-			customerManagerKey.IdentityClientID = *props.IdentityClientId
+		cmk := CustomerManagedKey{
+			IdentityClientID: pointer.From(props.IdentityClientId),
+			KeyVaultKeyID:    keyId.ID(),
 		}
 
-		switch {
-		case isHsmURI && keyVersion == "":
-			{
-				keyVaultKeyId := managedHsmParse.NewManagedHSMDataPlaneVersionlessKeyID(instanceName, domainSuffix, keyName)
-				customerManagerKey.ManagedHsmKeyID = keyVaultKeyId.ID()
-			}
-		case isHsmURI && keyVersion != "":
-			{
-				keyVaultKeyId := managedHsmParse.NewManagedHSMDataPlaneVersionedKeyID(instanceName, domainSuffix, keyName, keyVersion)
-				customerManagerKey.ManagedHsmKeyID = keyVaultKeyId.ID()
-			}
-		case !isHsmURI:
-			{
-				keyVaultKeyId, err := keyVaultParse.NewNestedItemID(keyVaultURI, keyVaultParse.NestedItemTypeKey, keyName, keyVersion)
-				if err != nil {
-					return nil, fmt.Errorf("parsing `key_vault_key_id`: %+v", err)
-				}
-				customerManagerKey.KeyVaultKeyID = keyVaultKeyId.ID()
-			}
+		if !features.FivePointOh() && keyId.IsManagedHSM() {
+			cmk.ManagedHsmKeyID = keyId.ID()
 		}
+
+		result = append(result, cmk)
 	}
 
-	return []CustomerManagedKey{customerManagerKey}, nil
+	return result, nil
 }
 
 func expandNetworkACLs(input []NetworkACLs) (*cognitiveservicesaccounts.NetworkRuleSet, []string) {

--- a/internal/services/cognitive/ai_services_resource_test.go
+++ b/internal/services/cognitive/ai_services_resource_test.go
@@ -7,13 +7,17 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
 	"testing"
+
+	"github.com/hashicorp/go-uuid"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2025-06-01/cognitiveservicesaccounts"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
@@ -176,6 +180,14 @@ func TestAccCognitiveAIServices_customerManagedKey_update(t *testing.T) {
 			Config: r.customerManagedKeyUpdate(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("customer_managed_key.0.key_vault_key_id").MatchesRegex(regexp.MustCompile(fmt.Sprintf("acctestkvkey-2-%s", data.RandomString))),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.customerManagedKeyRemove(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
@@ -196,16 +208,22 @@ func TestAccCognitiveAIServices_KVHsmManagedKey(t *testing.T) {
 		t.Skip("Skipping as ARM_TEST_HSM_KEY is not specified")
 		return
 	}
+
 	data := acceptance.BuildTestData(t, "azurerm_ai_services", "test")
 	r := AIServices{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.kvHsmManagedKey(data),
+			Config: r.customerManagedKeyHSM(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("customer_managed_key.0.managed_hsm_key_id").Exists(),
-				check.That(data.ResourceName).Key("customer_managed_key.0.identity_client_id").IsUUID(),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.customerManagedKeyHSMUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
@@ -226,39 +244,33 @@ func (AIServices) Exists(ctx context.Context, clients *clients.Client, state *pl
 	return pointer.To(resp.Model != nil), nil
 }
 
-func (AIServices) basic(data acceptance.TestData) string {
+func (r AIServices) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-cognitive-%d"
-  location = "%s"
-}
+%[1]s
 
 resource "azurerm_ai_services" "test" {
-  name                = "acctestcogacc-%d"
+  name                = "acctestcogacc-%[2]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   sku_name            = "S0"
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }
 
-func (AIServices) identitySystemAssigned(data acceptance.TestData) string {
+func (r AIServices) identitySystemAssigned(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-cognitive-%d"
-  location = "%s"
-}
+%[1]s
 
 resource "azurerm_ai_services" "test" {
-  name                = "acctestcogacc-%d"
+  name                = "acctestcogacc-%[2]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   sku_name            = "S0"
@@ -266,28 +278,25 @@ resource "azurerm_ai_services" "test" {
     type = "SystemAssigned"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }
 
-func (AIServices) identityUserAssigned(data acceptance.TestData) string {
+func (r AIServices) identityUserAssigned(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-cognitive-%d"
-  location = "%s"
-}
+%[1]s
 
 resource "azurerm_user_assigned_identity" "test" {
-  name                = "acctestUAI-%d"
+  name                = "acctestUAI-%[2]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_ai_services" "test" {
-  name                = "acctestcogacc-%d"
+  name                = "acctestcogacc-%[2]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   sku_name            = "S0"
@@ -298,28 +307,25 @@ resource "azurerm_ai_services" "test" {
     ]
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }
 
-func (AIServices) identitySystemAssignedUserAssigned(data acceptance.TestData) string {
+func (r AIServices) identitySystemAssignedUserAssigned(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-cognitive-%d"
-  location = "%s"
-}
+%[1]s
 
 resource "azurerm_user_assigned_identity" "test" {
-  name                = "acctestUAI-%d"
+  name                = "acctestUAI-%[2]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_ai_services" "test" {
-  name                = "acctestcogacc-%d"
+  name                = "acctestcogacc-%[2]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   sku_name            = "S0"
@@ -330,13 +336,12 @@ resource "azurerm_ai_services" "test" {
     ]
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }
 
-func (AIServices) requiresImport(data acceptance.TestData) string {
-	template := AIServices{}.basic(data)
+func (r AIServices) requiresImport(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "azurerm_ai_services" "import" {
   name                = azurerm_ai_services.test.name
@@ -344,27 +349,16 @@ resource "azurerm_ai_services" "import" {
   resource_group_name = azurerm_ai_services.test.resource_group_name
   sku_name            = "S0"
 }
-`, template)
+`, r.basic(data))
 }
 
-func (AIServices) complete(data acceptance.TestData) string {
+func (r AIServices) complete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-data "azurerm_client_config" "current" {}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-cognitive-%[1]d"
-  location = "%[2]s"
-}
-
-resource "azurerm_user_assigned_identity" "test" {
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  name                = "%[3]s"
-}
+%[1]s
 
 resource "azurerm_key_vault" "test" {
   name                       = "acctestkv%[3]s"
@@ -407,14 +401,14 @@ resource "azurerm_key_vault_key" "test" {
 }
 
 resource "azurerm_virtual_network" "test" {
-  name                = "acctestvirtnet%[1]d"
+  name                = "acctestvirtnet%[2]d"
   address_space       = ["10.0.0.0/16"]
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_subnet" "test_a" {
-  name                 = "acctestsubneta%[1]d"
+  name                 = "acctestsubneta%[2]d"
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.2.0/24"]
@@ -422,7 +416,7 @@ resource "azurerm_subnet" "test_a" {
 }
 
 resource "azurerm_subnet" "test_b" {
-  name                 = "acctestsubnetb%[1]d"
+  name                 = "acctestsubnetb%[2]d"
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.4.0/24"]
@@ -430,7 +424,7 @@ resource "azurerm_subnet" "test_b" {
 }
 
 resource "azurerm_ai_services" "test" {
-  name                               = "acctestcogacc-%[1]d"
+  name                               = "acctestcogacc-%[2]d"
   location                           = azurerm_resource_group.test.location
   resource_group_name                = azurerm_resource_group.test.name
   sku_name                           = "S0"
@@ -438,7 +432,7 @@ resource "azurerm_ai_services" "test" {
   local_authentication_enabled       = false
   outbound_network_access_restricted = false
   public_network_access              = "Disabled"
-  custom_subdomain_name              = "acctestcogacc-%[1]d"
+  custom_subdomain_name              = "acctestcogacc-%[2]d"
 
   customer_managed_key {
     key_vault_key_id   = azurerm_key_vault_key.test.id
@@ -465,27 +459,16 @@ resource "azurerm_ai_services" "test" {
     Acceptance = "Test"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomIntOfLength(8))
+`, r.template(data), data.RandomInteger, data.RandomStringOfLength(8))
 }
 
-func (AIServices) update(data acceptance.TestData) string {
+func (r AIServices) update(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-data "azurerm_client_config" "current" {}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-cognitive-%[1]d"
-  location = "%[2]s"
-}
-
-resource "azurerm_user_assigned_identity" "test" {
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  name                = "%[3]s"
-}
+%[1]s
 
 resource "azurerm_key_vault" "test" {
   name                       = "acctestkv%[3]s"
@@ -528,14 +511,14 @@ resource "azurerm_key_vault_key" "test" {
 }
 
 resource "azurerm_virtual_network" "test" {
-  name                = "acctestvirtnet%[1]d"
+  name                = "acctestvirtnet%[2]d"
   address_space       = ["10.0.0.0/16"]
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
 }
 
 resource "azurerm_subnet" "test_a" {
-  name                 = "acctestsubneta%[1]d"
+  name                 = "acctestsubneta%[2]d"
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.2.0/24"]
@@ -543,7 +526,7 @@ resource "azurerm_subnet" "test_a" {
 }
 
 resource "azurerm_subnet" "test_b" {
-  name                 = "acctestsubnetb%[1]d"
+  name                 = "acctestsubnetb%[2]d"
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.4.0/24"]
@@ -551,7 +534,7 @@ resource "azurerm_subnet" "test_b" {
 }
 
 resource "azurerm_ai_services" "test" {
-  name                               = "acctestcogacc-%[1]d"
+  name                               = "acctestcogacc-%[2]d"
   location                           = azurerm_resource_group.test.location
   resource_group_name                = azurerm_resource_group.test.name
   sku_name                           = "S0"
@@ -559,7 +542,7 @@ resource "azurerm_ai_services" "test" {
   local_authentication_enabled       = true
   outbound_network_access_restricted = true
   public_network_access              = "Enabled"
-  custom_subdomain_name              = "acctestcogacc-%[1]d"
+  custom_subdomain_name              = "acctestcogacc-%[2]d"
 
   customer_managed_key {
     key_vault_key_id   = azurerm_key_vault_key.test.id
@@ -587,19 +570,23 @@ resource "azurerm_ai_services" "test" {
     Environment = "Dev"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomIntOfLength(8))
+`, r.template(data), data.RandomInteger, data.RandomStringOfLength(8))
 }
 
 func (r AIServices) networkACLs(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-%s
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
 
 resource "azurerm_ai_services" "test" {
-  name                  = "acctestcogacc-%d"
+  name                  = "acctestcogacc-%[2]d"
   location              = azurerm_resource_group.test.location
   resource_group_name   = azurerm_resource_group.test.name
   sku_name              = "S0"
-  custom_subdomain_name = "acctestcogacc-%d"
+  custom_subdomain_name = "acctestcogacc-%[2]d"
 
   network_acls {
     default_action = "Deny"
@@ -611,18 +598,23 @@ resource "azurerm_ai_services" "test" {
     }
   }
 }
-`, r.networkACLsTemplate(data), data.RandomInteger, data.RandomInteger)
+`, r.networkACLsTemplate(data), data.RandomInteger)
 }
 
 func (r AIServices) networkACLsUpdated(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-%s
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
 resource "azurerm_ai_services" "test" {
-  name                  = "acctestcogacc-%d"
+  name                  = "acctestcogacc-%[2]d"
   location              = azurerm_resource_group.test.location
   resource_group_name   = azurerm_resource_group.test.name
   sku_name              = "S0"
-  custom_subdomain_name = "acctestcogacc-%d"
+  custom_subdomain_name = "acctestcogacc-%[2]d"
 
   network_acls {
     bypass         = "None"
@@ -636,18 +628,23 @@ resource "azurerm_ai_services" "test" {
     }
   }
 }
-`, r.networkACLsTemplate(data), data.RandomInteger, data.RandomInteger)
+`, r.networkACLsTemplate(data), data.RandomInteger)
 }
 
 func (r AIServices) networkACLsBypassUpdated(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-%s
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
 resource "azurerm_ai_services" "test" {
-  name                  = "acctestcogacc-%d"
+  name                  = "acctestcogacc-%[2]d"
   location              = azurerm_resource_group.test.location
   resource_group_name   = azurerm_resource_group.test.name
   sku_name              = "S0"
-  custom_subdomain_name = "acctestcogacc-%d"
+  custom_subdomain_name = "acctestcogacc-%[2]d"
 
   network_acls {
     bypass         = "AzureServices"
@@ -661,118 +658,28 @@ resource "azurerm_ai_services" "test" {
     }
   }
 }
-`, r.networkACLsTemplate(data), data.RandomInteger, data.RandomInteger)
+`, r.networkACLsTemplate(data), data.RandomInteger)
 }
 
-func (AIServices) networkACLsTemplate(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-data "azurerm_client_config" "current" {
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-cognitive-%d"
-  location = "%s"
-}
-
-resource "azurerm_virtual_network" "test" {
-  name                = "acctestvirtnet%d"
-  address_space       = ["10.0.0.0/16"]
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-}
-
-resource "azurerm_subnet" "test_a" {
-  name                 = "acctestsubneta%d"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.2.0/24"]
-  service_endpoints    = ["Microsoft.CognitiveServices"]
-}
-
-resource "azurerm_subnet" "test_b" {
-  name                 = "acctestsubnetb%d"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.4.0/24"]
-  service_endpoints    = ["Microsoft.CognitiveServices"]
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
-}
-
-func (AIServices) customerManagedKey(data acceptance.TestData) string {
+func (r AIServices) customerManagedKey(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {
     key_vault {
-      purge_soft_delete_on_destroy       = false
-      purge_soft_deleted_keys_on_destroy = false
+      purge_soft_delete_on_destroy       = true
+      purge_soft_deleted_keys_on_destroy = true
     }
   }
 }
 
-data "azurerm_client_config" "current" {}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-cognitive-%d"
-  location = "%s"
-}
-
-resource "azurerm_user_assigned_identity" "test" {
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  name                = "%s"
-}
-
-resource "azurerm_key_vault" "test" {
-  name                       = "acctestkv%s"
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  tenant_id                  = data.azurerm_client_config.current.tenant_id
-  sku_name                   = "standard"
-  soft_delete_retention_days = 7
-  purge_protection_enabled   = true
-
-  access_policy {
-    tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.object_id
-    key_permissions = [
-      "Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify", "GetRotationPolicy"
-    ]
-    secret_permissions = [
-      "Get",
-    ]
-  }
-
-  access_policy {
-    tenant_id = azurerm_user_assigned_identity.test.tenant_id
-    object_id = azurerm_user_assigned_identity.test.principal_id
-    key_permissions = [
-      "Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify", "GetRotationPolicy"
-    ]
-    secret_permissions = [
-      "Get",
-    ]
-  }
-}
-
-resource "azurerm_key_vault_key" "test" {
-  name         = "acctestkvkey%s"
-  key_vault_id = azurerm_key_vault.test.id
-  key_type     = "RSA"
-  key_size     = 2048
-  key_opts     = ["decrypt", "encrypt", "sign", "unwrapKey", "verify", "wrapKey"]
-}
+%[1]s
 
 resource "azurerm_ai_services" "test" {
-  name                  = "acctest-cogacc-%d"
+  name                  = "acctest-cogacc-%[2]d"
   location              = azurerm_resource_group.test.location
   resource_group_name   = azurerm_resource_group.test.name
   sku_name              = "S0"
-  custom_subdomain_name = "acctest-cogacc-%d"
+  custom_subdomain_name = "acctest-cogacc-%[2]d"
 
   identity {
     type = "SystemAssigned, UserAssigned"
@@ -786,35 +693,229 @@ resource "azurerm_ai_services" "test" {
     identity_client_id = azurerm_user_assigned_identity.test.client_id
   }
 }
-`, data.RandomInteger, data.Locations.Secondary, data.RandomString, data.RandomString, data.RandomString, data.RandomInteger, data.RandomInteger)
+`, r.keyVaultTemplate(data), data.RandomInteger)
 }
 
-func (AIServices) customerManagedKeyUpdate(data acceptance.TestData) string {
+func (r AIServices) customerManagedKeyUpdate(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {
     key_vault {
-      purge_soft_delete_on_destroy       = false
-      purge_soft_deleted_keys_on_destroy = false
+      purge_soft_delete_on_destroy       = true
+      purge_soft_deleted_keys_on_destroy = true
     }
   }
 }
 
-data "azurerm_client_config" "current" {}
+%[1]s
 
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-cognitive-%d"
-  location = "%s"
+resource "azurerm_ai_services" "test" {
+  name                  = "acctest-cogacc-%[2]d"
+  location              = azurerm_resource_group.test.location
+  resource_group_name   = azurerm_resource_group.test.name
+  sku_name              = "S0"
+  custom_subdomain_name = "acctest-cogacc-%[2]d"
+
+  identity {
+    type = "SystemAssigned, UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id
+    ]
+  }
+
+  customer_managed_key {
+    key_vault_key_id   = azurerm_key_vault_key.test2.id
+    identity_client_id = azurerm_user_assigned_identity.test.client_id
+  }
+}
+`, r.keyVaultTemplate(data), data.RandomInteger)
 }
 
-resource "azurerm_user_assigned_identity" "test" {
-  resource_group_name = azurerm_resource_group.test.name
+func (r AIServices) customerManagedKeyRemove(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy       = true
+      purge_soft_deleted_keys_on_destroy = true
+    }
+  }
+}
+
+%[1]s
+
+resource "azurerm_ai_services" "test" {
+  name                  = "acctest-cogacc-%[2]d"
+  location              = azurerm_resource_group.test.location
+  resource_group_name   = azurerm_resource_group.test.name
+  sku_name              = "S0"
+  custom_subdomain_name = "acctest-cogacc-%[2]d"
+
+  identity {
+    type = "SystemAssigned, UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id
+    ]
+  }
+}
+`, r.keyVaultTemplate(data), data.RandomInteger)
+}
+
+func (r AIServices) customerManagedKeyHSM(data acceptance.TestData) string {
+	if !features.FivePointOh() {
+		return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_ai_services" "test" {
+  name                  = "acctest-cogacc-%[2]d"
+  location              = azurerm_resource_group.test.location
+  resource_group_name   = azurerm_resource_group.test.name
+  sku_name              = "S0"
+  custom_subdomain_name = "acctest-cogacc-%[2]d"
+
+  identity {
+    type = "SystemAssigned, UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id
+    ]
+  }
+
+  customer_managed_key {
+    managed_hsm_key_id = azurerm_key_vault_managed_hardware_security_module_key.test.versioned_id
+    identity_client_id = azurerm_user_assigned_identity.test.client_id
+  }
+}
+`, r.managedHSMVaultTemplate(data), data.RandomInteger)
+	}
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_ai_services" "test" {
+  name                  = "acctest-cogacc-%[2]d"
+  location              = azurerm_resource_group.test.location
+  resource_group_name   = azurerm_resource_group.test.name
+  sku_name              = "S0"
+  custom_subdomain_name = "acctest-cogacc-%[2]d"
+
+  identity {
+    type = "SystemAssigned, UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id
+    ]
+  }
+
+  customer_managed_key {
+    key_vault_key_id   = azurerm_key_vault_managed_hardware_security_module_key.test.versioned_id
+    identity_client_id = azurerm_user_assigned_identity.test.client_id
+  }
+}
+`, r.managedHSMVaultTemplate(data), data.RandomInteger)
+}
+
+func (r AIServices) customerManagedKeyHSMUpdate(data acceptance.TestData) string {
+	if !features.FivePointOh() {
+		return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_ai_services" "test" {
+  name                  = "acctest-cogacc-%[2]d"
+  location              = azurerm_resource_group.test.location
+  resource_group_name   = azurerm_resource_group.test.name
+  sku_name              = "S0"
+  custom_subdomain_name = "acctest-cogacc-%[2]d"
+
+  identity {
+    type = "SystemAssigned, UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id
+    ]
+  }
+
+  customer_managed_key {
+    managed_hsm_key_id = azurerm_key_vault_managed_hardware_security_module_key.update.versioned_id
+    identity_client_id = azurerm_user_assigned_identity.test.client_id
+  }
+}
+`, r.managedHSMVaultTemplate(data), data.RandomInteger)
+	}
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_ai_services" "test" {
+  name                  = "acctest-cogacc-%[2]d"
+  location              = azurerm_resource_group.test.location
+  resource_group_name   = azurerm_resource_group.test.name
+  sku_name              = "S0"
+  custom_subdomain_name = "acctest-cogacc-%[2]d"
+
+  identity {
+    type = "SystemAssigned, UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id
+    ]
+  }
+
+  customer_managed_key {
+    key_vault_key_id   = azurerm_key_vault_managed_hardware_security_module_key.update.versioned_id
+    identity_client_id = azurerm_user_assigned_identity.test.client_id
+  }
+}
+`, r.managedHSMVaultTemplate(data), data.RandomInteger)
+}
+
+func (r AIServices) networkACLsTemplate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%[2]d"
+  address_space       = ["10.0.0.0/16"]
   location            = azurerm_resource_group.test.location
-  name                = "%s"
+  resource_group_name = azurerm_resource_group.test.name
 }
+
+resource "azurerm_subnet" "test_a" {
+  name                 = "acctestsubneta%[2]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+  service_endpoints    = ["Microsoft.CognitiveServices"]
+}
+
+resource "azurerm_subnet" "test_b" {
+  name                 = "acctestsubnetb%[2]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.4.0/24"]
+  service_endpoints    = ["Microsoft.CognitiveServices"]
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r AIServices) keyVaultTemplate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
 
 resource "azurerm_key_vault" "test" {
-  name                       = "acctestkv%s"
+  name                       = "acctestkv%[2]s"
   location                   = azurerm_resource_group.test.location
   resource_group_name        = azurerm_resource_group.test.name
   tenant_id                  = data.azurerm_client_config.current.tenant_id
@@ -846,41 +947,189 @@ resource "azurerm_key_vault" "test" {
 }
 
 resource "azurerm_key_vault_key" "test" {
-  name         = "acctestkvkey%s"
+  name         = "acctestkvkey%[2]s"
   key_vault_id = azurerm_key_vault.test.id
   key_type     = "RSA"
   key_size     = 2048
   key_opts     = ["decrypt", "encrypt", "sign", "unwrapKey", "verify", "wrapKey"]
 }
 
-resource "azurerm_ai_services" "test" {
-  name                  = "acctest-cogacc-%d"
-  location              = azurerm_resource_group.test.location
-  resource_group_name   = azurerm_resource_group.test.name
-  sku_name              = "S0"
-  custom_subdomain_name = "acctest-cogacc-%d"
+resource "azurerm_key_vault_key" "test2" {
+  name         = "acctestkvkey-2-%[2]s"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "RSA"
+  key_size     = 2048
+  key_opts     = ["decrypt", "encrypt", "sign", "unwrapKey", "verify", "wrapKey"]
+}
+`, r.template(data), data.RandomString)
+}
 
-  identity {
-    type = "SystemAssigned, UserAssigned"
-    identity_ids = [
-      azurerm_user_assigned_identity.test.id
+func (r AIServices) managedHSMVaultTemplate(data acceptance.TestData) string {
+	uuid1, _ := uuid.GenerateUUID()
+	uuid2, _ := uuid.GenerateUUID()
+	uuid3, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_key_vault" "test" {
+  name                       = "acc%[2]d"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "standard"
+  soft_delete_retention_days = 7
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    key_permissions = [
+      "Create",
+      "Delete",
+      "Get",
+      "Purge",
+      "Recover",
+      "Update",
+      "GetRotationPolicy",
+    ]
+
+    secret_permissions = [
+      "Delete",
+      "Get",
+      "Set",
+    ]
+
+    certificate_permissions = [
+      "Create",
+      "Delete",
+      "DeleteIssuers",
+      "Get",
+      "Purge",
+      "Update"
     ]
   }
 }
-`, data.RandomInteger, data.Locations.Secondary, data.RandomString, data.RandomString, data.RandomString, data.RandomInteger, data.RandomInteger)
-}
 
-func (AIServices) kvHsmManagedKey(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {
-    key_vault {
-      purge_soft_delete_on_destroy       = false
-      purge_soft_deleted_keys_on_destroy = false
+resource "azurerm_key_vault_certificate" "cert" {
+  count        = 3
+  name         = "acchsmcert${count.index}"
+  key_vault_id = azurerm_key_vault.test.id
+
+  certificate_policy {
+    issuer_parameters {
+      name = "Self"
+    }
+
+    key_properties {
+      exportable = true
+      key_size   = 2048
+      key_type   = "RSA"
+      reuse_key  = true
+    }
+
+    lifetime_action {
+      action {
+        action_type = "AutoRenew"
+      }
+
+      trigger {
+        days_before_expiry = 30
+      }
+    }
+
+    secret_properties {
+      content_type = "application/x-pkcs12"
+    }
+
+    x509_certificate_properties {
+      extended_key_usage = []
+
+      key_usage = [
+        "cRLSign",
+        "dataEncipherment",
+        "digitalSignature",
+        "keyAgreement",
+        "keyCertSign",
+        "keyEncipherment",
+      ]
+
+      subject            = "CN=hello-world"
+      validity_in_months = 12
     }
   }
 }
 
+resource "azurerm_key_vault_managed_hardware_security_module" "test" {
+  name                       = "kvHsm%[2]d"
+  resource_group_name        = azurerm_resource_group.test.name
+  location                   = azurerm_resource_group.test.location
+  sku_name                   = "Standard_B1"
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  admin_object_ids           = [data.azurerm_client_config.current.object_id]
+  purge_protection_enabled   = false
+  soft_delete_retention_days = 7
+
+  security_domain_key_vault_certificate_ids = [for cert in azurerm_key_vault_certificate.cert : cert.id]
+  security_domain_quorum                    = 3
+}
+
+resource "azurerm_key_vault_managed_hardware_security_module_role_assignment" "test" {
+  managed_hsm_id     = azurerm_key_vault_managed_hardware_security_module.test.id
+  name               = "%[3]s"
+  scope              = "/keys"
+  role_definition_id = "/Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/21dbd100-6940-42c2-9190-5d6cb909625b"
+  principal_id       = data.azurerm_client_config.current.object_id
+}
+
+resource "azurerm_key_vault_managed_hardware_security_module_role_assignment" "test1" {
+  managed_hsm_id     = azurerm_key_vault_managed_hardware_security_module.test.id
+  name               = "%[4]s"
+  scope              = "/keys"
+  role_definition_id = "/Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/515eb02d-2335-4d2d-92f2-b1cbdf9c3778"
+  principal_id       = data.azurerm_client_config.current.object_id
+}
+
+resource "azurerm_key_vault_managed_hardware_security_module_role_assignment" "user" {
+  managed_hsm_id     = azurerm_key_vault_managed_hardware_security_module.test.id
+  name               = "%[5]s"
+  scope              = "/keys"
+  role_definition_id = "/Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/21dbd100-6940-42c2-9190-5d6cb909625b"
+  principal_id       = azurerm_storage_account.test.identity.0.principal_id
+}
+
+resource "azurerm_key_vault_managed_hardware_security_module_key" "test" {
+  name           = "acctestHSMK-%[6]s"
+  managed_hsm_id = azurerm_key_vault_managed_hardware_security_module.test.id
+  key_type       = "RSA-HSM"
+  key_size       = 2048
+  key_opts       = ["unwrapKey", "wrapKey"]
+
+  depends_on = [
+    azurerm_key_vault_managed_hardware_security_module_role_assignment.test,
+    azurerm_key_vault_managed_hardware_security_module_role_assignment.test1,
+    azurerm_key_vault_managed_hardware_security_module_role_assignment.user
+  ]
+}
+
+resource "azurerm_key_vault_managed_hardware_security_module_key" "update" {
+  name           = "acctestHSMK2-%[6]s"
+  managed_hsm_id = azurerm_key_vault_managed_hardware_security_module.test.id
+  key_type       = "RSA-HSM"
+  key_size       = 2048
+  key_opts       = ["unwrapKey", "wrapKey"]
+
+  depends_on = [
+    azurerm_key_vault_managed_hardware_security_module_role_assignment.test,
+    azurerm_key_vault_managed_hardware_security_module_role_assignment.test1,
+    azurerm_key_vault_managed_hardware_security_module_role_assignment.user
+  ]
+}
+`, r.template(data), data.RandomInteger, uuid1, uuid2, uuid3, data.RandomStringOfLength(8))
+}
+
+func (AIServices) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
 data "azurerm_client_config" "current" {}
 
 resource "azurerm_resource_group" "test" {
@@ -891,67 +1140,7 @@ resource "azurerm_resource_group" "test" {
 resource "azurerm_user_assigned_identity" "test" {
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  name                = "%[3]s"
+  name                = "acctestUAI-%[1]d"
 }
-
-resource "azurerm_key_vault" "test" {
-  name                       = "acctestkv%[3]s"
-  location                   = azurerm_resource_group.test.location
-  resource_group_name        = azurerm_resource_group.test.name
-  tenant_id                  = data.azurerm_client_config.current.tenant_id
-  sku_name                   = "standard"
-  soft_delete_retention_days = 7
-  purge_protection_enabled   = true
-
-  access_policy {
-    tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.object_id
-    key_permissions = [
-      "Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify", "GetRotationPolicy"
-    ]
-    certificate_permissions = [
-      "Get",
-      "Create",
-      "Delete",
-      "Recover",
-      "List"
-    ]
-  }
-
-  access_policy {
-    tenant_id = azurerm_user_assigned_identity.test.tenant_id
-    object_id = azurerm_user_assigned_identity.test.principal_id
-    key_permissions = [
-      "Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify", "GetRotationPolicy"
-    ]
-    certificate_permissions = [
-      "Get",
-      "Create",
-      "Delete",
-      "Recover",
-      "List"
-    ]
-  }
-}
-
-resource "azurerm_ai_services" "test" {
-  name                  = "acctest-cogacc-%[1]d"
-  location              = azurerm_resource_group.test.location
-  resource_group_name   = azurerm_resource_group.test.name
-  sku_name              = "S0"
-  custom_subdomain_name = "acctest-cogacc-%[1]d"
-
-  identity {
-    type = "SystemAssigned, UserAssigned"
-    identity_ids = [
-      azurerm_user_assigned_identity.test.id
-    ]
-  }
-
-  customer_managed_key {
-    managed_hsm_key_id = "%[4]s"
-    identity_client_id = azurerm_user_assigned_identity.test.client_id
-  }
-}
-`, data.RandomInteger, data.Locations.Secondary, data.RandomString, os.Getenv("ARM_TEST_HSM_KEY"))
+`, data.RandomInteger, data.Locations.Primary)
 }

--- a/internal/services/mysql/mysql_flexible_server_resource.go
+++ b/internal/services/mysql/mysql_flexible_server_resource.go
@@ -629,10 +629,10 @@ func resourceMysqlFlexibleServerRead(d *pluginsdk.ResourceData, meta interface{}
 		return fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return resourceMysqlFlexibleServerFlatten(d, id, resp.Model, meta)
+	return resourceMysqlFlexibleServerFlatten(d, id, resp.Model)
 }
 
-func resourceMysqlFlexibleServerFlatten(d *pluginsdk.ResourceData, id *servers.FlexibleServerId, server *servers.Server, meta interface{}) error {
+func resourceMysqlFlexibleServerFlatten(d *pluginsdk.ResourceData, id *servers.FlexibleServerId, server *servers.Server) error {
 	d.Set("name", id.FlexibleServerName)
 	d.Set("resource_group_name", id.ResourceGroupName)
 

--- a/internal/services/mysql/mysql_flexible_server_resource.go
+++ b/internal/services/mysql/mysql_flexible_server_resource.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/keyvault"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/mysql/2023-12-30/serverfailover"
@@ -25,9 +26,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
-	keyVaultValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/validate"
-	managedHsmHelpers "github.com/hashicorp/terraform-provider-azurerm/internal/services/managedhsm/helpers"
-	hsmValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/managedhsm/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/mysql/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -132,10 +131,9 @@ func resourceMysqlFlexibleServer() *pluginsdk.Resource {
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"key_vault_key_id": {
-							Type:          pluginsdk.TypeString,
-							Optional:      true,
-							ValidateFunc:  keyVaultValidate.NestedItemIdWithOptionalVersion,
-							ConflictsWith: []string{"customer_managed_key.0.managed_hsm_key_id"},
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							ValidateFunc: keyvault.ValidateNestedItemID(keyvault.VersionTypeAny, keyvault.NestedItemTypeKey),
 							RequiredWith: []string{
 								"identity",
 								"customer_managed_key.0.primary_user_assigned_identity_id",
@@ -149,7 +147,7 @@ func resourceMysqlFlexibleServer() *pluginsdk.Resource {
 						"geo_backup_key_vault_key_id": {
 							Type:         pluginsdk.TypeString,
 							Optional:     true,
-							ValidateFunc: keyVaultValidate.NestedItemIdWithOptionalVersion,
+							ValidateFunc: keyvault.ValidateNestedItemID(keyvault.VersionTypeAny, keyvault.NestedItemTypeKey),
 							RequiredWith: []string{
 								"identity",
 								"customer_managed_key.0.geo_backup_user_assigned_identity_id",
@@ -159,16 +157,6 @@ func resourceMysqlFlexibleServer() *pluginsdk.Resource {
 							Type:         pluginsdk.TypeString,
 							Optional:     true,
 							ValidateFunc: commonids.ValidateUserAssignedIdentityID,
-						},
-						"managed_hsm_key_id": {
-							Type:          pluginsdk.TypeString,
-							Optional:      true,
-							ValidateFunc:  validation.Any(hsmValidate.ManagedHSMDataPlaneVersionedKeyID, hsmValidate.ManagedHSMDataPlaneVersionlessKeyID),
-							ConflictsWith: []string{"customer_managed_key.0.key_vault_key_id"},
-							RequiredWith: []string{
-								"identity",
-								"customer_managed_key.0.primary_user_assigned_identity_id",
-							},
 						},
 					},
 				},
@@ -364,6 +352,83 @@ func resourceMysqlFlexibleServer() *pluginsdk.Resource {
 			Type:     pluginsdk.TypeBool,
 			Computed: true,
 		}
+
+		resource.Schema["customer_managed_key"].Elem.(*pluginsdk.Resource).Schema = map[string]*pluginsdk.Schema{
+			"key_vault_key_id": {
+				Type:          pluginsdk.TypeString,
+				Optional:      true,
+				ValidateFunc:  keyvault.ValidateNestedItemID(keyvault.VersionTypeAny, keyvault.NestedItemTypeAny),
+				ConflictsWith: []string{"customer_managed_key.0.managed_hsm_key_id"},
+				RequiredWith: []string{
+					"identity",
+					"customer_managed_key.0.primary_user_assigned_identity_id",
+				},
+				DiffSuppressFunc: func(_, oldValue, newValue string, d *schema.ResourceData) bool {
+					if newValue == "" {
+						// If using `managed_hsm_key_id`, `key_vault_key_id` will also be set
+						// ignore diff if the 2 are equal.
+						raw, diags := d.GetRawConfigAt(sdk.ConstructCtyPath("customer_managed_key.0.managed_hsm_key_id"))
+						if diags != nil {
+							return false
+						}
+
+						if raw.IsKnown() && !raw.IsNull() {
+							return raw.AsString() == oldValue
+						}
+					}
+
+					return false
+				},
+				DiffSuppressOnRefresh: true,
+			},
+			"primary_user_assigned_identity_id": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: commonids.ValidateUserAssignedIdentityID,
+			},
+			"geo_backup_key_vault_key_id": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: keyvault.ValidateNestedItemID(keyvault.VersionTypeAny, keyvault.NestedItemTypeAny),
+				RequiredWith: []string{
+					"identity",
+					"customer_managed_key.0.geo_backup_user_assigned_identity_id",
+				},
+			},
+			"geo_backup_user_assigned_identity_id": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: commonids.ValidateUserAssignedIdentityID,
+			},
+			"managed_hsm_key_id": {
+				Type:          pluginsdk.TypeString,
+				Optional:      true,
+				ValidateFunc:  keyvault.ValidateNestedItemID(keyvault.VersionTypeAny, keyvault.NestedItemTypeAny),
+				ConflictsWith: []string{"customer_managed_key.0.key_vault_key_id"},
+				RequiredWith: []string{
+					"identity",
+					"customer_managed_key.0.primary_user_assigned_identity_id",
+				},
+				DiffSuppressFunc: func(_, oldValue, newValue string, d *schema.ResourceData) bool {
+					if newValue == "" {
+						// If using `key_vault_key_id` with MHSM key, `managed_hsm_key_id` will also be set
+						// ignore diff if the 2 are equal.
+						raw, diags := d.GetRawConfigAt(sdk.ConstructCtyPath("customer_managed_key.0.key_vault_key_id"))
+						if diags != nil {
+							return false
+						}
+
+						if raw.IsKnown() && !raw.IsNull() {
+							return raw.AsString() == oldValue
+						}
+					}
+
+					return false
+				},
+				DiffSuppressOnRefresh: true,
+				Deprecated:            "The `customer_managed_key.managed_hsm_key_id` property has been deprecated in favour of `customer_managed_key.key_vault_key_id` and will be removed in v5.0 of the AzureRM provider",
+			},
+		}
 	}
 
 	return resource
@@ -449,7 +514,7 @@ func resourceMysqlFlexibleServerCreate(d *pluginsdk.ResourceData, meta interface
 			Network:          expandArmServerNetwork(d),
 			HighAvailability: expandFlexibleServerHighAvailability(d.Get("high_availability").([]interface{})),
 			Backup:           expandArmServerBackup(d),
-			DataEncryption:   expandFlexibleServerDataEncryption(d.Get("customer_managed_key").([]interface{})),
+			DataEncryption:   expandFlexibleServerDataEncryption(d, d.Get("customer_managed_key").([]interface{})),
 		},
 		Sku:  sku,
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
@@ -590,7 +655,7 @@ func resourceMysqlFlexibleServerFlatten(d *pluginsdk.ResourceData, id *servers.F
 				}
 			}
 
-			cmk, err := flattenFlexibleServerDataEncryption(props.DataEncryption, meta)
+			cmk, err := flattenFlexibleServerDataEncryption(props.DataEncryption)
 			if err != nil {
 				return fmt.Errorf("flattening `customer_managed_key`: %+v", err)
 			}
@@ -767,7 +832,7 @@ func resourceMysqlFlexibleServerUpdate(d *pluginsdk.ResourceData, meta interface
 	}
 
 	if d.HasChange("customer_managed_key") {
-		parameters.Properties.DataEncryption = expandFlexibleServerDataEncryption(d.Get("customer_managed_key").([]interface{}))
+		parameters.Properties.DataEncryption = expandFlexibleServerDataEncryption(d, d.Get("customer_managed_key").([]interface{}))
 	}
 
 	if d.HasChange("identity") {
@@ -1099,7 +1164,7 @@ func flattenFlexibleServerHighAvailability(ha *servers.HighAvailability) []inter
 	}
 }
 
-func expandFlexibleServerDataEncryption(input []interface{}) *servers.DataEncryption {
+func expandFlexibleServerDataEncryption(d *pluginsdk.ResourceData, input []interface{}) *servers.DataEncryption {
 	if len(input) == 0 || input[0] == nil {
 		det := servers.DataEncryptionTypeSystemManaged
 		return &servers.DataEncryption{
@@ -1113,14 +1178,15 @@ func expandFlexibleServerDataEncryption(input []interface{}) *servers.DataEncryp
 		Type: &det,
 	}
 
-	if keyVaultKeyId := v["key_vault_key_id"].(string); keyVaultKeyId != "" {
+	if keyVaultKeyId := v["key_vault_key_id"].(string); keyVaultKeyId != "" && setInConfig(d, "customer_managed_key.0.key_vault_key_id") {
 		dataEncryption.PrimaryKeyURI = pointer.To(keyVaultKeyId)
 	}
 
-	if hsmManagedKeyId := v["managed_hsm_key_id"].(string); hsmManagedKeyId != "" {
-		dataEncryption.PrimaryKeyURI = pointer.To(hsmManagedKeyId)
+	if !features.FivePointOh() {
+		if hsmManagedKeyId := v["managed_hsm_key_id"].(string); hsmManagedKeyId != "" && setInConfig(d, "customer_managed_key.0.managed_hsm_key_id") {
+			dataEncryption.PrimaryKeyURI = pointer.To(hsmManagedKeyId)
+		}
 	}
-
 	if primaryUserAssignedIdentityId := v["primary_user_assigned_identity_id"].(string); primaryUserAssignedIdentityId != "" {
 		dataEncryption.PrimaryUserAssignedIdentityId = pointer.To(primaryUserAssignedIdentityId)
 	}
@@ -1136,24 +1202,37 @@ func expandFlexibleServerDataEncryption(input []interface{}) *servers.DataEncryp
 	return &dataEncryption
 }
 
-func flattenFlexibleServerDataEncryption(de *servers.DataEncryption, meta interface{}) ([]interface{}, error) {
+func setInConfig(d *pluginsdk.ResourceData, address string) bool {
+	// remove function in 5.0
+	if features.FivePointOh() {
+		// No need to check RawConfig in 5.0 as `key_vault_key_id` is no longer computed
+		// so the existing check will suffice
+		return true
+	}
+
+	raw, diags := d.GetRawConfigAt(sdk.ConstructCtyPath(address))
+	return !diags.HasError() && !raw.IsNull()
+}
+
+func flattenFlexibleServerDataEncryption(de *servers.DataEncryption) ([]interface{}, error) {
 	if de == nil || *de.Type == servers.DataEncryptionTypeSystemManaged {
 		return []interface{}{}, nil
 	}
 
-	env := meta.(*clients.Client).Account.Environment
-
 	item := map[string]interface{}{}
 	if de.PrimaryKeyURI != nil {
-		isHsmKey, _, _, err := managedHsmHelpers.IsManagedHSMURI(env, pointer.From(de.PrimaryKeyURI))
+		nestedItemType := keyvault.NestedItemTypeKey
+		if !features.FivePointOh() {
+			nestedItemType = keyvault.NestedItemTypeAny
+		}
+		keyID, err := keyvault.ParseNestedItemID(*de.PrimaryKeyURI, keyvault.VersionTypeAny, nestedItemType)
 		if err != nil {
 			return nil, err
 		}
 
-		if isHsmKey {
-			item["managed_hsm_key_id"] = pointer.From(de.PrimaryKeyURI)
-		} else {
-			item["key_vault_key_id"] = pointer.From(de.PrimaryKeyURI)
+		item["key_vault_key_id"] = keyID.ID()
+		if !features.FivePointOh() && keyID.IsManagedHSM() {
+			item["managed_hsm_key_id"] = keyID.ID()
 		}
 	}
 

--- a/internal/services/mysql/mysql_flexible_server_resource_list.go
+++ b/internal/services/mysql/mysql_flexible_server_resource_list.go
@@ -79,7 +79,7 @@ func (r MysqlFlexibleServerListResource) List(ctx context.Context, request list.
 			rd := resourceMysqlFlexibleServer().Data(&terraform.InstanceState{})
 			rd.SetId(id.ID())
 
-			if err := resourceMysqlFlexibleServerFlatten(rd, id, &server, metadata); err != nil {
+			if err := resourceMysqlFlexibleServerFlatten(rd, id, &server); err != nil {
 				sdk.SetErrorDiagnosticAndPushListResult(result, push, fmt.Sprintf("encoding `%s` resource data", mysqlFlexibleServerResourceName), err)
 				return
 			}

--- a/internal/services/mysql/mysql_flexible_server_resource_test.go
+++ b/internal/services/mysql/mysql_flexible_server_resource_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
@@ -470,12 +471,68 @@ func TestAccMySqlFlexibleServer_createWithHsmCustomerManagedKey(t *testing.T) {
 		t.Skip("Skipping as ARM_TEST_HSM_KEY is not specified")
 	}
 
+	uuids := make([]string, 0)
+	for range 3 {
+		u, _ := uuid.GenerateUUID()
+		uuids = append(uuids, u)
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_mysql_flexible_server", "test")
 	r := MysqlFlexibleServerResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.withHsmCustomerManagedKey(data),
+			Config: r.withHsmCustomerManagedKey(data, uuids),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("administrator_password"),
+	})
+}
+
+func TestAccMySqlFlexibleServer_createWithHsmCustomerManagedKeyFourOhUpdate(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as this test is not valid in 5.0+")
+	}
+
+	if os.Getenv("ARM_TEST_HSM_KEY") == "" {
+		t.Skip("Skipping as ARM_TEST_HSM_KEY is not specified")
+	}
+
+	uuids := make([]string, 0)
+	for range 3 {
+		u, _ := uuid.GenerateUUID()
+		uuids = append(uuids, u)
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_mysql_flexible_server", "test")
+	r := MysqlFlexibleServerResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withHsmCustomerManagedKeyFourOhHSMOnly(data, uuids),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("administrator_password"),
+		{
+			// Test migration from `managed_hsm_key_id` to `key_vault_key_id`. This should plan no changes.
+			Config:             r.withHsmCustomerManagedKeyFourOh(data, "azurerm_key_vault_managed_hardware_security_module_key.test.versioned_id", uuids),
+			PlanOnly:           true,
+			ExpectNonEmptyPlan: false,
+		},
+		data.ImportStep("administrator_password"),
+		{
+			Config: r.withHsmCustomerManagedKeyFourOh(data, "azurerm_key_vault_key.test2.id", uuids),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("administrator_password"),
+		{
+			Config: r.withHsmCustomerManagedKeyFourOh(data, "azurerm_key_vault_managed_hardware_security_module_key.test.versioned_id", uuids),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -1250,11 +1307,7 @@ resource "azurerm_key_vault_key" "test" {
 `, data.RandomInteger, data.Locations.Ternary, data.RandomString, data.RandomString)
 }
 
-func (r MysqlFlexibleServerResource) cmkWithManagedHsmTemplate(data acceptance.TestData) string {
-	roleAssignmentName1, _ := uuid.GenerateUUID()
-	roleAssignmentName2, _ := uuid.GenerateUUID()
-	roleAssignmentName3, _ := uuid.GenerateUUID()
-
+func (r MysqlFlexibleServerResource) cmkWithManagedHsmTemplate(data acceptance.TestData, uuids []string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1262,7 +1315,7 @@ provider "azurerm" {
 
 data "azurerm_client_config" "current" {}
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-mssql-%[2]s"
+  name     = "acctestRG-mssql-%[6]d"
   location = "%[1]s"
 }
 
@@ -1420,7 +1473,7 @@ resource "azurerm_key_vault_managed_hardware_security_module_key" "test" {
 }
 
 
-`, data.Locations.Primary, data.RandomStringOfLength(7), roleAssignmentName1, roleAssignmentName2, roleAssignmentName3)
+`, data.Locations.Primary, data.RandomString, uuids[0], uuids[1], uuids[2], data.RandomInteger)
 }
 
 func (r MysqlFlexibleServerResource) withoutCustomerManagedKey(data acceptance.TestData) string {
@@ -1465,7 +1518,7 @@ resource "azurerm_mysql_flexible_server" "test" {
 `, r.cmkTemplate(data), data.RandomInteger)
 }
 
-func (r MysqlFlexibleServerResource) withHsmCustomerManagedKey(data acceptance.TestData) string {
+func (r MysqlFlexibleServerResource) withHsmCustomerManagedKey(data acceptance.TestData, uuids []string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -1483,11 +1536,106 @@ resource "azurerm_mysql_flexible_server" "test" {
   }
 
   customer_managed_key {
+    key_vault_key_id                  = azurerm_key_vault_managed_hardware_security_module_key.test.versioned_id
+    primary_user_assigned_identity_id = azurerm_user_assigned_identity.test.id
+  }
+}
+`, r.cmkWithManagedHsmTemplate(data, uuids), data.RandomInteger)
+}
+
+func (r MysqlFlexibleServerResource) withHsmCustomerManagedKeyFourOhHSMOnly(data acceptance.TestData, uuids []string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_mysql_flexible_server" "test" {
+  name                   = "acctest-fs-%[2]d"
+  resource_group_name    = azurerm_resource_group.test.name
+  location               = azurerm_resource_group.test.location
+  administrator_login    = "_admin_Terraform_892123456789312"
+  administrator_password = "QAZwsx123"
+  sku_name               = "B_Standard_B1ms"
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+
+  customer_managed_key {
     managed_hsm_key_id                = azurerm_key_vault_managed_hardware_security_module_key.test.versioned_id
     primary_user_assigned_identity_id = azurerm_user_assigned_identity.test.id
   }
 }
-`, r.cmkWithManagedHsmTemplate(data), data.RandomInteger)
+`, r.withHsmCustomerManagedKeyFourOhTemplate(data, uuids), data.RandomInteger)
+}
+
+func (r MysqlFlexibleServerResource) withHsmCustomerManagedKeyFourOh(data acceptance.TestData, keyID string, uuids []string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_mysql_flexible_server" "test" {
+  name                   = "acctest-fs-%[2]d"
+  resource_group_name    = azurerm_resource_group.test.name
+  location               = azurerm_resource_group.test.location
+  administrator_login    = "_admin_Terraform_892123456789312"
+  administrator_password = "QAZwsx123"
+  sku_name               = "B_Standard_B1ms"
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+
+  customer_managed_key {
+    key_vault_key_id                  = %[3]s
+    primary_user_assigned_identity_id = azurerm_user_assigned_identity.test.id
+  }
+}
+`, r.withHsmCustomerManagedKeyFourOhTemplate(data, uuids), data.RandomInteger, keyID)
+}
+
+func (r MysqlFlexibleServerResource) withHsmCustomerManagedKeyFourOhTemplate(data acceptance.TestData, uuids []string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_key_vault" "test2" {
+  name                       = "acctestkv%[2]s"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "standard"
+  soft_delete_retention_days = 90
+  purge_protection_enabled   = true
+}
+
+resource "azurerm_key_vault_access_policy" "server" {
+  key_vault_id = azurerm_key_vault.test2.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = azurerm_user_assigned_identity.test.principal_id
+
+  key_permissions = ["Get", "List", "WrapKey", "UnwrapKey", "GetRotationPolicy", "SetRotationPolicy"]
+}
+
+resource "azurerm_key_vault_access_policy" "client" {
+  key_vault_id = azurerm_key_vault.test2.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = data.azurerm_client_config.current.object_id
+
+  key_permissions = ["Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify", "GetRotationPolicy", "SetRotationPolicy"]
+}
+
+resource "azurerm_key_vault_key" "test2" {
+  name         = "test"
+  key_vault_id = azurerm_key_vault.test2.id
+  key_type     = "RSA"
+  key_size     = 2048
+  key_opts     = ["decrypt", "encrypt", "sign", "unwrapKey", "verify", "wrapKey"]
+
+  depends_on = [
+    azurerm_key_vault_access_policy.client,
+    azurerm_key_vault_access_policy.server,
+  ]
+}
+`, r.cmkWithManagedHsmTemplate(data, uuids), data.RandomString)
 }
 
 func (r MysqlFlexibleServerResource) enableGeoRedundantBackup(data acceptance.TestData) string {

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -515,6 +515,7 @@ Please follow the format in the example below for listing breaking changes in re
 
 ### `azurerm_mysql_flexible_server`
 
+* The deprecated `customer_managed_key.managed_hsm_key_id` property has been removed in favour of the `customer_managed_key.key_vault_key_id` property.
 * The deprecated `public_network_access_enabled` property has been removed in favour of the `public_network_access` property.
 
 ### `azurerm_netapp_volume`


### PR DESCRIPTION


<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Migrates to common Nested Item ID funcs and deprecates `managed_hsm_key_id` in favour of `key_vault_key_id`

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

4.0 testing:
1 new failure, transient error, hit the quota for Managed HSM vaults in the region
<img width="334" height="144" alt="image" src="https://github.com/user-attachments/assets/28bdfae2-b676-49db-9610-38461b8ec574" />

5.0 beta testing:
<img width="336" height="168" alt="image" src="https://github.com/user-attachments/assets/2cb0cd5d-d4ba-4994-b6a2-36c87b3b6444" />



## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)



## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
