### PR TITLE
fix: use numeric comparison for `number_of_ip_addresses` in subnet `ip_address_pool`

### DIFF
--- a/internal/services/network/network_manager_resource_test.go
+++ b/internal/services/network/network_manager_resource_test.go
@@ -125,11 +125,12 @@ func TestAccNetworkManager(t *testing.T) {
 			"requiresImport": testAccNetworkManagerRoutingRuleCollection_requiresImport,
 		},
 		"SubnetIPAMPool": {
-			"ipAddressPool":              testAccSubnet_ipAddressPool,
-			"ipAddressPoolVNet":          testAccSubnet_ipAddressPoolVNet,
-			"ipAddressPoolIPv6":          testAccSubnet_ipAddressPoolIPv6,
-			"ipAddressPoolBlockUpdated":  testAccSubnet_ipAddressPoolBlockUpdated,
-			"ipAddressPoolNumberUpdated": testAccSubnet_ipAddressPoolNumberUpdated,
+			"ipAddressPool":                          testAccSubnet_ipAddressPool,
+			"ipAddressPoolVNet":                      testAccSubnet_ipAddressPoolVNet,
+			"ipAddressPoolIPv6":                      testAccSubnet_ipAddressPoolIPv6,
+			"ipAddressPoolBlockUpdated":              testAccSubnet_ipAddressPoolBlockUpdated,
+			"ipAddressPoolNumberUpdated":             testAccSubnet_ipAddressPoolNumberUpdated,
+			"ipAddressPoolNumberLexicographicUpdate": testAccSubnet_ipAddressPoolNumberLexicographicUpdate,
 		},
 		"VNETIPANPool": {
 			"ipAddressPool":             testAccVirtualNetwork_ipAddressPool,

--- a/internal/services/network/subnet_resource.go
+++ b/internal/services/network/subnet_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"math/big"
 	"regexp"
 	"strings"
 	"time"
@@ -463,8 +464,12 @@ func resourceSubnetUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 				for _, existingAllocation := range *props.IPamPoolPrefixAllocations {
 					for _, expandedAllocation := range *expandedIPAddressPool {
 						if existingAllocation.Pool != nil && expandedAllocation.Pool != nil && strings.EqualFold(pointer.From(existingAllocation.Pool.Id), pointer.From(expandedAllocation.Pool.Id)) &&
-							existingAllocation.NumberOfIPAddresses != nil && expandedAllocation.NumberOfIPAddresses != nil && *existingAllocation.NumberOfIPAddresses > *expandedAllocation.NumberOfIPAddresses {
-							return fmt.Errorf("`number_of_ip_addresses` cannot be decreased from %v to %v on pool: %v", *existingAllocation.NumberOfIPAddresses, *expandedAllocation.NumberOfIPAddresses, *expandedAllocation.Pool.Id)
+							existingAllocation.NumberOfIPAddresses != nil && expandedAllocation.NumberOfIPAddresses != nil {
+							existingNum, _ := new(big.Int).SetString(*existingAllocation.NumberOfIPAddresses, 10)
+							expandedNum, _ := new(big.Int).SetString(*expandedAllocation.NumberOfIPAddresses, 10)
+							if existingNum != nil && expandedNum != nil && existingNum.Cmp(expandedNum) > 0 {
+								return fmt.Errorf("`number_of_ip_addresses` cannot be decreased from %v to %v on pool: %v", *existingAllocation.NumberOfIPAddresses, *expandedAllocation.NumberOfIPAddresses, *expandedAllocation.Pool.Id)
+							}
 						}
 					}
 				}

--- a/internal/services/network/subnet_resource_test.go
+++ b/internal/services/network/subnet_resource_test.go
@@ -285,6 +285,30 @@ func testAccSubnet_ipAddressPoolNumberUpdated(t *testing.T) {
 	})
 }
 
+func testAccSubnet_ipAddressPoolNumberLexicographicUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_subnet", "test")
+	r := SubnetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.ipAddressPoolNumberLexicographicBase(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			// Increase from "32" to "128" - this crosses the lexicographic boundary
+			// where string comparison would incorrectly consider "32" > "128"
+			Config: r.ipAddressPoolNumberLexicographicUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccSubnet_privateEndpointNetworkPolicies(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_subnet", "test")
 	r := SubnetResource{}
@@ -927,6 +951,116 @@ resource "azurerm_subnet" "test" {
   ip_address_pool {
     id                     = azurerm_network_manager_ipam_pool.test.id
     number_of_ip_addresses = "50"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (r SubnetResource) ipAddressPoolNumberLexicographicBase(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-n-%[1]d"
+  location = "%[2]s"
+}
+
+data "azurerm_subscription" "current" {}
+
+resource "azurerm_network_manager" "test" {
+  name                = "acctest-nm-ipam-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  scope {
+    subscription_ids = [data.azurerm_subscription.current.id]
+  }
+}
+
+resource "azurerm_network_manager_ipam_pool" "test" {
+  name               = "acctest-ipampool-%[1]d"
+  network_manager_id = azurerm_network_manager.test.id
+  location           = azurerm_resource_group.test.location
+  display_name       = "ipampool1"
+  address_prefixes   = ["10.0.0.0/16"]
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  ip_address_pool {
+    id                     = azurerm_network_manager_ipam_pool.test.id
+    number_of_ip_addresses = "65535"
+  }
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet%[1]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  ip_address_pool {
+    id                     = azurerm_network_manager_ipam_pool.test.id
+    number_of_ip_addresses = "32"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (r SubnetResource) ipAddressPoolNumberLexicographicUpdated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-n-%[1]d"
+  location = "%[2]s"
+}
+
+data "azurerm_subscription" "current" {}
+
+resource "azurerm_network_manager" "test" {
+  name                = "acctest-nm-ipam-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  scope {
+    subscription_ids = [data.azurerm_subscription.current.id]
+  }
+}
+
+resource "azurerm_network_manager_ipam_pool" "test" {
+  name               = "acctest-ipampool-%[1]d"
+  network_manager_id = azurerm_network_manager.test.id
+  location           = azurerm_resource_group.test.location
+  display_name       = "ipampool1"
+  address_prefixes   = ["10.0.0.0/16"]
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  ip_address_pool {
+    id                     = azurerm_network_manager_ipam_pool.test.id
+    number_of_ip_addresses = "65535"
+  }
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet%[1]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  ip_address_pool {
+    id                     = azurerm_network_manager_ipam_pool.test.id
+    number_of_ip_addresses = "128"
   }
 }
 `, data.RandomInteger, data.Locations.Primary)


### PR DESCRIPTION
## Description

Fix string comparison bug in `azurerm_subnet` where `number_of_ip_addresses` in `ip_address_pool` used Go lexicographic string comparison instead of numeric comparison.

This caused valid increases (e.g., 32 → 128) to be incorrectly rejected with:
```
number_of_ip_addresses cannot be decreased from 32 to 128
```

The root cause: `NumberOfIPAddresses` is `*string` in the Azure SDK model, and the Go `>` operator on strings performs lexicographic comparison (`"32" > "128"` is true because `'3' > '1'`).

## Fix

Replace string comparison with `math/big.Int` numeric comparison for arbitrary-precision correctness.

## Changes

- `internal/services/network/subnet_resource.go`: Use `math/big.Int.Cmp()` instead of string `>` for the decrease check
- `internal/services/network/subnet_resource_test.go`: Add acceptance test for lexicographic boundary case (32 → 128)
- `internal/services/network/network_manager_resource_test.go`: Register new test

## Testing

- New test: `ipAddressPoolNumberLexicographicUpdate` — creates subnet with `number_of_ip_addresses = "32"` then updates to `"128"`
- `go build` and `go vet` pass

Fixes #32258