### PR TITLE
`azurerm_private_endpoint`: fix parallel resource deployments

### DIFF
--- a/internal/services/network/private_endpoint_resource.go
+++ b/internal/services/network/private_endpoint_resource.go
@@ -396,7 +396,7 @@ func resourcePrivateEndpointCreate(d *pluginsdk.ResourceData, meta interface{}) 
 					}
 				}
 
-				retryableErrorCodes := []string{"RetryableError", "StorageAccountOperationInProgress"}
+				retryableErrorCodes := []string{"RetryableError", "StorageAccountOperationInProgress", "ConflictError", "InvalidPrivateLinkServiceId"}
 				if slices.Contains(retryableErrorCodes, lroError.Error.Code) {
 					log.Printf("[WARN] Retry polling %q on error code: %q", id, lroError.Error.Code)
 					return &pluginsdk.RetryError{
@@ -542,20 +542,29 @@ func resourcePrivateEndpointUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 		return err
 	}
 
-	err = pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutCreate), func() *pluginsdk.RetryError {
+	err = pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutUpdate), func() *pluginsdk.RetryError {
 		if err = client.CreateOrUpdateThenPoll(ctx, *id, parameters); err != nil {
 			switch {
-			case strings.EqualFold(err.Error(), "is missing required parameter 'group Id'"):
+			case strings.Contains(err.Error(), "is missing required parameter 'group Id'"):
 				{
 					return &pluginsdk.RetryError{
-						Err:       fmt.Errorf("updating %s due to missing 'group Id', ensure that the 'subresource_names' type is populated: %+v", id, err),
+						Err:       fmt.Errorf("updating %s: missing 'group Id', ensure that the 'subresource_names' type is populated: %+v", id, err),
 						Retryable: false,
 					}
 				}
-			case strings.Contains(err.Error(), "PrivateLinkServiceId Invalid private link service id"):
+			case strings.Contains(err.Error(), "ConflictError"):
 				{
+					// Updating private endpoints on some resources (like KeyVault) can trigger update conflict errors.
 					return &pluginsdk.RetryError{
-						Err:       fmt.Errorf("creating Private Endpoint %s: %+v", id, err),
+						Err:       fmt.Errorf("updating %s: %+v", id, err),
+						Retryable: true,
+					}
+				}
+			case strings.Contains(err.Error(), "InvalidPrivateLinkServiceId"):
+				{
+					// This is required due to a bug in the API: https://github.com/Azure/azure-rest-api-specs/issues/20289
+					return &pluginsdk.RetryError{
+						Err:       fmt.Errorf("updating %s: %+v", id, err),
 						Retryable: true,
 					}
 				}

--- a/internal/services/network/private_endpoint_resource_test.go
+++ b/internal/services/network/private_endpoint_resource_test.go
@@ -1121,3 +1121,76 @@ resource "azurerm_private_endpoint" "test" {
 }
 `, r.template(data, r.serviceAutoApprove(data)), data.RandomInteger)
 }
+
+func TestAccPrivateEndpoint_parallelKeyVaultLink(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_private_endpoint", "test")
+	r := PrivateEndpointResource{}
+
+	instanceCount := 5
+	var checks []pluginsdk.TestCheckFunc
+	for i := 0; i < instanceCount; i++ {
+		checks = append(checks, check.That(fmt.Sprintf("%s.%d", data.ResourceName, i)).ExistsInAzure(r))
+	}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.parallelKeyVaultLink(data),
+			Check:  acceptance.ComposeTestCheckFunc(checks...),
+		},
+	})
+}
+
+func (PrivateEndpointResource) parallelKeyVaultLink(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-privatelink-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvnet-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  address_space       = ["10.5.0.0/16"]
+}
+
+resource "azurerm_subnet" "endpoint" {
+  name                 = "acctestsnetendpoint-%[1]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.5.2.0/24"]
+
+  private_endpoint_network_policies = "Disabled"
+}
+
+resource "azurerm_key_vault" "test" {
+  name                       = "acctestkv-%[3]s"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "standard"
+  soft_delete_retention_days = 7
+}
+
+resource "azurerm_private_endpoint" "test" {
+  count               = 5
+  name                = "acctest-privatelink-%[1]d-${count.index}"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  subnet_id           = azurerm_subnet.endpoint.id
+
+  private_service_connection {
+    name                           = "acctest-privatelink-kv-%[1]d-${count.index}"
+    private_connection_resource_id = azurerm_key_vault.test.id
+    subresource_names              = ["vault"]
+    is_manual_connection           = false
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR adds ConflictError to retryable errors to allow parallel private endpoints deployments, as well as deployments during modifications in case target resource is not managed by terraform. 

Running acceptance test before the fix would cause for KeyVault test:
```
{"status":"Failed","error":{"code":"ConflictError","message":"Call to Microsoft.KeyVault/vaults
  failed. Error message: A conflict occurred that prevented the operation from completing. The
  operation failed because the Key Vault 'acctestkv-xxxxx' changed from the point the operation
  began. This can happen if parallel operations are being performed on the Key Vault. To prevent
  this error, serialize the operations so that only one operation is performed on the Key Vault
  at a time.","details":[]}}
```

And for alias test:
```
    testcase.go:203: Step 1/3 error: Error running apply: exit status 1
        
        Error: creating Private Endpoint (Subscription: "[redacted]"
        Resource Group Name: "acctestRG-privatelink-260402164952999216"
        Private Endpoint Name: "acctest-privatelink-260402164952999216"): unexpected status 400 (400 Bad Request) with error: InvalidPrivateLinkServiceId: PrivateLinkServiceId Invalid private link service id: {0} passed in private link service connection: {1} passed in input is invalid
        
          with azurerm_private_endpoint.test,
          on terraform_plugin_test.tf line 109, in resource "azurerm_private_endpoint" "test":
         109: resource "azurerm_private_endpoint" "test" {
```

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<details><summary><h3>Test log</h3></summary>
<code>
=== RUN   TestAccPrivateEndpoint_resourceIdentity
=== PAUSE TestAccPrivateEndpoint_resourceIdentity
=== RUN   TestAccPrivateEndpoint_basic
=== PAUSE TestAccPrivateEndpoint_basic
=== RUN   TestAccPrivateEndpoint_updateTag
=== PAUSE TestAccPrivateEndpoint_updateTag
=== RUN   TestAccPrivateEndpoint_withCustomNicName
=== PAUSE TestAccPrivateEndpoint_withCustomNicName
=== RUN   TestAccPrivateEndpoint_requestMessage
=== PAUSE TestAccPrivateEndpoint_requestMessage
=== RUN   TestAccPrivateEndpoint_privateDnsZoneGroup
=== PAUSE TestAccPrivateEndpoint_privateDnsZoneGroup
=== RUN   TestAccPrivateEndpoint_privateDnsZoneRename
=== PAUSE TestAccPrivateEndpoint_privateDnsZoneRename
=== RUN   TestAccPrivateEndpoint_privateDnsZoneUpdate
=== PAUSE TestAccPrivateEndpoint_privateDnsZoneUpdate
=== RUN   TestAccPrivateEndpoint_privateDnsZoneIdsUpdate
=== PAUSE TestAccPrivateEndpoint_privateDnsZoneIdsUpdate
=== RUN   TestAccPrivateEndpoint_staticIpAddress
=== PAUSE TestAccPrivateEndpoint_staticIpAddress
=== RUN   TestAccPrivateEndpoint_privateDnsZoneRemove
=== PAUSE TestAccPrivateEndpoint_privateDnsZoneRemove
=== RUN   TestAccPrivateEndpoint_privateConnectionAlias
=== PAUSE TestAccPrivateEndpoint_privateConnectionAlias
=== RUN   TestAccPrivateEndpoint_updateToPrivateConnectionAlias
=== PAUSE TestAccPrivateEndpoint_updateToPrivateConnectionAlias
=== RUN   TestAccPrivateEndpoint_multipleInstances
=== PAUSE TestAccPrivateEndpoint_multipleInstances
=== RUN   TestAccPrivateEndpoint_multipleInstancesWithLinkAlias
=== PAUSE TestAccPrivateEndpoint_multipleInstancesWithLinkAlias
=== RUN   TestAccPrivateEndpoint_multipleIpConfigurations
=== PAUSE TestAccPrivateEndpoint_multipleIpConfigurations
=== RUN   TestAccPrivateEndpoint_parallelKeyVaultLink
=== PAUSE TestAccPrivateEndpoint_parallelKeyVaultLink
=== CONT  TestAccPrivateEndpoint_resourceIdentity
=== CONT  TestAccPrivateEndpoint_staticIpAddress
=== CONT  TestAccPrivateEndpoint_multipleInstances
=== CONT  TestAccPrivateEndpoint_parallelKeyVaultLink
=== CONT  TestAccPrivateEndpoint_privateConnectionAlias
=== CONT  TestAccPrivateEndpoint_privateDnsZoneGroup
=== CONT  TestAccPrivateEndpoint_withCustomNicName
=== CONT  TestAccPrivateEndpoint_privateDnsZoneIdsUpdate
=== CONT  TestAccPrivateEndpoint_privateDnsZoneUpdate
=== CONT  TestAccPrivateEndpoint_privateDnsZoneRemove
=== CONT  TestAccPrivateEndpoint_updateTag
=== CONT  TestAccPrivateEndpoint_basic
--- PASS: TestAccPrivateEndpoint_multipleInstances (252.07s)
=== CONT  TestAccPrivateEndpoint_privateDnsZoneRename
--- PASS: TestAccPrivateEndpoint_privateConnectionAlias (262.91s)
=== CONT  TestAccPrivateEndpoint_multipleIpConfigurations
--- PASS: TestAccPrivateEndpoint_basic (264.94s)
=== CONT  TestAccPrivateEndpoint_multipleInstancesWithLinkAlias
--- PASS: TestAccPrivateEndpoint_staticIpAddress (293.40s)
=== CONT  TestAccPrivateEndpoint_updateToPrivateConnectionAlias
--- PASS: TestAccPrivateEndpoint_withCustomNicName (320.09s)
=== CONT  TestAccPrivateEndpoint_requestMessage
--- PASS: TestAccPrivateEndpoint_resourceIdentity (324.32s)
--- PASS: TestAccPrivateEndpoint_updateTag (447.45s)
--- PASS: TestAccPrivateEndpoint_multipleInstancesWithLinkAlias (244.98s)
--- PASS: TestAccPrivateEndpoint_privateDnsZoneGroup (578.01s)
--- PASS: TestAccPrivateEndpoint_requestMessage (299.64s)
--- PASS: TestAccPrivateEndpoint_updateToPrivateConnectionAlias (332.49s)
--- PASS: TestAccPrivateEndpoint_privateDnsZoneUpdate (655.59s)
--- PASS: TestAccPrivateEndpoint_multipleIpConfigurations (402.17s)
--- PASS: TestAccPrivateEndpoint_privateDnsZoneIdsUpdate (697.85s)
--- PASS: TestAccPrivateEndpoint_privateDnsZoneRemove (755.20s)
--- PASS: TestAccPrivateEndpoint_privateDnsZoneRename (600.03s)
--- PASS: TestAccPrivateEndpoint_parallelKeyVaultLink (968.38s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network       970.964s
</code>
</details> 


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_private_endpoint` - fix parallel deployment


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

None found


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
