### PR TITLE
Resource Identity: normalisation and improved snakecase func

### DIFF
--- a/contributing/topics/guide-resource-identity.md
+++ b/contributing/topics/guide-resource-identity.md
@@ -4,8 +4,6 @@ This guide covers adding Resource Identity to a new or existing resource. For mo
 
 > The provider's Resource Identity generator does not yet support all identity types. `commonids.CompositeResourceID` and any custom resource IDs (i.e. not one provided by `commonids` or `go-azure-sdk/resource-manager`) are not supported.
 
-> **Caution:** Do not implement Resource Identity for resources with numbers in their ID segment names (e.g., `ServerGroupsv2Name`) until the `strcase.ToSnake()` issue is resolved. The current implementation splits on number boundaries, converting `ServerGroupsv2Name` to `server_groupsv_2_name` instead of the expected `server_groupsv2_name`. This causes test failures and incorrect identity schema field names.
-
 ## Adding Resource Identity
 
 ### Typed Resources
@@ -229,8 +227,6 @@ To go through these in order:
 - `-properties`: This flag specifies the 1:1 relationship between the Resource Schema and the Resource Identity Schema fields (i.e name, resource_group_name, etc), this would be specified as `name,resource_group_name`. If the schema property name does not match the Resource Identity schema name these should be mapped accordingly. This would be specified as `{id_field_name}:{schema_field_name}`, e.g. `api_management_id:api_management_name`.
 
 - `-compare-values`: This flag allows for comparing values that are exposed in the resource schema through another resource ID. This comes up when we use a parent resource ID in the schema but the Resource Identity Schema uses the individual parts of that parent ID. This would be specified as `{id_field_name}:{schema_field_id_name}`, e.g. `subscription_id:virtual_network_id,virtual_network_name:virtual_network_id`.
-
-> **Note:** The identity schema field names are generated using `strcase.ToSnake()` which splits on number boundaries. For example, `ServerGroupsv2Name` becomes `server_groupsv_2_name` (not `server_groupsv2_name`). This affects how you reference identity fields in `-properties` and `-compare-values` arguments.
 
 Please reference the [Resource Identity Test Generator](../../internal/tools/generator-tests/generators/resource_identity.go) for additional options that are used less frequently.
 

--- a/internal/sdk/framework_resource.go
+++ b/internal/sdk/framework_resource.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
 const removedSummary = "Resource removed from state"
@@ -290,7 +291,7 @@ type FrameworkWrappedResource interface {
 
 	ImportState(ctx context.Context, request resource.ImportStateRequest, response *resource.ImportStateResponse, metadata ResourceMetadata)
 
-	Identity() (resourceids.ResourceId, ResourceTypeForIdentity)
+	Identity() (resourceids.ResourceId, pluginsdk.ResourceTypeForIdentity)
 }
 
 // FrameworkWrappedResourceWithUpdate provides an extension to the base resource for resources that can be updated.

--- a/internal/sdk/framework_resource_wrapper.go
+++ b/internal/sdk/framework_resource_wrapper.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
 type FrameworkResourceWrapper struct {
@@ -266,8 +267,8 @@ func (r *FrameworkResourceWrapper) setIdentity(ctx context.Context, state *tfsdk
 		segments := id.Segments()
 		numSegments := len(segments)
 		for idx, segment := range segments {
-			if segmentTypeSupported(segment.Type) {
-				name := segmentName(segment, idType, numSegments, idx)
+			if pluginsdk.SegmentTypeSupported(segment.Type) {
+				name := pluginsdk.SegmentName(segment, idType, numSegments, idx)
 
 				field, ok := parsed.Parsed[segment.Name]
 				if !ok {

--- a/internal/sdk/resource_identity.go
+++ b/internal/sdk/resource_identity.go
@@ -4,22 +4,12 @@
 package sdk
 
 import (
-	"slices"
-	"strings"
-
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/hashicorp/terraform-plugin-framework/resource/identityschema"
-	"github.com/iancoleman/strcase"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
-type ResourceTypeForIdentity int
-
-const (
-	ResourceTypeForIdentityDefault = iota
-	ResourceTypeForIdentityVirtual
-)
-
-func GenerateIdentitySchema(id resourceids.ResourceId, idType ResourceTypeForIdentity) identityschema.Schema {
+func GenerateIdentitySchema(id resourceids.ResourceId, idType pluginsdk.ResourceTypeForIdentity) identityschema.Schema {
 	idSchema := identityschema.Schema{
 		Attributes: map[string]identityschema.Attribute{},
 	}
@@ -27,8 +17,8 @@ func GenerateIdentitySchema(id resourceids.ResourceId, idType ResourceTypeForIde
 	segments := id.Segments()
 	numSegments := len(segments)
 	for idx, segment := range segments {
-		if segmentTypeSupported(segment.Type) {
-			name := segmentName(segment, idType, numSegments, idx)
+		if pluginsdk.SegmentTypeSupported(segment.Type) {
+			name := pluginsdk.SegmentName(segment, idType, numSegments, idx)
 			idSchema.Attributes[name] = identityschema.StringAttribute{
 				RequiredForImport: true,
 			}
@@ -36,27 +26,4 @@ func GenerateIdentitySchema(id resourceids.ResourceId, idType ResourceTypeForIde
 	}
 
 	return idSchema
-}
-
-func segmentTypeSupported(segment resourceids.SegmentType) bool {
-	supportedSegmentTypes := []resourceids.SegmentType{
-		resourceids.SubscriptionIdSegmentType,
-		resourceids.ResourceGroupSegmentType,
-		resourceids.UserSpecifiedSegmentType,
-	}
-
-	return slices.Contains(supportedSegmentTypes, segment)
-}
-
-func segmentName(segment resourceids.Segment, idType ResourceTypeForIdentity, numSegments, idx int) string {
-	switch idType {
-	case ResourceTypeForIdentityVirtual:
-		return strcase.ToSnake(segment.Name)
-	default:
-		// For the last segment, if it's a `*Name` field, we generate it as `name` rather than snake casing the segment's name
-		if (idx+1) == numSegments && strings.HasSuffix(segment.Name, "Name") {
-			return "name"
-		}
-		return strcase.ToSnake(segment.Name)
-	}
 }

--- a/internal/services/cosmos/cosmosdb_postgresql_cluster_resource.go
+++ b/internal/services/cosmos/cosmosdb_postgresql_cluster_resource.go
@@ -3,10 +3,7 @@
 
 package cosmos
 
-// NOTE: Resource Identity is NOT implemented for this resource.
-// The ID contains "ServerGroupsv2" which strcase.ToSnake() incorrectly converts
-// to "server_groupsv_2" (splitting on the number boundary) instead of "server_groupsv2".
-// This will be addressed once the framework handles numeric boundaries correctly.
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name cosmosdb_postgresql_cluster -properties "name,resource_group_name" -test-expect-non-empty
 
 import (
 	"context"
@@ -17,6 +14,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresqlhsc/2022-11-08/clusters"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -66,7 +64,10 @@ type MaintenanceWindow struct {
 
 type CosmosDbPostgreSQLClusterResource struct{}
 
-var _ sdk.ResourceWithUpdate = CosmosDbPostgreSQLClusterResource{}
+var (
+	_ sdk.ResourceWithIdentity = CosmosDbPostgreSQLClusterResource{}
+	_ sdk.ResourceWithUpdate   = CosmosDbPostgreSQLClusterResource{}
+)
 
 func (r CosmosDbPostgreSQLClusterResource) ResourceType() string {
 	return CosmosDbPostgreSQLClusterResourceName
@@ -78,6 +79,10 @@ func (r CosmosDbPostgreSQLClusterResource) ModelObject() interface{} {
 
 func (r CosmosDbPostgreSQLClusterResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
 	return clusters.ValidateServerGroupsv2ID
+}
+
+func (r CosmosDbPostgreSQLClusterResource) Identity() resourceids.ResourceId {
+	return new(clusters.ServerGroupsv2Id)
 }
 
 func (r CosmosDbPostgreSQLClusterResource) Arguments() map[string]*pluginsdk.Schema {
@@ -430,7 +435,7 @@ func (r CosmosDbPostgreSQLClusterResource) Create() sdk.ResourceFunc {
 			}
 
 			metadata.SetID(id)
-			return nil
+			return pluginsdk.SetResourceIdentityData(metadata.ResourceData, &id)
 		},
 	}
 }
@@ -604,6 +609,10 @@ func (r CosmosDbPostgreSQLClusterResource) Read() sdk.ResourceFunc {
 
 			if model.Tags != nil {
 				state.Tags = *model.Tags
+			}
+
+			if err := pluginsdk.SetResourceIdentityData(metadata.ResourceData, id); err != nil {
+				return err
 			}
 
 			return metadata.Encode(&state)

--- a/internal/services/cosmos/cosmosdb_postgresql_cluster_resource_identity_gen_test.go
+++ b/internal/services/cosmos/cosmosdb_postgresql_cluster_resource_identity_gen_test.go
@@ -1,0 +1,39 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package cosmos_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
+)
+
+func TestAccCosmosdbPostgresqlCluster_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_postgresql_cluster", "test")
+	r := CosmosdbPostgresqlClusterResource{}
+
+	checkedFields := map[string]struct{}{
+		"subscription_id":     {},
+		"name":                {},
+		"resource_group_name": {},
+	}
+
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				customstatecheck.ExpectAllIdentityFieldsAreChecked("azurerm_cosmosdb_postgresql_cluster.test", checkedFields),
+				statecheck.ExpectIdentityValue("azurerm_cosmosdb_postgresql_cluster.test", tfjsonpath.New("subscription_id"), knownvalue.StringExact(data.Subscriptions.Primary)),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_cosmosdb_postgresql_cluster.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_cosmosdb_postgresql_cluster.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("resource_group_name")),
+			},
+		},
+		data.ImportBlockWithResourceIdentityStep(true),
+		data.ImportBlockWithIDStep(true),
+	}, false)
+}

--- a/internal/services/cosmos/cosmosdb_postgresql_coordinator_configuration_resource.go
+++ b/internal/services/cosmos/cosmosdb_postgresql_coordinator_configuration_resource.go
@@ -9,12 +9,15 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresqlhsc/2022-11-08/configurations"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
+
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name cosmosdb_postgresql_coordinator_configuration -properties "name" -compare-values "subscription_id:cluster_id,resource_group_name:cluster_id,server_groups_v2_name:cluster_id" -test-params "array_nulls,on"
 
 type CosmosDbPostgreSQLCoordinatorConfigurationModel struct {
 	Name      string `tfschema:"name"`
@@ -24,7 +27,10 @@ type CosmosDbPostgreSQLCoordinatorConfigurationModel struct {
 
 type CosmosDbPostgreSQLCoordinatorConfigurationResource struct{}
 
-var _ sdk.ResourceWithUpdate = CosmosDbPostgreSQLCoordinatorConfigurationResource{}
+var (
+	_ sdk.ResourceWithIdentity = CosmosDbPostgreSQLCoordinatorConfigurationResource{}
+	_ sdk.ResourceWithUpdate   = CosmosDbPostgreSQLCoordinatorConfigurationResource{}
+)
 
 func (r CosmosDbPostgreSQLCoordinatorConfigurationResource) ResourceType() string {
 	return "azurerm_cosmosdb_postgresql_coordinator_configuration"
@@ -36,6 +42,10 @@ func (r CosmosDbPostgreSQLCoordinatorConfigurationResource) ModelObject() interf
 
 func (r CosmosDbPostgreSQLCoordinatorConfigurationResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
 	return configurations.ValidateCoordinatorConfigurationID
+}
+
+func (r CosmosDbPostgreSQLCoordinatorConfigurationResource) Identity() resourceids.ResourceId {
+	return new(configurations.CoordinatorConfigurationId)
 }
 
 func (r CosmosDbPostgreSQLCoordinatorConfigurationResource) Arguments() map[string]*pluginsdk.Schema {
@@ -96,7 +106,7 @@ func (r CosmosDbPostgreSQLCoordinatorConfigurationResource) Create() sdk.Resourc
 			}
 
 			metadata.SetID(id)
-			return nil
+			return pluginsdk.SetResourceIdentityData(metadata.ResourceData, &id)
 		},
 	}
 }
@@ -166,6 +176,10 @@ func (r CosmosDbPostgreSQLCoordinatorConfigurationResource) Read() sdk.ResourceF
 				if props := model.Properties; props != nil {
 					state.Value = props.Value
 				}
+			}
+
+			if err := pluginsdk.SetResourceIdentityData(metadata.ResourceData, id); err != nil {
+				return err
 			}
 
 			return metadata.Encode(&state)

--- a/internal/services/cosmos/cosmosdb_postgresql_coordinator_configuration_resource.go
+++ b/internal/services/cosmos/cosmosdb_postgresql_coordinator_configuration_resource.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
 
-//go:generate go run ../../tools/generator-tests resourceidentity -resource-name cosmosdb_postgresql_coordinator_configuration -properties "name" -compare-values "subscription_id:cluster_id,resource_group_name:cluster_id,server_groups_v2_name:cluster_id" -test-params "array_nulls,on"
+//go:generate go run ../../tools/generator-tests resourceidentity -resource-name cosmosdb_postgresql_coordinator_configuration -properties "name" -compare-values "subscription_id:cluster_id,resource_group_name:cluster_id,server_groups_v2_name:cluster_id" -test-params "on"
 
 type CosmosDbPostgreSQLCoordinatorConfigurationModel struct {
 	Name      string `tfschema:"name"`

--- a/internal/services/cosmos/cosmosdb_postgresql_coordinator_configuration_resource_identity_gen_test.go
+++ b/internal/services/cosmos/cosmosdb_postgresql_coordinator_configuration_resource_identity_gen_test.go
@@ -25,7 +25,7 @@ func TestAccCosmosdbPostgresqlCoordinatorConfiguration_resourceIdentity(t *testi
 
 	data.ResourceIdentityTest(t, []acceptance.TestStep{
 		{
-			Config: r.basic(data, "array_nulls", "on"),
+			Config: r.basic(data, "on"),
 			ConfigStateChecks: []statecheck.StateCheck{
 				customstatecheck.ExpectAllIdentityFieldsAreChecked("azurerm_cosmosdb_postgresql_coordinator_configuration.test", checkedFields),
 				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_cosmosdb_postgresql_coordinator_configuration.test", tfjsonpath.New("name"), tfjsonpath.New("name")),

--- a/internal/services/cosmos/cosmosdb_postgresql_coordinator_configuration_resource_identity_gen_test.go
+++ b/internal/services/cosmos/cosmosdb_postgresql_coordinator_configuration_resource_identity_gen_test.go
@@ -1,0 +1,40 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package cosmos_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
+)
+
+func TestAccCosmosdbPostgresqlCoordinatorConfiguration_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_postgresql_coordinator_configuration", "test")
+	r := CosmosdbPostgresqlCoordinatorConfigurationResource{}
+
+	checkedFields := map[string]struct{}{
+		"name":                  {},
+		"resource_group_name":   {},
+		"server_groups_v2_name": {},
+		"subscription_id":       {},
+	}
+
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data, "array_nulls", "on"),
+			ConfigStateChecks: []statecheck.StateCheck{
+				customstatecheck.ExpectAllIdentityFieldsAreChecked("azurerm_cosmosdb_postgresql_coordinator_configuration.test", checkedFields),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_cosmosdb_postgresql_coordinator_configuration.test", tfjsonpath.New("name"), tfjsonpath.New("name")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_cosmosdb_postgresql_coordinator_configuration.test", tfjsonpath.New("resource_group_name"), tfjsonpath.New("cluster_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_cosmosdb_postgresql_coordinator_configuration.test", tfjsonpath.New("server_groups_v2_name"), tfjsonpath.New("cluster_id")),
+				customstatecheck.ExpectStateContainsIdentityValueAtPath("azurerm_cosmosdb_postgresql_coordinator_configuration.test", tfjsonpath.New("subscription_id"), tfjsonpath.New("cluster_id")),
+			},
+		},
+		data.ImportBlockWithResourceIdentityStep(false),
+		data.ImportBlockWithIDStep(false),
+	}, false)
+}

--- a/internal/services/cosmos/cosmosdb_postgresql_coordinator_configuration_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_postgresql_coordinator_configuration_resource_test.go
@@ -17,11 +17,11 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
-type CosmosDbPostgreSQLCoordinatorConfigurationResource struct{}
+type CosmosdbPostgresqlCoordinatorConfigurationResource struct{}
 
 func TestCosmosDbPostgreSQLCoordinatorConfiguration_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_postgresql_coordinator_configuration", "test")
-	r := CosmosDbPostgreSQLCoordinatorConfigurationResource{}
+	r := CosmosdbPostgresqlCoordinatorConfigurationResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -36,7 +36,7 @@ func TestCosmosDbPostgreSQLCoordinatorConfiguration_basic(t *testing.T) {
 
 func TestCosmosDbPostgreSQLCoordinatorConfiguration_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_postgresql_coordinator_configuration", "test")
-	r := CosmosDbPostgreSQLCoordinatorConfigurationResource{}
+	r := CosmosdbPostgresqlCoordinatorConfigurationResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -56,7 +56,7 @@ func TestCosmosDbPostgreSQLCoordinatorConfiguration_update(t *testing.T) {
 	})
 }
 
-func (r CosmosDbPostgreSQLCoordinatorConfigurationResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (r CosmosdbPostgresqlCoordinatorConfigurationResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := configurations.ParseCoordinatorConfigurationID(state.ID)
 	if err != nil {
 		return nil, err
@@ -73,7 +73,7 @@ func (r CosmosDbPostgreSQLCoordinatorConfigurationResource) Exists(ctx context.C
 	return pointer.To(resp.Model != nil), nil
 }
 
-func (r CosmosDbPostgreSQLCoordinatorConfigurationResource) template(data acceptance.TestData) string {
+func (r CosmosdbPostgresqlCoordinatorConfigurationResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -98,7 +98,7 @@ resource "azurerm_cosmosdb_postgresql_cluster" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
-func (r CosmosDbPostgreSQLCoordinatorConfigurationResource) basic(data acceptance.TestData, name, value string) string {
+func (r CosmosdbPostgresqlCoordinatorConfigurationResource) basic(data acceptance.TestData, name, value string) string {
 	return fmt.Sprintf(`
 %s
 

--- a/internal/services/cosmos/cosmosdb_postgresql_coordinator_configuration_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_postgresql_coordinator_configuration_resource_test.go
@@ -25,7 +25,7 @@ func TestCosmosDbPostgreSQLCoordinatorConfiguration_basic(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data, "array_nulls", "on"),
+			Config: r.basic(data, "on"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -40,14 +40,14 @@ func TestCosmosDbPostgreSQLCoordinatorConfiguration_update(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data, "array_nulls", "on"),
+			Config: r.basic(data, "on"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.basic(data, "array_nulls", "off"),
+			Config: r.basic(data, "off"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -98,14 +98,14 @@ resource "azurerm_cosmosdb_postgresql_cluster" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
-func (r CosmosdbPostgresqlCoordinatorConfigurationResource) basic(data acceptance.TestData, name, value string) string {
+func (r CosmosdbPostgresqlCoordinatorConfigurationResource) basic(data acceptance.TestData, value string) string {
 	return fmt.Sprintf(`
 %s
 
 resource "azurerm_cosmosdb_postgresql_coordinator_configuration" "test" {
-  name       = "%s"
+  name       = "array_nulls"
   cluster_id = azurerm_cosmosdb_postgresql_cluster.test.id
   value      = "%s"
 }
-`, r.template(data), name, value)
+`, r.template(data), value)
 }

--- a/internal/services/cosmos/cosmosdb_postgresql_coordinator_configuration_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_postgresql_coordinator_configuration_resource_test.go
@@ -19,7 +19,7 @@ import (
 
 type CosmosdbPostgresqlCoordinatorConfigurationResource struct{}
 
-func TestCosmosDbPostgreSQLCoordinatorConfiguration_basic(t *testing.T) {
+func TestAccCosmosDbPostgreSQLCoordinatorConfiguration_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_postgresql_coordinator_configuration", "test")
 	r := CosmosdbPostgresqlCoordinatorConfigurationResource{}
 
@@ -34,7 +34,7 @@ func TestCosmosDbPostgreSQLCoordinatorConfiguration_basic(t *testing.T) {
 	})
 }
 
-func TestCosmosDbPostgreSQLCoordinatorConfiguration_update(t *testing.T) {
+func TestAccCosmosDbPostgreSQLCoordinatorConfiguration_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_postgresql_coordinator_configuration", "test")
 	r := CosmosdbPostgresqlCoordinatorConfigurationResource{}
 
@@ -91,9 +91,7 @@ resource "azurerm_cosmosdb_postgresql_cluster" "test" {
   administrator_login_password    = "H@Sh1CoR3!"
   coordinator_storage_quota_in_mb = 131072
   coordinator_vcore_count         = 2
-  node_count                      = 2
-  node_storage_quota_in_mb        = 131072
-  node_vcores                     = 2
+  node_count                      = 0
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/resource/resource_group_resource_test.go
+++ b/internal/services/resource/resource_group_resource_test.go
@@ -196,7 +196,7 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
+  name     = "!acctestRG-%d"
   location = "%s"
 }
 `, data.RandomInteger, data.Locations.Primary)

--- a/internal/services/resource/resource_group_resource_test.go
+++ b/internal/services/resource/resource_group_resource_test.go
@@ -196,7 +196,7 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "!acctestRG-%d"
+  name     = "acctestRG-%d"
   location = "%s"
 }
 `, data.RandomInteger, data.Locations.Primary)

--- a/internal/tf/pluginsdk/resource_identity.go
+++ b/internal/tf/pluginsdk/resource_identity.go
@@ -229,12 +229,13 @@ func toSnakeCase(input string) string {
 			nextIsNum := next >= '0' && next <= '9'
 
 			// if it looks like a version (e.g. `ServerGroupsv2Name`), group `v2`/`V2` together -> `_v2_`
-			if (vIsLow || vIsCap) && nextIsNum {
-				if v == 'v' || v == 'V' {
+			if (vIsLow || vIsCap) && nextIsNum && (v == 'v' || v == 'V') {
+				// avoid duplicate delimiter
+				if b := []byte(n.String()); len(b)-1 >= 0 && b[len(b)-1] != delimiter {
 					n.WriteByte(delimiter)
-					n.WriteByte(v)
-					continue
 				}
+				n.WriteByte(v)
+				continue
 			}
 
 			// add underscore if next letter case type is changed

--- a/internal/tf/pluginsdk/resource_identity.go
+++ b/internal/tf/pluginsdk/resource_identity.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/iancoleman/strcase"
 )
 
 // These functions support generating the resource identity schema for the following types of identities and resources
@@ -40,10 +39,10 @@ func identityType(idType []ResourceTypeForIdentity) ResourceTypeForIdentity {
 	return t
 }
 
-// segmentTypeSupported contains a list of segments that should be used to construct the resource identity schema
+// SegmentTypeSupported contains a list of segments that should be used to construct the resource identity schema
 // this list will need to be extended to support hierarchical resource IDs for management groups or resources
 // that begin with a different prefix to /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1
-func segmentTypeSupported(segment resourceids.SegmentType) bool {
+func SegmentTypeSupported(segment resourceids.SegmentType) bool {
 	supportedSegmentTypes := []resourceids.SegmentType{
 		resourceids.ConstantSegmentType,
 		resourceids.SubscriptionIdSegmentType,
@@ -54,17 +53,19 @@ func segmentTypeSupported(segment resourceids.SegmentType) bool {
 	return slices.Contains(supportedSegmentTypes, segment)
 }
 
-func segmentName(segment resourceids.Segment, idType ResourceTypeForIdentity, numSegments, idx int) string {
+func SegmentName(segment resourceids.Segment, idType ResourceTypeForIdentity, numSegments, idx int) (name string) {
 	switch idType {
 	case ResourceTypeForIdentityVirtual:
-		return strcase.ToSnake(segment.Name)
+		name = toSnakeCase(segment.Name)
 	default:
 		// For the last segment, if it's a `*Name` field, we generate it as `name` rather than snake casing the segment's name
 		if (idx+1) == numSegments && strings.HasSuffix(segment.Name, "Name") {
 			return "name"
 		}
-		return strcase.ToSnake(segment.Name)
+		name = toSnakeCase(segment.Name)
 	}
+
+	return normaliseSegmentName(name)
 }
 
 // GenerateIdentitySchema generates the resource identity schema from the resource ID type
@@ -80,8 +81,8 @@ func identitySchema(id resourceids.ResourceId, idType ResourceTypeForIdentity) m
 	segments := id.Segments()
 	numSegments := len(segments)
 	for idx, segment := range segments {
-		if segmentTypeSupported(segment.Type) {
-			name := segmentName(segment, idType, numSegments, idx)
+		if SegmentTypeSupported(segment.Type) {
+			name := SegmentName(segment, idType, numSegments, idx)
 
 			idSchema[name] = &schema.Schema{
 				Type:              schema.TypeString,
@@ -109,8 +110,8 @@ func ValidateResourceIdentityData(d *schema.ResourceData, id resourceids.Resourc
 			identityString += pointer.From(segment.FixedValue) + "/"
 		}
 
-		if segmentTypeSupported(segment.Type) {
-			name := segmentName(segment, identityType(idType), numSegments, idx)
+		if SegmentTypeSupported(segment.Type) {
+			name := SegmentName(segment, identityType(idType), numSegments, idx)
 
 			field, ok := identity.GetOk(name)
 			if !ok {
@@ -171,8 +172,8 @@ func resourceIdentityData(identity *schema.IdentityData, id resourceids.Resource
 	segments := id.Segments()
 	numSegments := len(segments)
 	for idx, segment := range segments {
-		if segmentTypeSupported(segment.Type) {
-			name := segmentName(segment, idType, numSegments, idx)
+		if SegmentTypeSupported(segment.Type) {
+			name := SegmentName(segment, idType, numSegments, idx)
 
 			field, ok := parsed.Parsed[segment.Name]
 			if !ok {
@@ -186,4 +187,78 @@ func resourceIdentityData(identity *schema.IdentityData, id resourceids.Resource
 	}
 
 	return nil
+}
+
+// normaliseSegmentName replaces any known oddities when generating based on struct field names with predetermined values.
+func normaliseSegmentName(input string) string {
+	// For now, use complete values, if this becomes unmanageable investigate a more general replacement strategy
+	replacements := map[string]string{
+		"signal_r_name":    "signalr_name",
+		"web_pub_sub_name": "web_pubsub_name",
+	}
+
+	if v, ok := replacements[input]; ok {
+		return v
+	}
+
+	return input
+}
+
+// toSnakeCase is a slightly altered version of `strcase.ToSnake()`
+// the main difference is that it doesn't split patterns like `v2` to `v_2`
+func toSnakeCase(input string) string {
+	delimiter := uint8('_')
+
+	input = strings.TrimSpace(input)
+	n := strings.Builder{}
+	n.Grow(len(input) + 2) // nominal 2 bytes of extra space for inserted delimiters
+	for i, v := range []byte(input) {
+		vIsCap := v >= 'A' && v <= 'Z'
+		vIsLow := v >= 'a' && v <= 'z'
+		if vIsCap {
+			v += 'a'
+			v -= 'A'
+		}
+
+		// treat acronyms as words, eg for JSONData -> JSON is a whole word
+		if i+1 < len(input) {
+			next := input[i+1]
+			vIsNum := v >= '0' && v <= '9'
+			nextIsCap := next >= 'A' && next <= 'Z'
+			nextIsLow := next >= 'a' && next <= 'z'
+			nextIsNum := next >= '0' && next <= '9'
+
+			// if it looks like a version (e.g. `ServerGroupsv2Name`), group `v2`/`V2` together -> `_v2_`
+			if (vIsLow || vIsCap) && nextIsNum {
+				if v == 'v' || v == 'V' {
+					n.WriteByte(delimiter)
+					n.WriteByte(v)
+					continue
+				}
+			}
+
+			// add underscore if next letter case type is changed
+			if (vIsCap && (nextIsLow || nextIsNum)) || (vIsLow && (nextIsCap || nextIsNum)) || (vIsNum && (nextIsCap || nextIsLow)) {
+				if vIsCap && nextIsLow {
+					if prevIsCap := i > 0 && input[i-1] >= 'A' && input[i-1] <= 'Z'; prevIsCap {
+						n.WriteByte(delimiter)
+					}
+				}
+				n.WriteByte(v)
+				if vIsLow || vIsNum || nextIsNum {
+					n.WriteByte(delimiter)
+				}
+				continue
+			}
+		}
+
+		if v == ' ' || v == '_' || v == '-' || v == '.' {
+			// replace space/underscore/hyphen/dot with delimiter
+			n.WriteByte(delimiter)
+		} else {
+			n.WriteByte(v)
+		}
+	}
+
+	return n.String()
 }

--- a/internal/tf/pluginsdk/resource_identity_test.go
+++ b/internal/tf/pluginsdk/resource_identity_test.go
@@ -6,16 +6,6 @@ import (
 	"testing"
 )
 
-// TODO:
-//func TestSegmentName(t *testing.T) {
-//	data := []struct {
-//		Input string
-//		Output string
-//	}{
-//		{Input: , Output: },
-//	}
-//}
-
 func TestSnakeCase(t *testing.T) {
 	cases := []struct {
 		Input  string

--- a/internal/tf/pluginsdk/resource_identity_test.go
+++ b/internal/tf/pluginsdk/resource_identity_test.go
@@ -1,0 +1,83 @@
+package pluginsdk
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// TODO:
+//func TestSegmentName(t *testing.T) {
+//	data := []struct {
+//		Input string
+//		Output string
+//	}{
+//		{Input: , Output: },
+//	}
+//}
+
+func TestSnakeCase(t *testing.T) {
+	cases := []struct {
+		Input  string
+		Output string
+	}{
+		{
+			Input:  "ResourceGroupName",
+			Output: "resource_group_name",
+		},
+		{
+			Input:  "ServerGroupsv2Name",
+			Output: "server_groups_v2_name",
+		},
+		{
+			Input:  "ServerGroupsV2Name",
+			Output: "server_groups_v2_name",
+		},
+		{
+			Input:  "ServerGroupsV42Name",
+			Output: "server_groups_v42_name",
+		},
+		{
+			Input:  "ServerGroupsV2",
+			Output: "server_groups_v2",
+		},
+		{
+			Input:  "Terraform404",
+			Output: "terraform_404",
+		},
+		{
+			Input:  "1TerraformProvider",
+			Output: "1_terraform_provider",
+		},
+		{
+			Input:  "TFProvider",
+			Output: "tf_provider",
+		},
+		{
+			Input:  "Peer2Peer",
+			Output: "peer_2_peer",
+		},
+		{
+			Input:  "V2_Terraform",
+			Output: "v2_terraform",
+		},
+		{
+			Input:  "vV2_Terraform",
+			Output: "v_v2_terraform",
+		},
+		{
+			Input:  "VV2_Terraform",
+			Output: "v_v2_terraform",
+		},
+	}
+
+	failures := make([]string, 0)
+	for _, tc := range cases {
+		if v := toSnakeCase(tc.Input); v != tc.Output {
+			failures = append(failures, fmt.Sprintf("expected %s, got %s", tc.Output, v))
+		}
+	}
+	if len(failures) > 0 {
+		t.Fatal(strings.Join(failures, "\n"))
+	}
+}

--- a/internal/tools/generator-tests/generators/resource_identity.go
+++ b/internal/tools/generator-tests/generators/resource_identity.go
@@ -78,11 +78,6 @@ generate-resource-identity -resource-name some_azure_resource -properties "resou
 
 Caveats and TODOs:
 Expects that the test resource type is already declared in the test package for the service. (e.g. type LinuxFunctionAppResource struct{})
-
-CAUTION: Do not implement Resource Identity for resources with numbers in their ID segment names (e.g., 'ServerGroupsv2Name')
-until the strcase.ToSnake() issue is resolved. The current implementation splits on number boundaries,
-converting 'ServerGroupsv2Name' to 'server_groupsv_2_name' (not 'server_groupsv2_name').
-This causes test failures and incorrect identity schema field names.
 `
 }
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

- adds a `normaliseSegmentName` func (basic replacements for now)
- add modified implementation of the `strcase.ToSnake` func to avoid splitting on letter and number boundary when it looks like a version string, e.g. `server_groups_v2_name` instead of `server_groups_v_2_name`
- removes duplicate resource identity funcs in the framework wrapper in favour of reusing the main functions to avoid logic drift
- Adds resource identity to `azurerm_cosmosdb_postgresql_cluster` and `azurerm_cosmosdb_postgresql_coordinator_configuration` to confirm snakecase func fix


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

Running...

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
