### PR TITLE
Docs: `azurerm_lb_nat_rule` - correct Virtual Machine Scale Set note

### DIFF
--- a/website/docs/r/lb_nat_rule.html.markdown
+++ b/website/docs/r/lb_nat_rule.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Manages a Load Balancer NAT Rule.
 
--> **Note:** This resource cannot be used with with virtual machine scale sets, instead use the `azurerm_lb_nat_pool` resource.
+-> **Note:** To target a Virtual Machine Scale Set, set `frontend_port_start`, `frontend_port_end` and `backend_address_pool_id` to create an Inbound NAT rule v2. The legacy `azurerm_lb_nat_pool` resource maps to Inbound NAT rule v1, which Azure has scheduled for retirement on September 30, 2027.
 
 ~> **Note:** When using this resource, the Load Balancer needs to have a FrontEnd IP Configuration Attached
 


### PR DESCRIPTION
## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

The note at the top of the `azurerm_lb_nat_rule` page incorrectly said the resource cannot be used with Virtual Machine Scale Sets and pointed users to `azurerm_lb_nat_pool` instead. The resource does support Scale Sets via `frontend_port_start`, `frontend_port_end` and `backend_address_pool_id`, which create an [Inbound NAT rule v2](https://learn.microsoft.com/azure/load-balancer/inbound-nat-rules#types-of-inbound-nat-rules) targeting a backend pool. `azurerm_lb_nat_pool` maps to Inbound NAT rule v1, which Azure has [scheduled for retirement on 2027-09-30](https://learn.microsoft.com/azure/load-balancer/inbound-nat-rules#types-of-inbound-nat-rules), so steering Scale Set users toward it is the wrong recommendation today.

The `with with` typo in the original note is fixed by the rewrite.

## Testing

Documentation only, no code changes. Verified `misspell` (the same source-text check `make website-lint` runs) and `terrafmt` are clean against the file.

## Change Log

* `azurerm_lb_nat_rule` - corrected the documentation note about Virtual Machine Scale Set support [GH-00000]

This is a:

- [x] Bug Fix

## Related Issue(s)

Fixes #31750

## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

Claude Code was used to verify the current Inbound NAT rule v1/v2 behaviour against Microsoft Learn, draft the replacement note, and draft this PR description. The change was reviewed by the contributor before submission.

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

No changes to security controls.