### PR TITLE
`azurerm_data_protection_resource_guard` - add validations for `vault_critical_operation_exclusion_list`

### DIFF
--- a/internal/services/dataprotection/data_protection_resource_guard_resource.go
+++ b/internal/services/dataprotection/data_protection_resource_guard_resource.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/dataprotection/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -61,7 +60,7 @@ func resourceDataProtectionResourceGuard() *pluginsdk.Resource {
 				Optional: true,
 				Elem: &pluginsdk.Schema{
 					Type:         pluginsdk.TypeString,
-					ValidateFunc: validation.StringIsNotEmpty,
+					ValidateFunc: validate.ResourceGuardVaultCriticalOperationExclusionList(),
 				},
 			},
 

--- a/internal/services/dataprotection/data_protection_resource_guard_resource_test.go
+++ b/internal/services/dataprotection/data_protection_resource_guard_resource_test.go
@@ -159,7 +159,26 @@ resource "azurerm_data_protection_resource_guard" "test" {
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
 
-  vault_critical_operation_exclusion_list = ["Microsoft.RecoveryServices/vaults/backupconfig/delete", "Microsoft.RecoveryServices/vaults/backupResourceGuardProxies/write"]
+  vault_critical_operation_exclusion_list = [
+    "Microsoft.DataProtection/backupVaults/backupInstances/delete",
+    "Microsoft.DataProtection/backupVaults/backupInstances/restore/action",
+    "Microsoft.DataProtection/backupVaults/backupInstances/stopProtection/action",
+    "Microsoft.DataProtection/backupVaults/backupInstances/suspendBackups/action",
+    "Microsoft.DataProtection/backupVaults/backupInstances/write",
+    "Microsoft.DataProtection/backupVaults/write#modifyEncryptionSettings",
+    "Microsoft.DataProtection/backupVaults/write#reduceImmutabilityState",
+    "Microsoft.RecoveryServices/vaults/backupconfig/delete",
+    "Microsoft.RecoveryServices/vaults/backupEncryptionConfigs/backupResourceEncryptionConfig/write",
+    "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/delete",
+    "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/delete",
+    "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints/restore/action",
+    "Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/write",
+    "Microsoft.RecoveryServices/vaults/backupPolicies/write",
+    "Microsoft.RecoveryServices/vaults/backupResourceGuardProxies/write",
+    "Microsoft.RecoveryServices/vaults/backupSecurityPIN/action",
+    "Microsoft.RecoveryServices/vaults/write#modifyEncryptionSettings",
+    "Microsoft.RecoveryServices/vaults/write#reduceImmutabilityState",
+  ]
 
   tags = {
     ENV = "Test1"

--- a/internal/services/dataprotection/validate/resource_guard_vault_critical_operation_exclusion_list.go
+++ b/internal/services/dataprotection/validate/resource_guard_vault_critical_operation_exclusion_list.go
@@ -1,0 +1,29 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package validate
+
+import "github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+
+func ResourceGuardVaultCriticalOperationExclusionList() func(interface{}, string) ([]string, []error) {
+	return validation.StringInSlice([]string{
+		"Microsoft.DataProtection/backupVaults/backupInstances/delete",
+		"Microsoft.DataProtection/backupVaults/backupInstances/restore/action",
+		"Microsoft.DataProtection/backupVaults/backupInstances/stopProtection/action",
+		"Microsoft.DataProtection/backupVaults/backupInstances/suspendBackups/action",
+		"Microsoft.DataProtection/backupVaults/backupInstances/write",
+		"Microsoft.DataProtection/backupVaults/write#modifyEncryptionSettings",
+		"Microsoft.DataProtection/backupVaults/write#reduceImmutabilityState",
+		"Microsoft.RecoveryServices/vaults/backupconfig/delete",
+		"Microsoft.RecoveryServices/vaults/backupEncryptionConfigs/backupResourceEncryptionConfig/write",
+		"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/delete",
+		"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/delete",
+		"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints/restore/action",
+		"Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/write",
+		"Microsoft.RecoveryServices/vaults/backupPolicies/write",
+		"Microsoft.RecoveryServices/vaults/backupResourceGuardProxies/write",
+		"Microsoft.RecoveryServices/vaults/backupSecurityPIN/action",
+		"Microsoft.RecoveryServices/vaults/write#modifyEncryptionSettings",
+		"Microsoft.RecoveryServices/vaults/write#reduceImmutabilityState",
+	}, false)
+}

--- a/internal/services/dataprotection/validate/resource_guard_vault_critical_operation_exclusion_list_test.go
+++ b/internal/services/dataprotection/validate/resource_guard_vault_critical_operation_exclusion_list_test.go
@@ -1,0 +1,80 @@
+// Copyright IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package validate
+
+import "testing"
+
+func TestResourceGuardVaultCriticalOperationExclusionList(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected bool
+	}{
+		{
+			input:    "",
+			expected: false,
+		},
+		{
+			input:    "Microsoft.RecoveryServices/vaults/backupconfig/delete",
+			expected: true,
+		},
+		{
+			input:    "Microsoft.RecoveryServices/vaults/backupResourceGuardProxies/write",
+			expected: true,
+		},
+		{
+			input:    "Microsoft.RecoveryServices/vaults/write#reduceImmutabilityState",
+			expected: true,
+		},
+		{
+			input:    "Microsoft.RecoveryServices/vaults/write#modifyEncryptionSettings",
+			expected: true,
+		},
+		{
+			input:    "Microsoft.DataProtection/backupVaults/backupInstances/stopProtection/action",
+			expected: true,
+		},
+		{
+			input:    "Microsoft.DataProtection/backupVaults/write#reduceImmutabilityState",
+			expected: true,
+		},
+		{
+			input:    "Microsoft.DataProtection/backupVaults/write#modifyEncryptionSettings",
+			expected: true,
+		},
+		{
+			input:    "Microsoft.RecoveryServices/vaults/backupconfig/write",
+			expected: false,
+		},
+		{
+			input:    "Microsoft.DataProtection/backupVaults/backupResourceGuardProxies/delete",
+			expected: false,
+		},
+		{
+			input:    "Microsoft.DataProtection/backupVaults/write#reduceSoftDeleteSecurity",
+			expected: false,
+		},
+		{
+			input:    "Microsoft.RecoveryServices/vaults/backupPolicies/delete",
+			expected: false,
+		},
+		{
+			input:    "Microsoft.DataProtection/backupVaults/backupPolicies/write",
+			expected: false,
+		},
+		{
+			input:    "Microsoft.Compute/virtualMachines/delete",
+			expected: false,
+		},
+	}
+
+	validator := ResourceGuardVaultCriticalOperationExclusionList()
+
+	for _, testCase := range testCases {
+		_, errors := validator(testCase.input, "vault_critical_operation_exclusion_list")
+		result := len(errors) == 0
+		if result != testCase.expected {
+			t.Fatalf("expected the result to be %t but got %t for %q", testCase.expected, result, testCase.input)
+		}
+	}
+}

--- a/website/docs/r/data_protection_resource_guard.html.markdown
+++ b/website/docs/r/data_protection_resource_guard.html.markdown
@@ -37,7 +37,7 @@ The following arguments are supported:
 
 * `vault_critical_operation_exclusion_list` - (Optional) A list of the critical operations which are not protected by this Resource Guard.
 
--> **Note:** Azure Backup documentation describes these operations by friendly names, but the API expects the following literal values for `vault_critical_operation_exclusion_list`:
+-> **Note:** Azure Backup documentation describes these operations by friendly names. See [Recovery Services vault critical operations](https://learn.microsoft.com/azure/backup/multi-user-authorization-concept?tabs=recovery-services-vault#critical-operations) and [Backup vault critical operations](https://learn.microsoft.com/azure/backup/multi-user-authorization-concept?tabs=backup-vault#critical-operations). The API expects the following literal values for `vault_critical_operation_exclusion_list`:
 
   | Vault type | Azure documentation operation | Valid API value |
   |---|---|---|

--- a/website/docs/r/data_protection_resource_guard.html.markdown
+++ b/website/docs/r/data_protection_resource_guard.html.markdown
@@ -37,6 +37,29 @@ The following arguments are supported:
 
 * `vault_critical_operation_exclusion_list` - (Optional) A list of the critical operations which are not protected by this Resource Guard.
 
+-> **Note:** Azure Backup documentation describes these operations by friendly names, but the API expects the following literal values for `vault_critical_operation_exclusion_list`:
+
+  | Vault type | Azure documentation operation | Valid API value |
+  |---|---|---|
+  | Recovery Services vault | `Delete protection` | `Microsoft.RecoveryServices/vaults/backupconfig/delete` |
+  | Recovery Services vault | `Delete protection` | `Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/delete` |
+  | Recovery Services vault | `Modify protection` | `Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/write` |
+  | Recovery Services vault | `Modify protection` | `Microsoft.RecoveryServices/vaults/backupResourceGuardProxies/write` |
+  | Recovery Services vault | `Modify policy` | `Microsoft.RecoveryServices/vaults/backupPolicies/write` |
+  | Recovery Services vault | `Get backup security PIN` | `Microsoft.RecoveryServices/vaults/backupSecurityPIN/action` |
+  | Recovery Services vault | `Modify encryption settings` | `Microsoft.RecoveryServices/vaults/backupEncryptionConfigs/backupResourceEncryptionConfig/write` |
+  | Recovery Services vault | `Modify encryption settings` | `Microsoft.RecoveryServices/vaults/write#modifyEncryptionSettings` |
+  | Recovery Services vault | `Disable immutability` | `Microsoft.RecoveryServices/vaults/write#reduceImmutabilityState` |
+  | Recovery Services vault | `Restore` | `Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems/recoveryPoints/restore/action` |
+  | Recovery Services vault | `Delete hybrid container` | `Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/delete` |
+  | Backup vault | `Delete Backup Instance` | `Microsoft.DataProtection/backupVaults/backupInstances/delete` |
+  | Backup vault | `Disable immutability` | `Microsoft.DataProtection/backupVaults/write#reduceImmutabilityState` |
+  | Backup vault | `Modify encryption settings` | `Microsoft.DataProtection/backupVaults/write#modifyEncryptionSettings` |
+  | Backup vault | `Stop backup and retain forever` | `Microsoft.DataProtection/backupVaults/backupInstances/stopProtection/action` |
+  | Backup vault | `Stop backup and retain as per policy` | `Microsoft.DataProtection/backupVaults/backupInstances/suspendBackups/action` |
+  | Backup vault | `Change policy` | `Microsoft.DataProtection/backupVaults/backupInstances/write` |
+  | Backup vault | `Restore` | `Microsoft.DataProtection/backupVaults/backupInstances/restore/action` |
+
 * `tags` - (Optional) A mapping of tags which should be assigned to the Resource Guard.
 
 ## Attributes Reference


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->
Azure Backup documentation describes these operations by friendly names. See [Recovery Services vault critical operations](https://learn.microsoft.com/azure/backup/multi-user-authorization-concept?tabs=recovery-services-vault#critical-operations) and [Backup vault critical operations](https://learn.microsoft.com/azure/backup/multi-user-authorization-concept?tabs=backup-vault#critical-operations). The API expects the following literal values for 

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
