### PR TITLE
`common` - Add additional logs when HTTP response was failed to be dumped

### DIFF
--- a/internal/common/middleware.go
+++ b/internal/common/middleware.go
@@ -55,8 +55,11 @@ func responseLoggerMiddleware(providerName string) client.ResponseMiddleware {
 			log.Printf("[DEBUG] %s Response for %s: \n%s\n", providerName, request.URL, dump)
 		} else {
 			var bs bytes.Buffer
-			response.Header.Write(&bs)
-			log.Printf("[DEBUG] %s Response dump failed for %s: %s\nResponse Headers: %s", providerName, request.URL, err2, bs.String())
+			if err := response.Header.Write(&bs); err != nil {
+				log.Printf("[DEBUG] %s Response dump failed for %s: %s (header write also failed: %s)", providerName, request.URL, err2, err)
+			} else {
+				log.Printf("[DEBUG] %s Response dump failed for %s: %s\nResponse Headers: %s", providerName, request.URL, err2, bs.String())
+			}
 		}
 		return response, nil
 	}

--- a/internal/common/middleware.go
+++ b/internal/common/middleware.go
@@ -4,6 +4,7 @@
 package common
 
 import (
+	"bytes"
 	"log"
 	"net/http"
 	"net/http/httputil"
@@ -53,15 +54,9 @@ func responseLoggerMiddleware(providerName string) client.ResponseMiddleware {
 		if dump, err2 := httputil.DumpResponse(response, true); err2 == nil {
 			log.Printf("[DEBUG] %s Response for %s: \n%s\n", providerName, request.URL, dump)
 		} else {
-			log.Printf("[DEBUG] %s Response dump failed for %s: %s", providerName, request.URL, err2)
-
-			// fallback to basic message with headers
-			log.Printf("[DEBUG] %s Response: %s for %s", providerName, response.Status, request.URL)
-			for name, values := range response.Header {
-				for _, value := range values {
-					log.Printf("[DEBUG] %s Response Header: %s: %s", providerName, name, value)
-				}
-			}
+			var bs bytes.Buffer
+			response.Header.Write(&bs)
+			log.Printf("[DEBUG] %s Response dump failed for %s: %s\nResponse Headers: %s", providerName, request.URL, err2, bs.String())
 		}
 		return response, nil
 	}

--- a/internal/common/middleware.go
+++ b/internal/common/middleware.go
@@ -56,9 +56,9 @@ func responseLoggerMiddleware(providerName string) client.ResponseMiddleware {
 		} else {
 			var bs bytes.Buffer
 			if err := response.Header.Write(&bs); err != nil {
-				log.Printf("[DEBUG] %s Response dump failed for %s: %s (header write also failed: %s)", providerName, request.URL, err2, err)
+				log.Printf("[DEBUG] %s Response dump failed for %s: %s\nStatus: %s (header write also failed: %s)", providerName, request.URL, err2, response.Status, err)
 			} else {
-				log.Printf("[DEBUG] %s Response dump failed for %s: %s\nResponse Headers: %s", providerName, request.URL, err2, bs.String())
+				log.Printf("[DEBUG] %s Response dump failed for %s: %s\nStatus: %s\nResponse Headers: %s", providerName, request.URL, err2, response.Status, bs.String())
 			}
 		}
 		return response, nil

--- a/internal/common/middleware.go
+++ b/internal/common/middleware.go
@@ -53,8 +53,15 @@ func responseLoggerMiddleware(providerName string) client.ResponseMiddleware {
 		if dump, err2 := httputil.DumpResponse(response, true); err2 == nil {
 			log.Printf("[DEBUG] %s Response for %s: \n%s\n", providerName, request.URL, dump)
 		} else {
-			// fallback to basic message
-			log.Printf("[DEBUG] %s Response: %s for %s\n", providerName, response.Status, request.URL)
+			log.Printf("[DEBUG] %s Response dump failed for %s: %s", providerName, request.URL, err2)
+
+			// fallback to basic message with headers
+			log.Printf("[DEBUG] %s Response: %s for %s", providerName, response.Status, request.URL)
+			for name, values := range response.Header {
+				for _, value := range values {
+					log.Printf("[DEBUG] %s Response Header: %s: %s", providerName, name, value)
+				}
+			}
 		}
 		return response, nil
 	}


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR adds additional logs when the HTTP responses are failed to be dumped by Go/http. This is often caused by network issues, which is really hard to reproduce locally. Adding this additional log would be helpful in debugging and triaging.

Example scenario
- We recently had an internal ICM where customers receive intermittent `unexpected end of json` error. However, we are not able to get details from the logs. When `dumpResponse` is failed but the response is 200, it is logged in fallback mode, where it doesn't track any useful information.

For example:
Source: https://github.com/hashicorp/terraform-provider-azurerm/issues/28073#issuecomment-2860580864

```
2025-05-07T21:41:59.000Z [TRACE] provider.terraform-provider-azurerm_v4.27.0_x5: Received request: @caller=github.com/hashicorp/terraform-plugin-go@v0.26.0/tfprotov5/tf5server/server.go:578 tf_req_id=ae8bb884-fad8-f4f2-9223-b5d684c26740 tf_rpc=Configure @module=sdk.proto tf_proto_version=5.8 tf_provider_addr=registry.terraform.io/hashicorp/azurerm timestamp=2025-05-07T21:41:58.998Z
2025-05-07T21:41:59.000Z [TRACE] provider.terraform-provider-azurerm_v4.27.0_x5: Announced client capabilities: @caller=github.com/hashicorp/terraform-plugin-go@v0.26.0/tfprotov5/internal/tf5serverlogging/client_capabilities.go:38 @module=sdk.proto tf_client_capability_deferral_allowed=false tf_proto_version=5.8 tf_provider_addr=registry.terraform.io/hashicorp/azurerm tf_req_id=ae8bb884-fad8-f4f2-9223-b5d684c26740 tf_rpc=Configure timestamp=2025-05-07T21:41:58.998Z
2025-05-07T21:41:59.000Z [TRACE] provider.terraform-provider-azurerm_v4.27.0_x5: Sending request downstream: @caller=github.com/hashicorp/terraform-plugin-go@v0.26.0/tfprotov5/internal/tf5serverlogging/downstream_request.go:22 tf_req_id=ae8bb884-fad8-f4f2-9223-b5d684c26740 @module=sdk.proto tf_proto_version=5.8 tf_provider_addr=registry.terraform.io/hashicorp/azurerm tf_rpc=Configure timestamp=2025-05-07T21:41:58.998Z
2025-05-07T21:41:59.000Z [TRACE] provider.terraform-provider-azurerm_v4.27.0_x5: calling downstream server: tf_mux_provider="*schema.GRPCProviderServer" tf_rpc=ConfigureProvider @caller=github.com/hashicorp/terraform-plugin-mux@v0.17.0/internal/logging/mux.go:19 @module=sdk.mux timestamp=2025-05-07T21:41:58.998Z
2025-05-07T21:41:59.000Z [TRACE] provider.terraform-provider-azurerm_v4.27.0_x5: Calling downstream: @module=sdk.helper_schema tf_req_id=ae8bb884-fad8-f4f2-9223-b5d684c26740 tf_rpc=ConfigureProvider @caller=github.com/hashicorp/terraform-plugin-sdk/v2@v2.36.1/helper/schema/grpc_provider.go:646 tf_mux_provider="*schema.GRPCProviderServer" tf_provider_addr=registry.terraform.io/hashicorp/azurerm timestamp=2025-05-07T21:41:58.998Z
2025-05-07T21:41:59.000Z [DEBUG] provider.terraform-provider-azurerm_v4.27.0_x5: [DEBUG] Configuring built-in cloud environment by name: "public"
2025-05-07T21:41:59.000Z [DEBUG] provider.terraform-provider-azurerm_v4.27.0_x5: [DEBUG] POST https://login.microsoftonline.com/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/oauth2/v2.0/token
2025-05-07T21:41:59.372Z [DEBUG] provider.terraform-provider-azurerm_v4.27.0_x5: [DEBUG] Generated Provider Correlation Request Id: b8022f17-288d-7b89-35d6-3d957e8e0741
2025-05-07T21:41:59.492Z [DEBUG] provider.terraform-provider-azurerm_v4.27.0_x5: [DEBUG] POST https://login.microsoftonline.com/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/oauth2/v2.0/token
2025-05-07T21:41:59.626Z [DEBUG] provider.terraform-provider-azurerm_v4.27.0_x5: [DEBUG] AzureRM Request:
2025-05-07T21:41:59.626Z [DEBUG] provider.terraform-provider-azurerm_v4.27.0_x5: GET /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/providers?api-version=2022-09-01 HTTP/1.1
2025-05-07T21:41:59.626Z [DEBUG] provider.terraform-provider-azurerm_v4.27.0_x5: Host: management.azure.com
2025-05-07T21:41:59.626Z [DEBUG] provider.terraform-provider-azurerm_v4.27.0_x5: User-Agent: HashiCorp/go-azure-sdk (Go-http-Client/1.1 providers/2022-09-01) HashiCorp Terraform/1.11.4 (+https://www.terraform.io) terraform-provider-azurerm/4.27.0 pid-222c6c49-1b0a-5959-a213-6608f9eb8820
2025-05-07T21:41:59.626Z [DEBUG] provider.terraform-provider-azurerm_v4.27.0_x5: Accept: application/json; charset=utf-8; IEEE754Compatible=false
2025-05-07T21:41:59.626Z [DEBUG] provider.terraform-provider-azurerm_v4.27.0_x5: Content-Type: application/json; charset=utf-8
2025-05-07T21:41:59.626Z [DEBUG] provider.terraform-provider-azurerm_v4.27.0_x5: Odata-Maxversion: 4.0
2025-05-07T21:41:59.626Z [DEBUG] provider.terraform-provider-azurerm_v4.27.0_x5: Odata-Version: 4.0
2025-05-07T21:41:59.626Z [DEBUG] provider.terraform-provider-azurerm_v4.27.0_x5: Accept-Encoding: gzip
2025-05-07T21:41:59.626Z [DEBUG] provider.terraform-provider-azurerm_v4.27.0_x5
2025-05-07T21:41:59.626Z [DEBUG] provider.terraform-provider-azurerm_v4.27.0_x5
2025-05-07T21:41:59.626Z [DEBUG] provider.terraform-provider-azurerm_v4.27.0_x5: [DEBUG] GET https://management.azure.com/subscriptions//xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/providers?api-version=2022-09-01

<---DumpResponse failed but with no printed error message:-->
2025-05-07T21:42:01.722Z [DEBUG] provider.terraform-provider-azurerm_v4.27.0_x5: [DEBUG] AzureRM Response: 200 OK for https://management.azure.com/subscriptions/775fe06c-9d1f-4be1-ac80-f3aaa17424b0/providers?api-version=2022-09-01

// This is from the downstream operation to unmarshall the response body. The response body is an invalid json because `dumpResponse` reading HTTP response body from I/O into memory is interrupted above.
2025-05-07T21:42:01.755Z [DEBUG] provider.terraform-provider-azurerm_v4.27.0_x5: [DEBUG] error retrieving providers: populating cache: listing Resource Providers: loading results: unexpected end of JSON input. Enhanced validation will be unavailable
2025-05-07T21:42:01.755Z [DEBUG] provider.terraform-provider-azurerm_v4.27.0_x5: [DEBUG] AzureRM Request:
2025-05-07T21:42:01.755Z [DEBUG] provider.terraform-provider-azurerm_v4.27.0_x5: GET /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/providers?api-version=2022-09-01 HTTP/1.1
2025-05-07T21:42:01.755Z [DEBUG] provider.terraform-provider-azurerm_v4.27.0_x5: Host: management.azure.com
2025-05-07T21:42:01.755Z [DEBUG] provider.terraform-provider-azurerm_v4.27.0_x5: User-Agent: HashiCorp/go-azure-sdk (Go-http-Client/1.1 providers/2022-09-01) HashiCorp Terraform/1.11.4 (+https://www.terraform.io) terraform-provider-azurerm/4.27.0 pid-222c6c49-1b0a-5959-a213-6608f9eb8820
2025-05-07T21:42:01.756Z [DEBUG] provider.terraform-provider-azurerm_v4.27.0_x5: Accept: application/json; charset=utf-8; IEEE754Compatible=false
2025-05-07T21:42:01.756Z [DEBUG] provider.terraform-provider-azurerm_v4.27.0_x5: Content-Type: application/json; charset=utf-8
2025-05-07T21:42:01.756Z [DEBUG] provider.terraform-provider-azurerm_v4.27.0_x5: Odata-Maxversion: 4.0
2025-05-07T21:42:01.756Z [DEBUG] provider.terraform-provider-azurerm_v4.27.0_x5: Odata-Version: 4.0
2025-05-07T21:42:01.756Z [DEBUG] provider.terraform-provider-azurerm_v4.27.0_x5: Accept-Encoding: gzip
2025-05-07T21:42:01.756Z [DEBUG] provider.terraform-provider-azurerm_v4.27.0_x5
2025-05-07T21:42:01.756Z [DEBUG] provider.terraform-provider-azurerm_v4.27.0_x5
2025-05-07T21:42:01.756Z [DEBUG] provider.terraform-provider-azurerm_v4.27.0_x5: [DEBUG] GET https://management.azure.com/subscriptions//xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/providers?api-version=2022-09-01

<---DumpResponse failed but with no printed error message:-->
2025-05-07T21:42:04.058Z [DEBUG] provider.terraform-provider-azurerm_v4.27.0_x5: [DEBUG] AzureRM Response: 200 OK for https://management.azure.com/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/providers?api-version=2022-09-01

2025-05-07T21:42:04.079Z [TRACE] provider.terraform-provider-azurerm_v4.27.0_x5: Called downstream: tf_provider_addr=registry.terraform.io/hashicorp/azurerm @caller=github.com/hashicorp/terraform-plugin-sdk/v2@v2.36.1/helper/schema/grpc_provider.go:648 @module=sdk.helper_schema tf_mux_provider="*schema.GRPCProviderServer" tf_req_id=ae8bb884-fad8-f4f2-9223-b5d684c26740 tf_rpc=ConfigureProvider timestamp=2025-05-07T21:42:04.078Z
2025-05-07T21:42:04.079Z [TRACE] provider.terraform-provider-azurerm_v4.27.0_x5: Received downstream response: @module=sdk.proto diagnostic_error_count=1 diagnostic_warning_count=0 tf_req_duration_ms=5080 @caller=github.com/hashicorp/terraform-plugin-go@v0.26.0/tfprotov5/internal/tf5serverlogging/downstream_request.go:42 tf_req_id=ae8bb884-fad8-f4f2-9223-b5d684c26740 tf_rpc=Configure tf_proto_version=5.8 tf_provider_addr=registry.terraform.io/hashicorp/azurerm timestamp=2025-05-07T21:42:04.078Z
2025-05-07T21:42:04.079Z [ERROR] provider.terraform-provider-azurerm_v4.27.0_x5: Response contains error diagnostic: tf_proto_version=5.8 tf_provider_addr=registry.terraform.io/hashicorp/azurerm @caller=github.com/hashicorp/terraform-plugin-go@v0.26.0/tfprotov5/internal/diag/diagnostics.go:58 @module=sdk.proto diagnostic_severity=ERROR diagnostic_summary="populating Resource Provider cache: listing Resource Providers: loading results: unexpected end of JSON input" tf_rpc=Configure diagnostic_detail="" tf_req_id=ae8bb884-fad8-f4f2-9223-b5d684c26740 timestamp=2025-05-07T21:42:04.078Z
2025-05-07T21:42:04.079Z [TRACE] provider.terraform-provider-azurerm_v4.27.0_x5: Served request: @module=sdk.proto tf_proto_version=5.8 tf_provider_addr=registry.terraform.io/hashicorp/azurerm tf_req_id=ae8bb884-fad8-f4f2-9223-b5d684c26740 @caller=github.com/hashicorp/terraform-plugin-go@v0.26.0/tfprotov5/tf5server/server.go:598 tf_rpc=Configure timestamp=2025-05-07T21:42:04.079Z
2025-05-07T21:42:04.079Z [ERROR] vertex "provider[\"registry.terraform.io/hashicorp/azurerm\"]" error: populating Resource Provider cache: listing Resource Providers: loading results: unexpected end of JSON input
2025-05-07T21:42:04.079Z [TRACE] vertex "provider[\"registry.terraform.io/hashicorp/azurerm\"]": visit complete, with errors
```

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

<not applicable>
* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
