### PR TITLE
azurerm_monitor_metric_alert - Make action_group_id comparison case-insensitive

### DIFF
--- a/internal/services/monitor/monitor_metric_alert_resource.go
+++ b/internal/services/monitor/monitor_metric_alert_resource.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/Azure/go-autorest/autorest/date"
@@ -24,6 +25,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/monitor/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -313,9 +315,10 @@ func resourceMonitorMetricAlert() *pluginsdk.Resource {
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"action_group_id": {
-							Type:         pluginsdk.TypeString,
-							Required:     true,
-							ValidateFunc: azure.ValidateResourceID,
+							Type:             pluginsdk.TypeString,
+							Required:         true,
+							ValidateFunc:     azure.ValidateResourceID,
+							DiffSuppressFunc: suppress.CaseDifference,
 						},
 						"webhook_properties": {
 							Type:     pluginsdk.TypeMap,
@@ -905,7 +908,9 @@ func flattenMonitorMetricAlertAction(input *[]metricalerts.MetricAlertAction) (r
 func resourceMonitorMetricAlertActionHash(input interface{}) int {
 	var buf bytes.Buffer
 	if v, ok := input.(map[string]interface{}); ok {
-		buf.WriteString(fmt.Sprintf("%s-", v["action_group_id"].(string)))
+		// Use lowercase for the action_group_id to avoid case-sensitivity issues
+		// Azure API returns IDs with inconsistent casing (e.g., microsoft.insights vs Microsoft.Insights)
+		buf.WriteString(fmt.Sprintf("%s-", strings.ToLower(v["action_group_id"].(string))))
 		if m, ok := v["webhook_properties"].(map[string]interface{}); ok && m != nil {
 			buf.WriteString(fmt.Sprintf("%v-", m))
 		}


### PR DESCRIPTION
## Description

Fixes #22000

The Azure API returns action group IDs with inconsistent casing for the resource provider segment (`microsoft.insights` vs `Microsoft.Insights`). This causes perpetual diffs and 'Provider produced inconsistent final plan' errors because the `action` TypeSet hash function uses exact string comparison on the `action_group_id`.

## Changes

1. Added `DiffSuppressFunc: suppress.CaseDifference` to the `action_group_id` field
2. Normalized `action_group_id` to lowercase in `resourceMonitorMetricAlertActionHash` so that the same action group with different casings produces the same hash

## Testing

- Verified compilation succeeds
- The fix ensures Azure API responses with different ID casings are treated as identical

## PR Checklist

- [x] I have followed the guidelines in the Contributing Documentation
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change