### PR TITLE
azurerm_machine_learning_compute_cluster - Make vm_size comparison case-insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 4.72.0 (Unreleased)
+
+BUG FIXES:
+
+* `azurerm_machine_learning_compute_cluster` - make `vm_size` comparison case-insensitive to prevent perpetual diffs when Azure normalises casing ([#32288](https://github.com/hashicorp/terraform-provider-azurerm/pull/32288))
+
 ## 4.71.0 (April 30, 2026)
 
 FEATURES:

--- a/internal/services/machinelearning/machine_learning_compute_cluster_resource.go
+++ b/internal/services/machinelearning/machine_learning_compute_cluster_resource.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/machinelearning/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
@@ -58,9 +59,10 @@ func resourceComputeCluster() *pluginsdk.Resource {
 			"location": commonschema.Location(),
 
 			"vm_size": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:             pluginsdk.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				DiffSuppressFunc: suppress.CaseDifference,
 			},
 
 			"vm_priority": {


### PR DESCRIPTION
## Description

Fixes #18030

The Azure API returns `virtual_machine_size` in uppercase (e.g., `STANDARD_DS2_V2`) while users typically configure it as `Standard_DS2_V2`. Since `vm_size` has `ForceNew: true`, this case mismatch causes unnecessary resource replacement.

## Changes

Added `DiffSuppressFunc: suppress.CaseDifference` to the `vm_size` field so that case differences are ignored during plan, preventing unnecessary replacements.

## PR Checklist

- [x] I have followed the guidelines in the Contributing Documentation
- [x] I have successfully run tests with my changes locally