### PR TITLE
azurerm_firewall - Make subnet name validation case-insensitive

### DIFF
--- a/internal/services/firewall/validate/firewall_management_subnet_name.go
+++ b/internal/services/firewall/validate/firewall_management_subnet_name.go
@@ -5,6 +5,7 @@ package validate
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 )
@@ -16,8 +17,8 @@ func FirewallManagementSubnetName(v interface{}, k string) (warnings []string, e
 		return warnings, errors
 	}
 
-	if parsed.SubnetName != "AzureFirewallManagementSubnet" {
-		errors = append(errors, fmt.Errorf("the name of the management subnet for %q must be exactly 'AzureFirewallManagementSubnet' to be used for the Azure Firewall resource", k))
+	if !strings.EqualFold(parsed.SubnetName, "AzureFirewallManagementSubnet") {
+		errors = append(errors, fmt.Errorf("the name of the management subnet for %q must be 'AzureFirewallManagementSubnet' (case-insensitive) to be used for the Azure Firewall resource", k))
 	}
 
 	return warnings, errors

--- a/internal/services/firewall/validate/firewall_subnet_name.go
+++ b/internal/services/firewall/validate/firewall_subnet_name.go
@@ -5,6 +5,7 @@ package validate
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 )
@@ -16,8 +17,8 @@ func FirewallSubnetName(v interface{}, k string) (warnings []string, errors []er
 		return warnings, errors
 	}
 
-	if parsed.SubnetName != "AzureFirewallSubnet" {
-		errors = append(errors, fmt.Errorf("the name of the Subnet for %q must be exactly 'AzureFirewallSubnet' to be used for the Azure Firewall resource", k))
+	if !strings.EqualFold(parsed.SubnetName, "AzureFirewallSubnet") {
+		errors = append(errors, fmt.Errorf("the name of the Subnet for %q must be 'AzureFirewallSubnet' (case-insensitive) to be used for the Azure Firewall resource", k))
 	}
 
 	return warnings, errors


### PR DESCRIPTION
Fixes #20863

## Description

Azure allows creating firewall subnets with different casing (e.g., `azurefirewallsubnet` instead of `AzureFirewallSubnet`). When importing such resources, the provider rejected them with a validation error because the comparison was case-sensitive.

## Changes

- Changed `FirewallSubnetName` validator to use `strings.EqualFold` for case-insensitive comparison
- Changed `FirewallManagementSubnetName` validator to use `strings.EqualFold` for case-insensitive comparison

## Testing

- `go build ./internal/services/firewall/...` passes