### PR TITLE
azurerm_site_recovery_replicated_vm - fix case sensitivity for target_capacity_reservation_group_id

### DIFF
--- a/internal/services/recoveryservices/site_recovery_replicated_vm_resource.go
+++ b/internal/services/recoveryservices/site_recovery_replicated_vm_resource.go
@@ -268,9 +268,10 @@ func resourceSiteRecoveryReplicatedVM() *pluginsdk.Resource {
 			},
 
 			"target_capacity_reservation_group_id": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				ValidateFunc: capacityreservationgroups.ValidateCapacityReservationGroupID,
+				Type:             pluginsdk.TypeString,
+				Optional:         true,
+				DiffSuppressFunc: suppress.CaseDifference,
+				ValidateFunc:     capacityreservationgroups.ValidateCapacityReservationGroupID,
 			},
 
 			"target_virtual_machine_scale_set_id": {


### PR DESCRIPTION
Fixes #22695

The `target_capacity_reservation_group_id` field on `azurerm_site_recovery_replicated_vm` is case-sensitive, causing unnecessary plan changes when Azure returns the resource group name in a different case than configured (e.g. uppercase vs lowercase).

This adds `DiffSuppressFunc: suppress.CaseDifference` to the field, consistent with how other ID fields in the recovery services package handle case differences (e.g. `backup_protected_vm`, `site_recovery_hyperv_network_mapping`).