### PR TITLE
`azurerm_backup_protected_vm` - allow `include_disk_luns = []` to back up only the OS disk

### DIFF
--- a/internal/services/recoveryservices/backup_protected_vm_resource.go
+++ b/internal/services/recoveryservices/backup_protected_vm_resource.go
@@ -352,8 +352,11 @@ func resourceRecoveryServicesBackupProtectedVMDelete(d *pluginsdk.ResourceData, 
 }
 
 func expandDiskExclusion(d *pluginsdk.ResourceData) *protecteditems.ExtendedProperties {
-	if v, ok := d.GetOk("include_disk_luns"); ok {
-		diskLun := expandDiskLunList(v.(*pluginsdk.Set).List())
+	// `GetOk` collapses "absent" and an explicit empty list into the same false
+	// case, but `IsInclusionList=true, DiskLunList=[]` is the API's way of
+	// expressing "OS disk only". Use the raw config to tell them apart.
+	if !pluginsdk.IsExplicitlyNullInConfig(d, "include_disk_luns") {
+		diskLun := expandDiskLunList(d.Get("include_disk_luns").(*pluginsdk.Set).List())
 
 		return &protecteditems.ExtendedProperties{
 			DiskExclusionProperties: &protecteditems.DiskExclusionProperties{
@@ -363,8 +366,8 @@ func expandDiskExclusion(d *pluginsdk.ResourceData) *protecteditems.ExtendedProp
 		}
 	}
 
-	if v, ok := d.GetOk("exclude_disk_luns"); ok {
-		diskLun := expandDiskLunList(v.(*pluginsdk.Set).List())
+	if !pluginsdk.IsExplicitlyNullInConfig(d, "exclude_disk_luns") {
+		diskLun := expandDiskLunList(d.Get("exclude_disk_luns").(*pluginsdk.Set).List())
 
 		return &protecteditems.ExtendedProperties{
 			DiskExclusionProperties: &protecteditems.DiskExclusionProperties{

--- a/internal/services/recoveryservices/backup_protected_vm_resource_test.go
+++ b/internal/services/recoveryservices/backup_protected_vm_resource_test.go
@@ -153,6 +153,38 @@ func TestAccBackupProtectedVm_updateDiskExclusion(t *testing.T) {
 	})
 }
 
+func TestAccBackupProtectedVm_includeDiskLunsOnlyOSDisk(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_backup_protected_vm", "test")
+	r := BackupProtectedVmResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.includeDiskLunsEmpty(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("include_disk_luns.#").HasValue("0"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("include_disk_luns.#").HasValue("1"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.includeDiskLunsEmpty(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("include_disk_luns.#").HasValue("0"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccBackupProtectedVm_removeVM(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_backup_protected_vm", "test")
 	r := BackupProtectedVmResource{}
@@ -1014,6 +1046,21 @@ resource "azurerm_backup_protected_vm" "test" {
   backup_policy_id    = azurerm_backup_policy_vm.test.id
 
   exclude_disk_luns = [0, 1]
+}
+`, r.base(data))
+}
+
+func (r BackupProtectedVmResource) includeDiskLunsEmpty(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_backup_protected_vm" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  recovery_vault_name = azurerm_recovery_services_vault.test.name
+  source_vm_id        = azurerm_virtual_machine.test.id
+  backup_policy_id    = azurerm_backup_policy_vm.test.id
+
+  include_disk_luns = []
 }
 `, r.base(data))
 }

--- a/website/docs/r/backup_protected_vm.html.markdown
+++ b/website/docs/r/backup_protected_vm.html.markdown
@@ -72,7 +72,7 @@ The following arguments are supported:
 
 * `exclude_disk_luns` - (Optional) A list of Disks' Logical Unit Numbers (LUN) to be excluded for VM Protection.
 
-* `include_disk_luns` - (Optional) A list of Disks' Logical Unit Numbers (LUN) to be included for VM Protection.
+* `include_disk_luns` - (Optional) A list of Disks' Logical Unit Numbers (LUN) to be included for VM Protection. Setting this to an empty list (`[]`) backs up only the OS disk.
 
 * `protection_state` - (Optional) Specifies Protection state of the backup. Possible values are `Protected`, `BackupsSuspended`, and `ProtectionStopped`.
 


### PR DESCRIPTION
## Community Note

* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

The Azure Backup REST API distinguishes `IsInclusionList=true, DiskLunList=[]` ("back up only the OS disk") from "no `DiskExclusionProperties` set" ("back up all disks"), but `pluginsdk.ResourceData.GetOk` collapses an absent attribute and an empty set into the same `false` case. Today, configuring `include_disk_luns = []` is silently equivalent to omitting the field, so there is no way to express the OS-only mode without falling back to azapi.

This switches `expandDiskExclusion` to `pluginsdk.IsExplicitlyNullInConfig` (the same helper already used in `loganalytics`, `compute`, `storage`, `mssql`) so an explicit empty list is sent through to the API. `exclude_disk_luns = []` round-trips for symmetry; it is semantically equivalent to omitting both fields.

The read path already routes by `IsInclusionList`, so state round-trips cleanly. The update path already gates on `HasChange("include_disk_luns") || HasChange("exclude_disk_luns")`, so existing resources are unaffected by the upgrade — `expandDiskExclusion` is only invoked when one of those two fields actually changes.

### Alternatives considered

- **New `os_disk_only` boolean.** Adds a third schema field with a `ConflictsWith` graph. More API surface for the same expressivity.
- **Sentinel value (e.g. `[-1]`).** Wrong type for the slot.

## Testing

```
go vet ./internal/services/recoveryservices/...
go test ./internal/services/recoveryservices/...
```

New acceptance test `TestAccBackupProtectedVm_includeDiskLunsOnlyOSDisk` covers create with `[]`, update to `[0]`, and update back to `[]` with `ImportStep` between each transition. Acceptance run requires Azure credentials and was not executed here; happy to share output if a maintainer would like to retrigger it.

## Change Log

* `azurerm_backup_protected_vm` - support `include_disk_luns = []` to back up only the OS disk [GH-00000]

This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change

## Related Issue(s)

Fixes #28301

## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

Used Claude Code for codebase exploration, drafting the diff, and writing the commit/PR copy. Reviewed and tested by the author.

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

None.