### PR TITLE
[Contributor Docs:] Clarify `resource` and `data source` documentation `example` standards...

### DIFF
--- a/contributing/topics/reference-documentation-standards.md
+++ b/contributing/topics/reference-documentation-standards.md
@@ -6,14 +6,59 @@ This page will grow over time, and suggestions are welcome!
 
 ## Examples
 
-Each resource/data source must include an example, general guidelines for examples are as follows:
+Each resource/data source must include an example HCL configuration block in the documentation to show the end-user how to correctly use the resource/data source.
 
-- Examples MUST be functional, meaning that if a user copies the example and runs `terraform plan`, no errors should be returned.
-- Generally the resource instance name should simply be `example`. e.g. `resource "azurerm_resource_group" "example"`.
-- All name arguments within the example configuration should use simple example values that match the resource being defined. Where naming restrictions and field validation allow, prefer values prefixed with `example-`. If a field's validation or naming restrictions do not allow that pattern, use the simplest valid value for that field. Avoid overly complex naming, and ensure any naming restrictions and validation are followed. e.g. `name = example-resource-group`.
+### General Shared Rules
+
+- Generally the resource or data source instance name should simply be `example`. e.g. `resource "azurerm_resource_group" "example"` or `data "azurerm_resource_group" "example"`.
 - Avoid multiple examples unless a specific configuration is particularly difficult to configure. If there are many complex examples to document, consider using the `examples` folder in the repository instead.
-- Examples don't need to include every argument, generally the same configuration as the basic acceptance test will suffice (including any resource dependencies, such as the configuration from the template).
 - Resource/Data Source examples should not define a `terraform` or `provider` block.
+
+### Resource Examples
+
+- Resource examples MUST be functional and self-contained, meaning that if a user copies the example and runs `terraform plan`, no errors should be returned.
+- Resource examples don't need to include every argument, generally the same configuration as the basic acceptance test will suffice (including any resource dependencies, such as the configuration from the template).
+- Resource name arguments within the example configuration should use simple example values that match the Terraform resource being defined. Where naming restrictions and field validation allow, prefer values prefixed with `example-`. If a field's validation or naming restrictions do not allow that pattern, use the simplest valid value for that field. Avoid overly complex naming, and ensure any naming restrictions and validation are followed. e.g. `name = example-resource-group`.
+
+#### Example: Resource
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-resource-group"
+  location = "West Europe"
+}
+
+resource "azurerm_storage_account" "example" {
+  name                     = "examplestorageacct"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+```
+
+This is a good resource example because it is self-contained and can be planned on its own. Avoid resource examples that rely on undeclared existing infrastructure, for example a Resource Group name such as `existing-resource-group` without also declaring that Resource Group in the same example.
+
+> **Note:** The storage account example uses `examplestorageacct` intentionally because the resource schema's `ValidationFunc` controls what is valid for `name`, and for storage accounts that means a value between 3 and 24 characters long containing only lowercase letters and numbers.
+
+### Data Source Examples
+
+- Data source examples MUST be functional for the intended lookup scenario.
+- Data source examples may assume the looked-up object already exists and do not need to declare the backing resource in the same example.
+- Data source examples only need the arguments required to identify the looked-up object.
+- Data source name arguments within the example configuration should use simple values that reflect an existing object. Where practical, prefer values prefixed with `existing-`. If that pattern would not make sense for the field being demonstrated, use the simplest clear existing-object value instead. e.g. `name = "existing-subnet"`.
+
+#### Example: Data Source
+
+```hcl
+data "azurerm_subnet" "example" {
+  name                 = "existing-subnet"
+  virtual_network_name = "existing-virtual-network"
+  resource_group_name  = "existing-resource-group"
+}
+```
+
+This is a good data source example because it demonstrates the intended lookup scenario for an existing object using the identifying arguments required to find it. Avoid data source examples that add unnecessary resource scaffolding just to create the lookup target, as this treats the data source like a resource example rather than a lookup for an existing object.
 
 ## Code Fences
 
@@ -21,7 +66,7 @@ The following conventions apply to code fences:
 
 - Use the most specific code fence language that matches the snippet.
 - Terraform configuration should use `hcl` code fences. Do not use `terraform` code fences for HCL configuration blocks.
-- Keep Terraform examples copy/pasteable and self-contained.
+- Keep Terraform examples copy/pasteable. Resource examples should be self-contained, while data source examples may assume an existing object when demonstrating lookup behavior.
 
 ## Arguments
 


### PR DESCRIPTION
## Community Note
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

This PR updates the contributor documentation for provider docs examples in `contributing/topics/reference-documentation-standards.md`.

The main goal is to make the example guidance clearer for contributors by explicitly separating expectations for resource examples from expectations for data source examples. In particular, this change:

- clarifies that resource examples should be functional and self-contained
- clarifies that data source examples should demonstrate an existing-object lookup scenario and do not need to declare the backing resource in the same example
- adds example sections showing the expected pattern for both resource and data source documentation
- explains that example values should follow schema validation, using the storage account example to show when the normal `example-` naming pattern does not apply

This is a contributor-docs-only change. It does not change provider behavior, schema, tests, or generated provider documentation directly.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them.
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.

## Testing

This is a documentation-only change. No provider code or acceptance tests were changed.

## Change Log

No changelog entry required for this documentation-only change.

## Related Issue(s)

N/A

## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

Extent of AI usage:
- iterative wording and structure suggestions for the contributor documentation update

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

No changes to security controls.