### PR TITLE
`automation` - Fix TestAccAutomationSchedule_expiryTimeOfEuropeTimeZone

### DIFF
--- a/internal/services/automation/automation_schedule_resource_test.go
+++ b/internal/services/automation/automation_schedule_resource_test.go
@@ -39,16 +39,19 @@ func TestAccAutomationSchedule_expiryTimeOfEuropeTimeZone(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_automation_schedule", "test")
 	r := AutomationScheduleResource{}
 
+	loc, _ := time.LoadLocation("Europe/Amsterdam")
+	startTime := time.Now().UTC().Add(time.Hour * 7).In(loc).Format("2006-01-02T15:04:00Z07:00")
+
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.expiryTimeOfEuropeTimeZone(data, "foo"),
+			Config: r.expiryTimeOfEuropeTimeZone(data, "foo", startTime),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.expiryTimeOfEuropeTimeZone(data, "bar"),
+			Config: r.expiryTimeOfEuropeTimeZone(data, "bar", startTime),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -271,7 +274,7 @@ resource "azurerm_automation_schedule" "test" {
 `, AutomationScheduleResource{}.template(data), data.RandomInteger)
 }
 
-func (a AutomationScheduleResource) expiryTimeOfEuropeTimeZone(data acceptance.TestData, desc string) string {
+func (a AutomationScheduleResource) expiryTimeOfEuropeTimeZone(data acceptance.TestData, desc string, startTime string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -282,11 +285,11 @@ resource "azurerm_automation_schedule" "test" {
   frequency               = "Week"
   interval                = 1
   timezone                = "Europe/Amsterdam"
-  start_time              = "2026-04-15T18:01:15+02:00"
+  start_time              = "%s"
   description             = "%s"
   week_days               = ["Monday"]
 }
-`, a.template(data), data.RandomInteger, desc)
+`, a.template(data), data.RandomInteger, startTime, desc)
 }
 
 func (AutomationScheduleResource) requiresImport(data acceptance.TestData) string {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Fix `TestAccAutomationSchedule_expiryTimeOfEuropeTimeZone` by replacing a hardcoded `start_time` value with a dynamically computed one.

The test previously used a hardcoded start time (2026-04-15T18:01:15+02:00) which will fail once that date passes (the Azure Automation API rejects schedule start times in the past). This change computes the start time dynamically as 7 hours from now in the Europe/Amsterdam timezone, ensuring the test remains valid regardless of when it runs.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

<img width="2880" height="1434" alt="image" src="https://github.com/user-attachments/assets/393e3610-b35d-48ad-a87d-bcf52cbdeebd" />


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
