### PR TITLE
[ENHANCEMENT] azurerm_cdn_frontdoor_firewall_policy - expand support for custom_block_response_status_code

### DIFF
--- a/internal/services/cdn/cdn_frontdoor_firewall_policy_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_firewall_policy_resource.go
@@ -134,7 +134,7 @@ func resourceCdnFrontDoorFirewallPolicy() *pluginsdk.Resource {
 					996,
 					997,
 					998,
-					999 
+					999,
 				}),
 			},
 

--- a/internal/services/cdn/cdn_frontdoor_firewall_policy_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_firewall_policy_resource.go
@@ -125,6 +125,16 @@ func resourceCdnFrontDoorFirewallPolicy() *pluginsdk.Resource {
 					405,
 					406,
 					429,
+					990,
+					991,
+					992,
+					993,
+					994,
+					995,
+					996,
+					997,
+					998,
+					999 
 				}),
 			},
 

--- a/internal/services/cdn/cdn_frontdoor_firewall_policy_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_firewall_policy_resource_test.go
@@ -150,6 +150,28 @@ func TestAccCdnFrontDoorFirewallPolicy_requiresImport(t *testing.T) {
 	})
 }
 
+func TestAccCdnFrontDoorFirewallPolicy_customBlockResponseStatusCodes(t *testing.T) {
+	statusCodes := []int{200, 403, 405, 406, 429, 990, 991, 992, 993, 994, 995, 996, 997, 998, 999}
+
+	for _, code := range statusCodes {
+		code := code
+		t.Run(fmt.Sprintf("StatusCode%d", code), func(t *testing.T) {
+			data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_firewall_policy", "test")
+			r := CdnFrontDoorFirewallPolicyResource{}
+			data.ResourceTest(t, r, []acceptance.TestStep{
+				{
+					Config: r.customBlockResponseStatusCode(data, code),
+					Check: acceptance.ComposeTestCheckFunc(
+						check.That(data.ResourceName).ExistsInAzure(r),
+						check.That(data.ResourceName).Key("custom_block_response_status_code").HasValue(fmt.Sprintf("%d", code)),
+					),
+				},
+				data.ImportStep(),
+			})
+		})
+	}
+}
+
 func TestAccCdnFrontDoorFirewallPolicy_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_firewall_policy", "test")
 	r := CdnFrontDoorFirewallPolicyResource{}
@@ -2232,3 +2254,34 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "test" {
 }
 `, r.template(data), data.RandomInteger)
 }
+
+func (r CdnFrontDoorFirewallPolicyResource) customBlockResponseStatusCode(data acceptance.TestData, statusCode int) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_cdn_frontdoor_firewall_policy" "test" {
+  name                              = "accTestWAF%d"
+  resource_group_name               = azurerm_resource_group.test.name
+  sku_name                          = azurerm_cdn_frontdoor_profile.test.sku_name
+  enabled                           = true
+  mode                              = "Prevention"
+  custom_block_response_status_code = %d
+
+  custom_rule {
+    name     = "Rule1"
+    enabled  = true
+    priority = 1
+    type     = "MatchRule"
+    action   = "Block"
+
+    match_condition {
+      match_variable     = "RemoteAddr"
+      operator           = "IPMatch"
+      negation_condition = false
+      match_values       = ["192.168.1.0/24"]
+    }
+  }
+}
+`, r.template(data), data.RandomInteger, statusCode)
+}
+

--- a/internal/services/cdn/cdn_frontdoor_firewall_policy_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_firewall_policy_resource_test.go
@@ -150,26 +150,19 @@ func TestAccCdnFrontDoorFirewallPolicy_requiresImport(t *testing.T) {
 	})
 }
 
-func TestAccCdnFrontDoorFirewallPolicy_customBlockResponseStatusCodes(t *testing.T) {
-	statusCodes := []int{200, 403, 405, 406, 429, 990, 991, 992, 993, 994, 995, 996, 997, 998, 999}
-
-	for _, code := range statusCodes {
-		code := code
-		t.Run(fmt.Sprintf("StatusCode%d", code), func(t *testing.T) {
-			data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_firewall_policy", "test")
-			r := CdnFrontDoorFirewallPolicyResource{}
-			data.ResourceTest(t, r, []acceptance.TestStep{
-				{
-					Config: r.customBlockResponseStatusCode(data, code),
-					Check: acceptance.ComposeTestCheckFunc(
-						check.That(data.ResourceName).ExistsInAzure(r),
-						check.That(data.ResourceName).Key("custom_block_response_status_code").HasValue(fmt.Sprintf("%d", code)),
-					),
-				},
-				data.ImportStep(),
-			})
-		})
-	}
+func TestAccCdnFrontDoorFirewallPolicy_customBlockResponseStatusCode(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_firewall_policy", "test")
+	r := CdnFrontDoorFirewallPolicyResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.customBlockResponseStatusCode(data, 990),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("custom_block_response_status_code").HasValue("990"),
+			),
+		},
+		data.ImportStep(),
+	})
 }
 
 func TestAccCdnFrontDoorFirewallPolicy_update(t *testing.T) {

--- a/internal/services/cdn/cdn_frontdoor_firewall_policy_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_firewall_policy_resource_test.go
@@ -2284,4 +2284,3 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "test" {
 }
 `, r.template(data), data.RandomInteger, statusCode)
 }
-

--- a/website/docs/r/cdn_frontdoor_firewall_policy.html.markdown
+++ b/website/docs/r/cdn_frontdoor_firewall_policy.html.markdown
@@ -164,7 +164,7 @@ The following arguments are supported:
 
 * `custom_rule` - (Optional) One or more `custom_rule` blocks as defined below.
 
-* `custom_block_response_status_code` - (Optional) If a `custom_rule` block's action type is `block`, this is the response status code. Possible values are `200`, `403`, `405`, `406`, or `429`.
+* `custom_block_response_status_code` - (Optional) If a `custom_rule` block's action type is `block`, this is the response status code. Possible values are `200`, `403`, `405`, `406`, `429`, `990`, `991`, `992`, `993`, `994`, `995`, `996`, `997`, `998`, or `999`.
 
 * `custom_block_response_body` - (Optional) If a `custom_rule` block's action type is `block`, this is the response body. The body must be specified in base64 encoding.
 

--- a/website/docs/r/frontdoor_firewall_policy.html.markdown
+++ b/website/docs/r/frontdoor_firewall_policy.html.markdown
@@ -141,7 +141,7 @@ The following arguments are supported:
 
 * `custom_rule` - (Optional) One or more `custom_rule` blocks as defined below.
 
-* `custom_block_response_status_code` - (Optional) If a `custom_rule` block's action type is `block`, this is the response status code. Possible values are `200`, `403`, `405`, `406`, `429`, `990`, `991`, `992`, `993`, `994`, `995`, `996`, `997`, `998`, or `999`.
+* `custom_block_response_status_code` - (Optional) If a `custom_rule` block's action type is `block`, this is the response status code. Possible values are `200`, `403`, `405`, `406`, or `429`.
 
 * `custom_block_response_body` - (Optional) If a `custom_rule` block's action type is `block`, this is the response body. The body must be specified in base64 encoding.
 

--- a/website/docs/r/frontdoor_firewall_policy.html.markdown
+++ b/website/docs/r/frontdoor_firewall_policy.html.markdown
@@ -141,7 +141,7 @@ The following arguments are supported:
 
 * `custom_rule` - (Optional) One or more `custom_rule` blocks as defined below.
 
-* `custom_block_response_status_code` - (Optional) If a `custom_rule` block's action type is `block`, this is the response status code. Possible values are `200`, `403`, `405`, `406`, or `429`.
+* `custom_block_response_status_code` - (Optional) If a `custom_rule` block's action type is `block`, this is the response status code. Possible values are `200`, `403`, `405`, `406`, `429`, `990`, `991`, `992`, `993`, `994`, `995`, `996`, `997`, `998`, or `999`.
 
 * `custom_block_response_body` - (Optional) If a `custom_rule` block's action type is `block`, this is the response body. The body must be specified in base64 encoding.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

The custom_block_response_status_code field currently only accepts a restricted set of values (200, 403, 405, 406, 429), whereas the Azure Front Door WAF API itself supports a broader range, including custom codes like 990–999. This PR enhances the current code to include all custom codes supported by Azure.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #32304


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
