### PR TITLE
`azurerm_data_protection_backup_policy_kubernetes_cluster` - update `data_store_type` property to support `VaultStore` value

### DIFF
--- a/internal/services/dataprotection/data_protection_backup_policy_kubernetes_cluster_resource.go
+++ b/internal/services/dataprotection/data_protection_backup_policy_kubernetes_cluster_resource.go
@@ -128,9 +128,8 @@ func (r DataProtectionBackupPolicyKubernatesClusterResource) Arguments() map[str
 									Required: true,
 									ForceNew: true,
 									ValidateFunc: validation.StringInSlice([]string{
-										// confirmed with the service team that current possible value only support `OperationalStore`.
-										// However, considering that `VaultStore` might be supported in the future, it would be exposed for user specification.
 										string(basebackuppolicyresources.DataStoreTypesOperationalStore),
+										string(basebackuppolicyresources.DataStoreTypesVaultStore),
 									}, false),
 								},
 
@@ -232,9 +231,8 @@ func (r DataProtectionBackupPolicyKubernatesClusterResource) Arguments() map[str
 									Required: true,
 									ForceNew: true,
 									ValidateFunc: validation.StringInSlice([]string{
-										// confirmed with the service team that currently only `OperationalStore` is supported.
-										// However, since `VaultStore` is in public preview and will be supported in the future, it is open to user specification.
 										string(basebackuppolicyresources.DataStoreTypesOperationalStore),
+										string(basebackuppolicyresources.DataStoreTypesVaultStore),
 									}, false),
 								},
 

--- a/internal/services/dataprotection/data_protection_backup_policy_kubernetes_cluster_resource_test.go
+++ b/internal/services/dataprotection/data_protection_backup_policy_kubernetes_cluster_resource_test.go
@@ -61,6 +61,20 @@ func TestAccDataProtectionBackupPolicyKubernatesCluster_complete(t *testing.T) {
 	})
 }
 
+func TestAccDataProtectionBackupPolicyKubernatesCluster_vaultStore(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_protection_backup_policy_kubernetes_cluster", "test")
+	r := DataProtectionBackupPolicyKubernetesClusterResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.vaultStore(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r DataProtectionBackupPolicyKubernetesClusterResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := basebackuppolicyresources.ParseBackupPolicyID(state.ID)
 	if err != nil {
@@ -209,6 +223,45 @@ resource "azurerm_data_protection_backup_policy_kubernetes_cluster" "test" {
     life_cycle {
       duration        = "P7D"
       data_store_type = "OperationalStore"
+    }
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r DataProtectionBackupPolicyKubernetesClusterResource) vaultStore(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_data_protection_backup_policy_kubernetes_cluster" "test" {
+  name                = "acctest-aks-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  vault_name          = azurerm_data_protection_backup_vault.test.name
+
+  backup_repeating_time_intervals = ["R/2021-05-23T02:30:00+00:00/P1W"]
+
+  retention_rule {
+    name     = "Daily"
+    priority = 25
+
+    life_cycle {
+      duration        = "P7D"
+      data_store_type = "VaultStore"
+    }
+
+    criteria {
+      days_of_week           = ["Thursday"]
+      months_of_year         = ["November"]
+      weeks_of_month         = ["First"]
+      scheduled_backup_times = ["2021-05-23T02:30:00Z"]
+    }
+  }
+
+  default_retention_rule {
+    life_cycle {
+      duration        = "P7D"
+      data_store_type = "VaultStore"
     }
   }
 }

--- a/website/docs/r/data_protection_backup_policy_kubernetes_cluster.html.markdown
+++ b/website/docs/r/data_protection_backup_policy_kubernetes_cluster.html.markdown
@@ -114,7 +114,7 @@ A `criteria` block supports the following:
 
 A `life_cycle` block supports the following:
 
-* `data_store_type` - (Required) The type of data store. The only possible value is `OperationalStore`. Changing this forces a new resource to be created.
+* `data_store_type` - (Required) The type of data store. The possible values are `OperationalStore` and `VaultStore`. Changing this forces a new resource to be created.
 
 * `duration` - (Required) The retention duration up to which the backups are to be retained in the data stores. It should follow `ISO 8601` duration format. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Fixes #31366 

This PR adds support for the `VaultStore` value to the `data_store_type` argument for the `azurerm_data_protection_backup_policy_kubernetes_cluster` resource.

```
=== RUN   TestAccDataProtectionBackupPolicyKubernatesCluster_vaultStore
=== PAUSE TestAccDataProtectionBackupPolicyKubernatesCluster_vaultStore
=== CONT  TestAccDataProtectionBackupPolicyKubernatesCluster_vaultStore
--- PASS: TestAccDataProtectionBackupPolicyKubernatesCluster_vaultStore (134.35s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/dataprotection        134.393s
```

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_data_protection_backup_policy_kubernetes_cluster` - update `data_store_type` property to support `VaultStore` value [GH-32323]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #31366 


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

Used AI to help debug and test API behavior

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

Revert the change and remove the option to set the value to VaultStore.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
