### PR TITLE
`azurerm_cdn_frontdoor_firewall_policy` - recommend `SocketAddr` in example/docs

### DIFF
--- a/website/docs/r/cdn_frontdoor_firewall_policy.html.markdown
+++ b/website/docs/r/cdn_frontdoor_firewall_policy.html.markdown
@@ -44,7 +44,7 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "example" {
     action                         = "Block"
 
     match_condition {
-      match_variable     = "RemoteAddr"
+      match_variable     = "SocketAddr"
       operator           = "IPMatch"
       negation_condition = false
       match_values       = ["10.0.1.0/24", "10.0.0.0/24"]
@@ -61,7 +61,7 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "example" {
     action                         = "Block"
 
     match_condition {
-      match_variable     = "RemoteAddr"
+      match_variable     = "SocketAddr"
       operator           = "IPMatch"
       negation_condition = false
       match_values       = ["192.168.1.0/24"]
@@ -203,6 +203,8 @@ A `custom_rule` block supports the following:
 A `match_condition` block supports the following:
 
 * `match_variable` - (Required) The request variable to compare with. Possible values are `Cookies`, `PostArgs`, `QueryString`, `RemoteAddr`, `RequestBody`, `RequestHeader`, `RequestMethod`, `RequestUri`, or `SocketAddr`.
+
+-> **Note:** `RemoteAddr` inspects the original client IP from the `X-Forwarded-For` header. Use `SocketAddr` when you need to match the source IP address seen by Front Door WAF.
 
 * `match_values` - (Required) Up to `600` possible values to match. Limit is in total across all `match_condition` blocks and `match_values` arguments. String value itself can be up to `256` characters in length.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This updates the docs for `azurerm_cdn_frontdoor_firewall_policy` resource to recommend `SocketAddr` instead of `RemoteAddr`:

- Updated the Example Usage `IPMatch` conditions from `RemoteAddr` to `SocketAddr`
- Added a note in `match_variable` docs clarifying:
  - `RemoteAddr` inspects the `X-Forwarded-For` header
  - `SocketAddr` should be used when matching the source IP seen by Front Door WAF

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Related Issue(s)

Fixes #32325


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
