### PR TITLE
fix: add post-create polling to managed identity and DNS resources

### DIFF
--- a/internal/services/dns/dns_a_record_resource.go
+++ b/internal/services/dns/dns_a_record_resource.go
@@ -6,6 +6,7 @@ package dns
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -149,6 +150,23 @@ func resourceDnsARecordCreateUpdate(d *pluginsdk.ResourceData, meta interface{})
 
 	if _, err := client.CreateOrUpdate(ctx, id, parameters, recordsets.DefaultCreateOrUpdateOperationOptions()); err != nil {
 		return fmt.Errorf("creating/updating DNS A Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
+	}
+
+	if d.IsNewResource() {
+		stateConf := &pluginsdk.StateChangeConf{
+			Pending: []string{"NotFound"},
+			Target:  []string{"Found"},
+			Refresh: pluginsdk.ResourceCreateRefreshFunc(func() (*http.Response, error) {
+				resp, err := client.Get(ctx, id)
+				return resp.HttpResponse, err
+			}),
+			MinTimeout:                5 * time.Second,
+			ContinuousTargetOccurence: 3,
+			Timeout:                   d.Timeout(pluginsdk.TimeoutCreate),
+		}
+		if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+			return fmt.Errorf("waiting for %s to become available: %+v", id, err)
+		}
 	}
 
 	d.SetId(id.ID())

--- a/internal/services/dns/dns_aaaa_record_resource.go
+++ b/internal/services/dns/dns_aaaa_record_resource.go
@@ -6,6 +6,7 @@ package dns
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -153,6 +154,23 @@ func resourceDnsAaaaRecordCreateUpdate(d *pluginsdk.ResourceData, meta interface
 
 	if _, err := client.CreateOrUpdate(ctx, id, parameters, recordsets.DefaultCreateOrUpdateOperationOptions()); err != nil {
 		return fmt.Errorf("creating/updating %s: %+v", id, err)
+	}
+
+	if d.IsNewResource() {
+		stateConf := &pluginsdk.StateChangeConf{
+			Pending: []string{"NotFound"},
+			Target:  []string{"Found"},
+			Refresh: pluginsdk.ResourceCreateRefreshFunc(func() (*http.Response, error) {
+				resp, err := client.Get(ctx, id)
+				return resp.HttpResponse, err
+			}),
+			MinTimeout:                5 * time.Second,
+			ContinuousTargetOccurence: 3,
+			Timeout:                   d.Timeout(pluginsdk.TimeoutCreate),
+		}
+		if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+			return fmt.Errorf("waiting for %s to become available: %+v", id, err)
+		}
 	}
 
 	d.SetId(id.ID())

--- a/internal/services/dns/dns_caa_record_resource.go
+++ b/internal/services/dns/dns_caa_record_resource.go
@@ -6,6 +6,7 @@ package dns
 import (
 	"bytes"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
@@ -150,6 +151,23 @@ func resourceDnsCaaRecordCreateUpdate(d *pluginsdk.ResourceData, meta interface{
 
 	if _, err := client.CreateOrUpdate(ctx, id, parameters, recordsets.DefaultCreateOrUpdateOperationOptions()); err != nil {
 		return fmt.Errorf("creating/updating %s: %+v", id, err)
+	}
+
+	if d.IsNewResource() {
+		stateConf := &pluginsdk.StateChangeConf{
+			Pending: []string{"NotFound"},
+			Target:  []string{"Found"},
+			Refresh: pluginsdk.ResourceCreateRefreshFunc(func() (*http.Response, error) {
+				resp, err := client.Get(ctx, id)
+				return resp.HttpResponse, err
+			}),
+			MinTimeout:                5 * time.Second,
+			ContinuousTargetOccurence: 3,
+			Timeout:                   d.Timeout(pluginsdk.TimeoutCreate),
+		}
+		if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+			return fmt.Errorf("waiting for %s to become available: %+v", id, err)
+		}
 	}
 
 	d.SetId(id.ID())

--- a/internal/services/dns/dns_cname_record_resource.go
+++ b/internal/services/dns/dns_cname_record_resource.go
@@ -5,6 +5,7 @@ package dns
 
 import (
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -146,6 +147,21 @@ func resourceDnsCNameRecordCreate(d *pluginsdk.ResourceData, meta interface{}) e
 
 	if _, err := client.CreateOrUpdate(ctx, id, parameters, recordsets.DefaultCreateOrUpdateOperationOptions()); err != nil {
 		return fmt.Errorf("creating %s: %+v", id, err)
+	}
+
+	stateConf := &pluginsdk.StateChangeConf{
+		Pending: []string{"NotFound"},
+		Target:  []string{"Found"},
+		Refresh: pluginsdk.ResourceCreateRefreshFunc(func() (*http.Response, error) {
+			resp, err := client.Get(ctx, id)
+			return resp.HttpResponse, err
+		}),
+		MinTimeout:                5 * time.Second,
+		ContinuousTargetOccurence: 3,
+		Timeout:                   d.Timeout(pluginsdk.TimeoutCreate),
+	}
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+		return fmt.Errorf("waiting for %s to become available: %+v", id, err)
 	}
 
 	d.SetId(id.ID())

--- a/internal/services/dns/dns_mx_record_resource.go
+++ b/internal/services/dns/dns_mx_record_resource.go
@@ -6,6 +6,7 @@ package dns
 import (
 	"bytes"
 	"fmt"
+	"net/http"
 	"strconv"
 	"time"
 
@@ -141,6 +142,23 @@ func resourceDnsMxRecordCreateUpdate(d *pluginsdk.ResourceData, meta interface{}
 
 	if _, err := client.CreateOrUpdate(ctx, id, parameters, recordsets.DefaultCreateOrUpdateOperationOptions()); err != nil {
 		return fmt.Errorf("creating/updating %s: %+v", id, err)
+	}
+
+	if d.IsNewResource() {
+		stateConf := &pluginsdk.StateChangeConf{
+			Pending: []string{"NotFound"},
+			Target:  []string{"Found"},
+			Refresh: pluginsdk.ResourceCreateRefreshFunc(func() (*http.Response, error) {
+				resp, err := client.Get(ctx, id)
+				return resp.HttpResponse, err
+			}),
+			MinTimeout:                5 * time.Second,
+			ContinuousTargetOccurence: 3,
+			Timeout:                   d.Timeout(pluginsdk.TimeoutCreate),
+		}
+		if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+			return fmt.Errorf("waiting for %s to become available: %+v", id, err)
+		}
 	}
 
 	d.SetId(id.ID())

--- a/internal/services/dns/dns_ns_record_resource.go
+++ b/internal/services/dns/dns_ns_record_resource.go
@@ -5,6 +5,7 @@ package dns
 
 import (
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -128,6 +129,21 @@ func resourceDnsNsRecordCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 
 	if _, err := client.CreateOrUpdate(ctx, id, parameters, recordsets.DefaultCreateOrUpdateOperationOptions()); err != nil {
 		return fmt.Errorf("creating %s: %+v", id, err)
+	}
+
+	stateConf := &pluginsdk.StateChangeConf{
+		Pending: []string{"NotFound"},
+		Target:  []string{"Found"},
+		Refresh: pluginsdk.ResourceCreateRefreshFunc(func() (*http.Response, error) {
+			resp, err := client.Get(ctx, id)
+			return resp.HttpResponse, err
+		}),
+		MinTimeout:                5 * time.Second,
+		ContinuousTargetOccurence: 3,
+		Timeout:                   d.Timeout(pluginsdk.TimeoutCreate),
+	}
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+		return fmt.Errorf("waiting for %s to become available: %+v", id, err)
 	}
 
 	d.SetId(id.ID())

--- a/internal/services/dns/dns_ptr_record_resource.go
+++ b/internal/services/dns/dns_ptr_record_resource.go
@@ -5,6 +5,7 @@ package dns
 
 import (
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
@@ -124,6 +125,23 @@ func resourceDnsPtrRecordCreateUpdate(d *pluginsdk.ResourceData, meta interface{
 
 	if _, err := client.CreateOrUpdate(ctx, id, parameters, recordsets.DefaultCreateOrUpdateOperationOptions()); err != nil {
 		return fmt.Errorf("creating/updating %s: %+v", id, err)
+	}
+
+	if d.IsNewResource() {
+		stateConf := &pluginsdk.StateChangeConf{
+			Pending: []string{"NotFound"},
+			Target:  []string{"Found"},
+			Refresh: pluginsdk.ResourceCreateRefreshFunc(func() (*http.Response, error) {
+				resp, err := client.Get(ctx, id)
+				return resp.HttpResponse, err
+			}),
+			MinTimeout:                5 * time.Second,
+			ContinuousTargetOccurence: 3,
+			Timeout:                   d.Timeout(pluginsdk.TimeoutCreate),
+		}
+		if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+			return fmt.Errorf("waiting for %s to become available: %+v", id, err)
+		}
 	}
 
 	d.SetId(id.ID())

--- a/internal/services/dns/dns_srv_record_resource.go
+++ b/internal/services/dns/dns_srv_record_resource.go
@@ -6,6 +6,7 @@ package dns
 import (
 	"bytes"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -148,6 +149,21 @@ func resourceDnsSrvRecordCreate(d *pluginsdk.ResourceData, meta interface{}) err
 
 	if _, err := client.CreateOrUpdate(ctx, id, parameters, recordsets.DefaultCreateOrUpdateOperationOptions()); err != nil {
 		return fmt.Errorf("creating %s: %+v", id, err)
+	}
+
+	stateConf := &pluginsdk.StateChangeConf{
+		Pending: []string{"NotFound"},
+		Target:  []string{"Found"},
+		Refresh: pluginsdk.ResourceCreateRefreshFunc(func() (*http.Response, error) {
+			resp, err := client.Get(ctx, id)
+			return resp.HttpResponse, err
+		}),
+		MinTimeout:                5 * time.Second,
+		ContinuousTargetOccurence: 3,
+		Timeout:                   d.Timeout(pluginsdk.TimeoutCreate),
+	}
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+		return fmt.Errorf("waiting for %s to become available: %+v", id, err)
 	}
 
 	d.SetId(id.ID())

--- a/internal/services/dns/dns_txt_record_resource.go
+++ b/internal/services/dns/dns_txt_record_resource.go
@@ -5,6 +5,7 @@ package dns
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
@@ -134,6 +135,23 @@ func resourceDnsTxtRecordCreateUpdate(d *pluginsdk.ResourceData, meta interface{
 
 	if _, err := client.CreateOrUpdate(ctx, id, parameters, recordsets.DefaultCreateOrUpdateOperationOptions()); err != nil {
 		return fmt.Errorf("creating/updating %s: %+v", id, err)
+	}
+
+	if d.IsNewResource() {
+		stateConf := &pluginsdk.StateChangeConf{
+			Pending: []string{"NotFound"},
+			Target:  []string{"Found"},
+			Refresh: pluginsdk.ResourceCreateRefreshFunc(func() (*http.Response, error) {
+				resp, err := client.Get(ctx, id)
+				return resp.HttpResponse, err
+			}),
+			MinTimeout:                5 * time.Second,
+			ContinuousTargetOccurence: 3,
+			Timeout:                   d.Timeout(pluginsdk.TimeoutCreate),
+		}
+		if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+			return fmt.Errorf("waiting for %s to become available: %+v", id, err)
+		}
 	}
 
 	d.SetId(id.ID())

--- a/internal/services/dns/dns_zone_resource.go
+++ b/internal/services/dns/dns_zone_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"net/http"
 	"strings"
 	"time"
 
@@ -217,6 +218,21 @@ func (r DnsZoneResource) Create() sdk.ResourceFunc {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
 			metadata.SetID(id)
+
+			stateConf := &pluginsdk.StateChangeConf{
+				Pending: []string{"NotFound"},
+				Target:  []string{"Found"},
+				Refresh: pluginsdk.ResourceCreateRefreshFunc(func() (*http.Response, error) {
+					resp, err := client.Get(ctx, id)
+					return resp.HttpResponse, err
+				}),
+				MinTimeout:                5 * time.Second,
+				ContinuousTargetOccurence: 3,
+				Timeout:                   metadata.ResourceData.Timeout(pluginsdk.TimeoutCreate),
+			}
+			if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+				return fmt.Errorf("waiting for %s to become available: %+v", id, err)
+			}
 
 			if len(model.SoaRecord) == 1 {
 				soaRecordID := recordsets.NewRecordTypeID(id.SubscriptionId, id.ResourceGroupName, id.DnsZoneName, recordsets.RecordTypeSOA, "@")

--- a/internal/services/managedidentity/federated_identity_credential_resource.go
+++ b/internal/services/managedidentity/federated_identity_credential_resource.go
@@ -6,6 +6,7 @@ package managedidentity
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
@@ -156,6 +157,21 @@ func (r FederatedIdentityCredentialResource) Create() sdk.ResourceFunc {
 
 			if _, err := client.CreateOrUpdate(ctx, id, payload); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			stateConf := &pluginsdk.StateChangeConf{
+				Pending: []string{"NotFound"},
+				Target:  []string{"Found"},
+				Refresh: pluginsdk.ResourceCreateRefreshFunc(func() (*http.Response, error) {
+					resp, err := client.Get(ctx, id)
+					return resp.HttpResponse, err
+				}),
+				MinTimeout:                5 * time.Second,
+				ContinuousTargetOccurence: 3,
+				Timeout:                   metadata.ResourceData.Timeout(pluginsdk.TimeoutCreate),
+			}
+			if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+				return fmt.Errorf("waiting for %s to become available: %+v", id, err)
 			}
 
 			metadata.SetID(id)

--- a/internal/services/managedidentity/user_assigned_identity_resource.go
+++ b/internal/services/managedidentity/user_assigned_identity_resource.go
@@ -6,6 +6,7 @@ package managedidentity
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -141,6 +142,21 @@ func (r UserAssignedIdentityResource) Create() sdk.ResourceFunc {
 
 			if _, err := client.UserAssignedIdentitiesCreateOrUpdate(ctx, id, payload); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			stateConf := &pluginsdk.StateChangeConf{
+				Pending: []string{"NotFound"},
+				Target:  []string{"Found"},
+				Refresh: pluginsdk.ResourceCreateRefreshFunc(func() (*http.Response, error) {
+					resp, err := client.UserAssignedIdentitiesGet(ctx, id)
+					return resp.HttpResponse, err
+				}),
+				MinTimeout:                5 * time.Second,
+				ContinuousTargetOccurence: 3,
+				Timeout:                   metadata.ResourceData.Timeout(pluginsdk.TimeoutCreate),
+			}
+			if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+				return fmt.Errorf("waiting for %s to become available: %+v", id, err)
 			}
 
 			metadata.SetID(id)

--- a/internal/tf/pluginsdk/polling.go
+++ b/internal/tf/pluginsdk/polling.go
@@ -1,0 +1,25 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package pluginsdk
+
+import (
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+)
+
+// ResourceCreateRefreshFunc returns a StateRefreshFunc for the standard Azure
+// eventual-consistency pattern: poll until Get returns a non-404 response.
+func ResourceCreateRefreshFunc(getter func() (*http.Response, error)) StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		httpResp, err := getter()
+		if err != nil {
+			if response.WasNotFound(httpResp) {
+				return nil, "NotFound", nil
+			}
+			return nil, "Error", err
+		}
+		return httpResp, "Found", nil
+	}
+}


### PR DESCRIPTION
Azure's ARM API has eventual consistency: resources can return 404 on GET for a short window after a successful CreateOrUpdate. Terraform's SDK performs a Read immediately after Apply, which can race this window and produce "Root object was present, but now absent" errors.

This commit fixes the issue for three resource families:

azurerm_federated_identity_credential and azurerm_user_assigned_identity:
  Both resources called metadata.SetID() immediately after
  CreateOrUpdate with no polling. Added StateChangeConf with
  ContinuousTargetOccurence: 3 to require three consecutive
  successful GETs before considering the resource available.

azurerm_dns_zone and azurerm_dns_{a,aaaa,caa,cname,mx,ns,ptr,srv,txt}_record:
  All ten DNS resources had the same gap. For resources with a combined
  CreateUpdate function (A, AAAA, CAA, MX, PTR, TXT) the polling is
  guarded by d.IsNewResource(). For resources with a separate Create
  function (CNAME, NS, SRV) and for the zone, it runs unconditionally.
  The zone's polling is placed before the SOA record update so the
  subsequent SOA GET does not race zone propagation.

A shared helper pluginsdk.ResourceCreateRefreshFunc(getter func() (*http.Response, error)) is introduced in internal/tf/pluginsdk/polling.go and used at all twelve call sites, replacing per-resource refresh functions with inline closures.

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - add post-create polling to manage identity and DNS resources


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #31729 


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
