### PR TITLE
`azurerm_kubernetes_cluster_node_pool` - support `local_dns_profile` property

### DIFF
--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -224,6 +224,8 @@ func resourceKubernetesClusterNodePoolSchema() map[string]*pluginsdk.Schema {
 
 		"linux_os_config": schemaNodePoolLinuxOSConfig(),
 
+		"local_dns_profile": schemaNodePoolLocalDNSProfile(),
+
 		"fips_enabled": {
 			Type:     pluginsdk.TypeBool,
 			Optional: true,
@@ -741,6 +743,10 @@ func resourceKubernetesClusterNodePoolCreate(d *pluginsdk.ResourceData, meta int
 		profile.NetworkProfile = expandAgentPoolNetworkProfile(networkProfile)
 	}
 
+	if localDNSProfile := d.Get("local_dns_profile").([]interface{}); len(localDNSProfile) > 0 {
+		profile.LocalDNSProfile = expandAgentPoolLocalDNSProfile(localDNSProfile)
+	}
+
 	if snapshotId := d.Get("snapshot_id").(string); snapshotId != "" {
 		profile.CreationData = &agentpools.CreationData{
 			SourceResourceId: pointer.To(snapshotId),
@@ -970,6 +976,10 @@ func resourceKubernetesClusterNodePoolUpdate(d *pluginsdk.ResourceData, meta int
 
 	if d.HasChange("node_network_profile") {
 		props.NetworkProfile = expandAgentPoolNetworkProfile(d.Get("node_network_profile").([]interface{}))
+	}
+
+	if d.HasChange("local_dns_profile") {
+		props.LocalDNSProfile = expandAgentPoolLocalDNSProfile(d.Get("local_dns_profile").([]interface{}))
 	}
 
 	if d.HasChange("zones") {
@@ -1283,6 +1293,10 @@ func resourceKubernetesClusterNodePoolRead(d *pluginsdk.ResourceData, meta inter
 
 		if err := d.Set("node_network_profile", flattenAgentPoolNetworkProfile(props.NetworkProfile)); err != nil {
 			return fmt.Errorf("setting `node_network_profile`: %+v", err)
+		}
+
+		if err := d.Set("local_dns_profile", flattenAgentPoolLocalDNSProfile(props.LocalDNSProfile)); err != nil {
+			return fmt.Errorf("setting `local_dns_profile`: %+v", err)
 		}
 	}
 
@@ -1949,4 +1963,101 @@ func flattenAgentPoolNetworkProfileNodePublicIPTags(input *[]agentpools.IPTag) m
 	}
 
 	return out
+}
+
+func expandAgentPoolLocalDNSProfile(input []interface{}) *agentpools.LocalDNSProfile {
+	if len(input) == 0 || input[0] == nil {
+		return nil
+	}
+
+	raw := input[0].(map[string]interface{})
+	result := &agentpools.LocalDNSProfile{}
+
+	if v := raw["mode"].(string); v != "" {
+		result.Mode = pointer.To(agentpools.LocalDNSMode(v))
+	}
+
+	result.VnetDNSOverrides = expandAgentPoolLocalDNSOverrides(raw["vnet_dns_override"].(*pluginsdk.Set).List())
+	result.KubeDNSOverrides = expandAgentPoolLocalDNSOverrides(raw["kube_dns_override"].(*pluginsdk.Set).List())
+
+	return result
+}
+
+func expandAgentPoolLocalDNSOverrides(input []interface{}) *map[string]agentpools.LocalDNSOverride {
+	if len(input) == 0 {
+		return nil
+	}
+
+	result := make(map[string]agentpools.LocalDNSOverride)
+	for _, item := range input {
+		raw := item.(map[string]interface{})
+		domain := raw["domain"].(string)
+		override := agentpools.LocalDNSOverride{}
+
+		if v := raw["serve_stale"].(string); v != "" {
+			override.ServeStale = pointer.To(agentpools.LocalDNSServeStale(v))
+		}
+		if v := raw["serve_stale_duration"].(int); v > 0 {
+			override.ServeStaleDurationInSeconds = pointer.To(int64(v))
+		}
+		if v := raw["query_logging"].(string); v != "" {
+			override.QueryLogging = pointer.To(agentpools.LocalDNSQueryLogging(v))
+		}
+		if v := raw["protocol"].(string); v != "" {
+			override.Protocol = pointer.To(agentpools.LocalDNSProtocol(v))
+		}
+		if v := raw["forward_destination"].(string); v != "" {
+			override.ForwardDestination = pointer.To(agentpools.LocalDNSForwardDestination(v))
+		}
+		if v := raw["forward_policy"].(string); v != "" {
+			override.ForwardPolicy = pointer.To(agentpools.LocalDNSForwardPolicy(v))
+		}
+		if v := raw["max_concurrent"].(int); v > 0 {
+			override.MaxConcurrent = pointer.To(int64(v))
+		}
+		if v := raw["cache_duration_in_seconds"].(int); v > 0 {
+			override.CacheDurationInSeconds = pointer.To(int64(v))
+		}
+
+		result[domain] = override
+	}
+
+	return &result
+}
+
+func flattenAgentPoolLocalDNSProfile(input *agentpools.LocalDNSProfile) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"mode":              string(pointer.From(input.Mode)),
+			"vnet_dns_override": flattenAgentPoolLocalDNSOverrides(input.VnetDNSOverrides),
+			"kube_dns_override": flattenAgentPoolLocalDNSOverrides(input.KubeDNSOverrides),
+		},
+	}
+}
+
+func flattenAgentPoolLocalDNSOverrides(input *map[string]agentpools.LocalDNSOverride) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	results := make([]interface{}, 0)
+	for domain, override := range *input {
+		results = append(results, map[string]interface{}{
+			"domain":                    domain,
+			"serve_stale":               string(pointer.From(override.ServeStale)),
+			"serve_stale_duration":      int(pointer.From(override.ServeStaleDurationInSeconds)),
+			"query_logging":             string(pointer.From(override.QueryLogging)),
+			"protocol":                  string(pointer.From(override.Protocol)),
+			"forward_destination":       string(pointer.From(override.ForwardDestination)),
+			"forward_policy":            string(pointer.From(override.ForwardPolicy)),
+			"max_concurrent":            int(pointer.From(override.MaxConcurrent)),
+			"cache_duration_in_seconds": int(pointer.From(override.CacheDurationInSeconds)),
+		})
+	}
+
+	return results
 }

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -1479,6 +1479,43 @@ func TestAccKubernetesClusterNodePool_VMSizeOmitted(t *testing.T) {
 	})
 }
 
+func TestAccKubernetesClusterNodePool_localDNSProfile(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster_node_pool", "test")
+	r := KubernetesClusterNodePoolResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.localDNSProfile(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccKubernetesClusterNodePool_localDNSProfileUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster_node_pool", "test")
+	r := KubernetesClusterNodePoolResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.localDNSProfile(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.localDNSProfileUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r KubernetesClusterNodePoolResource) autoScaleConfig(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -4063,6 +4100,240 @@ resource "azurerm_kubernetes_cluster_node_pool" "pool2" {
   vnet_subnet_id        = azurerm_subnet.nodesubnet2.id
   upgrade_settings {
     max_surge = "10%%"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (KubernetesClusterNodePoolResource) localDNSProfile(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%[1]d"
+  address_space       = ["10.1.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet%[1]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.1.0.0/24"]
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%[1]d"
+
+  default_node_pool {
+    name           = "default"
+    node_count     = 1
+    vm_size        = "Standard_D4s_v3"
+    vnet_subnet_id = azurerm_subnet.test.id
+    upgrade_settings {
+      max_surge = "10%%%%"
+    }
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_kubernetes_cluster_node_pool" "test" {
+  name                  = "internal"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
+  vm_size               = "Standard_D4s_v3"
+  node_count            = 1
+  vnet_subnet_id        = azurerm_subnet.test.id
+  upgrade_settings {
+    max_surge = "10%%"
+  }
+
+  local_dns_profile {
+    mode = "Required"
+
+    vnet_dns_override {
+      domain                    = "."
+      serve_stale               = "Verify"
+      serve_stale_duration      = 3600
+      query_logging             = "Error"
+      protocol                  = "PreferUDP"
+      forward_destination       = "VnetDNS"
+      forward_policy            = "Sequential"
+      max_concurrent            = 1000
+      cache_duration_in_seconds = 3600
+    }
+
+    vnet_dns_override {
+      domain                    = "cluster.local"
+      serve_stale               = "Verify"
+      serve_stale_duration      = 3600
+      query_logging             = "Error"
+      protocol                  = "PreferUDP"
+      forward_destination       = "ClusterCoreDNS"
+      forward_policy            = "Sequential"
+      max_concurrent            = 1000
+      cache_duration_in_seconds = 3600
+    }
+
+    kube_dns_override {
+      domain                    = "cluster.local"
+      serve_stale               = "Verify"
+      serve_stale_duration      = 3600
+      query_logging             = "Error"
+      protocol                  = "PreferUDP"
+      forward_destination       = "ClusterCoreDNS"
+      forward_policy            = "Sequential"
+      max_concurrent            = 1000
+      cache_duration_in_seconds = 3600
+    }
+
+    kube_dns_override {
+      domain                    = "."
+      serve_stale               = "Verify"
+      serve_stale_duration      = 3600
+      query_logging             = "Error"
+      protocol                  = "PreferUDP"
+      forward_destination       = "ClusterCoreDNS"
+      forward_policy            = "Sequential"
+      max_concurrent            = 1000
+      cache_duration_in_seconds = 3600
+    }
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (KubernetesClusterNodePoolResource) localDNSProfileUpdated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%[1]d"
+  address_space       = ["10.1.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet%[1]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.1.0.0/24"]
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%[1]d"
+
+  default_node_pool {
+    name           = "default"
+    node_count     = 1
+    vm_size        = "Standard_D4s_v3"
+    vnet_subnet_id = azurerm_subnet.test.id
+    upgrade_settings {
+      max_surge = "10%%%%"
+    }
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_kubernetes_cluster_node_pool" "test" {
+  name                  = "internal"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
+  vm_size               = "Standard_D4s_v3"
+  node_count            = 1
+  vnet_subnet_id        = azurerm_subnet.test.id
+  upgrade_settings {
+    max_surge = "10%%"
+  }
+
+  local_dns_profile {
+    mode = "Required"
+
+    vnet_dns_override {
+      domain                    = "."
+      serve_stale               = "Verify"
+      serve_stale_duration      = 3600
+      query_logging             = "Error"
+      protocol                  = "PreferUDP"
+      forward_destination       = "VnetDNS"
+      forward_policy            = "RoundRobin"
+      max_concurrent            = 2000
+      cache_duration_in_seconds = 7200
+    }
+
+    vnet_dns_override {
+      domain                    = "mycustom.local"
+      serve_stale               = "Verify"
+      serve_stale_duration      = 3600
+      query_logging             = "Error"
+      protocol                  = "PreferUDP"
+      forward_destination       = "VnetDNS"
+      forward_policy            = "RoundRobin"
+      max_concurrent            = 2000
+      cache_duration_in_seconds = 7200
+    }
+
+    vnet_dns_override {
+      domain                    = "cluster.local"
+      serve_stale               = "Verify"
+      serve_stale_duration      = 3600
+      query_logging             = "Error"
+      protocol                  = "PreferUDP"
+      forward_destination       = "ClusterCoreDNS"
+      forward_policy            = "RoundRobin"
+      max_concurrent            = 2000
+      cache_duration_in_seconds = 7200
+    }
+
+    kube_dns_override {
+      domain                    = "cluster.local"
+      serve_stale               = "Immediate"
+      serve_stale_duration      = 3600
+      query_logging             = "Log"
+      protocol                  = "ForceTCP"
+      forward_destination       = "ClusterCoreDNS"
+      forward_policy            = "RoundRobin"
+      max_concurrent            = 2000
+      cache_duration_in_seconds = 7200
+    }
+
+    kube_dns_override {
+      domain                    = "."
+      serve_stale               = "Immediate"
+      serve_stale_duration      = 3600
+      query_logging             = "Log"
+      protocol                  = "ForceTCP"
+      forward_destination       = "ClusterCoreDNS"
+      forward_policy            = "RoundRobin"
+      max_concurrent            = 2000
+      cache_duration_in_seconds = 7200
+    }
   }
 }
 `, data.RandomInteger, data.Locations.Primary)

--- a/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -1252,6 +1252,43 @@ func TestAccKubernetesCluster_aiToolchainOperatorProfileToggle(t *testing.T) {
 	})
 }
 
+func TestAccKubernetesCluster_localDNSProfile(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
+	r := KubernetesClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.localDNSProfile(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("default_node_pool.0.temporary_name_for_rotation"),
+	})
+}
+
+func TestAccKubernetesCluster_localDNSProfileUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
+	r := KubernetesClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.localDNSProfile(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("default_node_pool.0.temporary_name_for_rotation"),
+		{
+			Config: r.localDNSProfileUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("default_node_pool.0.temporary_name_for_rotation"),
+	})
+}
+
 func (KubernetesClusterResource) sameSize(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -3800,4 +3837,206 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
 }
   `, data.RandomInteger, data.Locations.Primary, enabled)
+}
+
+func (KubernetesClusterResource) localDNSProfile(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%[1]d"
+  address_space       = ["10.1.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet%[1]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.1.0.0/24"]
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%[1]d"
+
+  default_node_pool {
+    name                        = "default"
+    node_count                  = 1
+    vm_size                     = "Standard_D4s_v3"
+    vnet_subnet_id              = azurerm_subnet.test.id
+    temporary_name_for_rotation = "temp"
+    upgrade_settings {
+      max_surge = "10%%"
+    }
+
+    local_dns_profile {
+      mode = "Required"
+
+      vnet_dns_override {
+        domain                    = "."
+        serve_stale               = "Verify"
+        serve_stale_duration      = 3600
+        query_logging             = "Error"
+        protocol                  = "PreferUDP"
+        forward_destination       = "VnetDNS"
+        forward_policy            = "Sequential"
+        max_concurrent            = 1000
+        cache_duration_in_seconds = 3600
+      }
+
+      vnet_dns_override {
+        domain                    = "cluster.local"
+        serve_stale               = "Verify"
+        serve_stale_duration      = 3600
+        query_logging             = "Error"
+        protocol                  = "PreferUDP"
+        forward_destination       = "ClusterCoreDNS"
+        forward_policy            = "Sequential"
+        max_concurrent            = 1000
+        cache_duration_in_seconds = 3600
+      }
+
+      kube_dns_override {
+        domain                    = "cluster.local"
+        serve_stale               = "Verify"
+        serve_stale_duration      = 3600
+        query_logging             = "Error"
+        protocol                  = "PreferUDP"
+        forward_destination       = "ClusterCoreDNS"
+        forward_policy            = "Sequential"
+        max_concurrent            = 1000
+        cache_duration_in_seconds = 3600
+      }
+
+      kube_dns_override {
+        domain                    = "."
+        serve_stale               = "Verify"
+        serve_stale_duration      = 3600
+        query_logging             = "Error"
+        protocol                  = "PreferUDP"
+        forward_destination       = "ClusterCoreDNS"
+        forward_policy            = "Sequential"
+        max_concurrent            = 1000
+        cache_duration_in_seconds = 3600
+      }
+    }
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (KubernetesClusterResource) localDNSProfileUpdated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%[1]d"
+  address_space       = ["10.1.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet%[1]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.1.0.0/24"]
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%[1]d"
+
+  default_node_pool {
+    name                        = "default"
+    node_count                  = 1
+    vm_size                     = "Standard_D4s_v3"
+    vnet_subnet_id              = azurerm_subnet.test.id
+    temporary_name_for_rotation = "temp"
+    upgrade_settings {
+      max_surge = "10%%"
+    }
+
+    local_dns_profile {
+      mode = "Required"
+
+      vnet_dns_override {
+        domain                    = "."
+        serve_stale               = "Verify"
+        serve_stale_duration      = 3600
+        query_logging             = "Error"
+        protocol                  = "PreferUDP"
+        forward_destination       = "VnetDNS"
+        forward_policy            = "RoundRobin"
+        max_concurrent            = 2000
+        cache_duration_in_seconds = 7200
+      }
+
+      vnet_dns_override {
+        domain                    = "cluster.local"
+        serve_stale               = "Verify"
+        serve_stale_duration      = 3600
+        query_logging             = "Error"
+        protocol                  = "PreferUDP"
+        forward_destination       = "ClusterCoreDNS"
+        forward_policy            = "RoundRobin"
+        max_concurrent            = 2000
+        cache_duration_in_seconds = 7200
+      }
+
+      kube_dns_override {
+        domain                    = "cluster.local"
+        serve_stale               = "Verify"
+        serve_stale_duration      = 3600
+        query_logging             = "Error"
+        protocol                  = "PreferUDP"
+        forward_destination       = "ClusterCoreDNS"
+        forward_policy            = "RoundRobin"
+        max_concurrent            = 2000
+        cache_duration_in_seconds = 7200
+      }
+
+      kube_dns_override {
+        domain                    = "."
+        serve_stale               = "Verify"
+        serve_stale_duration      = 3600
+        query_logging             = "Error"
+        protocol                  = "PreferUDP"
+        forward_destination       = "ClusterCoreDNS"
+        forward_policy            = "RoundRobin"
+        max_concurrent            = 2000
+        cache_duration_in_seconds = 7200
+      }
+    }
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
 }

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -701,6 +701,10 @@ func schemaLocalDNSOverride() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeSet,
 		Optional: true,
+		Set: func(v interface{}) int {
+			raw := v.(map[string]interface{})
+			return pluginsdk.HashStringInsensitively(raw["domain"].(string))
+		},
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
 				"domain": {

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -280,6 +280,8 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 						Type:     pluginsdk.TypeBool,
 						Optional: true,
 					},
+
+					"local_dns_profile": schemaNodePoolLocalDNSProfile(),
 				}
 			}(),
 		},
@@ -674,6 +676,88 @@ func schemaNodePoolNetworkProfile() *pluginsdk.Schema {
 	}
 }
 
+func schemaNodePoolLocalDNSProfile() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"mode": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringInSlice(managedclusters.PossibleValuesForLocalDNSMode(), false),
+				},
+
+				"vnet_dns_override": schemaLocalDNSOverride(),
+
+				"kube_dns_override": schemaLocalDNSOverride(),
+			},
+		},
+	}
+}
+
+func schemaLocalDNSOverride() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeSet,
+		Optional: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"domain": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+
+				"serve_stale": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringInSlice(managedclusters.PossibleValuesForLocalDNSServeStale(), false),
+				},
+
+				"serve_stale_duration": {
+					Type:     pluginsdk.TypeInt,
+					Optional: true,
+				},
+
+				"query_logging": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringInSlice(managedclusters.PossibleValuesForLocalDNSQueryLogging(), false),
+				},
+
+				"protocol": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringInSlice(managedclusters.PossibleValuesForLocalDNSProtocol(), false),
+				},
+
+				"forward_destination": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringInSlice(managedclusters.PossibleValuesForLocalDNSForwardDestination(), false),
+				},
+
+				"forward_policy": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringInSlice(managedclusters.PossibleValuesForLocalDNSForwardPolicy(), false),
+				},
+
+				"max_concurrent": {
+					Type:     pluginsdk.TypeInt,
+					Optional: true,
+				},
+
+				"cache_duration_in_seconds": {
+					Type:     pluginsdk.TypeInt,
+					Optional: true,
+				},
+			},
+		},
+	}
+}
+
 func upgradeSettingsSchemaClusterDefaultNodePool() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,
@@ -847,7 +931,56 @@ func ConvertDefaultNodePoolToAgentPool(input *[]managedclusters.ManagedClusterAg
 		agentpool.Properties.GpuInstanceProfile = pointer.To(agentpools.GPUInstanceProfile(*defaultCluster.GpuInstanceProfile))
 	}
 
+	if localDNS := defaultCluster.LocalDNSProfile; localDNS != nil {
+		converted := agentpools.LocalDNSProfile{}
+		if localDNS.Mode != nil {
+			converted.Mode = pointer.To(agentpools.LocalDNSMode(string(*localDNS.Mode)))
+		}
+		if localDNS.State != nil {
+			converted.State = pointer.To(agentpools.LocalDNSState(string(*localDNS.State)))
+		}
+		if localDNS.VnetDNSOverrides != nil {
+			overrides := make(map[string]agentpools.LocalDNSOverride)
+			for k, v := range *localDNS.VnetDNSOverrides {
+				overrides[k] = convertClusterLocalDNSOverrideToAgentPool(v)
+			}
+			converted.VnetDNSOverrides = &overrides
+		}
+		if localDNS.KubeDNSOverrides != nil {
+			overrides := make(map[string]agentpools.LocalDNSOverride)
+			for k, v := range *localDNS.KubeDNSOverrides {
+				overrides[k] = convertClusterLocalDNSOverrideToAgentPool(v)
+			}
+			converted.KubeDNSOverrides = &overrides
+		}
+		agentpool.Properties.LocalDNSProfile = &converted
+	}
+
 	return agentpool
+}
+
+func convertClusterLocalDNSOverrideToAgentPool(input managedclusters.LocalDNSOverride) agentpools.LocalDNSOverride {
+	result := agentpools.LocalDNSOverride{
+		CacheDurationInSeconds:      input.CacheDurationInSeconds,
+		MaxConcurrent:               input.MaxConcurrent,
+		ServeStaleDurationInSeconds: input.ServeStaleDurationInSeconds,
+	}
+	if input.ForwardDestination != nil {
+		result.ForwardDestination = pointer.To(agentpools.LocalDNSForwardDestination(string(*input.ForwardDestination)))
+	}
+	if input.ForwardPolicy != nil {
+		result.ForwardPolicy = pointer.To(agentpools.LocalDNSForwardPolicy(string(*input.ForwardPolicy)))
+	}
+	if input.Protocol != nil {
+		result.Protocol = pointer.To(agentpools.LocalDNSProtocol(string(*input.Protocol)))
+	}
+	if input.QueryLogging != nil {
+		result.QueryLogging = pointer.To(agentpools.LocalDNSQueryLogging(string(*input.QueryLogging)))
+	}
+	if input.ServeStale != nil {
+		result.ServeStale = pointer.To(agentpools.LocalDNSServeStale(string(*input.ServeStale)))
+	}
+	return result
 }
 
 func ExpandDefaultNodePool(d *pluginsdk.ResourceData) (*[]managedclusters.ManagedClusterAgentPoolProfile, error) {
@@ -1040,6 +1173,10 @@ func ExpandDefaultNodePool(d *pluginsdk.ResourceData) (*[]managedclusters.Manage
 
 	if networkProfile := raw["node_network_profile"].([]interface{}); len(networkProfile) > 0 {
 		profile.NetworkProfile = expandClusterPoolNetworkProfile(networkProfile)
+	}
+
+	if localDNSProfile := raw["local_dns_profile"].([]interface{}); len(localDNSProfile) > 0 {
+		profile.LocalDNSProfile = expandClusterNodePoolLocalDNSProfile(localDNSProfile)
 	}
 
 	return &[]managedclusters.ManagedClusterAgentPoolProfile{
@@ -1442,6 +1579,7 @@ func FlattenDefaultNodePool(input *[]managedclusters.ManagedClusterAgentPoolProf
 		"only_critical_addons_enabled":  criticalAddonsEnabled,
 		"kubelet_config":                flattenClusterNodePoolKubeletConfig(agentPool.KubeletConfig),
 		"linux_os_config":               linuxOSConfig,
+		"local_dns_profile":             flattenClusterNodePoolLocalDNSProfile(agentPool.LocalDNSProfile),
 		"zones":                         zones.FlattenUntyped(agentPool.AvailabilityZones),
 		"capacity_reservation_group_id": capacityReservationGroupId,
 	}
@@ -1967,4 +2105,101 @@ func flattenClusterPoolNetworkProfileNodePublicIPTags(input *[]managedclusters.I
 	}
 
 	return out
+}
+
+func expandClusterNodePoolLocalDNSProfile(input []interface{}) *managedclusters.LocalDNSProfile {
+	if len(input) == 0 || input[0] == nil {
+		return nil
+	}
+
+	raw := input[0].(map[string]interface{})
+	result := &managedclusters.LocalDNSProfile{}
+
+	if v := raw["mode"].(string); v != "" {
+		result.Mode = pointer.To(managedclusters.LocalDNSMode(v))
+	}
+
+	result.VnetDNSOverrides = expandClusterLocalDNSOverrides(raw["vnet_dns_override"].(*pluginsdk.Set).List())
+	result.KubeDNSOverrides = expandClusterLocalDNSOverrides(raw["kube_dns_override"].(*pluginsdk.Set).List())
+
+	return result
+}
+
+func expandClusterLocalDNSOverrides(input []interface{}) *map[string]managedclusters.LocalDNSOverride {
+	if len(input) == 0 {
+		return nil
+	}
+
+	result := make(map[string]managedclusters.LocalDNSOverride)
+	for _, item := range input {
+		raw := item.(map[string]interface{})
+		domain := raw["domain"].(string)
+		override := managedclusters.LocalDNSOverride{}
+
+		if v := raw["serve_stale"].(string); v != "" {
+			override.ServeStale = pointer.To(managedclusters.LocalDNSServeStale(v))
+		}
+		if v := raw["serve_stale_duration"].(int); v > 0 {
+			override.ServeStaleDurationInSeconds = pointer.To(int64(v))
+		}
+		if v := raw["query_logging"].(string); v != "" {
+			override.QueryLogging = pointer.To(managedclusters.LocalDNSQueryLogging(v))
+		}
+		if v := raw["protocol"].(string); v != "" {
+			override.Protocol = pointer.To(managedclusters.LocalDNSProtocol(v))
+		}
+		if v := raw["forward_destination"].(string); v != "" {
+			override.ForwardDestination = pointer.To(managedclusters.LocalDNSForwardDestination(v))
+		}
+		if v := raw["forward_policy"].(string); v != "" {
+			override.ForwardPolicy = pointer.To(managedclusters.LocalDNSForwardPolicy(v))
+		}
+		if v := raw["max_concurrent"].(int); v > 0 {
+			override.MaxConcurrent = pointer.To(int64(v))
+		}
+		if v := raw["cache_duration_in_seconds"].(int); v > 0 {
+			override.CacheDurationInSeconds = pointer.To(int64(v))
+		}
+
+		result[domain] = override
+	}
+
+	return &result
+}
+
+func flattenClusterNodePoolLocalDNSProfile(input *managedclusters.LocalDNSProfile) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"mode":              string(pointer.From(input.Mode)),
+			"vnet_dns_override": flattenClusterLocalDNSOverrides(input.VnetDNSOverrides),
+			"kube_dns_override": flattenClusterLocalDNSOverrides(input.KubeDNSOverrides),
+		},
+	}
+}
+
+func flattenClusterLocalDNSOverrides(input *map[string]managedclusters.LocalDNSOverride) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	results := make([]interface{}, 0)
+	for domain, override := range *input {
+		results = append(results, map[string]interface{}{
+			"domain":                    domain,
+			"serve_stale":               string(pointer.From(override.ServeStale)),
+			"serve_stale_duration":      int(pointer.From(override.ServeStaleDurationInSeconds)),
+			"query_logging":             string(pointer.From(override.QueryLogging)),
+			"protocol":                  string(pointer.From(override.Protocol)),
+			"forward_destination":       string(pointer.From(override.ForwardDestination)),
+			"forward_policy":            string(pointer.From(override.ForwardPolicy)),
+			"max_concurrent":            int(pointer.From(override.MaxConcurrent)),
+			"cache_duration_in_seconds": int(pointer.From(override.CacheDurationInSeconds)),
+		})
+	}
+
+	return results
 }

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -403,6 +403,8 @@ A `default_node_pool` block supports the following:
 
 * `linux_os_config` - (Optional) A `linux_os_config` block as defined below. `temporary_name_for_rotation` must be specified when changing this block.
 
+* `local_dns_profile` - (Optional) A `local_dns_profile` block as defined below. Configures the LocalDNS feature which deploys a DNS proxy on each node for low-latency DNS resolution.
+
 * `fips_enabled` - (Optional) Should the nodes in this Node Pool have Federal Information Processing Standard enabled? `temporary_name_for_rotation` must be specified when changing this block.
 
 * `kubelet_disk_type` - (Optional) The type of disk used by kubelet. Possible values are `OS` and `Temporary`. `temporary_name_for_rotation` must be specified when changing this block.
@@ -548,6 +550,38 @@ A `linux_os_config` block supports the following:
 * `transparent_huge_page_defrag` - (Optional) specifies the defrag configuration for Transparent Huge Page. Possible values are `always`, `defer`, `defer+madvise`, `madvise` and `never`.
 
 * `transparent_huge_page` - (Optional) Specifies the Transparent Huge Page configuration. Possible values are `always`, `madvise` and `never`.
+
+---
+
+A `local_dns_profile` block supports the following:
+
+* `mode` - (Optional) The mode for the LocalDNS feature. Possible values are `Required`, `Preferred` and `Disabled`.
+
+* `vnet_dns_override` - (Optional) One or more `vnet_dns_override` blocks as defined below. Configures DNS overrides for VNet DNS resolution.
+
+* `kube_dns_override` - (Optional) One or more `kube_dns_override` blocks as defined below. Configures DNS overrides for Kubernetes DNS resolution.
+
+---
+
+A `vnet_dns_override` and `kube_dns_override` block supports the following:
+
+* `domain` - (Required) The domain name to configure DNS overrides for. This is used as the map key in the API payload (e.g. `"."` or `"cluster.local"`).
+
+* `serve_stale` - (Optional) The serve stale configuration. Possible values are `Disable`, `Immediate` and `Verify`.
+
+* `serve_stale_duration` - (Optional) The serve stale duration in seconds.
+
+* `query_logging` - (Optional) The query logging configuration. Possible values are `Error` and `Log`.
+
+* `protocol` - (Optional) The DNS protocol to use. Possible values are `ForceTCP` and `PreferUDP`.
+
+* `forward_destination` - (Optional) The forward destination for DNS queries. Possible values are `ClusterCoreDNS` and `VnetDNS`.
+
+* `forward_policy` - (Optional) The forwarding policy. Possible values are `Random`, `RoundRobin` and `Sequential`.
+
+* `max_concurrent` - (Optional) The maximum number of concurrent DNS queries.
+
+* `cache_duration_in_seconds` - (Optional) The duration in seconds to cache DNS responses.
 
 ---
 

--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -92,6 +92,8 @@ The following arguments are supported:
 
 * `linux_os_config` - (Optional) A `linux_os_config` block as defined below. Changing this requires specifying `temporary_name_for_rotation`.
 
+* `local_dns_profile` - (Optional) A `local_dns_profile` block as defined below. Configures the LocalDNS feature which deploys a DNS proxy on each node for low-latency DNS resolution.
+
 * `fips_enabled` - (Optional) Should the nodes in this Node Pool have Federal Information Processing Standard enabled? Changing this property requires specifying `temporary_name_for_rotation`.
 
 ~> **Note:** FIPS support is in Public Preview - more information and details on how to opt into the Preview can be found in [this article](https://docs.microsoft.com/azure/aks/use-multiple-node-pools#add-a-fips-enabled-node-pool-preview).
@@ -217,6 +219,38 @@ A `linux_os_config` block supports the following:
 * `transparent_huge_page_defrag` - (Optional) specifies the defrag configuration for Transparent Huge Page. Possible values are `always`, `defer`, `defer+madvise`, `madvise` and `never`. 
 
 * `transparent_huge_page` - (Optional) Specifies the Transparent Huge Page configuration. Possible values are `always`, `madvise` and `never`.
+
+---
+
+A `local_dns_profile` block supports the following:
+
+* `mode` - (Optional) The mode for the LocalDNS feature. Possible values are `Required`, `Preferred` and `Disabled`.
+
+* `vnet_dns_override` - (Optional) One or more `vnet_dns_override` blocks as defined below. Configures DNS overrides for VNet DNS resolution.
+
+* `kube_dns_override` - (Optional) One or more `kube_dns_override` blocks as defined below. Configures DNS overrides for Kubernetes DNS resolution.
+
+---
+
+A `vnet_dns_override` and `kube_dns_override` block supports the following:
+
+* `domain` - (Required) The domain name to configure DNS overrides for. This is used as the map key in the API payload (e.g. `"."` or `"cluster.local"`).
+
+* `serve_stale` - (Optional) The serve stale configuration. Possible values are `Disable`, `Immediate` and `Verify`.
+
+* `serve_stale_duration` - (Optional) The serve stale duration in seconds.
+
+* `query_logging` - (Optional) The query logging configuration. Possible values are `Error` and `Log`.
+
+* `protocol` - (Optional) The DNS protocol to use. Possible values are `ForceTCP` and `PreferUDP`.
+
+* `forward_destination` - (Optional) The forward destination for DNS queries. Possible values are `ClusterCoreDNS` and `VnetDNS`.
+
+* `forward_policy` - (Optional) The forwarding policy. Possible values are `Random`, `RoundRobin` and `Sequential`.
+
+* `max_concurrent` - (Optional) The maximum number of concurrent DNS queries.
+
+* `cache_duration_in_seconds` - (Optional) The duration in seconds to cache DNS responses.
 
 ---
 

--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -92,7 +92,9 @@ The following arguments are supported:
 
 * `linux_os_config` - (Optional) A `linux_os_config` block as defined below. Changing this requires specifying `temporary_name_for_rotation`.
 
-* `local_dns_profile` - (Optional) A `local_dns_profile` block as defined below. Configures the LocalDNS feature which deploys a DNS proxy on each node for low-latency DNS resolution.
+* `local_dns_profile` - (Optional) A `local_dns_profile` block as defined below.
+
+~> **Note:** LocalDNS feature deploys a proxy on each node for low-latency DNS resolution. Learn more: [aka.ms/aks/localdns](https://aka.ms/aks/localdns).
 
 * `fips_enabled` - (Optional) Should the nodes in this Node Pool have Federal Information Processing Standard enabled? Changing this property requires specifying `temporary_name_for_rotation`.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Supports localDNSProfile in AKS agent pool.

**This feature is not yet supported in portal**

- Feature doc: https://aka.ms/aks/localdns
- REST API doc: https://learn.microsoft.com/en-us/rest/api/aks/agent-pools/create-or-update?view=rest-aks-2025-10-01&tabs=HTTP

This PR supersedes #31987 

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #31342


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
