### PR TITLE
[Enhancement:] `azurerm_cdn_frontdoor_custom_domain` - validate `host_name` values, refine `ManagedCertificate` hostname constraints, and harden related Front Door acceptance tests

### DIFF
--- a/internal/services/cdn/azure_front_door_cache_purge_action_test.go
+++ b/internal/services/cdn/azure_front_door_cache_purge_action_test.go
@@ -108,7 +108,7 @@ action "azurerm_cdn_front_door_cache_purge" "test" {
 func (a *AzureFrontDoorCachePurgeAction) complete(data acceptance.TestData) string {
 	dnsZoneName := os.Getenv("ARM_TEST_DNS_ZONE")
 	dnsZoneRG := os.Getenv("ARM_TEST_DATA_RESOURCE_GROUP")
-	childZoneSuffix := data.RandomIntOfLength(8)
+	childZoneSuffix := data.RandomString
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -138,7 +138,7 @@ data "azurerm_dns_zone" "test" {
 locals {
   # Create a delegated child zone inside the test RG.
   # NOTE: ARM_TEST_DNS_ZONE / ARM_TEST_DATA_RESOURCE_GROUP must refer to a real, delegated parent zone.
-  child_zone_label = "acctest%[6]d"
+  child_zone_label = "%[6]s"
   child_zone_name  = join(".", [local.child_zone_label, data.azurerm_dns_zone.test.name])
 }
 
@@ -207,5 +207,5 @@ action "azurerm_cdn_front_door_cache_purge" "test" {
     ]
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, dnsZoneName, dnsZoneRG, childZoneSuffix)
+`, data.RandomInteger, data.Locations.Primary, "fd", dnsZoneName, dnsZoneRG, childZoneSuffix)
 }

--- a/internal/services/cdn/azure_front_door_cache_purge_action_test.go
+++ b/internal/services/cdn/azure_front_door_cache_purge_action_test.go
@@ -167,7 +167,7 @@ resource "azurerm_cdn_frontdoor_custom_domain" "test" {
 
   tls {
     certificate_type    = "ManagedCertificate"
-    minimum_tls_version = "TLS12"
+    minimum_version = "TLS12"
   }
 }
 

--- a/internal/services/cdn/azure_front_door_cache_purge_action_test.go
+++ b/internal/services/cdn/azure_front_door_cache_purge_action_test.go
@@ -166,8 +166,8 @@ resource "azurerm_cdn_frontdoor_custom_domain" "test" {
   host_name   = join(".", ["%[3]s", azurerm_dns_zone.child.name])
 
   tls {
-    certificate_type    = "ManagedCertificate"
-    minimum_version = "TLS12"
+    certificate_type = "ManagedCertificate"
+    minimum_version  = "TLS12"
   }
 }
 

--- a/internal/services/cdn/cdn_frontdoor_custom_domain_association_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_custom_domain_association_resource_test.go
@@ -165,7 +165,7 @@ func (r CdnFrontDoorCustomDomainAssociationResource) remove(data acceptance.Test
 func (r CdnFrontDoorCustomDomainAssociationResource) template(data acceptance.TestData) string {
 	dnsZoneName := os.Getenv("ARM_TEST_DNS_ZONE")
 	dnsZoneRG := os.Getenv("ARM_TEST_DATA_RESOURCE_GROUP")
-	childZoneSuffix := data.RandomIntOfLength(8)
+	childZoneSuffix := data.RandomString
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -184,7 +184,7 @@ data "azurerm_dns_zone" "test" {
 locals {
   # Create a delegated child zone inside the test RG.
   # NOTE: ARM_TEST_DNS_ZONE / ARM_TEST_DATA_RESOURCE_GROUP must refer to a real, delegated parent zone.
-  child_zone_label = "acctest%[6]d"
+  child_zone_label = "%[6]s"
   child_zone_name  = join(".", [local.child_zone_label, data.azurerm_dns_zone.test.name])
 }
 
@@ -288,7 +288,7 @@ resource "azurerm_cdn_frontdoor_custom_domain" "contoso" {
   depends_on = [azurerm_dns_ns_record.delegation]
 
   dns_zone_id = azurerm_dns_zone.child.id
-  host_name   = join(".", ["%[3]s", azurerm_dns_zone.child.name])
+  host_name   = join(".", ["fd", azurerm_dns_zone.child.name])
 
   tls {
     certificate_type = "ManagedCertificate"

--- a/internal/services/cdn/cdn_frontdoor_custom_domain_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_custom_domain_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -49,6 +50,7 @@ func resourceCdnFrontDoorCustomDomain() *pluginsdk.Resource {
 		}),
 
 		CustomizeDiff: pluginsdk.CustomDiffWithAll(
+			pluginsdk.CustomizeDiffShim(validateManagedCertificateConfiguration),
 			pluginsdk.CustomizeDiffShim(validateCipherSuiteConfiguration),
 		),
 
@@ -75,9 +77,10 @@ func resourceCdnFrontDoorCustomDomain() *pluginsdk.Resource {
 			},
 
 			"host_name": {
-				Type:     pluginsdk.TypeString,
-				ForceNew: true,
-				Required: true,
+				Type:         pluginsdk.TypeString,
+				ForceNew:     true,
+				Required:     true,
+				ValidateFunc: validate.FrontDoorCustomDomainHostName,
 			},
 
 			"tls": {
@@ -601,6 +604,65 @@ func validateCipherSuiteConfiguration(ctx context.Context, diff *pluginsdk.Resou
 		}
 	} else if len(customCiphersRaw) > 0 && customCiphersRaw[0] != nil {
 		return errors.New("`custom_ciphers` cannot be specified when `type` is not `Customized`")
+	}
+
+	return nil
+}
+
+func validateManagedCertificateConfiguration(ctx context.Context, diff *pluginsdk.ResourceDiff, v interface{}) error {
+	tlsAny := diff.Get("tls")
+	tlsRaw, ok := tlsAny.([]interface{})
+	if !ok {
+		return errors.New("unexpected value for `tls`: expected list")
+	}
+	if len(tlsRaw) == 0 || tlsRaw[0] == nil {
+		return nil
+	}
+
+	tls, ok := tlsRaw[0].(map[string]interface{})
+	if !ok {
+		return errors.New("unexpected value for `tls`: expected object")
+	}
+
+	certificateType := string(afdcustomdomains.AfdCertificateTypeManagedCertificate)
+	if raw, exists := tls["certificate_type"]; exists && raw != nil {
+		v, ok := raw.(string)
+		if !ok {
+			return errors.New("unexpected value for `tls.certificate_type`: expected string")
+		}
+		if v != "" {
+			certificateType = v
+		}
+	}
+
+	if certificateType != string(afdcustomdomains.AfdCertificateTypeManagedCertificate) {
+		return nil
+	}
+
+	hostName, ok := diff.Get("host_name").(string)
+	if !ok {
+		return errors.New("unexpected value for `host_name`: expected string")
+	}
+
+	if len(hostName) > 64 {
+		return errors.New("`host_name` cannot be longer than 64 characters when `tls.certificate_type` is `ManagedCertificate`")
+	}
+
+	dnsZoneId, ok := diff.Get("dns_zone_id").(string)
+	if !ok {
+		return errors.New("unexpected value for `dns_zone_id`: expected string")
+	}
+	if dnsZoneId == "" {
+		return nil
+	}
+
+	zoneId, err := dnsValidate.ParseDnsZoneID(dnsZoneId)
+	if err != nil {
+		return err
+	}
+
+	if strings.EqualFold(hostName, zoneId.DnsZoneName) {
+		return errors.New("`host_name` cannot be an apex/root domain when `tls.certificate_type` is `ManagedCertificate`")
 	}
 
 	return nil

--- a/internal/services/cdn/cdn_frontdoor_custom_domain_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_custom_domain_resource.go
@@ -61,254 +61,8 @@ func resourceCdnFrontDoorCustomDomain() *pluginsdk.Resource {
 		}),
 
 		CustomizeDiff: pluginsdk.CustomDiffWithAll(
-			pluginsdk.CustomizeDiffShim(func(ctx context.Context, diff *pluginsdk.ResourceDiff, v interface{}) error {
-				tlsAny := diff.Get("tls")
-				tlsRaw, ok := tlsAny.([]interface{})
-				if !ok {
-					return errors.New("unexpected value for `tls`: expected list")
-				}
-				if len(tlsRaw) == 0 || tlsRaw[0] == nil {
-					return nil
-				}
-
-				tls, ok := tlsRaw[0].(map[string]interface{})
-				if !ok {
-					return errors.New("unexpected value for `tls`: expected object")
-				}
-
-				certificateType := string(afdcustomdomains.AfdCertificateTypeManagedCertificate)
-				if raw, exists := tls["certificate_type"]; exists && raw != nil {
-					v, ok := raw.(string)
-					if !ok {
-						return errors.New("unexpected value for `tls.certificate_type`: expected string")
-					}
-					if v != "" {
-						certificateType = v
-					}
-				}
-
-				if certificateType != string(afdcustomdomains.AfdCertificateTypeManagedCertificate) {
-					return nil
-				}
-
-				hostName, ok := diff.Get("host_name").(string)
-				if !ok {
-					return errors.New("unexpected value for `host_name`: expected string")
-				}
-
-				if len(hostName) > 64 {
-					return errors.New("`host_name` cannot be longer than 64 characters when `tls.certificate_type` is `ManagedCertificate`")
-				}
-
-				if strings.HasPrefix(hostName, "*.") {
-					return errors.New("`host_name` cannot be a wildcard domain when `tls.certificate_type` is `ManagedCertificate`")
-				}
-
-				return nil
-			}),
-			pluginsdk.CustomizeDiffShim(func(ctx context.Context, diff *pluginsdk.ResourceDiff, v interface{}) error {
-				tlsAny := diff.Get("tls")
-				tlsRaw, ok := tlsAny.([]interface{})
-				if !ok {
-					return errors.New("unexpected value for `tls`: expected list")
-				}
-				if len(tlsRaw) == 0 || tlsRaw[0] == nil {
-					return nil
-				}
-
-				tls, ok := tlsRaw[0].(map[string]interface{})
-				if !ok {
-					return errors.New("unexpected value for `tls`: expected object")
-				}
-
-				if !features.FivePointOh() {
-					if rawConfig := diff.GetRawConfig(); !rawConfig.IsNull() {
-						tlsConfig := rawConfig.GetAttr("tls")
-						if !tlsConfig.IsNull() && tlsConfig.LengthInt() > 0 {
-							tlsBlock := tlsConfig.AsValueSlice()[0]
-							if !tlsBlock.IsNull() {
-								if !tlsBlock.GetAttr("minimum_tls_version").IsNull() {
-									if minTlsVersion := tls["minimum_tls_version"].(string); minTlsVersion == string(afdcustomdomains.AfdMinimumTlsVersionTLSOneZero) {
-										return errors.New("support for TLS 1.0 and 1.1 was retired on March 1, 2025. Please use `minimum_version = \"TLS12\"` instead")
-									}
-								}
-							}
-						}
-					}
-				}
-
-				cipherSuiteAny, exists := tls["cipher_suite"]
-				if !exists || cipherSuiteAny == nil {
-					return nil
-				}
-
-				cipherSuiteRaw, ok := cipherSuiteAny.([]interface{})
-				if !ok {
-					return errors.New("unexpected value for `tls.cipher_suite`: expected list")
-				}
-				if cipherSuiteRaw == nil {
-					return nil
-				}
-
-				if len(cipherSuiteRaw) == 0 || cipherSuiteRaw[0] == nil {
-					return nil
-				}
-
-				cipherSuite, ok := cipherSuiteRaw[0].(map[string]interface{})
-				if !ok {
-					return errors.New("unexpected value for `tls.cipher_suite`: expected object")
-				}
-				cipherSuiteTypeAny, exists := cipherSuite["type"]
-				if !exists || cipherSuiteTypeAny == nil {
-					return errors.New("unexpected value for `tls.cipher_suite.type`: expected string")
-				}
-				cipherSuiteType, ok := cipherSuiteTypeAny.(string)
-				if !ok {
-					return errors.New("unexpected value for `tls.cipher_suite.type`: expected string")
-				}
-				customCiphersRaw := make([]interface{}, 0)
-				if raw, exists := cipherSuite["custom_ciphers"]; exists && raw != nil {
-					v, ok := raw.([]interface{})
-					if !ok {
-						return errors.New("unexpected value for `tls.cipher_suite.custom_ciphers`: expected list")
-					}
-					customCiphersRaw = v
-				}
-
-				if cipherSuiteType == string(afdcustomdomains.AfdCipherSuiteSetTypeCustomized) {
-					if len(customCiphersRaw) == 0 {
-						return errors.New("`custom_ciphers` is required when `type` is `Customized`")
-					}
-
-					if customCiphersRaw[0] == nil {
-						return errors.New("at least one cipher suite must be selected in `custom_ciphers` when `type` is set to `Customized`")
-					}
-
-					customCiphers, ok := customCiphersRaw[0].(map[string]interface{})
-					if !ok {
-						return errors.New("unexpected value for `tls.cipher_suite.custom_ciphers`: expected object")
-					}
-
-					setLen := func(s *pluginsdk.Set) int {
-						if s == nil {
-							return 0
-						}
-						return s.Len()
-					}
-
-					var tls12Suites *pluginsdk.Set
-					if raw, exists := customCiphers["tls12"]; exists && raw != nil {
-						v, ok := raw.(*pluginsdk.Set)
-						if !ok {
-							return errors.New("unexpected value for `custom_ciphers.tls12`: expected set")
-						}
-						tls12Suites = v
-					}
-
-					var tls13Suites *pluginsdk.Set
-					if raw, exists := customCiphers["tls13"]; exists && raw != nil {
-						v, ok := raw.(*pluginsdk.Set)
-						if !ok {
-							return errors.New("unexpected value for `custom_ciphers.tls13`: expected set")
-						}
-						tls13Suites = v
-					}
-
-					tls13Configured := false
-					if rawConfig := diff.GetRawConfig(); !rawConfig.IsNull() {
-						tlsConfig := rawConfig.GetAttr("tls")
-						if !tlsConfig.IsNull() && tlsConfig.LengthInt() > 0 {
-							tlsBlock := tlsConfig.AsValueSlice()[0]
-							if !tlsBlock.IsNull() {
-								cipherConfig := tlsBlock.GetAttr("cipher_suite")
-								if !cipherConfig.IsNull() && cipherConfig.LengthInt() > 0 {
-									cipherBlock := cipherConfig.AsValueSlice()[0]
-									if !cipherBlock.IsNull() {
-										customCiphersConfig := cipherBlock.GetAttr("custom_ciphers")
-										if !customCiphersConfig.IsNull() && customCiphersConfig.LengthInt() > 0 {
-											customCiphersBlock := customCiphersConfig.AsValueSlice()[0]
-											if !customCiphersBlock.IsNull() {
-												tls13Config := customCiphersBlock.GetAttr("tls13")
-												tls13Configured = !tls13Config.IsNull()
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-
-					if setLen(tls12Suites) == 0 && setLen(tls13Suites) == 0 {
-						return errors.New("at least one cipher suite must be selected in `custom_ciphers` when `type` is set to `Customized`")
-					}
-
-					if tls13Configured {
-						has128 := false
-						has256 := false
-						if tls13Suites != nil {
-							for _, raw := range tls13Suites.List() {
-								v, ok := raw.(string)
-								if !ok {
-									continue
-								}
-								switch v {
-								case "TLS_AES_128_GCM_SHA256":
-									has128 = true
-								case "TLS_AES_256_GCM_SHA384":
-									has256 = true
-								}
-							}
-						}
-
-						if !has128 || !has256 {
-							return errors.New("`custom_ciphers.tls13` must contain both `TLS_AES_128_GCM_SHA256` and `TLS_AES_256_GCM_SHA384` when specified")
-						}
-					}
-
-					minimumVersion := ""
-
-					if features.FivePointOh() {
-						if rawMin := tls["minimum_version"]; rawMin != nil {
-							if minStr, ok := rawMin.(string); ok {
-								minimumVersion = minStr
-							} else {
-								return errors.New("unexpected value for `tls.minimum_version`: expected string")
-							}
-						}
-					}
-
-					if !features.FivePointOh() {
-						if rawConfig := diff.GetRawConfig(); !rawConfig.IsNull() {
-							tlsConfig := rawConfig.GetAttr("tls")
-							if !tlsConfig.IsNull() && tlsConfig.LengthInt() > 0 {
-								tlsBlock := tlsConfig.AsValueSlice()[0]
-								if !tlsBlock.IsNull() {
-									switch {
-									case !tlsBlock.GetAttr("minimum_version").IsNull():
-										minimumVersion = tls["minimum_version"].(string)
-									case !tlsBlock.GetAttr("minimum_tls_version").IsNull():
-										minimumVersion = tls["minimum_tls_version"].(string)
-									default:
-										minimumVersion = string(afdcustomdomains.AfdMinimumTlsVersionTLSOneTwo)
-									}
-								}
-							}
-						}
-					}
-
-					if minimumVersion == string(afdcustomdomains.AfdMinimumTlsVersionTLSOneTwo) && setLen(tls12Suites) == 0 {
-						return errors.New("at least one TLS 1.2 cipher suite must be specified in `custom_ciphers.tls12` when `minimum_version` is set to `TLS12`")
-					}
-
-					if minimumVersion == string(afdcustomdomains.AfdMinimumTlsVersionTLSOneThree) && tls13Configured && setLen(tls13Suites) == 0 {
-						return errors.New("at least one TLS 1.3 cipher suite must be specified in `custom_ciphers.tls13` when `minimum_version` is set to `TLS13`")
-					}
-				} else if len(customCiphersRaw) > 0 && customCiphersRaw[0] != nil {
-					return errors.New("`custom_ciphers` cannot be specified when `type` is not `Customized`")
-				}
-
-				return nil
-			}),
+			pluginsdk.CustomizeDiffShim(frontDoorCustomDomainHostNameCustomizeDiff),
+			pluginsdk.CustomizeDiffShim(frontDoorCustomDomainTlsCustomizeDiff),
 		),
 
 		Schema: map[string]*pluginsdk.Schema{
@@ -675,50 +429,40 @@ func expandAfdDomainTlsParameters(d *pluginsdk.ResourceData, input []interface{}
 	certType := v["certificate_type"].(string)
 	secretRaw := v["cdn_frontdoor_secret_id"].(string)
 	secretWasConfigured := false
+	minimumVersionConfigured := false
+	minimumTlsVersionConfigured := false
 
 	minTlsVersion := ""
 
-	// `cdn_frontdoor_secret_id` is Optional+Computed. When `certificate_type` is
-	// ManagedCertificate, the service may populate a value in state even when
-	// the user didn't configure it. Only treat it as user-specified when it
-	// exists in raw config.
 	if rawConfig := d.GetRawConfig(); !rawConfig.IsNull() {
 		tlsConfig := rawConfig.GetAttr("tls")
 		if !tlsConfig.IsNull() && tlsConfig.LengthInt() > 0 {
 			tlsBlock := tlsConfig.AsValueSlice()[0]
 			if !tlsBlock.IsNull() {
 				secretWasConfigured = !tlsBlock.GetAttr("cdn_frontdoor_secret_id").IsNull()
-			}
-		}
-	}
-
-	if features.FivePointOh() {
-		minTlsVersion = v["minimum_version"].(string)
-	}
-
-	if !features.FivePointOh() {
-		if rawConfig := d.GetRawConfig(); !rawConfig.IsNull() {
-			tlsConfig := rawConfig.GetAttr("tls")
-			if !tlsConfig.IsNull() && tlsConfig.LengthInt() > 0 {
-				tlsBlock := tlsConfig.AsValueSlice()[0]
-				if !tlsBlock.IsNull() {
-					switch {
-					case !tlsBlock.GetAttr("minimum_version").IsNull():
-						minTlsVersion = v["minimum_version"].(string)
-					case !tlsBlock.GetAttr("minimum_tls_version").IsNull():
-						minTlsVersion = v["minimum_tls_version"].(string)
-					default:
-						minTlsVersion = string(afdcustomdomains.AfdMinimumTlsVersionTLSOneTwo)
-					}
+				minimumVersionConfigured = !tlsBlock.GetAttr("minimum_version").IsNull()
+				if ! features.FivePointOh() {
+					minimumTlsVersionConfigured = !tlsBlock.GetAttr("minimum_tls_version").IsNull()
 				}
 			}
 		}
 	}
 
+	if !features.FivePointOh() {
+		switch {
+		case minimumVersionConfigured:
+			minTlsVersion = v["minimum_version"].(string)
+		case minimumTlsVersionConfigured:
+			minTlsVersion = v["minimum_tls_version"].(string)
+		default:
+			minTlsVersion = string(afdcustomdomains.AfdMinimumTlsVersionTLSOneTwo)
+		}
+	} else {
+		minTlsVersion = v["minimum_version"].(string)
+	}
+
 	cipherSuiteRaw := v["cipher_suite"].([]interface{})
 
-	// NOTE: Cert type has to always be passed in the else you will get a
-	// "AfdDomain.TlsSettings.CertificateType' is required but it was not set" error
 	tls := afdcustomdomains.AFDDomainHTTPSParameters{
 		CertificateType: afdcustomdomains.AfdCertificateType(certType),
 	}
@@ -940,4 +684,244 @@ func flattenAfdDNSZoneResourceReference(input *afdcustomdomains.ResourceReferenc
 	}
 
 	return ""
+}
+
+func frontDoorCustomDomainHostNameCustomizeDiff(_ context.Context, diff *pluginsdk.ResourceDiff, _ interface{}) error {
+	tlsAny := diff.Get("tls")
+	tlsRaw, ok := tlsAny.([]interface{})
+	if !ok {
+		return errors.New("unexpected value for `tls`: expected list")
+	}
+	if len(tlsRaw) == 0 || tlsRaw[0] == nil {
+		return nil
+	}
+
+	tls, ok := tlsRaw[0].(map[string]interface{})
+	if !ok {
+		return errors.New("unexpected value for `tls`: expected object")
+	}
+
+	certificateType := string(afdcustomdomains.AfdCertificateTypeManagedCertificate)
+	if raw, exists := tls["certificate_type"]; exists && raw != nil {
+		v, ok := raw.(string)
+		if !ok {
+			return errors.New("unexpected value for `tls.certificate_type`: expected string")
+		}
+		if v != "" {
+			certificateType = v
+		}
+	}
+
+	if certificateType != string(afdcustomdomains.AfdCertificateTypeManagedCertificate) {
+		return nil
+	}
+
+	hostName, ok := diff.Get("host_name").(string)
+	if !ok {
+		return errors.New("unexpected value for `host_name`: expected string")
+	}
+
+	if len(hostName) > 64 {
+		return errors.New("`host_name` cannot be longer than 64 characters when `tls.certificate_type` is `ManagedCertificate`")
+	}
+
+	if strings.HasPrefix(hostName, "*.") {
+		return errors.New("`host_name` cannot be a wildcard domain when `tls.certificate_type` is `ManagedCertificate`")
+	}
+
+	return nil
+}
+
+func frontDoorCustomDomainTlsCustomizeDiff(_ context.Context, diff *pluginsdk.ResourceDiff, _ interface{}) error {
+	tlsAny := diff.Get("tls")
+	tlsRaw, ok := tlsAny.([]interface{})
+	if !ok {
+		return errors.New("unexpected value for `tls`: expected list")
+	}
+	if len(tlsRaw) == 0 || tlsRaw[0] == nil {
+		return nil
+	}
+
+	tls, ok := tlsRaw[0].(map[string]interface{})
+	if !ok {
+		return errors.New("unexpected value for `tls`: expected object")
+	}
+
+	rawConfig := diff.GetRawConfig()
+	minimumVersionConfigured := false
+	minimumTlsVersionConfigured := false
+	tls13Configured := false
+
+	if !rawConfig.IsNull() {
+		tlsConfig := rawConfig.GetAttr("tls")
+		if !tlsConfig.IsNull() && tlsConfig.LengthInt() > 0 {
+			tlsBlock := tlsConfig.AsValueSlice()[0]
+			if !tlsBlock.IsNull() {
+				minimumVersionConfigured = !tlsBlock.GetAttr("minimum_version").IsNull()
+				if !features.FivePointOh(){
+					minimumTlsVersionConfigured = !tlsBlock.GetAttr("minimum_tls_version").IsNull()
+				}
+
+				cipherConfig := tlsBlock.GetAttr("cipher_suite")
+				if !cipherConfig.IsNull() && cipherConfig.LengthInt() > 0 {
+					cipherBlock := cipherConfig.AsValueSlice()[0]
+					if !cipherBlock.IsNull() {
+						customCiphersConfig := cipherBlock.GetAttr("custom_ciphers")
+						if !customCiphersConfig.IsNull() && customCiphersConfig.LengthInt() > 0 {
+							customCiphersBlock := customCiphersConfig.AsValueSlice()[0]
+							if !customCiphersBlock.IsNull() {
+								tls13Config := customCiphersBlock.GetAttr("tls13")
+								tls13Configured = !tls13Config.IsNull()
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	if !features.FivePointOh() {
+		if minimumTlsVersionConfigured {
+			if minTlsVersion := tls["minimum_tls_version"].(string); strings.EqualFold(minTlsVersion, string(afdcustomdomains.AfdMinimumTlsVersionTLSOneZero)) {
+				return errors.New("support for TLS 1.0 and 1.1 was retired on March 1, 2025. Please use `minimum_version = \"TLS12\"` instead")
+			}
+		}
+	}
+
+	cipherSuiteAny, exists := tls["cipher_suite"]
+	if !exists || cipherSuiteAny == nil {
+		return nil
+	}
+
+	cipherSuiteRaw, ok := cipherSuiteAny.([]interface{})
+	if !ok {
+		return errors.New("unexpected value for `tls.cipher_suite`: expected list")
+	}
+	if cipherSuiteRaw == nil {
+		return nil
+	}
+	if len(cipherSuiteRaw) == 0 || cipherSuiteRaw[0] == nil {
+		return nil
+	}
+
+	cipherSuite, ok := cipherSuiteRaw[0].(map[string]interface{})
+	if !ok {
+		return errors.New("unexpected value for `tls.cipher_suite`: expected object")
+	}
+	cipherSuiteTypeAny, exists := cipherSuite["type"]
+	if !exists || cipherSuiteTypeAny == nil {
+		return errors.New("unexpected value for `tls.cipher_suite.type`: expected string")
+	}
+	cipherSuiteType, ok := cipherSuiteTypeAny.(string)
+	if !ok {
+		return errors.New("unexpected value for `tls.cipher_suite.type`: expected string")
+	}
+	customCiphersRaw := make([]interface{}, 0)
+	if raw, exists := cipherSuite["custom_ciphers"]; exists && raw != nil {
+		v, ok := raw.([]interface{})
+		if !ok {
+			return errors.New("unexpected value for `tls.cipher_suite.custom_ciphers`: expected list")
+		}
+		customCiphersRaw = v
+	}
+
+	if cipherSuiteType == string(afdcustomdomains.AfdCipherSuiteSetTypeCustomized) {
+		if len(customCiphersRaw) == 0 {
+			return errors.New("`custom_ciphers` is required when `type` is `Customized`")
+		}
+
+		if customCiphersRaw[0] == nil {
+			return errors.New("at least one cipher suite must be selected in `custom_ciphers` when `type` is set to `Customized`")
+		}
+
+		customCiphers, ok := customCiphersRaw[0].(map[string]interface{})
+		if !ok {
+			return errors.New("unexpected value for `tls.cipher_suite.custom_ciphers`: expected object")
+		}
+
+		setLen := func(s *pluginsdk.Set) int {
+			if s == nil {
+				return 0
+			}
+			return s.Len()
+		}
+
+		var tls12Suites *pluginsdk.Set
+		if raw, exists := customCiphers["tls12"]; exists && raw != nil {
+			v, ok := raw.(*pluginsdk.Set)
+			if !ok {
+				return errors.New("unexpected value for `custom_ciphers.tls12`: expected set")
+			}
+			tls12Suites = v
+		}
+
+		var tls13Suites *pluginsdk.Set
+		if raw, exists := customCiphers["tls13"]; exists && raw != nil {
+			v, ok := raw.(*pluginsdk.Set)
+			if !ok {
+				return errors.New("unexpected value for `custom_ciphers.tls13`: expected set")
+			}
+			tls13Suites = v
+		}
+
+		if setLen(tls12Suites) == 0 && setLen(tls13Suites) == 0 {
+			return errors.New("at least one cipher suite must be selected in `custom_ciphers` when `type` is set to `Customized`")
+		}
+
+		if tls13Configured {
+			has128 := false
+			has256 := false
+			if tls13Suites != nil {
+				for _, raw := range tls13Suites.List() {
+					v, ok := raw.(string)
+					if !ok {
+						continue
+					}
+					switch v {
+					case "TLS_AES_128_GCM_SHA256":
+						has128 = true
+					case "TLS_AES_256_GCM_SHA384":
+						has256 = true
+					}
+				}
+			}
+
+			if !has128 || !has256 {
+				return errors.New("`custom_ciphers.tls13` must contain both `TLS_AES_128_GCM_SHA256` and `TLS_AES_256_GCM_SHA384` when specified")
+			}
+		}
+
+		minimumVersion := ""
+
+		if !features.FivePointOh() {
+			switch {
+			case minimumVersionConfigured:
+				minimumVersion = tls["minimum_version"].(string)
+			case minimumTlsVersionConfigured:
+				minimumVersion = tls["minimum_tls_version"].(string)
+			default:
+				minimumVersion = string(afdcustomdomains.AfdMinimumTlsVersionTLSOneTwo)
+			}
+		} else {
+			if rawMin := tls["minimum_version"]; rawMin != nil {
+				if minStr, ok := rawMin.(string); ok {
+					minimumVersion = minStr
+				} else {
+					return errors.New("unexpected value for `tls.minimum_version`: expected string")
+				}
+			}
+		}
+
+		if minimumVersion == string(afdcustomdomains.AfdMinimumTlsVersionTLSOneTwo) && setLen(tls12Suites) == 0 {
+			return errors.New("at least one TLS 1.2 cipher suite must be specified in `custom_ciphers.tls12` when `minimum_version` is set to `TLS12`")
+		}
+
+		if minimumVersion == string(afdcustomdomains.AfdMinimumTlsVersionTLSOneThree) && tls13Configured && setLen(tls13Suites) == 0 {
+			return errors.New("at least one TLS 1.3 cipher suite must be specified in `custom_ciphers.tls13` when `minimum_version` is set to `TLS13`")
+		}
+	} else if len(customCiphersRaw) > 0 && customCiphersRaw[0] != nil {
+		return errors.New("`custom_ciphers` cannot be specified when `type` is not `Customized`")
+	}
+
+	return nil
 }

--- a/internal/services/cdn/cdn_frontdoor_custom_domain_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_custom_domain_resource.go
@@ -432,7 +432,7 @@ func expandAfdDomainTlsParameters(d *pluginsdk.ResourceData, input []interface{}
 	minimumVersionConfigured := false
 	minimumTlsVersionConfigured := false
 
-	minTlsVersion := ""
+	var minTlsVersion string
 
 	if rawConfig := d.GetRawConfig(); !rawConfig.IsNull() {
 		tlsConfig := rawConfig.GetAttr("tls")

--- a/internal/services/cdn/cdn_frontdoor_custom_domain_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_custom_domain_resource.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -61,8 +60,250 @@ func resourceCdnFrontDoorCustomDomain() *pluginsdk.Resource {
 		}),
 
 		CustomizeDiff: pluginsdk.CustomDiffWithAll(
-			pluginsdk.CustomizeDiffShim(validateManagedCertificateConfiguration),
-			pluginsdk.CustomizeDiffShim(validateCipherSuiteConfiguration),
+			pluginsdk.CustomizeDiffShim(func(ctx context.Context, diff *pluginsdk.ResourceDiff, v interface{}) error {
+				tlsAny := diff.Get("tls")
+				tlsRaw, ok := tlsAny.([]interface{})
+				if !ok {
+					return errors.New("unexpected value for `tls`: expected list")
+				}
+				if len(tlsRaw) == 0 || tlsRaw[0] == nil {
+					return nil
+				}
+
+				tls, ok := tlsRaw[0].(map[string]interface{})
+				if !ok {
+					return errors.New("unexpected value for `tls`: expected object")
+				}
+
+				certificateType := string(afdcustomdomains.AfdCertificateTypeManagedCertificate)
+				if raw, exists := tls["certificate_type"]; exists && raw != nil {
+					v, ok := raw.(string)
+					if !ok {
+						return errors.New("unexpected value for `tls.certificate_type`: expected string")
+					}
+					if v != "" {
+						certificateType = v
+					}
+				}
+
+				if certificateType != string(afdcustomdomains.AfdCertificateTypeManagedCertificate) {
+					return nil
+				}
+
+				hostName, ok := diff.Get("host_name").(string)
+				if !ok {
+					return errors.New("unexpected value for `host_name`: expected string")
+				}
+
+				if len(hostName) > 64 {
+					return errors.New("`host_name` cannot be longer than 64 characters when `tls.certificate_type` is `ManagedCertificate`")
+				}
+
+				return nil
+			}),
+			pluginsdk.CustomizeDiffShim(func(ctx context.Context, diff *pluginsdk.ResourceDiff, v interface{}) error {
+				tlsAny := diff.Get("tls")
+				tlsRaw, ok := tlsAny.([]interface{})
+				if !ok {
+					return errors.New("unexpected value for `tls`: expected list")
+				}
+				if len(tlsRaw) == 0 || tlsRaw[0] == nil {
+					return nil
+				}
+
+				tls, ok := tlsRaw[0].(map[string]interface{})
+				if !ok {
+					return errors.New("unexpected value for `tls`: expected object")
+				}
+
+				if !features.FivePointOh() {
+					if rawConfig := diff.GetRawConfig(); !rawConfig.IsNull() {
+						tlsConfig := rawConfig.GetAttr("tls")
+						if !tlsConfig.IsNull() && tlsConfig.LengthInt() > 0 {
+							tlsBlock := tlsConfig.AsValueSlice()[0]
+							if !tlsBlock.IsNull() {
+								if !tlsBlock.GetAttr("minimum_tls_version").IsNull() {
+									if minTlsVersion := tls["minimum_tls_version"].(string); minTlsVersion == string(afdcustomdomains.AfdMinimumTlsVersionTLSOneZero) {
+										return errors.New("support for TLS 1.0 and 1.1 was retired on March 1, 2025. Please use `minimum_version = \"TLS12\"` instead")
+									}
+								}
+							}
+						}
+					}
+				}
+
+				cipherSuiteAny, exists := tls["cipher_suite"]
+				if !exists || cipherSuiteAny == nil {
+					return nil
+				}
+
+				cipherSuiteRaw, ok := cipherSuiteAny.([]interface{})
+				if !ok {
+					return errors.New("unexpected value for `tls.cipher_suite`: expected list")
+				}
+				if cipherSuiteRaw == nil {
+					return nil
+				}
+
+				if len(cipherSuiteRaw) == 0 || cipherSuiteRaw[0] == nil {
+					return nil
+				}
+
+				cipherSuite, ok := cipherSuiteRaw[0].(map[string]interface{})
+				if !ok {
+					return errors.New("unexpected value for `tls.cipher_suite`: expected object")
+				}
+				cipherSuiteTypeAny, exists := cipherSuite["type"]
+				if !exists || cipherSuiteTypeAny == nil {
+					return errors.New("unexpected value for `tls.cipher_suite.type`: expected string")
+				}
+				cipherSuiteType, ok := cipherSuiteTypeAny.(string)
+				if !ok {
+					return errors.New("unexpected value for `tls.cipher_suite.type`: expected string")
+				}
+				customCiphersRaw := make([]interface{}, 0)
+				if raw, exists := cipherSuite["custom_ciphers"]; exists && raw != nil {
+					v, ok := raw.([]interface{})
+					if !ok {
+						return errors.New("unexpected value for `tls.cipher_suite.custom_ciphers`: expected list")
+					}
+					customCiphersRaw = v
+				}
+
+				if cipherSuiteType == string(afdcustomdomains.AfdCipherSuiteSetTypeCustomized) {
+					if len(customCiphersRaw) == 0 {
+						return errors.New("`custom_ciphers` is required when `type` is `Customized`")
+					}
+
+					if customCiphersRaw[0] == nil {
+						return errors.New("at least one cipher suite must be selected in `custom_ciphers` when `type` is set to `Customized`")
+					}
+
+					customCiphers, ok := customCiphersRaw[0].(map[string]interface{})
+					if !ok {
+						return errors.New("unexpected value for `tls.cipher_suite.custom_ciphers`: expected object")
+					}
+
+					setLen := func(s *pluginsdk.Set) int {
+						if s == nil {
+							return 0
+						}
+						return s.Len()
+					}
+
+					var tls12Suites *pluginsdk.Set
+					if raw, exists := customCiphers["tls12"]; exists && raw != nil {
+						v, ok := raw.(*pluginsdk.Set)
+						if !ok {
+							return errors.New("unexpected value for `custom_ciphers.tls12`: expected set")
+						}
+						tls12Suites = v
+					}
+
+					var tls13Suites *pluginsdk.Set
+					if raw, exists := customCiphers["tls13"]; exists && raw != nil {
+						v, ok := raw.(*pluginsdk.Set)
+						if !ok {
+							return errors.New("unexpected value for `custom_ciphers.tls13`: expected set")
+						}
+						tls13Suites = v
+					}
+
+					tls13Configured := false
+					if rawConfig := diff.GetRawConfig(); !rawConfig.IsNull() {
+						tlsConfig := rawConfig.GetAttr("tls")
+						if !tlsConfig.IsNull() && tlsConfig.LengthInt() > 0 {
+							tlsBlock := tlsConfig.AsValueSlice()[0]
+							if !tlsBlock.IsNull() {
+								cipherConfig := tlsBlock.GetAttr("cipher_suite")
+								if !cipherConfig.IsNull() && cipherConfig.LengthInt() > 0 {
+									cipherBlock := cipherConfig.AsValueSlice()[0]
+									if !cipherBlock.IsNull() {
+										customCiphersConfig := cipherBlock.GetAttr("custom_ciphers")
+										if !customCiphersConfig.IsNull() && customCiphersConfig.LengthInt() > 0 {
+											customCiphersBlock := customCiphersConfig.AsValueSlice()[0]
+											if !customCiphersBlock.IsNull() {
+												tls13Config := customCiphersBlock.GetAttr("tls13")
+												tls13Configured = !tls13Config.IsNull()
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+
+					if setLen(tls12Suites) == 0 && setLen(tls13Suites) == 0 {
+						return errors.New("at least one cipher suite must be selected in `custom_ciphers` when `type` is set to `Customized`")
+					}
+
+					if tls13Configured {
+						has128 := false
+						has256 := false
+						if tls13Suites != nil {
+							for _, raw := range tls13Suites.List() {
+								v, ok := raw.(string)
+								if !ok {
+									continue
+								}
+								switch v {
+								case "TLS_AES_128_GCM_SHA256":
+									has128 = true
+								case "TLS_AES_256_GCM_SHA384":
+									has256 = true
+								}
+							}
+						}
+
+						if !has128 || !has256 {
+							return errors.New("`custom_ciphers.tls13` must contain both `TLS_AES_128_GCM_SHA256` and `TLS_AES_256_GCM_SHA384` when specified")
+						}
+					}
+
+					minimumVersion := ""
+
+					if features.FivePointOh() {
+						if rawMin := tls["minimum_version"]; rawMin != nil {
+							if minStr, ok := rawMin.(string); ok {
+								minimumVersion = minStr
+							} else {
+								return errors.New("unexpected value for `tls.minimum_version`: expected string")
+							}
+						}
+					}
+
+					if !features.FivePointOh() {
+						if rawConfig := diff.GetRawConfig(); !rawConfig.IsNull() {
+							tlsConfig := rawConfig.GetAttr("tls")
+							if !tlsConfig.IsNull() && tlsConfig.LengthInt() > 0 {
+								tlsBlock := tlsConfig.AsValueSlice()[0]
+								if !tlsBlock.IsNull() {
+									switch {
+									case !tlsBlock.GetAttr("minimum_version").IsNull():
+										minimumVersion = tls["minimum_version"].(string)
+									case !tlsBlock.GetAttr("minimum_tls_version").IsNull():
+										minimumVersion = tls["minimum_tls_version"].(string)
+									default:
+										minimumVersion = string(afdcustomdomains.AfdMinimumTlsVersionTLSOneTwo)
+									}
+								}
+							}
+						}
+					}
+
+					if minimumVersion == string(afdcustomdomains.AfdMinimumTlsVersionTLSOneTwo) && setLen(tls12Suites) == 0 {
+						return errors.New("at least one TLS 1.2 cipher suite must be specified in `custom_ciphers.tls12` when `minimum_version` is set to `TLS12`")
+					}
+
+					if minimumVersion == string(afdcustomdomains.AfdMinimumTlsVersionTLSOneThree) && tls13Configured && setLen(tls13Suites) == 0 {
+						return errors.New("at least one TLS 1.3 cipher suite must be specified in `custom_ciphers.tls13` when `minimum_version` is set to `TLS13`")
+					}
+				} else if len(customCiphersRaw) > 0 && customCiphersRaw[0] != nil {
+					return errors.New("`custom_ciphers` cannot be specified when `type` is not `Customized`")
+				}
+
+				return nil
+			}),
 		),
 
 		Schema: map[string]*pluginsdk.Schema{
@@ -411,269 +652,6 @@ func resourceCdnFrontDoorCustomDomainDelete(d *pluginsdk.ResourceData, meta inte
 
 	if err := poller.PollUntilDone(ctx); err != nil {
 		return fmt.Errorf("waiting for deletion of %s: %+v", *id, err)
-	}
-
-	return nil
-}
-
-func validateCipherSuiteConfiguration(ctx context.Context, diff *pluginsdk.ResourceDiff, v interface{}) error {
-	tlsAny := diff.Get("tls")
-	tlsRaw, ok := tlsAny.([]interface{})
-	if !ok {
-		return errors.New("unexpected value for `tls`: expected list")
-	}
-	if len(tlsRaw) == 0 || tlsRaw[0] == nil {
-		return nil
-	}
-
-	tls, ok := tlsRaw[0].(map[string]interface{})
-	if !ok {
-		return errors.New("unexpected value for `tls`: expected object")
-	}
-
-	if !features.FivePointOh() {
-		if rawConfig := diff.GetRawConfig(); !rawConfig.IsNull() {
-			tlsConfig := rawConfig.GetAttr("tls")
-			if !tlsConfig.IsNull() && tlsConfig.LengthInt() > 0 {
-				tlsBlock := tlsConfig.AsValueSlice()[0]
-				if !tlsBlock.IsNull() {
-					if !tlsBlock.GetAttr("minimum_tls_version").IsNull() {
-						if minTlsVersion := tls["minimum_tls_version"].(string); minTlsVersion == string(afdcustomdomains.AfdMinimumTlsVersionTLSOneZero) {
-							return errors.New("support for TLS 1.0 and 1.1 was retired on March 1, 2025. Please use `minimum_version = \"TLS12\"` instead")
-						}
-					}
-				}
-			}
-		}
-	}
-
-	cipherSuiteAny, exists := tls["cipher_suite"]
-	if !exists || cipherSuiteAny == nil {
-		return nil
-	}
-
-	cipherSuiteRaw, ok := cipherSuiteAny.([]interface{})
-	if !ok {
-		return errors.New("unexpected value for `tls.cipher_suite`: expected list")
-	}
-	if cipherSuiteRaw == nil {
-		return nil
-	}
-
-	if len(cipherSuiteRaw) == 0 || cipherSuiteRaw[0] == nil {
-		return nil
-	}
-
-	cipherSuite, ok := cipherSuiteRaw[0].(map[string]interface{})
-	if !ok {
-		return errors.New("unexpected value for `tls.cipher_suite`: expected object")
-	}
-	cipherSuiteTypeAny, exists := cipherSuite["type"]
-	if !exists || cipherSuiteTypeAny == nil {
-		return errors.New("unexpected value for `tls.cipher_suite.type`: expected string")
-	}
-	cipherSuiteType, ok := cipherSuiteTypeAny.(string)
-	if !ok {
-		return errors.New("unexpected value for `tls.cipher_suite.type`: expected string")
-	}
-	customCiphersRaw := make([]interface{}, 0)
-	if raw, exists := cipherSuite["custom_ciphers"]; exists && raw != nil {
-		v, ok := raw.([]interface{})
-		if !ok {
-			return errors.New("unexpected value for `tls.cipher_suite.custom_ciphers`: expected list")
-		}
-		customCiphersRaw = v
-	}
-
-	if cipherSuiteType == string(afdcustomdomains.AfdCipherSuiteSetTypeCustomized) {
-		if len(customCiphersRaw) == 0 {
-			return errors.New("`custom_ciphers` is required when `type` is `Customized`")
-		}
-
-		if customCiphersRaw[0] == nil {
-			return errors.New("at least one cipher suite must be selected in `custom_ciphers` when `type` is set to `Customized`")
-		}
-
-		customCiphers, ok := customCiphersRaw[0].(map[string]interface{})
-		if !ok {
-			return errors.New("unexpected value for `tls.cipher_suite.custom_ciphers`: expected object")
-		}
-
-		setLen := func(s *pluginsdk.Set) int {
-			if s == nil {
-				return 0
-			}
-			return s.Len()
-		}
-
-		var tls12Suites *pluginsdk.Set
-		if raw, exists := customCiphers["tls12"]; exists && raw != nil {
-			v, ok := raw.(*pluginsdk.Set)
-			if !ok {
-				return errors.New("unexpected value for `custom_ciphers.tls12`: expected set")
-			}
-			tls12Suites = v
-		}
-
-		var tls13Suites *pluginsdk.Set
-		if raw, exists := customCiphers["tls13"]; exists && raw != nil {
-			v, ok := raw.(*pluginsdk.Set)
-			if !ok {
-				return errors.New("unexpected value for `custom_ciphers.tls13`: expected set")
-			}
-			tls13Suites = v
-		}
-
-		tls13Configured := false
-		if rawConfig := diff.GetRawConfig(); !rawConfig.IsNull() {
-			tlsConfig := rawConfig.GetAttr("tls")
-			if !tlsConfig.IsNull() && tlsConfig.LengthInt() > 0 {
-				tlsBlock := tlsConfig.AsValueSlice()[0]
-				if !tlsBlock.IsNull() {
-					cipherConfig := tlsBlock.GetAttr("cipher_suite")
-					if !cipherConfig.IsNull() && cipherConfig.LengthInt() > 0 {
-						cipherBlock := cipherConfig.AsValueSlice()[0]
-						if !cipherBlock.IsNull() {
-							customCiphersConfig := cipherBlock.GetAttr("custom_ciphers")
-							if !customCiphersConfig.IsNull() && customCiphersConfig.LengthInt() > 0 {
-								customCiphersBlock := customCiphersConfig.AsValueSlice()[0]
-								if !customCiphersBlock.IsNull() {
-									tls13Config := customCiphersBlock.GetAttr("tls13")
-									tls13Configured = !tls13Config.IsNull()
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-
-		if setLen(tls12Suites) == 0 && setLen(tls13Suites) == 0 {
-			return errors.New("at least one cipher suite must be selected in `custom_ciphers` when `type` is set to `Customized`")
-		}
-
-		if tls13Configured {
-			has128 := false
-			has256 := false
-			if tls13Suites != nil {
-				for _, raw := range tls13Suites.List() {
-					v, ok := raw.(string)
-					if !ok {
-						continue
-					}
-					switch v {
-					case "TLS_AES_128_GCM_SHA256":
-						has128 = true
-					case "TLS_AES_256_GCM_SHA384":
-						has256 = true
-					}
-				}
-			}
-
-			if !has128 || !has256 {
-				return errors.New("`custom_ciphers.tls13` must contain both `TLS_AES_128_GCM_SHA256` and `TLS_AES_256_GCM_SHA384` when specified")
-			}
-		}
-
-		minimumVersion := ""
-
-		if features.FivePointOh() {
-			if rawMin := tls["minimum_version"]; rawMin != nil {
-				if minStr, ok := rawMin.(string); ok {
-					minimumVersion = minStr
-				} else {
-					return errors.New("unexpected value for `tls.minimum_version`: expected string")
-				}
-			}
-		}
-
-		if !features.FivePointOh() {
-			if rawConfig := diff.GetRawConfig(); !rawConfig.IsNull() {
-				tlsConfig := rawConfig.GetAttr("tls")
-				if !tlsConfig.IsNull() && tlsConfig.LengthInt() > 0 {
-					tlsBlock := tlsConfig.AsValueSlice()[0]
-					if !tlsBlock.IsNull() {
-						switch {
-						case !tlsBlock.GetAttr("minimum_version").IsNull():
-							minimumVersion = tls["minimum_version"].(string)
-						case !tlsBlock.GetAttr("minimum_tls_version").IsNull():
-							minimumVersion = tls["minimum_tls_version"].(string)
-						default:
-							minimumVersion = string(afdcustomdomains.AfdMinimumTlsVersionTLSOneTwo)
-						}
-					}
-				}
-			}
-		}
-
-		if minimumVersion == string(afdcustomdomains.AfdMinimumTlsVersionTLSOneTwo) && setLen(tls12Suites) == 0 {
-			return errors.New("at least one TLS 1.2 cipher suite must be specified in `custom_ciphers.tls12` when `minimum_version` is set to `TLS12`")
-		}
-
-		if minimumVersion == string(afdcustomdomains.AfdMinimumTlsVersionTLSOneThree) && tls13Configured && setLen(tls13Suites) == 0 {
-			return errors.New("at least one TLS 1.3 cipher suite must be specified in `custom_ciphers.tls13` when `minimum_version` is set to `TLS13`")
-		}
-	} else if len(customCiphersRaw) > 0 && customCiphersRaw[0] != nil {
-		return errors.New("`custom_ciphers` cannot be specified when `type` is not `Customized`")
-	}
-
-	return nil
-}
-
-func validateManagedCertificateConfiguration(ctx context.Context, diff *pluginsdk.ResourceDiff, v interface{}) error {
-	tlsAny := diff.Get("tls")
-	tlsRaw, ok := tlsAny.([]interface{})
-	if !ok {
-		return errors.New("unexpected value for `tls`: expected list")
-	}
-	if len(tlsRaw) == 0 || tlsRaw[0] == nil {
-		return nil
-	}
-
-	tls, ok := tlsRaw[0].(map[string]interface{})
-	if !ok {
-		return errors.New("unexpected value for `tls`: expected object")
-	}
-
-	certificateType := string(afdcustomdomains.AfdCertificateTypeManagedCertificate)
-	if raw, exists := tls["certificate_type"]; exists && raw != nil {
-		v, ok := raw.(string)
-		if !ok {
-			return errors.New("unexpected value for `tls.certificate_type`: expected string")
-		}
-		if v != "" {
-			certificateType = v
-		}
-	}
-
-	if certificateType != string(afdcustomdomains.AfdCertificateTypeManagedCertificate) {
-		return nil
-	}
-
-	hostName, ok := diff.Get("host_name").(string)
-	if !ok {
-		return errors.New("unexpected value for `host_name`: expected string")
-	}
-
-	if len(hostName) > 64 {
-		return errors.New("`host_name` cannot be longer than 64 characters when `tls.certificate_type` is `ManagedCertificate`")
-	}
-
-	dnsZoneId, ok := diff.Get("dns_zone_id").(string)
-	if !ok {
-		return errors.New("unexpected value for `dns_zone_id`: expected string")
-	}
-	if dnsZoneId == "" {
-		return nil
-	}
-
-	zoneId, err := dnsValidate.ParseDnsZoneID(dnsZoneId)
-	if err != nil {
-		return err
-	}
-
-	if strings.EqualFold(hostName, zoneId.DnsZoneName) {
-		return errors.New("`host_name` cannot be an apex/root domain when `tls.certificate_type` is `ManagedCertificate`")
 	}
 
 	return nil

--- a/internal/services/cdn/cdn_frontdoor_custom_domain_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_custom_domain_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -97,6 +98,10 @@ func resourceCdnFrontDoorCustomDomain() *pluginsdk.Resource {
 
 				if len(hostName) > 64 {
 					return errors.New("`host_name` cannot be longer than 64 characters when `tls.certificate_type` is `ManagedCertificate`")
+				}
+
+				if strings.HasPrefix(hostName, "*.") {
+					return errors.New("`host_name` cannot be a wildcard domain when `tls.certificate_type` is `ManagedCertificate`")
 				}
 
 				return nil

--- a/internal/services/cdn/cdn_frontdoor_custom_domain_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_custom_domain_resource.go
@@ -441,7 +441,7 @@ func expandAfdDomainTlsParameters(d *pluginsdk.ResourceData, input []interface{}
 			if !tlsBlock.IsNull() {
 				secretWasConfigured = !tlsBlock.GetAttr("cdn_frontdoor_secret_id").IsNull()
 				minimumVersionConfigured = !tlsBlock.GetAttr("minimum_version").IsNull()
-				if ! features.FivePointOh() {
+				if !features.FivePointOh() {
 					minimumTlsVersionConfigured = !tlsBlock.GetAttr("minimum_tls_version").IsNull()
 				}
 			}
@@ -758,7 +758,7 @@ func frontDoorCustomDomainTlsCustomizeDiff(_ context.Context, diff *pluginsdk.Re
 			tlsBlock := tlsConfig.AsValueSlice()[0]
 			if !tlsBlock.IsNull() {
 				minimumVersionConfigured = !tlsBlock.GetAttr("minimum_version").IsNull()
-				if !features.FivePointOh(){
+				if !features.FivePointOh() {
 					minimumTlsVersionConfigured = !tlsBlock.GetAttr("minimum_tls_version").IsNull()
 				}
 

--- a/internal/services/cdn/cdn_frontdoor_custom_domain_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_custom_domain_resource.go
@@ -28,6 +28,17 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
+// Front Door currently rejects the DHE TLS 1.2 suites exposed by the SDK helper.
+// The service team confirmed this supported set officially, so this is not a
+// temporary workaround. We keep an explicit allowlist of the accepted ECDHE
+// values here.
+var frontDoorCustomDomainCustomizedCipherSuitesForTls12 = []string{
+	string(afdcustomdomains.AfdCustomizedCipherSuiteForTls12ECDHERSAAESOneTwoEightGCMSHATwoFiveSix),
+	string(afdcustomdomains.AfdCustomizedCipherSuiteForTls12ECDHERSAAESTwoFiveSixGCMSHAThreeEightFour),
+	string(afdcustomdomains.AfdCustomizedCipherSuiteForTls12ECDHERSAAESOneTwoEightSHATwoFiveSix),
+	string(afdcustomdomains.AfdCustomizedCipherSuiteForTls12ECDHERSAAESTwoFiveSixSHAThreeEightFour),
+}
+
 func resourceCdnFrontDoorCustomDomain() *pluginsdk.Resource {
 	resource := &pluginsdk.Resource{
 		Create: resourceCdnFrontDoorCustomDomainCreate,
@@ -149,7 +160,7 @@ func resourceCdnFrontDoorCustomDomain() *pluginsdk.Resource {
 													Elem: &pluginsdk.Schema{
 														Type: pluginsdk.TypeString,
 														ValidateFunc: validation.StringInSlice(
-															afdcustomdomains.PossibleValuesForAfdCustomizedCipherSuiteForTls12(),
+															frontDoorCustomDomainCustomizedCipherSuitesForTls12,
 															false,
 														),
 													},

--- a/internal/services/cdn/cdn_frontdoor_custom_domain_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_custom_domain_resource_test.go
@@ -852,7 +852,7 @@ resource "azurerm_cdn_frontdoor_custom_domain" "test" {
   depends_on = [azurerm_dns_ns_record.delegation]
 
   dns_zone_id = azurerm_dns_zone.child.id
-  host_name   = join(".", ["abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz", azurerm_dns_zone.child.name])
+  host_name   = join(".", ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", azurerm_dns_zone.child.name])
 
   tls {
     certificate_type = "ManagedCertificate"

--- a/internal/services/cdn/cdn_frontdoor_custom_domain_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_custom_domain_resource_test.go
@@ -138,6 +138,10 @@ func TestAccCdnFrontDoorCustomDomain_cipherSuites_validation(t *testing.T) {
 			ExpectError: regexp.MustCompile("`custom_ciphers\\.tls13` must contain both `TLS_AES_128_GCM_SHA256` and `TLS_AES_256_GCM_SHA384`"),
 		},
 		{
+			Config:      r.customizedCipherSuiteTls12Unsupported(data),
+			ExpectError: regexp.MustCompile("DHE_RSA_AES128_GCM_SHA256"),
+		},
+		{
 			Config:      r.customCiphersWithPresetType(data),
 			ExpectError: regexp.MustCompile("`custom_ciphers` cannot be specified when `type` is not `Customized`"),
 		},
@@ -551,6 +555,41 @@ resource "azurerm_cdn_frontdoor_custom_domain" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
+func (r CdnFrontDoorCustomDomainResource) customizedCipherSuiteTls12Unsupported(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_cdn_frontdoor_custom_domain" "test" {
+  name                     = "acctest-customdomain-tls12-unsupported-%[2]d"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+
+  depends_on = [azurerm_dns_ns_record.delegation]
+
+  dns_zone_id = azurerm_dns_zone.child.id
+  host_name   = join(".", ["fd", azurerm_dns_zone.child.name])
+
+  tls {
+    certificate_type = "ManagedCertificate"
+    minimum_version  = "TLS12"
+
+    cipher_suite {
+      type = "Customized"
+
+      custom_ciphers {
+        tls12 = [
+          "DHE_RSA_AES128_GCM_SHA256",
+        ]
+        tls13 = [
+          "TLS_AES_128_GCM_SHA256",
+          "TLS_AES_256_GCM_SHA384",
+        ]
+      }
+    }
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
 func (r CdnFrontDoorCustomDomainResource) cipherSuitesTls12Single(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %[1]s
@@ -610,7 +649,7 @@ resource "azurerm_cdn_frontdoor_custom_domain" "test" {
         tls12 = [
           "ECDHE_RSA_AES128_GCM_SHA256",
           "ECDHE_RSA_AES256_GCM_SHA384",
-          "DHE_RSA_AES128_GCM_SHA256",
+          "ECDHE_RSA_AES128_SHA256",
         ]
         tls13 = [
           "TLS_AES_128_GCM_SHA256",

--- a/internal/services/cdn/cdn_frontdoor_custom_domain_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_custom_domain_resource_test.go
@@ -153,6 +153,23 @@ func TestAccCdnFrontDoorCustomDomain_cipherSuites_validation(t *testing.T) {
 	data.ResourceTest(t, r, testSteps)
 }
 
+func TestAccCdnFrontDoorCustomDomain_managedCertificate_validation(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_custom_domain", "test")
+	r := CdnFrontDoorCustomDomainResource{}
+	r.preCheck(t)
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:      r.managedCertificateHostNameTooLong(data),
+			ExpectError: regexp.MustCompile("`host_name` cannot be longer than 64 characters when `tls\\.certificate_type` is `ManagedCertificate`"),
+		},
+		{
+			Config:      r.managedCertificateApexDomain(data),
+			ExpectError: regexp.MustCompile("`host_name` cannot be an apex/root domain when `tls\\.certificate_type` is `ManagedCertificate`"),
+		},
+	})
+}
+
 func TestAccCdnFrontDoorCustomDomain_cipherSuites_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_custom_domain", "test")
 	r := CdnFrontDoorCustomDomainResource{}
@@ -251,14 +268,14 @@ resource "azurerm_cdn_frontdoor_custom_domain" "test" {
   depends_on = [azurerm_dns_ns_record.delegation]
 
   dns_zone_id = azurerm_dns_zone.child.id
-  host_name   = join(".", ["%s", azurerm_dns_zone.child.name])
+  host_name   = join(".", ["fd", azurerm_dns_zone.child.name])
 
   tls {
     certificate_type = "ManagedCertificate"
     minimum_version  = "TLS12"
   }
 }
-`, template, data.RandomInteger, data.RandomString)
+`, template, data.RandomInteger)
 }
 
 func (r CdnFrontDoorCustomDomainResource) requiresImport(data acceptance.TestData) string {
@@ -292,14 +309,14 @@ resource "azurerm_cdn_frontdoor_custom_domain" "test" {
   depends_on = [azurerm_dns_ns_record.delegation]
 
   dns_zone_id = azurerm_dns_zone.child.id
-  host_name   = join(".", ["%s", azurerm_dns_zone.child.name])
+  host_name   = join(".", ["fd", azurerm_dns_zone.child.name])
 
   tls {
     certificate_type = "ManagedCertificate"
     minimum_version  = "TLS12"
   }
 }
-`, template, data.RandomInteger, data.RandomString)
+`, template, data.RandomInteger)
 }
 
 func (r CdnFrontDoorCustomDomainResource) update(data acceptance.TestData) string {
@@ -314,7 +331,7 @@ resource "azurerm_cdn_frontdoor_custom_domain" "test" {
   depends_on = [azurerm_dns_ns_record.delegation]
 
   dns_zone_id = azurerm_dns_zone.child.id
-  host_name   = join(".", ["%s", azurerm_dns_zone.child.name])
+  host_name   = join(".", ["fd", azurerm_dns_zone.child.name])
 
   tls {
     certificate_type = "ManagedCertificate"
@@ -322,7 +339,7 @@ resource "azurerm_cdn_frontdoor_custom_domain" "test" {
   }
 
 }
-`, template, data.RandomInteger, data.RandomString)
+`, template, data.RandomInteger)
 }
 
 func (r CdnFrontDoorCustomDomainResource) tlsVersionLegacy(data acceptance.TestData) string {
@@ -337,14 +354,14 @@ resource "azurerm_cdn_frontdoor_custom_domain" "test" {
   depends_on = [azurerm_dns_ns_record.delegation]
 
   dns_zone_id = azurerm_dns_zone.child.id
-  host_name   = join(".", ["%s", azurerm_dns_zone.child.name])
+  host_name   = join(".", ["fd", azurerm_dns_zone.child.name])
 
   tls {
     certificate_type    = "ManagedCertificate"
     minimum_tls_version = "TLS12"
   }
 }
-`, template, data.RandomInteger, data.RandomString)
+`, template, data.RandomInteger)
 }
 
 // TODO: Add test case that uses pre_validated_custom_domain_resource_id
@@ -355,7 +372,7 @@ resource "azurerm_cdn_frontdoor_custom_domain" "test" {
 func (r CdnFrontDoorCustomDomainResource) template(data acceptance.TestData) string {
 	dnsZoneName := os.Getenv("ARM_TEST_DNS_ZONE")
 	dnsZoneRG := os.Getenv("ARM_TEST_DATA_RESOURCE_GROUP")
-	childZoneSuffix := data.RandomIntOfLength(8)
+	childZoneSuffix := data.RandomString
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -374,7 +391,7 @@ data "azurerm_dns_zone" "test" {
 locals {
   # Create a delegated child zone inside the test RG.
   # NOTE: ARM_TEST_DNS_ZONE / ARM_TEST_DATA_RESOURCE_GROUP must refer to a real, delegated parent zone.
-  child_zone_label = "acctest%[5]d"
+  child_zone_label = "%[5]s"
   child_zone_name  = join(".", [local.child_zone_label, data.azurerm_dns_zone.test.name])
 }
 
@@ -424,7 +441,7 @@ resource "azurerm_cdn_frontdoor_custom_domain" "test" {
   depends_on = [azurerm_dns_ns_record.delegation]
 
   dns_zone_id = azurerm_dns_zone.child.id
-  host_name   = join(".", ["acctest-%[2]d", azurerm_dns_zone.child.name])
+  host_name   = join(".", ["fd", azurerm_dns_zone.child.name])
 
   tls {
     certificate_type = "ManagedCertificate"
@@ -449,7 +466,7 @@ resource "azurerm_cdn_frontdoor_custom_domain" "test" {
   depends_on = [azurerm_dns_ns_record.delegation]
 
   dns_zone_id = azurerm_dns_zone.child.id
-  host_name   = join(".", ["acctest-empty-%[2]d", azurerm_dns_zone.child.name])
+  host_name   = join(".", ["fd", azurerm_dns_zone.child.name])
 
   tls {
     certificate_type = "ManagedCertificate"
@@ -479,7 +496,7 @@ resource "azurerm_cdn_frontdoor_custom_domain" "test" {
   depends_on = [azurerm_dns_ns_record.delegation]
 
   dns_zone_id = azurerm_dns_zone.child.id
-  host_name   = join(".", ["acctest-tls12-%[2]d", azurerm_dns_zone.child.name])
+  host_name   = join(".", ["fd", azurerm_dns_zone.child.name])
 
   tls {
     certificate_type = "ManagedCertificate"
@@ -511,7 +528,7 @@ resource "azurerm_cdn_frontdoor_custom_domain" "test" {
   depends_on = [azurerm_dns_ns_record.delegation]
 
   dns_zone_id = azurerm_dns_zone.child.id
-  host_name   = join(".", ["acctest-tls13-single-%[2]d", azurerm_dns_zone.child.name])
+  host_name   = join(".", ["fd", azurerm_dns_zone.child.name])
 
   tls {
     certificate_type = "ManagedCertificate"
@@ -545,7 +562,7 @@ resource "azurerm_cdn_frontdoor_custom_domain" "test" {
   depends_on = [azurerm_dns_ns_record.delegation]
 
   dns_zone_id = azurerm_dns_zone.child.id
-  host_name   = join(".", ["%[3]s", azurerm_dns_zone.child.name])
+  host_name   = join(".", ["fd", azurerm_dns_zone.child.name])
 
   tls {
     certificate_type = "ManagedCertificate"
@@ -566,7 +583,7 @@ resource "azurerm_cdn_frontdoor_custom_domain" "test" {
     }
   }
 }
-`, r.template(data), data.RandomInteger, data.RandomString)
+`, r.template(data), data.RandomInteger)
 }
 
 func (r CdnFrontDoorCustomDomainResource) cipherSuitesTls12Multiple(data acceptance.TestData) string {
@@ -580,7 +597,7 @@ resource "azurerm_cdn_frontdoor_custom_domain" "test" {
   depends_on = [azurerm_dns_ns_record.delegation]
 
   dns_zone_id = azurerm_dns_zone.child.id
-  host_name   = join(".", ["%[3]s", azurerm_dns_zone.child.name])
+  host_name   = join(".", ["fd", azurerm_dns_zone.child.name])
 
   tls {
     certificate_type = "ManagedCertificate"
@@ -603,7 +620,7 @@ resource "azurerm_cdn_frontdoor_custom_domain" "test" {
     }
   }
 }
-`, r.template(data), data.RandomInteger, data.RandomString)
+`, r.template(data), data.RandomInteger)
 }
 
 // func (r CdnFrontDoorCustomDomainResource) cipherSuitesMixedWithTls12MinSingle(data acceptance.TestData) string {
@@ -652,7 +669,7 @@ resource "azurerm_cdn_frontdoor_custom_domain" "test" {
   depends_on = [azurerm_dns_ns_record.delegation]
 
   dns_zone_id = azurerm_dns_zone.child.id
-  host_name   = join(".", ["%[3]s", azurerm_dns_zone.child.name])
+  host_name   = join(".", ["fd", azurerm_dns_zone.child.name])
 
   tls {
     certificate_type = "ManagedCertificate"
@@ -673,7 +690,7 @@ resource "azurerm_cdn_frontdoor_custom_domain" "test" {
     }
   }
 }
-`, r.template(data), data.RandomInteger, data.RandomString)
+`, r.template(data), data.RandomInteger)
 }
 
 func (r CdnFrontDoorCustomDomainResource) customCiphersWithPresetType(data acceptance.TestData) string {
@@ -687,7 +704,7 @@ resource "azurerm_cdn_frontdoor_custom_domain" "test" {
   depends_on = [azurerm_dns_ns_record.delegation]
 
   dns_zone_id = azurerm_dns_zone.child.id
-  host_name   = join(".", ["acctest-%[2]d", azurerm_dns_zone.child.name])
+  host_name   = join(".", ["fd", azurerm_dns_zone.child.name])
 
   tls {
     certificate_type = "ManagedCertificate"
@@ -719,11 +736,53 @@ resource "azurerm_cdn_frontdoor_custom_domain" "test" {
   depends_on = [azurerm_dns_ns_record.delegation]
 
   dns_zone_id = azurerm_dns_zone.child.id
-  host_name   = join(".", ["acctest-%[2]d", azurerm_dns_zone.child.name])
+  host_name   = join(".", ["fd", azurerm_dns_zone.child.name])
 
   tls {
     certificate_type    = "ManagedCertificate"
     minimum_tls_version = "TLS10"
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r CdnFrontDoorCustomDomainResource) managedCertificateHostNameTooLong(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_cdn_frontdoor_custom_domain" "test" {
+  name                     = "acctest-customdomain-%[2]d"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+
+  depends_on = [azurerm_dns_ns_record.delegation]
+
+  dns_zone_id = azurerm_dns_zone.child.id
+  host_name   = join(".", ["abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz", azurerm_dns_zone.child.name])
+
+  tls {
+    certificate_type = "ManagedCertificate"
+    minimum_version  = "TLS12"
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r CdnFrontDoorCustomDomainResource) managedCertificateApexDomain(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_cdn_frontdoor_custom_domain" "test" {
+  name                     = "acctest-customdomain-%[2]d"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+
+  depends_on = [azurerm_dns_ns_record.delegation]
+
+  dns_zone_id = azurerm_dns_zone.child.id
+  host_name   = azurerm_dns_zone.child.name
+
+  tls {
+    certificate_type = "ManagedCertificate"
+    minimum_version  = "TLS12"
   }
 }
 `, r.template(data), data.RandomInteger)

--- a/internal/services/cdn/cdn_frontdoor_custom_domain_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_custom_domain_resource_test.go
@@ -167,6 +167,10 @@ func TestAccCdnFrontDoorCustomDomain_managedCertificate_validation(t *testing.T)
 			Config:      r.managedCertificateHostNameTooLong(data),
 			ExpectError: regexp.MustCompile("`host_name` cannot be longer than 64 characters when `tls\\.certificate_type` is `ManagedCertificate`"),
 		},
+		{
+			Config:      r.managedCertificateWildcardDomain(data),
+			ExpectError: regexp.MustCompile("`host_name` cannot be a wildcard domain when `tls\\.certificate_type` is `ManagedCertificate`"),
+		},
 	})
 }
 
@@ -371,6 +375,10 @@ resource "azurerm_cdn_frontdoor_custom_domain" "test" {
 // to mutate that parent-domain setup until the dedicated test approach is
 // agreed by the reviewer who owns the domain.
 
+// TODO: Add positive wildcard-domain coverage with `CustomerCertificate`.
+// This needs a real customer-managed certificate fixture, which is expensive
+// enough that we are deferring it until a reusable test certificate setup is agreed.
+
 // TODO: Add test case that uses CMK, this cannot be a test cert or a self
 // signed cert it must be an official cert from the approved list of cert
 // providers by the service.
@@ -432,6 +440,52 @@ resource "azurerm_dns_txt_record" "validation" {
   record {
     value = azurerm_cdn_frontdoor_custom_domain.test.validation_token
   }
+}
+`, data.RandomInteger, data.Locations.Primary, dnsZoneName, dnsZoneRG, childZoneSuffix)
+}
+
+func (r CdnFrontDoorCustomDomainResource) validationTemplate(data acceptance.TestData) string {
+	dnsZoneName := os.Getenv("ARM_TEST_DNS_ZONE")
+	dnsZoneRG := os.Getenv("ARM_TEST_DATA_RESOURCE_GROUP")
+	childZoneSuffix := data.RandomString
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-cdn-afdx-%[1]d"
+  location = "%[2]s"
+}
+
+data "azurerm_dns_zone" "test" {
+  name                = "%[3]s"
+  resource_group_name = "%[4]s"
+}
+
+locals {
+  child_zone_label = "%[5]s"
+  child_zone_name  = join(".", [local.child_zone_label, data.azurerm_dns_zone.test.name])
+}
+
+resource "azurerm_dns_zone" "child" {
+  name                = local.child_zone_name
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_dns_ns_record" "delegation" {
+  name                = local.child_zone_label
+  resource_group_name = data.azurerm_dns_zone.test.resource_group_name
+  zone_name           = data.azurerm_dns_zone.test.name
+  ttl                 = 300
+
+  records = azurerm_dns_zone.child.name_servers
+}
+
+resource "azurerm_cdn_frontdoor_profile" "test" {
+  name                = "acctestcdnfdprofile-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  sku_name            = "Standard_AzureFrontDoor"
 }
 `, data.RandomInteger, data.Locations.Primary, dnsZoneName, dnsZoneRG, childZoneSuffix)
 }
@@ -805,5 +859,26 @@ resource "azurerm_cdn_frontdoor_custom_domain" "test" {
     minimum_version  = "TLS12"
   }
 }
-`, r.template(data), data.RandomInteger)
+`, r.validationTemplate(data), data.RandomInteger)
+}
+
+func (r CdnFrontDoorCustomDomainResource) managedCertificateWildcardDomain(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_cdn_frontdoor_custom_domain" "test" {
+  name                     = "acctest-customdomain-%[2]d"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+
+  depends_on = [azurerm_dns_ns_record.delegation]
+
+  dns_zone_id = azurerm_dns_zone.child.id
+  host_name   = join(".", ["*", azurerm_dns_zone.child.name])
+
+  tls {
+    certificate_type = "ManagedCertificate"
+    minimum_version  = "TLS12"
+  }
+}
+`, r.validationTemplate(data), data.RandomInteger)
 }

--- a/internal/services/cdn/cdn_frontdoor_custom_domain_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_custom_domain_resource_test.go
@@ -167,10 +167,6 @@ func TestAccCdnFrontDoorCustomDomain_managedCertificate_validation(t *testing.T)
 			Config:      r.managedCertificateHostNameTooLong(data),
 			ExpectError: regexp.MustCompile("`host_name` cannot be longer than 64 characters when `tls\\.certificate_type` is `ManagedCertificate`"),
 		},
-		{
-			Config:      r.managedCertificateApexDomain(data),
-			ExpectError: regexp.MustCompile("`host_name` cannot be an apex/root domain when `tls\\.certificate_type` is `ManagedCertificate`"),
-		},
 	})
 }
 
@@ -369,6 +365,12 @@ resource "azurerm_cdn_frontdoor_custom_domain" "test" {
 }
 
 // TODO: Add test case that uses pre_validated_custom_domain_resource_id
+
+// TODO: Apex-domain managed certificate coverage is intentionally omitted for now.
+// The shared DNS fixture is reused across Front Door tests, and we do not want
+// to mutate that parent-domain setup until the dedicated test approach is
+// agreed by the reviewer who owns the domain.
+
 // TODO: Add test case that uses CMK, this cannot be a test cert or a self
 // signed cert it must be an official cert from the approved list of cert
 // providers by the service.
@@ -797,27 +799,6 @@ resource "azurerm_cdn_frontdoor_custom_domain" "test" {
 
   dns_zone_id = azurerm_dns_zone.child.id
   host_name   = join(".", ["abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz", azurerm_dns_zone.child.name])
-
-  tls {
-    certificate_type = "ManagedCertificate"
-    minimum_version  = "TLS12"
-  }
-}
-`, r.template(data), data.RandomInteger)
-}
-
-func (r CdnFrontDoorCustomDomainResource) managedCertificateApexDomain(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%[1]s
-
-resource "azurerm_cdn_frontdoor_custom_domain" "test" {
-  name                     = "acctest-customdomain-%[2]d"
-  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
-
-  depends_on = [azurerm_dns_ns_record.delegation]
-
-  dns_zone_id = azurerm_dns_zone.child.id
-  host_name   = azurerm_dns_zone.child.name
 
   tls {
     certificate_type = "ManagedCertificate"

--- a/internal/services/cdn/cdn_frontdoor_security_policy_data_source_test.go
+++ b/internal/services/cdn/cdn_frontdoor_security_policy_data_source_test.go
@@ -16,6 +16,7 @@ type CdnFrontDoorSecurityPolicyDataSource struct{}
 func TestAccCdnFrontDoorSecurityPolicyDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_cdn_frontdoor_security_policy", "test")
 	d := CdnFrontDoorSecurityPolicyDataSource{}
+	d.preCheck(t)
 
 	data.DataSourceTest(t, []acceptance.TestStep{
 		{
@@ -28,6 +29,10 @@ func TestAccCdnFrontDoorSecurityPolicyDataSource_basic(t *testing.T) {
 			),
 		},
 	})
+}
+
+func (CdnFrontDoorSecurityPolicyDataSource) preCheck(t *testing.T) {
+	CdnFrontDoorSecurityPolicyResource{}.preCheck(t)
 }
 
 func (CdnFrontDoorSecurityPolicyDataSource) basic(data acceptance.TestData) string {

--- a/internal/services/cdn/cdn_frontdoor_security_policy_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_security_policy_resource_test.go
@@ -159,7 +159,7 @@ func (r CdnFrontDoorSecurityPolicyResource) preCheck(t *testing.T) {
 func (r CdnFrontDoorSecurityPolicyResource) template(data acceptance.TestData) string {
 	dnsZoneName := os.Getenv("ARM_TEST_DNS_ZONE")
 	dnsZoneRG := os.Getenv("ARM_TEST_DATA_RESOURCE_GROUP")
-	childZoneSuffix := data.RandomIntOfLength(8)
+	childZoneSuffix := data.RandomString
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-cdn-afdx-%[1]d"
@@ -174,7 +174,7 @@ data "azurerm_dns_zone" "test" {
 locals {
   # Create a delegated child zone inside the test RG.
   # NOTE: ARM_TEST_DNS_ZONE / ARM_TEST_DATA_RESOURCE_GROUP must refer to a real, delegated parent zone.
-  child_zone_label = "acctest%[5]d"
+  child_zone_label = "%[5]s"
   child_zone_name  = join(".", [local.child_zone_label, data.azurerm_dns_zone.test.name])
 }
 
@@ -255,7 +255,7 @@ resource "azurerm_cdn_frontdoor_custom_domain" "test" {
   depends_on = [azurerm_dns_ns_record.delegation]
 
   dns_zone_id = azurerm_dns_zone.child.id
-  host_name   = join(".", ["fabrikam", azurerm_dns_zone.child.name])
+  host_name   = join(".", ["fd", azurerm_dns_zone.child.name])
 
   tls {
     certificate_type    = "ManagedCertificate"
@@ -480,7 +480,7 @@ resource "azurerm_cdn_frontdoor_custom_domain" "update_test" {
   depends_on = [azurerm_dns_ns_record.delegation]
 
   dns_zone_id = azurerm_dns_zone.child.id
-  host_name   = join(".", ["fabrikam${count.index}", azurerm_dns_zone.child.name])
+  host_name   = join(".", ["fd${count.index}", azurerm_dns_zone.child.name])
 
   tls { certificate_type = "ManagedCertificate" }
 }

--- a/internal/services/cdn/cdn_frontdoor_security_policy_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_security_policy_resource_test.go
@@ -258,8 +258,8 @@ resource "azurerm_cdn_frontdoor_custom_domain" "test" {
   host_name   = join(".", ["fd", azurerm_dns_zone.child.name])
 
   tls {
-    certificate_type    = "ManagedCertificate"
-    minimum_tls_version = "TLS12"
+    certificate_type = "ManagedCertificate"
+    minimum_version  = "TLS12"
   }
 }
 
@@ -349,7 +349,6 @@ resource "azurerm_cdn_frontdoor_endpoint" "test" {
 }
 
 func (r CdnFrontDoorSecurityPolicyResource) basic(data acceptance.TestData) string {
-	template := r.template(data)
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -377,7 +376,7 @@ resource "azurerm_cdn_frontdoor_security_policy" "test" {
     }
   }
 }
-`, template, data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }
 
 func (r CdnFrontDoorSecurityPolicyResource) basicEndpoint(data acceptance.TestData) string {
@@ -521,7 +520,6 @@ resource "azurerm_cdn_frontdoor_security_policy" "test" {
 }
 
 func (r CdnFrontDoorSecurityPolicyResource) complete(data acceptance.TestData) string {
-	template := r.template(data)
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -549,7 +547,7 @@ resource "azurerm_cdn_frontdoor_security_policy" "test" {
     }
   }
 }
-`, template, data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }
 
 func (r CdnFrontDoorSecurityPolicyResource) completeEndpoint(data acceptance.TestData) string {

--- a/internal/services/cdn/cdn_profile_data_source_test.go
+++ b/internal/services/cdn/cdn_profile_data_source_test.go
@@ -9,11 +9,16 @@ import (
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cdn"
 )
 
 type CdnProfileDataSource struct{}
 
 func TestAccCdnProfileDataSource_basic(t *testing.T) {
+	if cdn.IsCdnDeprecatedForCreation() {
+		t.Skip(cdn.CreateDeprecationMessage)
+	}
+
 	data := acceptance.BuildTestData(t, "data.azurerm_cdn_profile", "test")
 	d := CdnProfileDataSource{}
 
@@ -28,6 +33,10 @@ func TestAccCdnProfileDataSource_basic(t *testing.T) {
 }
 
 func TestAccCdnProfileDataSource_withTags(t *testing.T) {
+	if cdn.IsCdnDeprecatedForCreation() {
+		t.Skip(cdn.CreateDeprecationMessage)
+	}
+
 	data := acceptance.BuildTestData(t, "data.azurerm_cdn_profile", "test")
 	d := CdnProfileDataSource{}
 

--- a/internal/services/cdn/validate/front_door_custom_domain_host_name.go
+++ b/internal/services/cdn/validate/front_door_custom_domain_host_name.go
@@ -1,0 +1,39 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package validate
+
+import (
+	"fmt"
+	"strings"
+
+	helperValidate "github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
+)
+
+func FrontDoorCustomDomainHostName(i interface{}, k string) (_ []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		return nil, []error{fmt.Errorf("expected type of %q to be string", k)}
+	}
+
+	if len(v) > 253 {
+		return nil, []error{fmt.Errorf("%q must be a valid fully qualified domain name, got %q", k, v)}
+	}
+
+	labels := strings.Split(v, ".")
+	if len(labels) < 2 {
+		return nil, []error{fmt.Errorf("%q must be a valid fully qualified domain name, got %q", k, v)}
+	}
+
+	for _, label := range labels {
+		if label == "" || len(label) > 63 {
+			return nil, []error{fmt.Errorf("%q must be a valid fully qualified domain name, got %q", k, v)}
+		}
+
+		if m, _ := helperValidate.RegExHelper(label, k, `^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$`); !m {
+			return nil, []error{fmt.Errorf("%q must be a valid fully qualified domain name, got %q", k, v)}
+		}
+	}
+
+	return nil, nil
+}

--- a/internal/services/cdn/validate/front_door_custom_domain_host_name.go
+++ b/internal/services/cdn/validate/front_door_custom_domain_host_name.go
@@ -25,9 +25,13 @@ func FrontDoorCustomDomainHostName(i interface{}, k string) (_ []string, errors 
 		return nil, []error{fmt.Errorf("%q must be a valid fully qualified domain name, got %q", k, v)}
 	}
 
-	for _, label := range labels {
+	for index, label := range labels {
 		if label == "" || len(label) > 63 {
 			return nil, []error{fmt.Errorf("%q must be a valid fully qualified domain name, got %q", k, v)}
+		}
+
+		if index == 0 && label == "*" {
+			continue
 		}
 
 		if m, _ := helperValidate.RegExHelper(label, k, `^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$`); !m {

--- a/internal/services/cdn/validate/front_door_custom_domain_host_name_test.go
+++ b/internal/services/cdn/validate/front_door_custom_domain_host_name_test.go
@@ -1,0 +1,59 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package validate
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFrontDoorCustomDomainHostName(t *testing.T) {
+	cases := []struct {
+		input string
+		valid bool
+	}{
+		{
+			input: "",
+			valid: false,
+		},
+		{
+			input: "contoso.example.com",
+			valid: true,
+		},
+		{
+			input: "a.b",
+			valid: true,
+		},
+		{
+			input: "localhost",
+			valid: false,
+		},
+		{
+			input: "-contoso.example.com",
+			valid: false,
+		},
+		{
+			input: "contoso-.example.com",
+			valid: false,
+		},
+		{
+			input: strings.Repeat("a", 64) + ".example.com",
+			valid: false,
+		},
+		{
+			input: strings.Repeat("a", 63) + "." + strings.Repeat("b", 63) + "." + strings.Repeat("c", 63) + "." + strings.Repeat("d", 62),
+			valid: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.input)
+		_, errors := FrontDoorCustomDomainHostName(tc.input, "test")
+		valid := len(errors) == 0
+
+		if tc.valid != valid {
+			t.Fatalf("expected %t but got %t", tc.valid, valid)
+		}
+	}
+}

--- a/internal/services/cdn/validate/front_door_custom_domain_host_name_test.go
+++ b/internal/services/cdn/validate/front_door_custom_domain_host_name_test.go
@@ -30,6 +30,14 @@ func TestFrontDoorCustomDomainHostName(t *testing.T) {
 			valid: true,
 		},
 		{
+			input: "*foo",
+			valid: false,
+		},
+		{
+			input: "*foo.example.com",
+			valid: false,
+		},
+		{
 			input: "localhost",
 			valid: false,
 		},

--- a/internal/services/cdn/validate/front_door_custom_domain_host_name_test.go
+++ b/internal/services/cdn/validate/front_door_custom_domain_host_name_test.go
@@ -26,7 +26,15 @@ func TestFrontDoorCustomDomainHostName(t *testing.T) {
 			valid: true,
 		},
 		{
+			input: "*.contoso.com",
+			valid: true,
+		},
+		{
 			input: "localhost",
+			valid: false,
+		},
+		{
+			input: "foo.*.contoso.com",
 			valid: false,
 		},
 		{

--- a/website/docs/r/cdn_frontdoor_custom_domain.html.markdown
+++ b/website/docs/r/cdn_frontdoor_custom_domain.html.markdown
@@ -176,7 +176,7 @@ A `tls` block supports the following:
 
 -> **Note:** It may take up to 15 minutes for the Front Door Service to validate the state and domain ownership of the Custom Domain.
 
-~> **Note:** When `certificate_type` is `ManagedCertificate`, `host_name` must not exceed 64 characters and apex/root domains are not supported. Use `CustomerCertificate` for apex/root domains or for host names longer than 64 characters.
+~> **Note:** When `certificate_type` is `ManagedCertificate`, `host_name` must not exceed 64 characters. Azure Front Door supports managed certificates for apex domains, but apex-domain certificate rotation can require revalidation of domain ownership. Use `CustomerCertificate` for host names longer than 64 characters.
 
 * `cipher_suite` - (Optional) A `cipher_suite` block as defined below.
 

--- a/website/docs/r/cdn_frontdoor_custom_domain.html.markdown
+++ b/website/docs/r/cdn_frontdoor_custom_domain.html.markdown
@@ -176,7 +176,7 @@ A `tls` block supports the following:
 
 -> **Note:** It may take up to 15 minutes for the Front Door Service to validate the state and domain ownership of the Custom Domain.
 
-~> **Note:** When `certificate_type` is `ManagedCertificate`, `host_name` must not exceed 64 characters. Azure Front Door supports managed certificates for apex domains, but apex-domain certificate rotation can require revalidation of domain ownership. Use `CustomerCertificate` for host names longer than 64 characters.
+~> **Note:** When `certificate_type` is `ManagedCertificate`, `host_name` must not exceed 64 characters. Azure Front Door supports managed certificates for apex domains, but apex-domain certificate rotation can require revalidation of domain ownership. Wildcard domains require `CustomerCertificate`. Use `CustomerCertificate` for wildcard domains or host names longer than 64 characters.
 
 * `cipher_suite` - (Optional) A `cipher_suite` block as defined below.
 

--- a/website/docs/r/cdn_frontdoor_custom_domain.html.markdown
+++ b/website/docs/r/cdn_frontdoor_custom_domain.html.markdown
@@ -196,7 +196,7 @@ A `cipher_suite` block supports the following:
 
 A `custom_ciphers` block supports the following:
 
-* `tls12` - (Optional) A set of TLS 1.2 cipher suites. Possible values are `DHE_RSA_AES128_GCM_SHA256`, `DHE_RSA_AES256_GCM_SHA384`, `ECDHE_RSA_AES128_GCM_SHA256`, `ECDHE_RSA_AES128_SHA256`, `ECDHE_RSA_AES256_GCM_SHA384`, and `ECDHE_RSA_AES256_SHA384`.
+* `tls12` - (Optional) A set of TLS 1.2 cipher suites. Possible values are `ECDHE_RSA_AES128_GCM_SHA256`, `ECDHE_RSA_AES128_SHA256`, `ECDHE_RSA_AES256_GCM_SHA384`, and `ECDHE_RSA_AES256_SHA384`.
 
 ~> **Note:** At least one TLS 1.2 cipher suite must be specified in `tls12` when `minimum_version` is `TLS12` and `type` is `Customized`.
 

--- a/website/docs/r/cdn_frontdoor_custom_domain.html.markdown
+++ b/website/docs/r/cdn_frontdoor_custom_domain.html.markdown
@@ -168,13 +168,15 @@ The following arguments are supported:
 
 A `tls` block supports the following:
 
+* `cdn_frontdoor_secret_id` - (Optional) Resource ID of the Front Door Secret.
+
+~> **Note:** `cdn_frontdoor_secret_id` must be specified when `certificate_type` is `CustomerCertificate` and must not be specified when `certificate_type` is `ManagedCertificate`.
+
 * `certificate_type` - (Optional) Defines the source of the SSL certificate. Possible values are `CustomerCertificate` and `ManagedCertificate`. Defaults to `ManagedCertificate`.
 
 -> **Note:** It may take up to 15 minutes for the Front Door Service to validate the state and domain ownership of the Custom Domain.
 
-* `cdn_frontdoor_secret_id` - (Optional) Resource ID of the Front Door Secret.
-
-~> **Note:** `cdn_frontdoor_secret_id` must be specified when `certificate_type` is `CustomerCertificate` and must not be specified when `certificate_type` is `ManagedCertificate`.
+~> **Note:** When `certificate_type` is `ManagedCertificate`, `host_name` must not exceed 64 characters and apex/root domains are not supported. Use `CustomerCertificate` for apex/root domains or for host names longer than 64 characters.
 
 * `cipher_suite` - (Optional) A `cipher_suite` block as defined below.
 


### PR DESCRIPTION
## Community Note
* Please vote on this PR by adding a :thumbsup: reaction to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

This PR updates validation and related test coverage for `azurerm_cdn_frontdoor_custom_domain`, including managed-certificate-specific hostname constraints, wildcard-domain handling, refreshed documentation for current Azure Front Door behavior, and adjacent CDN acceptance test fixes needed to keep the suite aligned with current deprecation rules.

### The Provider Changes Are:
- Add provider-side validation for `host_name` so it must be a valid fully qualified domain name
- Add managed-certificate-specific diff validation so `tls.certificate_type = "ManagedCertificate"` rejects `host_name` values longer than 64 characters
- Preserve the existing customized cipher suite validation behavior alongside the managed certificate validation
- Restrict the accepted custom TLS 1.2 cipher suites to the ECDHE values that the Front Door service actually supports
- The Front Door service team confirmed the supported TLS 1.2 cipher set excludes the DHE suites returned by the SDK helper, and they also confirmed the Learn documentation has been queued for update to match
- Keep wildcard domains valid for `host_name` validation generally, while rejecting wildcard domains specifically when `tls.certificate_type = "ManagedCertificate"`

### The Test Changes Are:
- Add local unit coverage for the new `host_name` validator
- Add targeted acceptance coverage for the managed certificate validation path using `ExpectError`
- Shorten managed-certificate host labels in the affected Front Door acceptance helpers so generated host names stay within the service limit
- Replace the delegated child-zone suffix generation in the affected Front Door acceptance helpers with `data.RandomString` to reduce collisions between tests started close together
- Omit apex-domain managed certificate acceptance coverage for now, and document that limitation inline in the acceptance test file until a dedicated reviewer-approved approach is agreed
- Fix existing CDN acceptance/data source tests that still create deprecated CDN resources, so they respect the current long-tail creation deprecation behavior and skip cleanly instead of failing at plan time
- Add unit coverage for wildcard-domain `host_name` validation and keep managed-certificate wildcard rejection covered in acceptance validation
- Document that positive wildcard-domain coverage with `CustomerCertificate` is deferred until a reusable customer-certificate test fixture is available

### The Documentation Changes Are:
- Document the managed certificate hostname limits for `azurerm_cdn_frontdoor_custom_domain`
- Document that Azure Front Door supports managed certificates for apex domains, but apex-domain certificate rotation can require domain revalidation
- Keep the nested `tls` argument ordering aligned with the docs contract

## PR Checklist

- [x] I have followed the guidelines in our Contributing Documentation.
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate closing keywords below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them.
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a state migration only). I have manually tested the migration path between relevant versions of the provider.

## Testing

- [x] My submission includes Test coverage as described in the Contribution Guide.
- [x] The tests pass locally for all relevant acceptance coverage.

<img width="1210" height="188" alt="image" src="https://github.com/user-attachments/assets/ca3f4dee-9cac-483f-839e-308fddaba45e" />

> [!NOTE] 
>Apex-domain managed certificate acceptance test coverage is intentionally not included in this PR. Azure Front Door now supports managed certificates for apex domains, and the provider/docs changes here align with that behavior. However, the current Front Door acceptance fixture reuses a shared DNS parent-domain setup across tests, and I did not want to mutate that shared setup without agreement on a dedicated approach from the reviewer who owns the domain. I left an inline note in `cdn_frontdoor_custom_domain_resource_test.go` so this limitation is documented in the code as well.

## Change Log

* `azurerm_cdn_frontdoor_custom_domain` - validate `host_name` values, refine `ManagedCertificate` hostname constraints, and harden related Front Door acceptance tests

This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change

## Related Issue(s)

N/A

## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

Extent of AI usage:
- Initial code, test, and documentation drafting
- Static review of local changes
- Iteration on wording and acceptance test helper changes

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No changes to security controls.