### PR TITLE
`Contributor Guides` - Document resource ID normalization convention

### DIFF
--- a/contributing/topics/guide-resource-ids.md
+++ b/contributing/topics/guide-resource-ids.md
@@ -87,9 +87,9 @@ func (r NatGatewayPublicIpAssociation) Read() sdk.ResourceFunc {
 
 ## Normalizing Resource IDs Before Setting Into State
 
-Azure APIs can return resource IDs with inconsistent casing on static segments (e.g. `/Subscriptions/` vs `/subscriptions/`). Since the provider is largely case-sensitive, storing a raw API-returned ID directly into state can cause unexpected diffs on subsequent plans. To prevent this, always parse any resource ID through its resource ID parser before setting it into state — this normalizes the static segments.
+Azure APIs can return resource IDs with inconsistent casing on static segments (e.g. `/Subscriptions/` vs `/subscriptions/`). Always parse resource IDs through their typed parser before setting into state — this normalizes the casing and prevents phantom diffs on subsequent plans.
 
-This applies to scoped resource IDs where the scope must be parsed separately, and to resource IDs returned as properties in API responses:
+This applies to **scoped resource IDs** (where the scope must be parsed separately) and **IDs returned as properties** in API responses:
 
 ```go
 // Scoped IDs: parse the scope portion into a typed ID

--- a/contributing/topics/guide-resource-ids.md
+++ b/contributing/topics/guide-resource-ids.md
@@ -85,6 +85,28 @@ func (r NatGatewayPublicIpAssociation) Read() sdk.ResourceFunc {
 }
 ```
 
+## Normalizing Resource IDs Before Setting Into State
+
+Azure APIs can return resource IDs with inconsistent casing on static segments (e.g. `/Subscriptions/` vs `/subscriptions/`). Since the provider is largely case-sensitive, storing a raw API-returned ID directly into state can cause unexpected diffs on subsequent plans. To prevent this, always parse any resource ID through its resource ID parser before setting it into state — this normalizes the static segments.
+
+This applies to scoped resource IDs where the scope must be parsed separately, and to resource IDs returned as properties in API responses:
+
+```go
+// Scoped IDs: parse the scope portion into a typed ID
+storageAccountId, err := commonids.ParseStorageAccountID(id.Scope)
+if err != nil {
+    return err
+}
+state.StorageAccountId = storageAccountId.ID()
+
+// IDs from API response properties: parse before setting into state
+projectId, err := devcenters.ParseProjectID(props.DevCenterProjectResourceId)
+if err != nil {
+    return err
+}
+state.DevCenterProjectId = projectId.ID()
+```
+
 ## Generated Resource ID Parsers and Validators (legacy)
 
 Prior to generating the parser and validation functions within the SDK, we generated these functions in the provider with [this automation](https://github.com/hashicorp/terraform-provider-azurerm/tree/main/internal/tools/generator-resource-id) which generates the functions for all IDs defined in `resourceids.go`.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This adds a new section to `guide-resource-ids.md` documenting the convention of parsing resource IDs before setting them into state fields.

Azure APIs can return resource IDs with inconsistent casing on static segments (e.g. /Subscriptions/ vs /subscriptions/), which can cause unexpected diffs on subsequent plans. This convention has been enforced during code review but was not previously documented.

The new section covers following scenario:

- Resource IDs from API response properties — parsing any resource ID returned as a property value before setting it into state

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

Not applied - development enhancement

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
