### PR TITLE
Replacement of Standard_F2 sizes on the website with Standard_D4_v5

### DIFF
--- a/website/docs/r/dev_test_linux_virtual_machine.html.markdown
+++ b/website/docs/r/dev_test_linux_virtual_machine.html.markdown
@@ -81,7 +81,7 @@ The following arguments are supported:
 
 * `lab_virtual_network_id` - (Required) The ID of the Dev Test Virtual Network where this Virtual Machine should be created. Changing this forces a new resource to be created.
 
-* `size` - (Required) The Machine Size to use for this Virtual Machine, such as `Standard_F2`. Changing this forces a new resource to be created.
+* `size` - (Required) The Machine Size to use for this Virtual Machine, such as `Standard_D4_v5`. Changing this forces a new resource to be created.
 
 * `storage_type` - (Required) The type of Storage to use on this Virtual Machine. Possible values are `Standard` and `Premium`. Changing this forces a new resource to be created.
 

--- a/website/docs/r/dev_test_windows_virtual_machine.html.markdown
+++ b/website/docs/r/dev_test_windows_virtual_machine.html.markdown
@@ -83,7 +83,7 @@ The following arguments are supported:
 
 * `password` - (Required) The Password associated with the `username` used to login to this Virtual Machine. Changing this forces a new resource to be created.
 
-* `size` - (Required) The Machine Size to use for this Virtual Machine, such as `Standard_F2`. Changing this forces a new resource to be created.
+* `size` - (Required) The Machine Size to use for this Virtual Machine, such as `Standard_D4_v5`. Changing this forces a new resource to be created.
 
 * `storage_type` - (Required) The type of Storage to use on this Virtual Machine. Possible values are `Standard` and `Premium`. Changing this forces a new resource to be created.
 

--- a/website/docs/r/linux_virtual_machine.html.markdown
+++ b/website/docs/r/linux_virtual_machine.html.markdown
@@ -64,7 +64,7 @@ resource "azurerm_linux_virtual_machine" "example" {
   name                = "example-machine"
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
-  size                = "Standard_F2"
+  size                = "Standard_D4_v5"
   admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.example.id,
@@ -105,7 +105,7 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the Resource Group in which the Linux Virtual Machine should be exist. Changing this forces a new resource to be created.
 
-* `size` - (Required) The SKU which should be used for this Virtual Machine, such as `Standard_F2`.
+* `size` - (Required) The SKU which should be used for this Virtual Machine, such as `Standard_D4_v5`.
 
 ---
 

--- a/website/docs/r/linux_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/linux_virtual_machine_scale_set.html.markdown
@@ -54,7 +54,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "example" {
   name                = "example-vmss"
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
-  sku                 = "Standard_F2"
+  sku                 = "Standard_D4_v5"
   instances           = 1
   admin_username      = "adminuser"
 
@@ -102,7 +102,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "example" {
 
 -> **Note:** If you are using AutoScaling, you may wish to use [Terraform's `ignore_changes` functionality](https://developer.hashicorp.com/terraform/language/block/resource#ignore_changes) to ignore changes to this field.
 
-* `sku` - (Required) The Virtual Machine SKU for the Scale Set, such as `Standard_F2`.
+* `sku` - (Required) The Virtual Machine SKU for the Scale Set, such as `Standard_D4_v5`.
 
 * `network_interface` - (Required) One or more `network_interface` blocks as defined below.
 

--- a/website/docs/r/maintenance_assignment_virtual_machine.html.markdown
+++ b/website/docs/r/maintenance_assignment_virtual_machine.html.markdown
@@ -52,7 +52,7 @@ resource "azurerm_linux_virtual_machine" "example" {
   name                = "example-machine"
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
-  size                = "Standard_F2"
+  size                = "Standard_D4_v5"
   admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.example.id,

--- a/website/docs/r/maintenance_assignment_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/maintenance_assignment_virtual_machine_scale_set.html.markdown
@@ -107,7 +107,7 @@ resource "azurerm_linux_virtual_machine" "example" {
   name                = "example-machine"
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
-  size                = "Standard_F2"
+  size                = "Standard_D4_v5"
   admin_username      = "adminuser"
 
   network_interface_ids = [
@@ -124,7 +124,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "example" {
   name                            = "example"
   resource_group_name             = azurerm_resource_group.example.name
   location                        = azurerm_resource_group.example.location
-  sku                             = "Standard_F2"
+  sku                             = "Standard_D4_v5"
   instances                       = 1
   admin_username                  = "adminuser"
   admin_password                  = "P@ssword1234!"

--- a/website/docs/r/policy_virtual_machine_configuration_assignment.html.markdown
+++ b/website/docs/r/policy_virtual_machine_configuration_assignment.html.markdown
@@ -50,7 +50,7 @@ resource "azurerm_windows_virtual_machine" "example" {
   name                = "examplevm"
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
-  size                = "Standard_F2"
+  size                = "Standard_D4_v5"
   admin_username      = "adminuser"
   admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [

--- a/website/docs/r/virtual_machine_automanage_configuration_assignment.html.markdown
+++ b/website/docs/r/virtual_machine_automanage_configuration_assignment.html.markdown
@@ -52,7 +52,7 @@ resource "azurerm_linux_virtual_machine" "example" {
   name                            = "examplevm"
   resource_group_name             = azurerm_resource_group.example.name
   location                        = azurerm_resource_group.example.location
-  size                            = "Standard_F2"
+  size                            = "Standard_D4_v5"
   admin_username                  = "adminuser"
   admin_password                  = "P@$$w0rd1234!"
   disable_password_authentication = false

--- a/website/docs/r/virtual_machine_data_disk_attachment.html.markdown
+++ b/website/docs/r/virtual_machine_data_disk_attachment.html.markdown
@@ -61,7 +61,7 @@ resource "azurerm_virtual_machine" "example" {
   location              = azurerm_resource_group.example.location
   resource_group_name   = azurerm_resource_group.example.name
   network_interface_ids = [azurerm_network_interface.main.id]
-  vm_size               = "Standard_F2"
+  vm_size               = "Standard_D4_v5"
 
   storage_image_reference {
     publisher = "Canonical"

--- a/website/docs/r/virtual_machine_extension.html.markdown
+++ b/website/docs/r/virtual_machine_extension.html.markdown
@@ -54,7 +54,7 @@ resource "azurerm_linux_virtual_machine" "example" {
   name                = "example-machine"
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
-  size                = "Standard_F2"
+  size                = "Standard_D4_v5"
   admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.example.id,

--- a/website/docs/r/virtual_machine_implicit_data_disk_from_source.html.markdown
+++ b/website/docs/r/virtual_machine_implicit_data_disk_from_source.html.markdown
@@ -59,7 +59,7 @@ resource "azurerm_virtual_machine" "example" {
   location              = azurerm_resource_group.example.location
   resource_group_name   = azurerm_resource_group.example.name
   network_interface_ids = [azurerm_network_interface.main.id]
-  vm_size               = "Standard_F2"
+  vm_size               = "Standard_D4_v5"
 
   storage_image_reference {
     publisher = "Canonical"

--- a/website/docs/r/virtual_machine_packet_capture.html.markdown
+++ b/website/docs/r/virtual_machine_packet_capture.html.markdown
@@ -56,7 +56,7 @@ resource "azurerm_virtual_machine" "example" {
   location              = azurerm_resource_group.example.location
   resource_group_name   = azurerm_resource_group.example.name
   network_interface_ids = [azurerm_network_interface.example.id]
-  vm_size               = "Standard_F2"
+  vm_size               = "Standard_D4_v5"
 
   storage_image_reference {
     publisher = "Canonical"

--- a/website/docs/r/virtual_machine_restore_point.html.markdown
+++ b/website/docs/r/virtual_machine_restore_point.html.markdown
@@ -52,7 +52,7 @@ resource "azurerm_linux_virtual_machine" "example" {
   name                = "example-machine"
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
-  size                = "Standard_F2"
+  size                = "Standard_D4_v5"
   admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.example.id,

--- a/website/docs/r/virtual_machine_restore_point_collection.html.markdown
+++ b/website/docs/r/virtual_machine_restore_point_collection.html.markdown
@@ -52,7 +52,7 @@ resource "azurerm_linux_virtual_machine" "example" {
   name                = "example-machine"
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
-  size                = "Standard_F2"
+  size                = "Standard_D4_v5"
   admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.example.id,

--- a/website/docs/r/virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/virtual_machine_scale_set.html.markdown
@@ -105,7 +105,7 @@ resource "azurerm_virtual_machine_scale_set" "example" {
   health_probe_id = azurerm_lb_probe.example.id
 
   sku {
-    name     = "Standard_F2"
+    name     = "Standard_D4_v5"
     tier     = "Standard"
     capacity = 2
   }
@@ -211,7 +211,7 @@ resource "azurerm_virtual_machine_scale_set" "example" {
   upgrade_policy_mode = "Manual"
 
   sku {
-    name     = "Standard_F2"
+    name     = "Standard_D4_v5"
     tier     = "Standard"
     capacity = 2
   }

--- a/website/docs/r/virtual_machine_scale_set_extension.html.markdown
+++ b/website/docs/r/virtual_machine_scale_set_extension.html.markdown
@@ -24,7 +24,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "example" {
   name                = "example"
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
-  sku                 = "Standard_F2"
+  sku                 = "Standard_D4_v5"
   admin_username      = "adminuser"
   instances           = 1
 

--- a/website/docs/r/virtual_machine_scale_set_packet_capture.html.markdown
+++ b/website/docs/r/virtual_machine_scale_set_packet_capture.html.markdown
@@ -43,7 +43,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "example" {
   name                 = "example-vmss"
   resource_group_name  = azurerm_resource_group.example.name
   location             = azurerm_resource_group.example.location
-  sku                  = "Standard_F2"
+  sku                  = "Standard_D4_v5"
   instances            = 4
   admin_username       = "adminuser"
   admin_password       = "P@ssword1234!"

--- a/website/docs/r/windows_virtual_machine.html.markdown
+++ b/website/docs/r/windows_virtual_machine.html.markdown
@@ -68,7 +68,7 @@ resource "azurerm_windows_virtual_machine" "example" {
   name                = "example-machine"
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
-  size                = "Standard_F2"
+  size                = "Standard_D4_v5"
   admin_username      = "adminuser"
   admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
@@ -103,7 +103,7 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the Resource Group in which the Windows Virtual Machine should be exist. Changing this forces a new resource to be created.
 
-* `size` - (Required) The SKU which should be used for this Virtual Machine, such as `Standard_F2`.
+* `size` - (Required) The SKU which should be used for this Virtual Machine, such as `Standard_D4_v5`.
 
 ---
 

--- a/website/docs/r/windows_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/windows_virtual_machine_scale_set.html.markdown
@@ -52,7 +52,7 @@ resource "azurerm_windows_virtual_machine_scale_set" "example" {
   name                 = "example-vmss"
   resource_group_name  = azurerm_resource_group.example.name
   location             = azurerm_resource_group.example.location
-  sku                  = "Standard_F2"
+  sku                  = "Standard_D4_v5"
   instances            = 1
   admin_password       = "P@55w0rd1234!"
   admin_username       = "adminuser"
@@ -99,7 +99,7 @@ resource "azurerm_windows_virtual_machine_scale_set" "example" {
 
 -> **Note:** If you're using AutoScaling, you may wish to use [Terraform's `ignore_changes` functionality](https://developer.hashicorp.com/terraform/language/block/resource#ignore_changes) to ignore changes to this field.
 
-* `sku` - (Required) The Virtual Machine SKU for the Scale Set, such as `Standard_F2`.
+* `sku` - (Required) The Virtual Machine SKU for the Scale Set, such as `Standard_D4_v5`.
 
 * `network_interface` - (Required) One or more `network_interface` blocks as defined below.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Microsoft retired the VM Family F as stated here: https://azure.microsoft.com/en-us/updates?id=500682.
So I updated all relevant website documentation regarding the Virtual Machine resources by replacing the retired `Standard_F2` VM size with `Standard_D4_v5`. 


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 

## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
