### PR TITLE
Services `P`/`Q`/`R` - add support for 2 new features

### DIFF
--- a/internal/resourceproviders/custompollers/resource_provider_existence_poller.go
+++ b/internal/resourceproviders/custompollers/resource_provider_existence_poller.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
-
 	"github.com/hashicorp/go-azure-sdk/resource-manager/resources/2022-09-01/providers"
 	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
 )

--- a/internal/services/paloalto/palo_alto_local_rulestack_certificate_resource.go
+++ b/internal/services/paloalto/palo_alto_local_rulestack_certificate_resource.go
@@ -120,14 +120,17 @@ func (r LocalRuleStackCertificate) Create() sdk.ResourceFunc {
 			defer locks.UnlockByID(rulestackId.ID())
 
 			id := certificateobjectlocalrulestack.NewLocalRulestackCertificateID(rulestackId.SubscriptionId, rulestackId.ResourceGroupName, rulestackId.LocalRulestackName, model.Name)
-			existing, err := client.CertificateObjectLocalRulestackGet(ctx, id)
-			if err != nil {
-				if !response.WasNotFound(existing.HttpResponse) {
-					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+
+			if !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				existing, err := client.CertificateObjectLocalRulestackGet(ctx, id)
+				if err != nil {
+					if !response.WasNotFound(existing.HttpResponse) {
+						return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+					}
 				}
-			}
-			if !response.WasNotFound(existing.HttpResponse) {
-				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				if !response.WasNotFound(existing.HttpResponse) {
+					return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				}
 			}
 
 			props := certificateobjectlocalrulestack.CertificateObject{

--- a/internal/services/paloalto/palo_alto_local_rulestack_fqdn_list_resource.go
+++ b/internal/services/paloalto/palo_alto_local_rulestack_fqdn_list_resource.go
@@ -107,15 +107,17 @@ func (r LocalRulestackFQDNList) Create() sdk.ResourceFunc {
 
 			id := fqdnlistlocalrulestack.NewLocalRulestackFqdnListID(rulestackId.SubscriptionId, rulestackId.ResourceGroupName, rulestackId.LocalRulestackName, model.Name)
 
-			existing, err := client.FqdnListLocalRulestackGet(ctx, id)
-			if err != nil {
-				if !response.WasNotFound(existing.HttpResponse) {
-					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+			if !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				existing, err := client.FqdnListLocalRulestackGet(ctx, id)
+				if err != nil {
+					if !response.WasNotFound(existing.HttpResponse) {
+						return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+					}
 				}
-			}
 
-			if !response.WasNotFound(existing.HttpResponse) {
-				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				if !response.WasNotFound(existing.HttpResponse) {
+					return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				}
 			}
 
 			props := fqdnlistlocalrulestack.FqdnObject{

--- a/internal/services/paloalto/palo_alto_local_rulestack_outbound_trust_certificate_association_resource.go
+++ b/internal/services/paloalto/palo_alto_local_rulestack_outbound_trust_certificate_association_resource.go
@@ -92,15 +92,15 @@ func (l LocalRulestackOutboundTrustCertificateAssociationResource) Create() sdk.
 
 			rulestack.Properties = props
 
-			if err = client.LocalRulestacksCreateOrUpdateThenPoll(ctx, rulestackId, rulestack); err != nil {
+			if err := client.LocalRulestacksCreateOrUpdateCallbackThenPoll(ctx, rulestackId, rulestack, metadata.SetIDCallback(certificateId)); err != nil {
 				return fmt.Errorf("creating Outbound Trust Certificate Association for %s: %+v", rulestackId, err)
 			}
 
-			if err = client.LocalRulestackscommitThenPoll(ctx, rulestackId); err != nil {
+			metadata.SetID(certificateId)
+
+			if err := client.LocalRulestackscommitThenPoll(ctx, rulestackId); err != nil {
 				return fmt.Errorf("committing Local Rulestack configuration for Outbound Trust Certificate for %s: %+v", rulestackId, err)
 			}
-
-			metadata.SetID(certificateId)
 
 			return nil
 		},

--- a/internal/services/paloalto/palo_alto_local_rulestack_outbound_untrust_certificate_association_resource.go
+++ b/internal/services/paloalto/palo_alto_local_rulestack_outbound_untrust_certificate_association_resource.go
@@ -92,15 +92,15 @@ func (l LocalRulestackOutboundUnTrustCertificateAssociationResource) Create() sd
 
 			rulestack.Properties = props
 
-			if err = client.LocalRulestacksCreateOrUpdateThenPoll(ctx, rulestackId, rulestack); err != nil {
+			if err := client.LocalRulestacksCreateOrUpdateCallbackThenPoll(ctx, rulestackId, rulestack, metadata.SetIDCallback(certificateId)); err != nil {
 				return fmt.Errorf("creating Outbound UnTrust association for %s: %+v", rulestackId, err)
 			}
 
-			if err = client.LocalRulestackscommitThenPoll(ctx, rulestackId); err != nil {
+			metadata.SetID(certificateId)
+
+			if err := client.LocalRulestackscommitThenPoll(ctx, rulestackId); err != nil {
 				return fmt.Errorf("committing rulestack configuration for Outbound UnTrust Certificate for %s: %+v", rulestackId, err)
 			}
-
-			metadata.SetID(certificateId)
 
 			return nil
 		},

--- a/internal/services/paloalto/palo_alto_local_rulestack_prefix_list_resource.go
+++ b/internal/services/paloalto/palo_alto_local_rulestack_prefix_list_resource.go
@@ -106,15 +106,17 @@ func (r LocalRuleStackPrefixList) Create() sdk.ResourceFunc {
 
 			id := prefixlistlocalrulestack.NewLocalRulestackPrefixListID(rulestackId.SubscriptionId, rulestackId.ResourceGroupName, rulestackId.LocalRulestackName, model.Name)
 
-			existing, err := client.PrefixListLocalRulestackGet(ctx, id)
-			if err != nil {
-				if !response.WasNotFound(existing.HttpResponse) {
-					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+			if !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				existing, err := client.PrefixListLocalRulestackGet(ctx, id)
+				if err != nil {
+					if !response.WasNotFound(existing.HttpResponse) {
+						return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+					}
 				}
-			}
 
-			if !response.WasNotFound(existing.HttpResponse) {
-				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				if !response.WasNotFound(existing.HttpResponse) {
+					return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				}
 			}
 
 			props := prefixlistlocalrulestack.PrefixObject{
@@ -133,7 +135,7 @@ func (r LocalRuleStackPrefixList) Create() sdk.ResourceFunc {
 				Properties: props,
 			}
 
-			if err = client.PrefixListLocalRulestackCreateOrUpdateThenPoll(ctx, id, prefixList); err != nil {
+			if err = client.PrefixListLocalRulestackCreateOrUpdateCallbackThenPoll(ctx, id, prefixList, metadata.SetIDCallback(&id)); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
 

--- a/internal/services/paloalto/palo_alto_local_rulestack_resource.go
+++ b/internal/services/paloalto/palo_alto_local_rulestack_resource.go
@@ -149,14 +149,16 @@ func (r LocalRuleStack) Create() sdk.ResourceFunc {
 			locks.ByID(id.ID())
 			defer locks.UnlockByID(id.ID())
 
-			existing, err := client.LocalRulestacksGet(ctx, id)
-			if err != nil {
-				if !response.WasNotFound(existing.HttpResponse) {
-					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+			if !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				existing, err := client.LocalRulestacksGet(ctx, id)
+				if err != nil {
+					if !response.WasNotFound(existing.HttpResponse) {
+						return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+					}
 				}
-			}
-			if !response.WasNotFound(existing.HttpResponse) {
-				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				if !response.WasNotFound(existing.HttpResponse) {
+					return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				}
 			}
 
 			secServices := localrulestacks.SecurityServices{
@@ -197,10 +199,9 @@ func (r LocalRuleStack) Create() sdk.ResourceFunc {
 				},
 			}
 
-			if err = client.LocalRulestacksCreateOrUpdateThenPoll(ctx, id, localRuleStack); err != nil {
+			if err := client.LocalRulestacksCreateOrUpdateCallbackThenPoll(ctx, id, localRuleStack, metadata.SetIDCallback(&id)); err != nil {
 				return err
 			}
-
 			metadata.SetID(id)
 
 			return nil

--- a/internal/services/paloalto/palo_alto_local_rulestack_rule_resource.go
+++ b/internal/services/paloalto/palo_alto_local_rulestack_rule_resource.go
@@ -212,15 +212,17 @@ func (r LocalRuleStackRule) Create() sdk.ResourceFunc {
 			// API uses Priority not Name for ID, despite swagger defining `ruleName` as required, not Priority - https://github.com/Azure/azure-rest-api-specs/issues/24697
 			id := localrules.NewLocalRuleID(metadata.Client.Account.SubscriptionId, rulestackId.ResourceGroupName, rulestackId.LocalRulestackName, strconv.FormatInt(model.Priority, 10))
 
-			existing, err := client.LocalRulesGet(ctx, id)
-			if err != nil {
-				if !response.WasNotFound(existing.HttpResponse) {
-					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+			if !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				existing, err := client.LocalRulesGet(ctx, id)
+				if err != nil {
+					if !response.WasNotFound(existing.HttpResponse) {
+						return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+					}
 				}
-			}
 
-			if !response.WasNotFound(existing.HttpResponse) {
-				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				if !response.WasNotFound(existing.HttpResponse) {
+					return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				}
 			}
 
 			destination, err := schema.ExpandDestination(model.Destination)
@@ -285,13 +287,13 @@ func (r LocalRuleStackRule) Create() sdk.ResourceFunc {
 				props.Protocol = pointer.To(model.Protocol)
 			}
 
-			if _, err = client.LocalRulesCreateOrUpdate(ctx, id, localrules.LocalRulesResource{Properties: props}); err != nil {
+			if _, err := client.LocalRulesCreateOrUpdate(ctx, id, localrules.LocalRulesResource{Properties: props}); err != nil {
 				return err
 			}
 
 			metadata.SetID(id)
 
-			if err = rulestackClient.LocalRulestackscommitThenPoll(ctx, *rulestackId); err != nil {
+			if err := rulestackClient.LocalRulestackscommitThenPoll(ctx, *rulestackId); err != nil {
 				return fmt.Errorf("committing Local Rulestack config for %s: %+v", id, err)
 			}
 

--- a/internal/services/paloalto/palo_alto_next_generation_firewall_virtual_hub_local_rulestack_resource.go
+++ b/internal/services/paloalto/palo_alto_next_generation_firewall_virtual_hub_local_rulestack_resource.go
@@ -120,14 +120,16 @@ func (r NextGenerationFirewallVHubLocalRuleStackResource) Create() sdk.ResourceF
 
 			id := firewalls.NewFirewallID(metadata.Client.Account.SubscriptionId, model.ResourceGroupName, model.Name)
 
-			existing, err := client.FirewallsGet(ctx, id)
-			if err != nil {
-				if !response.WasNotFound(existing.HttpResponse) {
-					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+			if !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				existing, err := client.FirewallsGet(ctx, id)
+				if err != nil {
+					if !response.WasNotFound(existing.HttpResponse) {
+						return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+					}
 				}
-			}
-			if !response.WasNotFound(existing.HttpResponse) {
-				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				if !response.WasNotFound(existing.HttpResponse) {
+					return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				}
 			}
 
 			ruleStackID, err := localrulestacks.ParseLocalRulestackID(model.RuleStackId)
@@ -168,10 +170,9 @@ func (r NextGenerationFirewallVHubLocalRuleStackResource) Create() sdk.ResourceF
 			locks.ByID(ruleStackID.ID())
 			defer locks.UnlockByID(ruleStackID.ID())
 
-			if err = client.FirewallsCreateOrUpdateThenPoll(ctx, id, firewall); err != nil {
+			if err := client.FirewallsCreateOrUpdateCallbackThenPoll(ctx, id, firewall, metadata.SetIDCallback(&id)); err != nil {
 				return err
 			}
-
 			metadata.SetID(id)
 
 			return nil

--- a/internal/services/paloalto/palo_alto_next_generation_firewall_virtual_hub_panorama_resource.go
+++ b/internal/services/paloalto/palo_alto_next_generation_firewall_virtual_hub_panorama_resource.go
@@ -125,14 +125,16 @@ func (r NextGenerationFirewallVHubPanoramaResource) Create() sdk.ResourceFunc {
 
 			id := firewalls.NewFirewallID(metadata.Client.Account.SubscriptionId, model.ResourceGroupName, model.Name)
 
-			existing, err := client.FirewallsGet(ctx, id)
-			if err != nil {
-				if !response.WasNotFound(existing.HttpResponse) {
-					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+			if !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				existing, err := client.FirewallsGet(ctx, id)
+				if err != nil {
+					if !response.WasNotFound(existing.HttpResponse) {
+						return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+					}
 				}
-			}
-			if !response.WasNotFound(existing.HttpResponse) {
-				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				if !response.WasNotFound(existing.HttpResponse) {
+					return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				}
 			}
 
 			firewall := firewalls.FirewallResource{
@@ -157,10 +159,9 @@ func (r NextGenerationFirewallVHubPanoramaResource) Create() sdk.ResourceFunc {
 				Tags: tags.Expand(model.Tags),
 			}
 
-			if err = client.FirewallsCreateOrUpdateThenPoll(ctx, id, firewall); err != nil {
+			if err := client.FirewallsCreateOrUpdateCallbackThenPoll(ctx, id, firewall, metadata.SetIDCallback(&id)); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
-
 			metadata.SetID(id)
 
 			return nil

--- a/internal/services/paloalto/palo_alto_next_generation_firewall_virtual_hub_strata_cloud_manager_resource.go
+++ b/internal/services/paloalto/palo_alto_next_generation_firewall_virtual_hub_strata_cloud_manager_resource.go
@@ -114,12 +114,14 @@ func (r NextGenerationFirewallVHubStrataCloudManagerResource) Create() sdk.Resou
 
 			id := firewalls.NewFirewallID(metadata.Client.Account.SubscriptionId, model.ResourceGroupName, model.Name)
 
-			existing, err := client.FirewallsGet(ctx, id)
-			if err != nil && !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
-			}
-			if !response.WasNotFound(existing.HttpResponse) {
-				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+			if !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				existing, err := client.FirewallsGet(ctx, id)
+				if err != nil && !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+				}
+				if !response.WasNotFound(existing.HttpResponse) {
+					return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				}
 			}
 
 			identity, err := identity.ExpandLegacySystemAndUserAssignedMapFromModel(model.Identity)
@@ -150,10 +152,9 @@ func (r NextGenerationFirewallVHubStrataCloudManagerResource) Create() sdk.Resou
 				Tags:     tags.Expand(model.Tags),
 			}
 
-			if err = client.FirewallsCreateOrUpdateThenPoll(ctx, id, firewall); err != nil {
+			if err = client.FirewallsCreateOrUpdateCallbackThenPoll(ctx, id, firewall, metadata.SetIDCallback(&id)); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
-
 			metadata.SetID(id)
 
 			return nil

--- a/internal/services/paloalto/palo_alto_next_generation_firewall_virtual_network_local_rulestack_resource.go
+++ b/internal/services/paloalto/palo_alto_next_generation_firewall_virtual_network_local_rulestack_resource.go
@@ -116,14 +116,16 @@ func (r NextGenerationFirewallVNetLocalRulestackResource) Create() sdk.ResourceF
 
 			id := firewalls.NewFirewallID(metadata.Client.Account.SubscriptionId, model.ResourceGroupName, model.Name)
 
-			existing, err := client.FirewallsGet(ctx, id)
-			if err != nil {
-				if !response.WasNotFound(existing.HttpResponse) {
-					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+			if !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				existing, err := client.FirewallsGet(ctx, id)
+				if err != nil {
+					if !response.WasNotFound(existing.HttpResponse) {
+						return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+					}
 				}
-			}
-			if !response.WasNotFound(existing.HttpResponse) {
-				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				if !response.WasNotFound(existing.HttpResponse) {
+					return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				}
 			}
 
 			ruleStackID, err := localrulestacks.ParseLocalRulestackID(model.RuleStackId)
@@ -163,10 +165,9 @@ func (r NextGenerationFirewallVNetLocalRulestackResource) Create() sdk.ResourceF
 			locks.ByID(ruleStackID.ID())
 			defer locks.UnlockByID(ruleStackID.ID())
 
-			if err = client.FirewallsCreateOrUpdateThenPoll(ctx, id, firewall); err != nil {
+			if err = client.FirewallsCreateOrUpdateCallbackThenPoll(ctx, id, firewall, metadata.SetIDCallback(&id)); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
-
 			metadata.SetID(id)
 
 			return nil

--- a/internal/services/paloalto/palo_alto_next_generation_firewall_virtual_network_panorama_resource.go
+++ b/internal/services/paloalto/palo_alto_next_generation_firewall_virtual_network_panorama_resource.go
@@ -120,14 +120,16 @@ func (r NextGenerationFirewallVNetPanoramaResource) Create() sdk.ResourceFunc {
 
 			id := firewalls.NewFirewallID(metadata.Client.Account.SubscriptionId, model.ResourceGroupName, model.Name)
 
-			existing, err := client.FirewallsGet(ctx, id)
-			if err != nil {
-				if !response.WasNotFound(existing.HttpResponse) {
-					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+			if !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				existing, err := client.FirewallsGet(ctx, id)
+				if err != nil {
+					if !response.WasNotFound(existing.HttpResponse) {
+						return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+					}
 				}
-			}
-			if !response.WasNotFound(existing.HttpResponse) {
-				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				if !response.WasNotFound(existing.HttpResponse) {
+					return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				}
 			}
 
 			firewall := firewalls.FirewallResource{
@@ -152,10 +154,9 @@ func (r NextGenerationFirewallVNetPanoramaResource) Create() sdk.ResourceFunc {
 				Tags: tags.Expand(model.Tags),
 			}
 
-			if err = client.FirewallsCreateOrUpdateThenPoll(ctx, id, firewall); err != nil {
+			if err := client.FirewallsCreateOrUpdateCallbackThenPoll(ctx, id, firewall, metadata.SetIDCallback(&id)); err != nil {
 				return err
 			}
-
 			metadata.SetID(id)
 
 			return nil

--- a/internal/services/paloalto/palo_alto_next_generation_firewall_virtual_network_strata_cloud_manager_resource.go
+++ b/internal/services/paloalto/palo_alto_next_generation_firewall_virtual_network_strata_cloud_manager_resource.go
@@ -114,14 +114,16 @@ func (r NextGenerationFirewallVNetStrataCloudManagerResource) Create() sdk.Resou
 
 			id := firewalls.NewFirewallID(metadata.Client.Account.SubscriptionId, model.ResourceGroupName, model.Name)
 
-			existing, err := client.FirewallsGet(ctx, id)
-			if err != nil {
-				if !response.WasNotFound(existing.HttpResponse) {
-					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+			if !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				existing, err := client.FirewallsGet(ctx, id)
+				if err != nil {
+					if !response.WasNotFound(existing.HttpResponse) {
+						return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+					}
 				}
-			}
-			if !response.WasNotFound(existing.HttpResponse) {
-				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				if !response.WasNotFound(existing.HttpResponse) {
+					return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				}
 			}
 
 			identity, err := identity.ExpandLegacySystemAndUserAssignedMapFromModel(model.Identity)
@@ -152,10 +154,9 @@ func (r NextGenerationFirewallVNetStrataCloudManagerResource) Create() sdk.Resou
 				Tags:     tags.Expand(model.Tags),
 			}
 
-			if err = client.FirewallsCreateOrUpdateThenPoll(ctx, id, firewall); err != nil {
+			if err = client.FirewallsCreateOrUpdateCallbackThenPoll(ctx, id, firewall, metadata.SetIDCallback(&id)); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
-
 			metadata.SetID(id)
 
 			return nil

--- a/internal/services/paloalto/palo_alto_virtual_network_appliance_resource.go
+++ b/internal/services/paloalto/palo_alto_virtual_network_appliance_resource.go
@@ -91,14 +91,16 @@ func (r NetworkVirtualApplianceResource) Create() sdk.ResourceFunc {
 
 			loc := location.Normalize(pointer.From(hub.Model.Location))
 
-			existing, err := client.Get(ctx, id, networkvirtualappliances.DefaultGetOperationOptions())
-			if err != nil {
-				if !response.WasNotFound(existing.HttpResponse) {
-					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+			if !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				existing, err := client.Get(ctx, id, networkvirtualappliances.DefaultGetOperationOptions())
+				if err != nil {
+					if !response.WasNotFound(existing.HttpResponse) {
+						return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+					}
 				}
-			}
-			if !response.WasNotFound(existing.HttpResponse) {
-				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				if !response.WasNotFound(existing.HttpResponse) {
+					return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				}
 			}
 
 			props := networkvirtualappliances.NetworkVirtualAppliancePropertiesFormat{
@@ -115,10 +117,9 @@ func (r NetworkVirtualApplianceResource) Create() sdk.ResourceFunc {
 				Properties: pointer.To(props),
 			}
 
-			if err = client.CreateOrUpdateThenPoll(ctx, id, appliance); err != nil {
+			if err = client.CreateOrUpdateCallbackThenPoll(ctx, id, appliance, metadata.SetIDCallback(&id)); err != nil {
 				return fmt.Errorf("creating Virtual Network Appliance for %s: %+v", id, err)
 			}
-
 			metadata.SetID(id)
 
 			return nil

--- a/internal/services/policy/assignment_resource_base.go
+++ b/internal/services/policy/assignment_resource_base.go
@@ -31,15 +31,18 @@ func (br assignmentBaseResource) createFunc(resourceName, scopeFieldName string)
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
 			client := metadata.Client.Policy.AssignmentsClient
 			id := policyassignments.NewScopedPolicyAssignmentID(metadata.ResourceData.Get(scopeFieldName).(string), metadata.ResourceData.Get("name").(string))
-			existing, err := client.Get(ctx, id)
-			if err != nil {
-				if !response.WasNotFound(existing.HttpResponse) {
-					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
-				}
-			}
 
-			if !response.WasNotFound(existing.HttpResponse) {
-				return tf.ImportAsExistsError(resourceName, id.ID())
+			if !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				existing, err := client.Get(ctx, id)
+				if err != nil {
+					if !response.WasNotFound(existing.HttpResponse) {
+						return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+					}
+				}
+
+				if !response.WasNotFound(existing.HttpResponse) {
+					return tf.ImportAsExistsError(resourceName, id.ID())
+				}
 			}
 
 			assignment := policyassignments.PolicyAssignment{
@@ -112,13 +115,14 @@ func (br assignmentBaseResource) createFunc(resourceName, scopeFieldName string)
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
 
+			metadata.SetID(id)
+
 			// Policy Assignments are eventually consistent; wait for them to stabilize
 			log.Printf("[DEBUG] Waiting for %s to become available..", id)
 			if err := waitForPolicyAssignmentToStabilize(ctx, client, id, true); err != nil {
 				return fmt.Errorf("waiting for %s to become available: %s", id, err)
 			}
 
-			metadata.SetID(id)
 			return nil
 		},
 		Timeout: 30 * time.Minute,

--- a/internal/services/policy/management_group_policy_exemption_resource.go
+++ b/internal/services/policy/management_group_policy_exemption_resource.go
@@ -120,14 +120,16 @@ func resourceArmManagementGroupPolicyExemptionCreateUpdate(d *pluginsdk.Resource
 	}
 
 	if d.IsNewResource() {
-		existing, err := client.Get(ctx, managementGroupId.ID(), id.Name)
-		if err != nil {
-			if !utils.ResponseWasNotFound(existing.Response) {
-				return fmt.Errorf("checking for presence of existing %s: %+v", id.ID(), err)
+		if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+			existing, err := client.Get(ctx, managementGroupId.ID(), id.Name)
+			if err != nil {
+				if !utils.ResponseWasNotFound(existing.Response) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id.ID(), err)
+				}
 			}
-		}
-		if existing.ID != nil && *existing.ID != "" {
-			return tf.ImportAsExistsError("azurerm_management_group_policy_exemption", *existing.ID)
+			if existing.ID != nil && *existing.ID != "" {
+				return tf.ImportAsExistsError("azurerm_management_group_policy_exemption", *existing.ID)
+			}
 		}
 	}
 
@@ -167,7 +169,9 @@ func resourceArmManagementGroupPolicyExemptionCreateUpdate(d *pluginsdk.Resource
 		return fmt.Errorf("creating/updating %s: %+v", id.ID(), err)
 	}
 
-	d.SetId(id.ID())
+	if d.IsNewResource() {
+		d.SetId(id.ID())
+	}
 
 	return resourceArmManagementGroupPolicyExemptionRead(d, meta)
 }

--- a/internal/services/policy/management_group_policy_remediation_resource.go
+++ b/internal/services/policy/management_group_policy_remediation_resource.go
@@ -122,14 +122,16 @@ func resourceArmManagementGroupPolicyRemediationCreateUpdate(d *pluginsdk.Resour
 	id := remediations.NewProviders2RemediationID(managementID.Name, d.Get("name").(string))
 
 	if d.IsNewResource() {
-		existing, err := client.GetAtManagementGroup(ctx, id)
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for presence of existing %s: %+v", id.ID(), err)
+		if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+			existing, err := client.GetAtManagementGroup(ctx, id)
+			if err != nil {
+				if !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id.ID(), err)
+				}
 			}
-		}
-		if existing.Model != nil {
-			return tf.ImportAsExistsError("azurerm_management_group_policy_remediation", id.ID())
+			if existing.Model != nil {
+				return tf.ImportAsExistsError("azurerm_management_group_policy_remediation", id.ID())
+			}
 		}
 	}
 
@@ -162,7 +164,9 @@ func resourceArmManagementGroupPolicyRemediationCreateUpdate(d *pluginsdk.Resour
 		return fmt.Errorf("creating/updating %s: %+v", id.ID(), err)
 	}
 
-	d.SetId(id.ID())
+	if d.IsNewResource() {
+		d.SetId(id.ID())
+	}
 
 	return resourceArmManagementGroupPolicyRemediationRead(d, meta)
 }

--- a/internal/services/policy/management_group_policy_set_definition_resource.go
+++ b/internal/services/policy/management_group_policy_set_definition_resource.go
@@ -121,13 +121,15 @@ func (r ManagementGroupPolicySetDefinitionResource) Create() sdk.ResourceFunc {
 
 			id := policysetdefinitions.NewProviders2PolicySetDefinitionID(managementGroupID.GroupId, model.Name)
 
-			existing, err := client.GetAtManagementGroup(ctx, id, policysetdefinitions.DefaultGetAtManagementGroupOperationOptions())
-			if err != nil && !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
-			}
+			if !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				existing, err := client.GetAtManagementGroup(ctx, id, policysetdefinitions.DefaultGetAtManagementGroupOperationOptions())
+				if err != nil && !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+				}
 
-			if !response.WasNotFound(existing.HttpResponse) {
-				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				if !response.WasNotFound(existing.HttpResponse) {
+					return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				}
 			}
 
 			parameters := policysetdefinitions.PolicySetDefinition{

--- a/internal/services/policy/policy_definition_resource.go
+++ b/internal/services/policy/policy_definition_resource.go
@@ -96,15 +96,17 @@ func resourceArmPolicyDefinitionCreateUpdate(d *pluginsdk.ResourceData, meta int
 	}
 
 	if d.IsNewResource() {
-		existing, err := getPolicyDefinitionByName(ctx, client, name, managementGroupName)
-		if err != nil {
-			if !utils.ResponseWasNotFound(existing.Response) {
-				return fmt.Errorf("checking for presence of existing Policy Definition %q: %+v", name, err)
+		if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+			existing, err := getPolicyDefinitionByName(ctx, client, name, managementGroupName)
+			if err != nil {
+				if !utils.ResponseWasNotFound(existing.Response) {
+					return fmt.Errorf("checking for presence of existing Policy Definition %q: %+v", name, err)
+				}
 			}
-		}
 
-		if existing.ID != nil && *existing.ID != "" {
-			return tf.ImportAsExistsError("azurerm_policy_definition", *existing.ID)
+			if existing.ID != nil && *existing.ID != "" {
+				return tf.ImportAsExistsError("azurerm_policy_definition", *existing.ID)
+			}
 		}
 	}
 

--- a/internal/services/policy/policy_set_definition_resource.go
+++ b/internal/services/policy/policy_set_definition_resource.go
@@ -237,15 +237,17 @@ func resourceArmPolicySetDefinitionCreate(d *pluginsdk.ResourceData, meta interf
 
 	id := policysetdefinitions.NewProviderPolicySetDefinitionID(subscriptionId, d.Get("name").(string))
 
-	resp, _, err := getPolicySetDefinitionByID(ctx, client, id)
-	if err != nil {
-		if !response.WasNotFound(resp) {
-			return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+	if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+		resp, _, err := getPolicySetDefinitionByID(ctx, client, id)
+		if err != nil {
+			if !response.WasNotFound(resp) {
+				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+			}
 		}
-	}
 
-	if !response.WasNotFound(resp) {
-		return tf.ImportAsExistsError("azurerm_policy_set_definition", id.ID())
+		if !response.WasNotFound(resp) {
+			return tf.ImportAsExistsError("azurerm_policy_set_definition", id.ID())
+		}
 	}
 
 	parameters := policysetdefinitions.PolicySetDefinition{
@@ -288,7 +290,7 @@ func resourceArmPolicySetDefinitionCreate(d *pluginsdk.ResourceData, meta interf
 		props.PolicyDefinitionGroups = expandAzureRMPolicySetDefinitionPolicyGroups(v.(*pluginsdk.Set).List())
 	}
 
-	if _, err = client.CreateOrUpdate(ctx, id, parameters); err != nil {
+	if _, err := client.CreateOrUpdate(ctx, id, parameters); err != nil {
 		return fmt.Errorf("creating %s: %+v", id, err)
 	}
 
@@ -303,7 +305,7 @@ func resourceArmPolicySetDefinitionCreate(d *pluginsdk.ResourceData, meta interf
 		ContinuousTargetOccurence: 10,
 	}
 
-	if _, err = stateConf.WaitForStateContext(ctx); err != nil {
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
 		return fmt.Errorf("waiting for %s to become available: %+v", id, err)
 	}
 
@@ -325,15 +327,17 @@ func createForManagementGroup(ctx context.Context, client *policysetdefinitions.
 
 	id := policysetdefinitions.NewProviders2PolicySetDefinitionID(managementGroupId.Name, d.Get("name").(string))
 
-	resp, _, err := getPolicySetDefinitionByID(ctx, client, id)
-	if err != nil {
-		if !response.WasNotFound(resp) {
-			return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+	if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+		resp, _, err := getPolicySetDefinitionByID(ctx, client, id)
+		if err != nil {
+			if !response.WasNotFound(resp) {
+				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+			}
 		}
-	}
 
-	if !response.WasNotFound(resp) {
-		return tf.ImportAsExistsError("azurerm_policy_set_definition", id.ID())
+		if !response.WasNotFound(resp) {
+			return tf.ImportAsExistsError("azurerm_policy_set_definition", id.ID())
+		}
 	}
 
 	parameters := policysetdefinitions.PolicySetDefinition{
@@ -1000,13 +1004,15 @@ func (r PolicySetDefinitionResource) Create() sdk.ResourceFunc {
 
 			id := policysetdefinitions.NewProviderPolicySetDefinitionID(subscriptionId, model.Name)
 
-			resp, _, err := getPolicySetDefinition(ctx, client, id)
-			if err != nil && !response.WasNotFound(resp) {
-				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
-			}
+			if !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				resp, _, err := getPolicySetDefinition(ctx, client, id)
+				if err != nil && !response.WasNotFound(resp) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+				}
 
-			if !response.WasNotFound(resp) {
-				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				if !response.WasNotFound(resp) {
+					return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				}
 			}
 
 			parameters := policysetdefinitions.PolicySetDefinition{
@@ -1050,7 +1056,7 @@ func (r PolicySetDefinitionResource) Create() sdk.ResourceFunc {
 				props.PolicyDefinitionGroups = expandPolicyDefinitionGroup(model.PolicyDefinitionGroup)
 			}
 
-			if _, err = client.CreateOrUpdate(ctx, id, parameters); err != nil {
+			if _, err := client.CreateOrUpdate(ctx, id, parameters); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
 

--- a/internal/services/policy/policy_virtual_machine_configuration_assignment_resource.go
+++ b/internal/services/policy/policy_virtual_machine_configuration_assignment_resource.go
@@ -137,14 +137,16 @@ func resourcePolicyVirtualMachineConfigurationAssignmentCreateUpdate(d *pluginsd
 	id := guestconfigurationassignments.NewVirtualMachineProviders2GuestConfigurationAssignmentID(subscriptionId, vmId.ResourceGroupName, vmId.VirtualMachineName, d.Get("name").(string))
 
 	if d.IsNewResource() {
-		existing, err := client.Get(ctx, id)
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for present of existing %s: %+v", id, err)
+		if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+			existing, err := client.Get(ctx, id)
+			if err != nil {
+				if !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for present of existing %s: %+v", id, err)
+				}
 			}
-		}
-		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError("azurerm_policy_virtual_machine_configuration_assignment", id.ID())
+			if !response.WasNotFound(existing.HttpResponse) {
+				return tf.ImportAsExistsError("azurerm_policy_virtual_machine_configuration_assignment", id.ID())
+			}
 		}
 	}
 	guestConfiguration := expandGuestConfigurationAssignment(d.Get("configuration").([]interface{}), id.GuestConfigurationAssignmentName)
@@ -172,7 +174,9 @@ func resourcePolicyVirtualMachineConfigurationAssignmentCreateUpdate(d *pluginsd
 		return fmt.Errorf("creating/updating %s: %+v", id, err)
 	}
 
-	d.SetId(id.ID())
+	if d.IsNewResource() {
+		d.SetId(id.ID())
+	}
 
 	return resourcePolicyVirtualMachineConfigurationAssignmentRead(d, meta)
 }

--- a/internal/services/policy/resource_group_policy_exemption_resource.go
+++ b/internal/services/policy/resource_group_policy_exemption_resource.go
@@ -121,14 +121,16 @@ func resourceArmResourceGroupPolicyExemptionCreateUpdate(d *pluginsdk.ResourceDa
 	id := parse.NewResourceGroupPolicyExemptionID(resourceGroupId.SubscriptionId, resourceGroupId.ResourceGroup, d.Get("name").(string))
 
 	if d.IsNewResource() {
-		existing, err := client.Get(ctx, resourceGroupId.ID(), id.PolicyExemptionName)
-		if err != nil {
-			if !utils.ResponseWasNotFound(existing.Response) {
-				return fmt.Errorf("checking for presence of existing %s: %+v", id.ID(), err)
+		if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+			existing, err := client.Get(ctx, resourceGroupId.ID(), id.PolicyExemptionName)
+			if err != nil {
+				if !utils.ResponseWasNotFound(existing.Response) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id.ID(), err)
+				}
 			}
-		}
-		if existing.ID != nil && *existing.ID != "" {
-			return tf.ImportAsExistsError("azurerm_resource_group_policy_exemption", *existing.ID)
+			if existing.ID != nil && *existing.ID != "" {
+				return tf.ImportAsExistsError("azurerm_resource_group_policy_exemption", *existing.ID)
+			}
 		}
 	}
 
@@ -168,7 +170,9 @@ func resourceArmResourceGroupPolicyExemptionCreateUpdate(d *pluginsdk.ResourceDa
 		return fmt.Errorf("creating/updating %s: %+v", id.ID(), err)
 	}
 
-	d.SetId(id.ID())
+	if d.IsNewResource() {
+		d.SetId(id.ID())
+	}
 
 	return resourceArmResourceGroupPolicyExemptionRead(d, meta)
 }

--- a/internal/services/policy/resource_group_policy_remediation_resource.go
+++ b/internal/services/policy/resource_group_policy_remediation_resource.go
@@ -130,14 +130,16 @@ func resourceArmResourceGroupPolicyRemediationCreateUpdate(d *pluginsdk.Resource
 	id := remediations.NewProviderRemediationID(resourceGroupId.SubscriptionId, resourceGroupId.ResourceGroup, d.Get("name").(string))
 
 	if d.IsNewResource() {
-		existing, err := client.GetAtResourceGroup(ctx, id)
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for presence of existing %s: %+v", id.ID(), err)
+		if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+			existing, err := client.GetAtResourceGroup(ctx, id)
+			if err != nil {
+				if !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id.ID(), err)
+				}
 			}
-		}
-		if existing.Model != nil {
-			return tf.ImportAsExistsError("azurerm_resource_group_policy_remediation", id.ID())
+			if existing.Model != nil {
+				return tf.ImportAsExistsError("azurerm_resource_group_policy_remediation", id.ID())
+			}
 		}
 	}
 
@@ -149,7 +151,9 @@ func resourceArmResourceGroupPolicyRemediationCreateUpdate(d *pluginsdk.Resource
 		return fmt.Errorf("creating/updating %s: %+v", id.ID(), err)
 	}
 
-	d.SetId(id.ID())
+	if d.IsNewResource() {
+		d.SetId(id.ID())
+	}
 
 	return resourceArmResourceGroupPolicyRemediationRead(d, meta)
 }

--- a/internal/services/policy/resource_policy_exemption_resource.go
+++ b/internal/services/policy/resource_policy_exemption_resource.go
@@ -115,14 +115,16 @@ func resourceArmResourcePolicyExemptionCreateUpdate(d *pluginsdk.ResourceData, m
 	id := parse.NewResourcePolicyExemptionId(d.Get("resource_id").(string), d.Get("name").(string))
 
 	if d.IsNewResource() {
-		existing, err := client.Get(ctx, id.ResourceId, id.Name)
-		if err != nil {
-			if !utils.ResponseWasNotFound(existing.Response) {
-				return fmt.Errorf("checking for presence of existing %s: %+v", id.ID(), err)
+		if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+			existing, err := client.Get(ctx, id.ResourceId, id.Name)
+			if err != nil {
+				if !utils.ResponseWasNotFound(existing.Response) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id.ID(), err)
+				}
 			}
-		}
-		if existing.ID != nil && *existing.ID != "" {
-			return tf.ImportAsExistsError("azurerm_resource_policy_exemption", *existing.ID)
+			if existing.ID != nil && *existing.ID != "" {
+				return tf.ImportAsExistsError("azurerm_resource_policy_exemption", *existing.ID)
+			}
 		}
 	}
 
@@ -162,7 +164,9 @@ func resourceArmResourcePolicyExemptionCreateUpdate(d *pluginsdk.ResourceData, m
 		return fmt.Errorf("creating/updating %s: %+v", id.ID(), err)
 	}
 
-	d.SetId(id.ID())
+	if d.IsNewResource() {
+		d.SetId(id.ID())
+	}
 
 	return resourceArmResourcePolicyExemptionRead(d, meta)
 }

--- a/internal/services/policy/resource_policy_remediation_resource.go
+++ b/internal/services/policy/resource_policy_remediation_resource.go
@@ -128,14 +128,16 @@ func resourceArmResourcePolicyRemediationCreateUpdate(d *pluginsdk.ResourceData,
 	id := remediations.NewScopedRemediationID(resourceId, d.Get("name").(string))
 
 	if d.IsNewResource() {
-		existing, err := client.GetAtResource(ctx, id)
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for presence of existing %s: %+v", id.ID(), err)
+		if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+			existing, err := client.GetAtResource(ctx, id)
+			if err != nil {
+				if !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id.ID(), err)
+				}
 			}
-		}
-		if existing.Model != nil {
-			return tf.ImportAsExistsError("azurerm_resource_policy_remediation", id.ID())
+			if !response.WasNotFound(existing.HttpResponse) {
+				return tf.ImportAsExistsError("azurerm_resource_policy_remediation", id.ID())
+			}
 		}
 	}
 
@@ -147,7 +149,9 @@ func resourceArmResourcePolicyRemediationCreateUpdate(d *pluginsdk.ResourceData,
 		return fmt.Errorf("creating/updating %s: %+v", id.ID(), err)
 	}
 
-	d.SetId(id.ID())
+	if d.IsNewResource() {
+		d.SetId(id.ID())
+	}
 
 	return resourceArmResourcePolicyRemediationRead(d, meta)
 }

--- a/internal/services/policy/subscription_policy_exemption_resource.go
+++ b/internal/services/policy/subscription_policy_exemption_resource.go
@@ -119,14 +119,16 @@ func resourceArmSubscriptionPolicyExemptionCreateUpdate(d *pluginsdk.ResourceDat
 	id := parse.NewSubscriptionPolicyExemptionID(subscriptionId.SubscriptionId, d.Get("name").(string))
 
 	if d.IsNewResource() {
-		existing, err := client.Get(ctx, subscriptionId.ID(), id.PolicyExemptionName)
-		if err != nil {
-			if !utils.ResponseWasNotFound(existing.Response) {
-				return fmt.Errorf("checking for presence of existing %s: %+v", id.ID(), err)
+		if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+			existing, err := client.Get(ctx, subscriptionId.ID(), id.PolicyExemptionName)
+			if err != nil {
+				if !utils.ResponseWasNotFound(existing.Response) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id.ID(), err)
+				}
 			}
-		}
-		if existing.ID != nil && *existing.ID != "" {
-			return tf.ImportAsExistsError("azurerm_resource_group_policy_exemption", *existing.ID)
+			if existing.ID != nil && *existing.ID != "" {
+				return tf.ImportAsExistsError("azurerm_resource_group_policy_exemption", *existing.ID)
+			}
 		}
 	}
 
@@ -166,7 +168,9 @@ func resourceArmSubscriptionPolicyExemptionCreateUpdate(d *pluginsdk.ResourceDat
 		return fmt.Errorf("creating/updating %s: %+v", id.ID(), err)
 	}
 
-	d.SetId(id.ID())
+	if d.IsNewResource() {
+		d.SetId(id.ID())
+	}
 
 	return resourceArmSubscriptionPolicyExemptionRead(d, meta)
 }

--- a/internal/services/policy/subscription_policy_remediation_resource.go
+++ b/internal/services/policy/subscription_policy_remediation_resource.go
@@ -129,14 +129,16 @@ func resourceArmSubscriptionPolicyRemediationCreateUpdate(d *pluginsdk.ResourceD
 	id := remediations.NewRemediationID(subscriptionId.SubscriptionId, d.Get("name").(string))
 
 	if d.IsNewResource() {
-		existing, err := client.GetAtSubscription(ctx, id)
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for presence of existing %s: %+v", id.ID(), err)
+		if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+			existing, err := client.GetAtSubscription(ctx, id)
+			if err != nil {
+				if !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id.ID(), err)
+				}
 			}
-		}
-		if existing.Model != nil {
-			return tf.ImportAsExistsError("azurerm_subscription_policy_remediation", id.ID())
+			if existing.Model != nil {
+				return tf.ImportAsExistsError("azurerm_subscription_policy_remediation", id.ID())
+			}
 		}
 	}
 
@@ -148,7 +150,9 @@ func resourceArmSubscriptionPolicyRemediationCreateUpdate(d *pluginsdk.ResourceD
 		return fmt.Errorf("creating/updating %s: %+v", id.ID(), err)
 	}
 
-	d.SetId(id.ID())
+	if d.IsNewResource() {
+		d.SetId(id.ID())
+	}
 
 	return resourceArmSubscriptionPolicyRemediationRead(d, meta)
 }

--- a/internal/services/portal/portal_dashboard_resource.go
+++ b/internal/services/portal/portal_dashboard_resource.go
@@ -72,16 +72,19 @@ func resourcePortalDashboardCreateUpdate(d *pluginsdk.ResourceData, meta interfa
 	defer cancel()
 
 	id := dashboard.NewDashboardID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
-	if d.IsNewResource() {
-		existing, err := client.Get(ctx, id)
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for the presence of an existing %s: %+v", id, err)
-			}
-		}
 
-		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError("azurerm_portal_dashboard", id.ID())
+	if d.IsNewResource() {
+		if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+			existing, err := client.Get(ctx, id)
+			if err != nil {
+				if !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for the presence of an existing %s: %+v", id, err)
+				}
+			}
+
+			if !response.WasNotFound(existing.HttpResponse) {
+				return tf.ImportAsExistsError("azurerm_portal_dashboard", id.ID())
+			}
 		}
 	}
 
@@ -103,7 +106,10 @@ func resourcePortalDashboardCreateUpdate(d *pluginsdk.ResourceData, meta interfa
 		return fmt.Errorf("creating/updating %s %+v", id, err)
 	}
 
-	d.SetId(id.ID())
+	if d.IsNewResource() {
+		d.SetId(id.ID())
+	}
+
 	return resourcePortalDashboardRead(d, meta)
 }
 

--- a/internal/services/portal/portal_tenant_configuration_resource.go
+++ b/internal/services/portal/portal_tenant_configuration_resource.go
@@ -56,15 +56,17 @@ func resourcePortalTenantConfigurationCreateUpdate(d *pluginsdk.ResourceData, me
 	// since this is an operation on a Tenant (which doesn't expose any configurable values).
 	id := parse.NewPortalTenantConfigurationID("default")
 	if d.IsNewResource() {
-		existing, err := client.Get(ctx)
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for existing %s: %+v", id, err)
+		if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+			existing, err := client.Get(ctx)
+			if err != nil {
+				if !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for existing %s: %+v", id, err)
+				}
 			}
-		}
 
-		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError("azurerm_portal_tenant_configuration", id.ID())
+			if !response.WasNotFound(existing.HttpResponse) {
+				return tf.ImportAsExistsError("azurerm_portal_tenant_configuration", id.ID())
+			}
 		}
 	}
 
@@ -78,7 +80,9 @@ func resourcePortalTenantConfigurationCreateUpdate(d *pluginsdk.ResourceData, me
 		return fmt.Errorf("creating/updating %s: %+v", id, err)
 	}
 
-	d.SetId(id.ID())
+	if d.IsNewResource() {
+		d.SetId(id.ID())
+	}
 
 	return resourcePortalTenantConfigurationRead(d, meta)
 }

--- a/internal/services/postgres/postgresql_active_directory_administrator_resource.go
+++ b/internal/services/postgres/postgresql_active_directory_administrator_resource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/serveradministrators"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/postgres/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/postgres/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -82,16 +83,19 @@ func resourcePostgreSQLAdministratorCreateUpdate(d *pluginsdk.ResourceData, meta
 	defer cancel()
 
 	id := serveradministrators.NewServerID(subscriptionId, d.Get("resource_group_name").(string), d.Get("server_name").(string))
-	if d.IsNewResource() {
-		existing, err := client.Get(ctx, id)
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
-			}
-		}
 
-		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError("azurerm_postgresql_active_directory_administrator", id.ID())
+	if d.IsNewResource() {
+		if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+			existing, err := client.Get(ctx, id)
+			if err != nil {
+				if !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+				}
+			}
+
+			if !response.WasNotFound(existing.HttpResponse) {
+				return tf.ImportAsExistsError("azurerm_postgresql_active_directory_administrator", id.ID())
+			}
 		}
 	}
 
@@ -104,11 +108,17 @@ func resourcePostgreSQLAdministratorCreateUpdate(d *pluginsdk.ResourceData, meta
 		},
 	}
 
-	if err := client.CreateOrUpdateThenPoll(ctx, id, parameters); err != nil {
-		return fmt.Errorf("creating/updating %s: %+v", id, err)
+	if d.IsNewResource() {
+		if err := client.CreateOrUpdateCallbackThenPoll(ctx, id, parameters, sdk.SetIDCallback(meta, &id, d)); err != nil {
+			return fmt.Errorf("creating %s: %+v", id, err)
+		}
+		d.SetId(id.ID())
+	} else {
+		if err := client.CreateOrUpdateThenPoll(ctx, id, parameters); err != nil {
+			return fmt.Errorf("updating %s: %+v", id, err)
+		}
 	}
 
-	d.SetId(id.ID())
 	return nil
 }
 

--- a/internal/services/postgres/postgresql_configuration_resource.go
+++ b/internal/services/postgres/postgresql_configuration_resource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/configurations"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/postgres/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
@@ -80,11 +81,11 @@ func resourcePostgreSQLConfigurationCreate(d *pluginsdk.ResourceData, meta inter
 		},
 	}
 
-	if err := client.CreateOrUpdateThenPoll(ctx, id, properties); err != nil {
-		return fmt.Errorf("creating/updating %s: %+v", id, err)
+	if err := client.CreateOrUpdateCallbackThenPoll(ctx, id, properties, sdk.SetIDCallback(meta, &id, d)); err != nil {
+		return fmt.Errorf("creating %s: %+v", id, err)
 	}
-
 	d.SetId(id.ID())
+
 	return resourcePostgreSQLConfigurationRead(d, meta)
 }
 

--- a/internal/services/postgres/postgresql_database_resource.go
+++ b/internal/services/postgres/postgresql_database_resource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/databases"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/postgres/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/postgres/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -84,15 +85,18 @@ func resourcePostgreSQLDatabaseCreate(d *pluginsdk.ResourceData, meta interface{
 	defer cancel()
 
 	id := databases.NewDatabaseID(subscriptionId, d.Get("resource_group_name").(string), d.Get("server_name").(string), d.Get("name").(string))
-	existing, err := client.Get(ctx, id)
-	if err != nil {
-		if !response.WasNotFound(existing.HttpResponse) {
-			return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
-		}
-	}
 
-	if !response.WasNotFound(existing.HttpResponse) {
-		return tf.ImportAsExistsError("azurerm_postgresql_database", id.ID())
+	if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+		existing, err := client.Get(ctx, id)
+		if err != nil {
+			if !response.WasNotFound(existing.HttpResponse) {
+				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+			}
+		}
+
+		if !response.WasNotFound(existing.HttpResponse) {
+			return tf.ImportAsExistsError("azurerm_postgresql_database", id.ID())
+		}
 	}
 
 	properties := databases.Database{
@@ -102,11 +106,11 @@ func resourcePostgreSQLDatabaseCreate(d *pluginsdk.ResourceData, meta interface{
 		},
 	}
 
-	if err = client.CreateOrUpdateThenPoll(ctx, id, properties); err != nil {
-		return fmt.Errorf("creating/updating %s: %+v", id, err)
+	if err := client.CreateOrUpdateCallbackThenPoll(ctx, id, properties, sdk.SetIDCallback(meta, &id, d)); err != nil {
+		return fmt.Errorf("creating %s: %+v", id, err)
 	}
-
 	d.SetId(id.ID())
+
 	return resourcePostgreSQLDatabaseRead(d, meta)
 }
 

--- a/internal/services/postgres/postgresql_firewall_rule_resource.go
+++ b/internal/services/postgres/postgresql_firewall_rule_resource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/firewallrules"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/postgres/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -82,15 +83,18 @@ func resourcePostgreSQLFirewallRuleCreate(d *pluginsdk.ResourceData, meta interf
 	defer cancel()
 
 	id := firewallrules.NewFirewallRuleID(subscriptionId, d.Get("resource_group_name").(string), d.Get("server_name").(string), d.Get("name").(string))
-	existing, err := client.Get(ctx, id)
-	if err != nil {
-		if !response.WasNotFound(existing.HttpResponse) {
-			return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
-		}
-	}
 
-	if !response.WasNotFound(existing.HttpResponse) {
-		return tf.ImportAsExistsError("azurerm_postgresql_firewall_rule", id.ID())
+	if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+		existing, err := client.Get(ctx, id)
+		if err != nil {
+			if !response.WasNotFound(existing.HttpResponse) {
+				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+			}
+		}
+
+		if !response.WasNotFound(existing.HttpResponse) {
+			return tf.ImportAsExistsError("azurerm_postgresql_firewall_rule", id.ID())
+		}
 	}
 
 	properties := firewallrules.FirewallRule{
@@ -100,11 +104,11 @@ func resourcePostgreSQLFirewallRuleCreate(d *pluginsdk.ResourceData, meta interf
 		},
 	}
 
-	if err = client.CreateOrUpdateThenPoll(ctx, id, properties); err != nil {
-		return fmt.Errorf("creating/updating %s: %+v", id, err)
+	if err := client.CreateOrUpdateCallbackThenPoll(ctx, id, properties, sdk.SetIDCallback(meta, &id, d)); err != nil {
+		return fmt.Errorf("creating %s: %+v", id, err)
 	}
-
 	d.SetId(id.ID())
+
 	return resourcePostgreSQLFirewallRuleRead(d, meta)
 }
 

--- a/internal/services/postgres/postgresql_flexible_server_active_directory_administrator_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_active_directory_administrator_resource.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
@@ -91,7 +92,7 @@ func resourcePostgresqlFlexibleServerAdministratorCreate(d *pluginsdk.ResourceDa
 	locks.ByName(id.FlexibleServerName, postgresqlFlexibleServerResourceName)
 	defer locks.UnlockByName(id.FlexibleServerName, postgresqlFlexibleServerResourceName)
 
-	if d.IsNewResource() {
+	if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
 		existing, err := client.AdministratorsMicrosoftEntraGet(ctx, id)
 		if err != nil {
 			if !response.WasNotFound(existing.HttpResponse) {
@@ -115,11 +116,11 @@ func resourcePostgresqlFlexibleServerAdministratorCreate(d *pluginsdk.ResourceDa
 		},
 	}
 
-	if err := client.AdministratorsMicrosoftEntraCreateOrUpdateThenPoll(ctx, id, parameters); err != nil {
+	if err := client.AdministratorsMicrosoftEntraCreateOrUpdateCallbackThenPoll(ctx, id, parameters, sdk.SetIDCallback(meta, &id, d)); err != nil {
 		return fmt.Errorf("creating %s: %+v", id, err)
 	}
-
 	d.SetId(id.ID())
+
 	return nil
 }
 

--- a/internal/services/postgres/postgresql_flexible_server_backup_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_backup_resource.go
@@ -84,19 +84,21 @@ func (r PostgresqlFlexibleServerBackupResource) Create() sdk.ResourceFunc {
 			locks.ByName(id.FlexibleServerName, postgresqlFlexibleServerResourceName)
 			defer locks.UnlockByName(id.FlexibleServerName, postgresqlFlexibleServerResourceName)
 
-			existing, err := client.BackupsAutomaticAndOnDemandGet(ctx, id)
-			if err != nil && !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
-			}
-			if !response.WasNotFound(existing.HttpResponse) {
-				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+			if !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				existing, err := client.BackupsAutomaticAndOnDemandGet(ctx, id)
+				if err != nil && !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+				}
+				if !response.WasNotFound(existing.HttpResponse) {
+					return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				}
 			}
 
-			if err := client.BackupsAutomaticAndOnDemandCreateThenPoll(ctx, id); err != nil {
+			if err := client.BackupsAutomaticAndOnDemandCreateCallbackThenPoll(ctx, id, metadata.SetIDCallback(&id)); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
-
 			metadata.SetID(id)
+
 			return nil
 		},
 	}

--- a/internal/services/postgres/postgresql_flexible_server_configuration_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_configuration_resource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2025-08-01/servers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
@@ -21,9 +22,9 @@ import (
 
 func resourcePostgresqlFlexibleServerConfiguration() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create: resourceFlexibleServerConfigurationUpdate,
+		Create: resourceFlexibleServerConfigurationCreateUpdate,
 		Read:   resourceFlexibleServerConfigurationRead,
-		Update: resourceFlexibleServerConfigurationUpdate,
+		Update: resourceFlexibleServerConfigurationCreateUpdate,
 		Delete: resourceFlexibleServerConfigurationDelete,
 
 		Timeouts: &pluginsdk.ResourceTimeout{
@@ -62,7 +63,7 @@ func resourcePostgresqlFlexibleServerConfiguration() *pluginsdk.Resource {
 	}
 }
 
-func resourceFlexibleServerConfigurationUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+func resourceFlexibleServerConfigurationCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	client := meta.(*clients.Client).Postgres.FlexibleServersConfigurationsClient
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
@@ -84,9 +85,10 @@ func resourceFlexibleServerConfigurationUpdate(d *pluginsdk.ResourceData, meta i
 		},
 	}
 
-	if err := client.UpdateThenPoll(ctx, id, props); err != nil {
+	if err := client.UpdateCallbackThenPoll(ctx, id, props, sdk.SetIDCallback(meta, &id, d)); err != nil {
 		return fmt.Errorf("updating %s: %+v", id, err)
 	}
+	d.SetId(id.ID())
 
 	resp, err := client.Get(ctx, id)
 	if err != nil {
@@ -106,8 +108,6 @@ func resourceFlexibleServerConfigurationUpdate(d *pluginsdk.ResourceData, meta i
 			}
 		}
 	}
-
-	d.SetId(id.ID())
 
 	return resourceFlexibleServerConfigurationRead(d, meta)
 }

--- a/internal/services/postgres/postgresql_flexible_server_database_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_database_resource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/postgres/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
@@ -87,7 +88,7 @@ func resourcePostgresqlFlexibleServerDatabaseCreate(d *pluginsdk.ResourceData, m
 	locks.ByName(id.FlexibleServerName, postgresqlFlexibleServerResourceName)
 	defer locks.UnlockByName(id.FlexibleServerName, postgresqlFlexibleServerResourceName)
 
-	if d.IsNewResource() {
+	if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
 		existing, err := client.Get(ctx, id)
 		if err != nil {
 			if !response.WasNotFound(existing.HttpResponse) {
@@ -106,11 +107,11 @@ func resourcePostgresqlFlexibleServerDatabaseCreate(d *pluginsdk.ResourceData, m
 		},
 	}
 
-	if err = client.CreateThenPoll(ctx, id, properties); err != nil {
+	if err = client.CreateCallbackThenPoll(ctx, id, properties, sdk.SetIDCallback(meta, &id, d)); err != nil {
 		return fmt.Errorf("creating %s: %+v", id, err)
 	}
-
 	d.SetId(id.ID())
+
 	return resourcePostgresqlFlexibleServerDatabaseRead(d, meta)
 }
 

--- a/internal/services/postgres/postgresql_flexible_server_firewall_rule_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_firewall_rule_resource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/postgres/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -89,14 +90,16 @@ func resourcePostgresqlFlexibleServerFirewallRuleCreateUpdate(d *pluginsdk.Resou
 	defer locks.UnlockByName(id.FlexibleServerName, postgresqlFlexibleServerResourceName)
 
 	if d.IsNewResource() {
-		existing, err := client.Get(ctx, id)
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for present of existing %q: %+v", id, err)
+		if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+			existing, err := client.Get(ctx, id)
+			if err != nil {
+				if !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for present of existing %q: %+v", id, err)
+				}
 			}
-		}
-		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError("azurerm_postgresql_flexible_server_firewall_rule", id.ID())
+			if !response.WasNotFound(existing.HttpResponse) {
+				return tf.ImportAsExistsError("azurerm_postgresql_flexible_server_firewall_rule", id.ID())
+			}
 		}
 	}
 
@@ -107,13 +110,18 @@ func resourcePostgresqlFlexibleServerFirewallRuleCreateUpdate(d *pluginsdk.Resou
 		},
 	}
 
-	if err = client.CreateOrUpdateThenPoll(ctx, id, properties); err != nil {
-		return fmt.Errorf("creating/updating %q: %+v", id, err)
-	}
-
-	d.SetId(id.ID())
-	if err := pluginsdk.SetResourceIdentityData(d, &id); err != nil {
-		return err
+	if d.IsNewResource() {
+		if err := client.CreateOrUpdateCallbackThenPoll(ctx, id, properties, sdk.SetIDCallback(meta, &id, d)); err != nil {
+			return fmt.Errorf("creating %s: %+v", id, err)
+		}
+		d.SetId(id.ID())
+		if err := pluginsdk.SetResourceIdentityData(d, &id); err != nil {
+			return err
+		}
+	} else {
+		if err := client.CreateOrUpdateThenPoll(ctx, id, properties); err != nil {
+			return fmt.Errorf("updating %s: %+v", id, err)
+		}
 	}
 
 	return resourcePostgresqlFlexibleServerFirewallRuleRead(d, meta)

--- a/internal/services/postgres/postgresql_flexible_server_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/postgres/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
@@ -581,14 +582,16 @@ func resourcePostgresqlFlexibleServerCreate(d *pluginsdk.ResourceData, meta inte
 
 	id := servers.NewFlexibleServerID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
-	existing, err := client.Get(ctx, id)
-	if err != nil {
-		if !response.WasNotFound(existing.HttpResponse) {
-			return fmt.Errorf("checking for presence of %s: %+v", id, err)
+	if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+		existing, err := client.Get(ctx, id)
+		if err != nil {
+			if !response.WasNotFound(existing.HttpResponse) {
+				return fmt.Errorf("checking for presence of %s: %+v", id, err)
+			}
 		}
-	}
-	if !response.WasNotFound(existing.HttpResponse) {
-		return tf.ImportAsExistsError("azurerm_postgresql_flexible_server", id.ID())
+		if !response.WasNotFound(existing.HttpResponse) {
+			return tf.ImportAsExistsError("azurerm_postgresql_flexible_server", id.ID())
+		}
 	}
 
 	createMode := d.Get("create_mode").(string)
@@ -745,9 +748,10 @@ func resourcePostgresqlFlexibleServerCreate(d *pluginsdk.ResourceData, meta inte
 	}
 	parameters.Identity = identity
 
-	if err = client.CreateOrUpdateThenPoll(ctx, id, parameters); err != nil {
+	if err = client.CreateOrUpdateCallbackThenPoll(ctx, id, parameters, sdk.SetIDCallback(meta, &id, d)); err != nil {
 		return fmt.Errorf("creating %s: %+v", id, err)
 	}
+	d.SetId(id.ID())
 
 	requireAdditionalUpdate := false
 	updateProperties := servers.ServerPropertiesForPatch{}
@@ -765,8 +769,6 @@ func resourcePostgresqlFlexibleServerCreate(d *pluginsdk.ResourceData, meta inte
 			return fmt.Errorf("updating %s: %+v", id, err)
 		}
 	}
-
-	d.SetId(id.ID())
 
 	return resourcePostgresqlFlexibleServerRead(d, meta)
 }

--- a/internal/services/postgres/postgresql_flexible_server_virtual_endpoint_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_virtual_endpoint_resource.go
@@ -135,20 +135,19 @@ func (r PostgresqlFlexibleServerVirtualEndpointResource) Create() sdk.ResourceFu
 				defer locks.UnlockByName(replicaServerId.FlexibleServerName, postgresqlFlexibleServerResourceName)
 			}
 
-			// This API can be a bit flaky if the same named resource is created/destroyed quickly
-			// usually waiting a minute or two before redeploying is enough to resolve the conflict
-			if err = client.CreateThenPoll(ctx, sourceEndpointId, virtualendpoints.VirtualEndpoint{
+			id := commonids.NewCompositeResourceID(&sourceEndpointId, &replicaEndpointId)
+
+			payload := virtualendpoints.VirtualEndpoint{
 				Name: &virtualEndpoint.Name,
 				Properties: &virtualendpoints.VirtualEndpointResourceProperties{
 					EndpointType: pointer.To(virtualendpoints.VirtualEndpointType(virtualEndpoint.Type)),
 					Members:      &[]string{replicaServerId.FlexibleServerName},
 				},
-			}); err != nil {
-				return fmt.Errorf("creating %s: %+v", sourceEndpointId, err)
 			}
 
-			id := commonids.NewCompositeResourceID(&sourceEndpointId, &replicaEndpointId)
-
+			if err = client.CreateCallbackThenPoll(ctx, sourceEndpointId, payload, metadata.SetIDCallback(id)); err != nil {
+				return fmt.Errorf("creating %s: %+v", sourceEndpointId, err)
+			}
 			metadata.SetID(id)
 
 			return nil

--- a/internal/services/postgres/postgresql_server_key_resource.go
+++ b/internal/services/postgres/postgresql_server_key_resource.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/client"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
@@ -106,22 +107,24 @@ func resourcePostgreSQLServerKeyCreateUpdate(d *pluginsdk.ResourceData, meta int
 		// This resource is a singleton, but its name can be anything.
 		// If you create a new key with different name with the old key, the service will not give you any warning but directly replace the old key with the new key.
 		// Therefore sometimes you cannot get the old key using the GET API since you may not know the name of the old key
-		resp, err := keysClient.List(ctx, *serverId)
-		if err != nil {
-			return fmt.Errorf("listing existing Keys in %s: %+v", serverId, err)
-		}
-		if resp.Model != nil && len(*resp.Model) >= 1 {
-			keys := *resp.Model
-			if rawId := keys[0].Id; rawId != nil && *rawId != "" {
-				id, err := serverkeys.ParseKeyID(*rawId)
-				if err != nil {
-					return fmt.Errorf("parsing existing Server Key ID %q: %+v", *rawId, err)
-				}
+		if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+			resp, err := keysClient.List(ctx, *serverId)
+			if err != nil {
+				return fmt.Errorf("listing existing Keys in %s: %+v", serverId, err)
+			}
+			if resp.Model != nil && len(*resp.Model) >= 1 {
+				keys := *resp.Model
+				if rawId := keys[0].Id; rawId != nil && *rawId != "" {
+					id, err := serverkeys.ParseKeyID(*rawId)
+					if err != nil {
+						return fmt.Errorf("parsing existing Server Key ID %q: %+v", *rawId, err)
+					}
 
-				// API allows adding same key again with Create action, which would trigger revalidation of the key on the server.
-				// This is required to revalidate Replica server after creation.
-				if *rawId != id.ID() {
-					return tf.ImportAsExistsError("azurerm_postgresql_server_key", id.ID())
+					// API allows adding same key again with Create action, which would trigger revalidation of the key on the server.
+					// This is required to revalidate Replica server after creation.
+					if *rawId != id.ID() {
+						return tf.ImportAsExistsError("azurerm_postgresql_server_key", id.ID())
+					}
 				}
 			}
 		}
@@ -134,11 +137,17 @@ func resourcePostgreSQLServerKeyCreateUpdate(d *pluginsdk.ResourceData, meta int
 		},
 	}
 
-	if err = keysClient.CreateOrUpdateThenPoll(ctx, id, param); err != nil {
-		return fmt.Errorf("creating/updating %s: %+v", id, err)
+	if d.IsNewResource() {
+		if err := keysClient.CreateOrUpdateCallbackThenPoll(ctx, id, param, sdk.SetIDCallback(meta, &id, d)); err != nil {
+			return fmt.Errorf("creating %s: %+v", id, err)
+		}
+		d.SetId(id.ID())
+	} else {
+		if err := keysClient.CreateOrUpdateThenPoll(ctx, id, param); err != nil {
+			return fmt.Errorf("updating %s: %+v", id, err)
+		}
 	}
 
-	d.SetId(id.ID())
 	return resourcePostgreSQLServerKeyRead(d, meta)
 }
 

--- a/internal/services/postgres/postgresql_server_resource.go
+++ b/internal/services/postgres/postgresql_server_resource.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/postgres/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/postgres/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -388,15 +389,17 @@ func resourcePostgreSQLServerCreate(d *pluginsdk.ResourceData, meta interface{})
 	defer cancel()
 
 	id := servers.NewServerID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
-	existing, err := client.Get(ctx, id)
-	if err != nil {
-		if !response.WasNotFound(existing.HttpResponse) {
-			return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+	if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+		existing, err := client.Get(ctx, id)
+		if err != nil {
+			if !response.WasNotFound(existing.HttpResponse) {
+				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+			}
 		}
-	}
 
-	if !response.WasNotFound(existing.HttpResponse) {
-		return tf.ImportAsExistsError("azurerm_postgresql_server", id.ID())
+		if !response.WasNotFound(existing.HttpResponse) {
+			return tf.ImportAsExistsError("azurerm_postgresql_server", id.ID())
+		}
 	}
 
 	mode := servers.CreateMode(d.Get("create_mode").(string))
@@ -516,9 +519,10 @@ func resourcePostgreSQLServerCreate(d *pluginsdk.ResourceData, meta interface{})
 		Tags:       tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
 
-	if err = client.CreateThenPoll(ctx, id, server); err != nil {
+	if err = client.CreateCallbackThenPoll(ctx, id, server, sdk.SetIDCallback(meta, &id, d)); err != nil {
 		return fmt.Errorf("creating %s: %+v", id, err)
 	}
+	d.SetId(id.ID())
 
 	log.Printf("[DEBUG] Waiting for %s to become available", id)
 	stateConf := &pluginsdk.StateChangeConf{
@@ -532,8 +536,6 @@ func resourcePostgreSQLServerCreate(d *pluginsdk.ResourceData, meta interface{})
 	if _, err = stateConf.WaitForStateContext(ctx); err != nil {
 		return fmt.Errorf("waiting for %s to become available: %+v", id, err)
 	}
-
-	d.SetId(id.ID())
 
 	if v, ok := d.GetOk("threat_detection_policy"); ok {
 		securityAlertId := serversecurityalertpolicies.NewServerID(id.SubscriptionId, id.ResourceGroupName, id.ServerName)

--- a/internal/services/postgres/postgresql_virtual_network_rule_resource.go
+++ b/internal/services/postgres/postgresql_virtual_network_rule_resource.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/virtualnetworkrules"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	networkValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/postgres/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -81,16 +82,19 @@ func resourcePostgreSQLVirtualNetworkRuleCreateUpdate(d *pluginsdk.ResourceData,
 	defer cancel()
 
 	id := virtualnetworkrules.NewVirtualNetworkRuleID(subscriptionId, d.Get("resource_group_name").(string), d.Get("server_name").(string), d.Get("name").(string))
-	if d.IsNewResource() {
-		existing, err := client.Get(ctx, id)
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
-			}
-		}
 
-		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError("azurerm_postgresql_virtual_network_rule", id.ID())
+	if d.IsNewResource() {
+		if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+			existing, err := client.Get(ctx, id)
+			if err != nil {
+				if !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+				}
+			}
+
+			if !response.WasNotFound(existing.HttpResponse) {
+				return tf.ImportAsExistsError("azurerm_postgresql_virtual_network_rule", id.ID())
+			}
 		}
 	}
 
@@ -101,11 +105,19 @@ func resourcePostgreSQLVirtualNetworkRuleCreateUpdate(d *pluginsdk.ResourceData,
 		},
 	}
 
-	if err := client.CreateOrUpdateThenPoll(ctx, id, parameters); err != nil {
-		return fmt.Errorf("creating %s: %+v", id, err)
+	if d.IsNewResource() {
+		if err := client.CreateOrUpdateCallbackThenPoll(ctx, id, parameters, sdk.SetIDCallback(meta, &id, d)); err != nil {
+			return fmt.Errorf("creating %s: %+v", id, err)
+		}
+		d.SetId(id.ID())
+	} else {
+		if err := client.CreateOrUpdateThenPoll(ctx, id, parameters); err != nil {
+			return fmt.Errorf("updating %s: %+v", id, err)
+		}
 	}
 
 	// Wait for the provisioning state to become ready
+	// TODO: check whether this can be removed now that this resource uses `go-azure-sdk` polling methods
 	log.Printf("[DEBUG] Waiting for %s to become ready", id)
 	stateConf := &pluginsdk.StateChangeConf{
 		Pending:                   []string{"Initializing", "InProgress", "Unknown", "ResponseNotFound"},
@@ -125,7 +137,6 @@ func resourcePostgreSQLVirtualNetworkRuleCreateUpdate(d *pluginsdk.ResourceData,
 		return fmt.Errorf("waiting for %s to be created or updated: %+v", id, err)
 	}
 
-	d.SetId(id.ID())
 	return resourcePostgreSQLVirtualNetworkRuleRead(d, meta)
 }
 

--- a/internal/services/powerbi/powerbi_embedded_resource.go
+++ b/internal/services/powerbi/powerbi_embedded_resource.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/powerbi/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -107,14 +108,17 @@ func resourcePowerBIEmbeddedCreate(d *pluginsdk.ResourceData, meta interface{}) 
 	defer cancel()
 
 	id := capacities.NewCapacityID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
-	existing, err := client.GetDetails(ctx, id)
-	if err != nil {
-		if !response.WasNotFound(existing.HttpResponse) {
-			return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+
+	if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+		existing, err := client.GetDetails(ctx, id)
+		if err != nil {
+			if !response.WasNotFound(existing.HttpResponse) {
+				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+			}
 		}
-	}
-	if !response.WasNotFound(existing.HttpResponse) {
-		return tf.ImportAsExistsError("azurerm_powerbi_embedded", id.ID())
+		if !response.WasNotFound(existing.HttpResponse) {
+			return tf.ImportAsExistsError("azurerm_powerbi_embedded", id.ID())
+		}
 	}
 
 	administrators := d.Get("administrators").(*pluginsdk.Set).List()
@@ -134,11 +138,11 @@ func resourcePowerBIEmbeddedCreate(d *pluginsdk.ResourceData, meta interface{}) 
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
 
-	if err := client.CreateThenPoll(ctx, id, parameters); err != nil {
+	if err := client.CreateCallbackThenPoll(ctx, id, parameters, sdk.SetIDCallback(meta, &id, d)); err != nil {
 		return fmt.Errorf("creating %s: %+v", id, err)
 	}
-
 	d.SetId(id.ID())
+
 	return resourcePowerBIEmbeddedRead(d, meta)
 }
 

--- a/internal/services/privatedns/private_dns_a_record_resource.go
+++ b/internal/services/privatedns/private_dns_a_record_resource.go
@@ -108,15 +108,17 @@ func resourcePrivateDnsARecordCreateUpdate(d *pluginsdk.ResourceData, meta inter
 
 	id := privatedns.NewRecordTypeID(subscriptionId, d.Get("resource_group_name").(string), d.Get("zone_name").(string), privatedns.RecordTypeA, d.Get("name").(string))
 	if d.IsNewResource() {
-		existing, err := client.RecordSetsGet(ctx, id)
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+		if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+			existing, err := client.RecordSetsGet(ctx, id)
+			if err != nil {
+				if !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+				}
 			}
-		}
 
-		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError("azurerm_private_dns_a_record", id.ID())
+			if !response.WasNotFound(existing.HttpResponse) {
+				return tf.ImportAsExistsError("azurerm_private_dns_a_record", id.ID())
+			}
 		}
 	}
 
@@ -137,9 +139,11 @@ func resourcePrivateDnsARecordCreateUpdate(d *pluginsdk.ResourceData, meta inter
 		return fmt.Errorf("creating/updating %s: %+v", id, err)
 	}
 
-	d.SetId(id.ID())
-	if err := pluginsdk.SetResourceIdentityData(d, &id); err != nil {
-		return err
+	if d.IsNewResource() {
+		d.SetId(id.ID())
+		if err := pluginsdk.SetResourceIdentityData(d, &id); err != nil {
+			return err
+		}
 	}
 
 	return resourcePrivateDnsARecordRead(d, meta)

--- a/internal/services/privatedns/private_dns_aaaa_record_resource.go
+++ b/internal/services/privatedns/private_dns_aaaa_record_resource.go
@@ -92,16 +92,19 @@ func resourcePrivateDnsAaaaRecordCreateUpdate(d *pluginsdk.ResourceData, meta in
 	defer cancel()
 
 	id := privatedns.NewRecordTypeID(subscriptionId, d.Get("resource_group_name").(string), d.Get("zone_name").(string), privatedns.RecordTypeAAAA, d.Get("name").(string))
-	if d.IsNewResource() {
-		existing, err := client.RecordSetsGet(ctx, id)
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
-			}
-		}
 
-		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError("azurerm_private_dns_aaaa_record", id.ID())
+	if d.IsNewResource() {
+		if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+			existing, err := client.RecordSetsGet(ctx, id)
+			if err != nil {
+				if !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+				}
+			}
+
+			if !response.WasNotFound(existing.HttpResponse) {
+				return tf.ImportAsExistsError("azurerm_private_dns_aaaa_record", id.ID())
+			}
 		}
 	}
 
@@ -122,7 +125,10 @@ func resourcePrivateDnsAaaaRecordCreateUpdate(d *pluginsdk.ResourceData, meta in
 		return fmt.Errorf("creating/updating %s: %+v", id, err)
 	}
 
-	d.SetId(id.ID())
+	if d.IsNewResource() {
+		d.SetId(id.ID())
+	}
+
 	return resourcePrivateDnsAaaaRecordRead(d, meta)
 }
 

--- a/internal/services/privatedns/private_dns_cname_record_resource.go
+++ b/internal/services/privatedns/private_dns_cname_record_resource.go
@@ -109,16 +109,19 @@ func resourcePrivateDnsCNameRecordCreateUpdate(d *pluginsdk.ResourceData, meta i
 	defer cancel()
 
 	id := privatedns.NewRecordTypeID(subscriptionId, d.Get("resource_group_name").(string), d.Get("zone_name").(string), privatedns.RecordTypeCNAME, d.Get("name").(string))
-	if d.IsNewResource() {
-		existing, err := client.RecordSetsGet(ctx, id)
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
-			}
-		}
 
-		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError(azurePrivateDnsCNameRecordResourceName, id.ID())
+	if d.IsNewResource() {
+		if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+			existing, err := client.RecordSetsGet(ctx, id)
+			if err != nil {
+				if !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+				}
+			}
+
+			if !response.WasNotFound(existing.HttpResponse) {
+				return tf.ImportAsExistsError(azurePrivateDnsCNameRecordResourceName, id.ID())
+			}
 		}
 	}
 
@@ -141,9 +144,11 @@ func resourcePrivateDnsCNameRecordCreateUpdate(d *pluginsdk.ResourceData, meta i
 		return fmt.Errorf("creating/updating %s: %+v", id, err)
 	}
 
-	d.SetId(id.ID())
-	if err := pluginsdk.SetResourceIdentityData(d, &id); err != nil {
-		return err
+	if d.IsNewResource() {
+		d.SetId(id.ID())
+		if err := pluginsdk.SetResourceIdentityData(d, &id); err != nil {
+			return err
+		}
 	}
 
 	return resourcePrivateDnsCNameRecordRead(d, meta)

--- a/internal/services/privatedns/private_dns_mx_record_resource.go
+++ b/internal/services/privatedns/private_dns_mx_record_resource.go
@@ -114,15 +114,17 @@ func resourcePrivateDnsMxRecordCreateUpdate(d *pluginsdk.ResourceData, meta inte
 
 	id := privatedns.NewRecordTypeID(subscriptionId, d.Get("resource_group_name").(string), d.Get("zone_name").(string), privatedns.RecordTypeMX, d.Get("name").(string))
 	if d.IsNewResource() {
-		existing, err := client.RecordSetsGet(ctx, id)
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+		if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+			existing, err := client.RecordSetsGet(ctx, id)
+			if err != nil {
+				if !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+				}
 			}
-		}
 
-		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError("azurerm_private_dns_mx_record", id.ID())
+			if !response.WasNotFound(existing.HttpResponse) {
+				return tf.ImportAsExistsError("azurerm_private_dns_mx_record", id.ID())
+			}
 		}
 	}
 
@@ -143,7 +145,10 @@ func resourcePrivateDnsMxRecordCreateUpdate(d *pluginsdk.ResourceData, meta inte
 		return fmt.Errorf("creating/updating %s: %+v", id, err)
 	}
 
-	d.SetId(id.ID())
+	if d.IsNewResource() {
+		d.SetId(id.ID())
+	}
+
 	return resourcePrivateDnsMxRecordRead(d, meta)
 }
 

--- a/internal/services/privatedns/private_dns_ptr_record_resource.go
+++ b/internal/services/privatedns/private_dns_ptr_record_resource.go
@@ -98,15 +98,17 @@ func resourcePrivateDnsPtrRecordCreateUpdate(d *pluginsdk.ResourceData, meta int
 
 	id := privatedns.NewRecordTypeID(subscriptionId, d.Get("resource_group_name").(string), d.Get("zone_name").(string), privatedns.RecordTypePTR, d.Get("name").(string))
 	if d.IsNewResource() {
-		existing, err := client.RecordSetsGet(ctx, id)
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+		if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+			existing, err := client.RecordSetsGet(ctx, id)
+			if err != nil {
+				if !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+				}
 			}
-		}
 
-		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError("azurerm_private_dns_ptr_record", id.ID())
+			if !response.WasNotFound(existing.HttpResponse) {
+				return tf.ImportAsExistsError("azurerm_private_dns_ptr_record", id.ID())
+			}
 		}
 	}
 
@@ -127,7 +129,10 @@ func resourcePrivateDnsPtrRecordCreateUpdate(d *pluginsdk.ResourceData, meta int
 		return fmt.Errorf("creating/updating %s: %+v", id, err)
 	}
 
-	d.SetId(id.ID())
+	if d.IsNewResource() {
+		d.SetId(id.ID())
+	}
+
 	return resourcePrivateDnsPtrRecordRead(d, meta)
 }
 

--- a/internal/services/privatedns/private_dns_srv_record_resource.go
+++ b/internal/services/privatedns/private_dns_srv_record_resource.go
@@ -124,15 +124,17 @@ func resourcePrivateDnsSrvRecordCreateUpdate(d *pluginsdk.ResourceData, meta int
 
 	id := privatedns.NewRecordTypeID(subscriptionId, d.Get("resource_group_name").(string), d.Get("zone_name").(string), privatedns.RecordTypeSRV, d.Get("name").(string))
 	if d.IsNewResource() {
-		existing, err := client.RecordSetsGet(ctx, id)
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for presence of %s: %+v", id, err)
+		if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+			existing, err := client.RecordSetsGet(ctx, id)
+			if err != nil {
+				if !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for presence of %s: %+v", id, err)
+				}
 			}
-		}
 
-		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError("azurerm_private_dns_srv_record", id.ID())
+			if !response.WasNotFound(existing.HttpResponse) {
+				return tf.ImportAsExistsError("azurerm_private_dns_srv_record", id.ID())
+			}
 		}
 	}
 
@@ -153,7 +155,10 @@ func resourcePrivateDnsSrvRecordCreateUpdate(d *pluginsdk.ResourceData, meta int
 		return fmt.Errorf("creating/updating %s: %+v", id, err)
 	}
 
-	d.SetId(id.ID())
+	if d.IsNewResource() {
+		d.SetId(id.ID())
+	}
+
 	return resourcePrivateDnsSrvRecordRead(d, meta)
 }
 

--- a/internal/services/privatedns/private_dns_txt_record_resource.go
+++ b/internal/services/privatedns/private_dns_txt_record_resource.go
@@ -105,15 +105,17 @@ func resourcePrivateDnsTxtRecordCreateUpdate(d *pluginsdk.ResourceData, meta int
 
 	id := privatedns.NewRecordTypeID(subscriptionId, d.Get("resource_group_name").(string), d.Get("zone_name").(string), privatedns.RecordTypeTXT, d.Get("name").(string))
 	if d.IsNewResource() {
-		existing, err := client.RecordSetsGet(ctx, id)
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for presence of %s: %+v", id, err)
+		if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+			existing, err := client.RecordSetsGet(ctx, id)
+			if err != nil {
+				if !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for presence of %s: %+v", id, err)
+				}
 			}
-		}
 
-		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError("azurerm_private_dns_txt_record", id.ID())
+			if !response.WasNotFound(existing.HttpResponse) {
+				return tf.ImportAsExistsError("azurerm_private_dns_txt_record", id.ID())
+			}
 		}
 	}
 
@@ -135,7 +137,10 @@ func resourcePrivateDnsTxtRecordCreateUpdate(d *pluginsdk.ResourceData, meta int
 		return fmt.Errorf("creating/updating %s: %+v", id, err)
 	}
 
-	d.SetId(id.ID())
+	if d.IsNewResource() {
+		d.SetId(id.ID())
+	}
+
 	return resourcePrivateDnsTxtRecordRead(d, meta)
 }
 

--- a/internal/services/privatedns/private_dns_zone_resource.go
+++ b/internal/services/privatedns/private_dns_zone_resource.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/privatedns/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -168,15 +169,17 @@ func resourcePrivateDnsZoneCreateUpdate(d *pluginsdk.ResourceData, meta interfac
 
 	id := privatezones.NewPrivateDnsZoneID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 	if d.IsNewResource() {
-		existing, err := client.Get(ctx, id)
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+		if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+			existing, err := client.Get(ctx, id)
+			if err != nil {
+				if !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+				}
 			}
-		}
 
-		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError(privateDnsZoneResourceName, id.ID())
+			if !response.WasNotFound(existing.HttpResponse) {
+				return tf.ImportAsExistsError(privateDnsZoneResourceName, id.ID())
+			}
 		}
 	}
 
@@ -190,8 +193,18 @@ func resourcePrivateDnsZoneCreateUpdate(d *pluginsdk.ResourceData, meta interfac
 		IfNoneMatch: pointer.To(""),
 	}
 
-	if err := client.CreateOrUpdateThenPoll(ctx, id, parameters, options); err != nil {
-		return fmt.Errorf("creating/updating %s: %s", id, err)
+	if d.IsNewResource() {
+		if err := client.CreateOrUpdateCallbackThenPoll(ctx, id, parameters, options, sdk.SetIDAndIdentityCallback(meta, &id, d)); err != nil {
+			return fmt.Errorf("creating %s: %s", id, err)
+		}
+		d.SetId(id.ID())
+		if err := pluginsdk.SetResourceIdentityData(d, &id); err != nil {
+			return err
+		}
+	} else {
+		if err := client.CreateOrUpdateThenPoll(ctx, id, parameters, options); err != nil {
+			return fmt.Errorf("updating %s: %s", id, err)
+		}
 	}
 
 	if v, ok := d.GetOk("soa_record"); ok {
@@ -220,11 +233,6 @@ func resourcePrivateDnsZoneCreateUpdate(d *pluginsdk.ResourceData, meta interfac
 		if _, err := recordSetsClient.RecordSetsCreateOrUpdate(ctx, recordId, rsParameters, createOptions); err != nil {
 			return fmt.Errorf("creating/updating %s: %s", recordId, err)
 		}
-	}
-
-	d.SetId(id.ID())
-	if err := pluginsdk.SetResourceIdentityData(d, &id); err != nil {
-		return err
 	}
 
 	return resourcePrivateDnsZoneRead(d, meta)

--- a/internal/services/privatedns/private_dns_zone_virtual_network_link_resource.go
+++ b/internal/services/privatedns/private_dns_zone_virtual_network_link_resource.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -99,15 +100,17 @@ func resourcePrivateDnsZoneVirtualNetworkLinkCreateUpdate(d *pluginsdk.ResourceD
 
 	id := virtualnetworklinks.NewVirtualNetworkLinkID(subscriptionId, d.Get("resource_group_name").(string), d.Get("private_dns_zone_name").(string), d.Get("name").(string))
 	if d.IsNewResource() {
-		existing, err := client.Get(ctx, id)
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for presence of existing %s: %s", id, err)
+		if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+			existing, err := client.Get(ctx, id)
+			if err != nil {
+				if !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for presence of existing %s: %s", id, err)
+				}
 			}
-		}
 
-		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError("azurerm_private_dns_zone_virtual_network_link", id.ID())
+			if !response.WasNotFound(existing.HttpResponse) {
+				return tf.ImportAsExistsError("azurerm_private_dns_zone_virtual_network_link", id.ID())
+			}
 		}
 	}
 
@@ -131,13 +134,18 @@ func resourcePrivateDnsZoneVirtualNetworkLinkCreateUpdate(d *pluginsdk.ResourceD
 		IfNoneMatch: pointer.To(""),
 	}
 
-	if err := client.CreateOrUpdateThenPoll(ctx, id, parameters, options); err != nil {
-		return fmt.Errorf("creating/updating %s: %+v", id, err)
-	}
-
-	d.SetId(id.ID())
-	if err := pluginsdk.SetResourceIdentityData(d, &id); err != nil {
-		return err
+	if d.IsNewResource() {
+		if err := client.CreateOrUpdateCallbackThenPoll(ctx, id, parameters, options, sdk.SetIDAndIdentityCallback(meta, &id, d)); err != nil {
+			return fmt.Errorf("creating %s: %+v", id, err)
+		}
+		d.SetId(id.ID())
+		if err := pluginsdk.SetResourceIdentityData(d, &id); err != nil {
+			return err
+		}
+	} else {
+		if err := client.CreateOrUpdateThenPoll(ctx, id, parameters, options); err != nil {
+			return fmt.Errorf("updating %s: %+v", id, err)
+		}
 	}
 
 	return resourcePrivateDnsZoneVirtualNetworkLinkRead(d, meta)

--- a/internal/services/privatednsresolver/private_dns_resolver_dns_forwarding_ruleset_resource.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_dns_forwarding_ruleset_resource.go
@@ -84,13 +84,16 @@ func (r PrivateDNSResolverDnsForwardingRulesetResource) Create() sdk.ResourceFun
 			client := metadata.Client.PrivateDnsResolver.DnsForwardingRulesetsClient
 			subscriptionId := metadata.Client.Account.SubscriptionId
 			id := dnsforwardingrulesets.NewDnsForwardingRulesetID(subscriptionId, model.ResourceGroupName, model.Name)
-			existing, err := client.Get(ctx, id)
-			if err != nil && !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for existing %s: %+v", id, err)
-			}
 
-			if !response.WasNotFound(existing.HttpResponse) {
-				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+			if !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				existing, err := client.Get(ctx, id)
+				if err != nil && !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for existing %s: %+v", id, err)
+				}
+
+				if !response.WasNotFound(existing.HttpResponse) {
+					return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				}
 			}
 
 			properties := &dnsforwardingrulesets.DnsForwardingRuleset{
@@ -105,11 +108,11 @@ func (r PrivateDNSResolverDnsForwardingRulesetResource) Create() sdk.ResourceFun
 				properties.Properties.DnsResolverOutboundEndpoints = *dnsResolverOutboundEndpointsValue
 			}
 
-			if err := client.CreateOrUpdateThenPoll(ctx, id, *properties, dnsforwardingrulesets.CreateOrUpdateOperationOptions{}); err != nil {
+			if err := client.CreateOrUpdateCallbackThenPoll(ctx, id, *properties, dnsforwardingrulesets.CreateOrUpdateOperationOptions{}, metadata.SetIDCallback(&id)); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
-
 			metadata.SetID(id)
+
 			return nil
 		},
 	}

--- a/internal/services/privatednsresolver/private_dns_resolver_forwarding_rule_resource.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_forwarding_rule_resource.go
@@ -124,13 +124,16 @@ func (r PrivateDNSResolverForwardingRuleResource) Create() sdk.ResourceFunc {
 			}
 
 			id := forwardingrules.NewForwardingRuleID(dnsForwardingRulesetId.SubscriptionId, dnsForwardingRulesetId.ResourceGroupName, dnsForwardingRulesetId.DnsForwardingRulesetName, model.Name)
-			existing, err := client.Get(ctx, id)
-			if err != nil && !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for existing %s: %+v", id, err)
-			}
 
-			if !response.WasNotFound(existing.HttpResponse) {
-				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+			if !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				existing, err := client.Get(ctx, id)
+				if err != nil && !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for existing %s: %+v", id, err)
+				}
+
+				if !response.WasNotFound(existing.HttpResponse) {
+					return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				}
 			}
 
 			forwardingRuleState := forwardingrules.ForwardingRuleStateEnabled

--- a/internal/services/privatednsresolver/private_dns_resolver_inbound_endpoint_resource.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_inbound_endpoint_resource.go
@@ -124,13 +124,16 @@ func (r PrivateDNSResolverInboundEndpointResource) Create() sdk.ResourceFunc {
 			}
 
 			id := inboundendpoints.NewInboundEndpointID(dnsResolverId.SubscriptionId, dnsResolverId.ResourceGroupName, dnsResolverId.DnsResolverName, model.Name)
-			existing, err := client.Get(ctx, id)
-			if err != nil && !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for existing %s: %+v", id, err)
-			}
 
-			if !response.WasNotFound(existing.HttpResponse) {
-				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+			if !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				existing, err := client.Get(ctx, id)
+				if err != nil && !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for existing %s: %+v", id, err)
+				}
+
+				if !response.WasNotFound(existing.HttpResponse) {
+					return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				}
 			}
 
 			properties := &inboundendpoints.InboundEndpoint{
@@ -148,11 +151,11 @@ func (r PrivateDNSResolverInboundEndpointResource) Create() sdk.ResourceFunc {
 				properties.Properties.IPConfigurations = *iPConfigurationsValue
 			}
 
-			if err := client.CreateOrUpdateThenPoll(ctx, id, *properties, inboundendpoints.CreateOrUpdateOperationOptions{}); err != nil {
+			if err := client.CreateOrUpdateCallbackThenPoll(ctx, id, *properties, inboundendpoints.CreateOrUpdateOperationOptions{}, metadata.SetIDCallback(&id)); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
-
 			metadata.SetID(id)
+
 			return nil
 		},
 	}

--- a/internal/services/privatednsresolver/private_dns_resolver_outbound_endpoint_resource.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_outbound_endpoint_resource.go
@@ -93,13 +93,16 @@ func (r PrivateDNSResolverOutboundEndpointResource) Create() sdk.ResourceFunc {
 			}
 
 			id := outboundendpoints.NewOutboundEndpointID(dnsResolverId.SubscriptionId, dnsResolverId.ResourceGroupName, dnsResolverId.DnsResolverName, model.Name)
-			existing, err := client.Get(ctx, id)
-			if err != nil && !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for existing %s: %+v", id, err)
-			}
 
-			if !response.WasNotFound(existing.HttpResponse) {
-				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+			if !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				existing, err := client.Get(ctx, id)
+				if err != nil && !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for existing %s: %+v", id, err)
+				}
+
+				if !response.WasNotFound(existing.HttpResponse) {
+					return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				}
 			}
 
 			properties := &outboundendpoints.OutboundEndpoint{
@@ -112,11 +115,11 @@ func (r PrivateDNSResolverOutboundEndpointResource) Create() sdk.ResourceFunc {
 				Tags: &model.Tags,
 			}
 
-			if err := client.CreateOrUpdateThenPoll(ctx, id, *properties, outboundendpoints.CreateOrUpdateOperationOptions{}); err != nil {
+			if err := client.CreateOrUpdateCallbackThenPoll(ctx, id, *properties, outboundendpoints.CreateOrUpdateOperationOptions{}, metadata.SetIDCallback(&id)); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
-
 			metadata.SetID(id)
+
 			return nil
 		},
 	}

--- a/internal/services/privatednsresolver/private_dns_resolver_resource.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_resource.go
@@ -82,13 +82,16 @@ func (r PrivateDNSResolverDnsResolverResource) Create() sdk.ResourceFunc {
 			client := metadata.Client.PrivateDnsResolver.DnsResolversClient
 			subscriptionId := metadata.Client.Account.SubscriptionId
 			id := dnsresolvers.NewDnsResolverID(subscriptionId, model.ResourceGroupName, model.Name)
-			existing, err := client.Get(ctx, id)
-			if err != nil && !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for existing %s: %+v", id, err)
-			}
 
-			if !response.WasNotFound(existing.HttpResponse) {
-				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+			if !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				existing, err := client.Get(ctx, id)
+				if err != nil && !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for existing %s: %+v", id, err)
+				}
+
+				if !response.WasNotFound(existing.HttpResponse) {
+					return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				}
 			}
 
 			properties := &dnsresolvers.DnsResolver{
@@ -101,11 +104,11 @@ func (r PrivateDNSResolverDnsResolverResource) Create() sdk.ResourceFunc {
 				Tags: &model.Tags,
 			}
 
-			if err := client.CreateOrUpdateThenPoll(ctx, id, *properties, dnsresolvers.CreateOrUpdateOperationOptions{}); err != nil {
+			if err := client.CreateOrUpdateCallbackThenPoll(ctx, id, *properties, dnsresolvers.CreateOrUpdateOperationOptions{}, metadata.SetIDCallback(&id)); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
-
 			metadata.SetID(id)
+
 			return nil
 		},
 	}

--- a/internal/services/privatednsresolver/private_dns_resolver_virtual_network_link_resource.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_virtual_network_link_resource.go
@@ -93,13 +93,16 @@ func (r PrivateDNSResolverVirtualNetworkLinkResource) Create() sdk.ResourceFunc 
 			}
 
 			id := virtualnetworklinks.NewVirtualNetworkLinkID(dnsForwardingRulesetId.SubscriptionId, dnsForwardingRulesetId.ResourceGroupName, dnsForwardingRulesetId.DnsForwardingRulesetName, model.Name)
-			existing, err := client.Get(ctx, id)
-			if err != nil && !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for existing %s: %+v", id, err)
-			}
 
-			if !response.WasNotFound(existing.HttpResponse) {
-				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+			if !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				existing, err := client.Get(ctx, id)
+				if err != nil && !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for existing %s: %+v", id, err)
+				}
+
+				if !response.WasNotFound(existing.HttpResponse) {
+					return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				}
 			}
 
 			properties := &virtualnetworklinks.VirtualNetworkLink{
@@ -111,11 +114,11 @@ func (r PrivateDNSResolverVirtualNetworkLinkResource) Create() sdk.ResourceFunc 
 				},
 			}
 
-			if err := client.CreateOrUpdateThenPoll(ctx, id, *properties, virtualnetworklinks.CreateOrUpdateOperationOptions{}); err != nil {
+			if err := client.CreateOrUpdateCallbackThenPoll(ctx, id, *properties, virtualnetworklinks.CreateOrUpdateOperationOptions{}, metadata.SetIDCallback(&id)); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
-
 			metadata.SetID(id)
+
 			return nil
 		},
 	}

--- a/internal/services/purview/purview_account_resource.go
+++ b/internal/services/purview/purview_account_resource.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
@@ -148,15 +149,17 @@ func resourcePurviewAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 
 	id := account.NewAccountID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
-	existing, err := client.Get(ctx, id)
-	if err != nil {
-		if !response.WasNotFound(existing.HttpResponse) {
-			return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+	if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+		existing, err := client.Get(ctx, id)
+		if err != nil {
+			if !response.WasNotFound(existing.HttpResponse) {
+				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+			}
 		}
-	}
 
-	if !response.WasNotFound(existing.HttpResponse) {
-		return tf.ImportAsExistsError("azurerm_purview_account", id.ID())
+		if !response.WasNotFound(existing.HttpResponse) {
+			return tf.ImportAsExistsError("azurerm_purview_account", id.ID())
+		}
 	}
 
 	purviewAccount := account.Account{
@@ -187,11 +190,11 @@ func resourcePurviewAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 		purviewAccount.Properties.ManagedEventHubState = pointer.To(account.ManagedEventHubStateDisabled)
 	}
 
-	if err := client.CreateOrUpdateThenPoll(ctx, id, purviewAccount); err != nil {
+	if err := client.CreateOrUpdateCallbackThenPoll(ctx, id, purviewAccount, sdk.SetIDCallback(meta, &id, d)); err != nil {
 		return fmt.Errorf("creating %s: %+v", id, err)
 	}
-
 	d.SetId(id.ID())
+
 	return resourcePurviewAccountRead(d, meta)
 }
 

--- a/internal/services/qumulo/qumulo_file_system_resource.go
+++ b/internal/services/qumulo/qumulo_file_system_resource.go
@@ -148,12 +148,14 @@ func (r FileSystemResource) Create() sdk.ResourceFunc {
 
 			id := filesystems.NewFileSystemID(subscriptionId, config.ResourceGroupName, config.Name)
 
-			existing, err := client.Get(ctx, id)
-			if err != nil && !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for the presence of an existing %s: %+v", id, err)
-			}
-			if !response.WasNotFound(existing.HttpResponse) {
-				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+			if !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				existing, err := client.Get(ctx, id)
+				if err != nil && !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for the presence of an existing %s: %+v", id, err)
+				}
+				if !response.WasNotFound(existing.HttpResponse) {
+					return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				}
 			}
 
 			// check the subnet is valid: https://learn.microsoft.com/en-us/azure/partner-solutions/qumulo/qumulo-troubleshoot#you-cant-create-a-resource
@@ -180,11 +182,11 @@ func (r FileSystemResource) Create() sdk.ResourceFunc {
 				},
 			}
 
-			if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
+			if err := client.CreateOrUpdateCallbackThenPoll(ctx, id, payload, metadata.SetIDCallback(&id)); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
-
 			metadata.SetID(id)
+
 			return nil
 		},
 	}

--- a/internal/services/recoveryservices/backup_container_storage_account_resource.go
+++ b/internal/services/recoveryservices/backup_container_storage_account_resource.go
@@ -74,7 +74,8 @@ func resourceBackupProtectionContainerStorageAccountCreate(d *pluginsdk.Resource
 	containerName := fmt.Sprintf("StorageContainer;storage;%s;%s", parsedStorageAccountID.ResourceGroupName, parsedStorageAccountID.StorageAccountName)
 
 	id := protectioncontainers.NewProtectionContainerID(subscriptionId, d.Get("resource_group_name").(string), d.Get("recovery_vault_name").(string), "Azure", containerName)
-	if d.IsNewResource() {
+
+	if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
 		existing, err := client.Get(ctx, id)
 		if err != nil {
 			if !response.WasNotFound(existing.HttpResponse) {

--- a/internal/services/recoveryservices/backup_policy_file_share_resource.go
+++ b/internal/services/recoveryservices/backup_policy_file_share_resource.go
@@ -125,15 +125,17 @@ func resourceBackupProtectionPolicyFileShareCreateUpdate(d *pluginsdk.ResourceDa
 	}
 
 	if d.IsNewResource() {
-		existing, err := client.Get(ctx, id)
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+		if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+			existing, err := client.Get(ctx, id)
+			if err != nil {
+				if !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+				}
 			}
-		}
 
-		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError("azurerm_backup_policy_file_share", id.ID())
+			if !response.WasNotFound(existing.HttpResponse) {
+				return tf.ImportAsExistsError("azurerm_backup_policy_file_share", id.ID())
+			}
 		}
 	}
 

--- a/internal/services/recoveryservices/backup_policy_vm_resource.go
+++ b/internal/services/recoveryservices/backup_policy_vm_resource.go
@@ -121,15 +121,17 @@ func resourceBackupProtectionPolicyVMCreate(d *pluginsdk.ResourceData, meta inte
 	timeOfDay := fmt.Sprintf("%s:00Z", d.Get("backup.0.time").(string))
 	times := append(make([]string, 0), timeOfDay)
 
-	existing, err := client.Get(ctx, id)
-	if err != nil {
-		if !response.WasNotFound(existing.HttpResponse) {
-			return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+	if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+		existing, err := client.Get(ctx, id)
+		if err != nil {
+			if !response.WasNotFound(existing.HttpResponse) {
+				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+			}
 		}
-	}
 
-	if !response.WasNotFound(existing.HttpResponse) {
-		return tf.ImportAsExistsError("azurerm_backup_policy_vm", id.ID())
+		if !response.WasNotFound(existing.HttpResponse) {
+			return tf.ImportAsExistsError("azurerm_backup_policy_vm", id.ID())
+		}
 	}
 
 	// Less than 7 daily backups is no longer supported for create/update

--- a/internal/services/recoveryservices/backup_policy_vm_workload_resource.go
+++ b/internal/services/recoveryservices/backup_policy_vm_workload_resource.go
@@ -428,14 +428,16 @@ func (r BackupProtectionPolicyVMWorkloadResource) Create() sdk.ResourceFunc {
 
 			id := protectionpolicies.NewBackupPolicyID(subscriptionId, model.ResourceGroupName, model.RecoveryVaultName, model.Name)
 
-			existing, err := client.Get(ctx, id)
-			if err != nil {
-				if !response.WasNotFound(existing.HttpResponse) {
-					return fmt.Errorf("checking for existing %s: %+v", id, err)
+			if !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				existing, err := client.Get(ctx, id)
+				if err != nil {
+					if !response.WasNotFound(existing.HttpResponse) {
+						return fmt.Errorf("checking for existing %s: %+v", id, err)
+					}
 				}
-			}
-			if !response.WasNotFound(existing.HttpResponse) {
-				return tf.ImportAsExistsError("azurerm_backup_policy_vm_workload", id.ID())
+				if !response.WasNotFound(existing.HttpResponse) {
+					return tf.ImportAsExistsError("azurerm_backup_policy_vm_workload", id.ID())
+				}
 			}
 
 			protectionPolicy, err := expandBackupProtectionPolicyVMWorkloadProtectionPolicies(model.ProtectionPolicies, model.WorkloadType)

--- a/internal/services/recoveryservices/backup_protected_file_share_resource.go
+++ b/internal/services/recoveryservices/backup_protected_file_share_resource.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+
 	"github.com/Azure/azure-sdk-for-go/services/recoveryservices/mgmt/2021-12-01/backup" // nolint: staticcheck
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
@@ -217,15 +219,17 @@ func resourceBackupProtectedFileShareCreateUpdate(d *pluginsdk.ResourceData, met
 	id := protecteditems.NewProtectedItemID(subscriptionId, d.Get("resource_group_name").(string), d.Get("recovery_vault_name").(string), "Azure", containerName, fileShareSystemName)
 
 	if d.IsNewResource() {
-		existing, err2 := client.Get(ctx, id, protecteditems.GetOperationOptions{})
-		if err2 != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for presence of existing Recovery Service Protected File Share %q (Resource Group %q): %+v", fileShareName, resourceGroup, err2)
+		if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+			existing, err2 := client.Get(ctx, id, protecteditems.GetOperationOptions{})
+			if err2 != nil {
+				if !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for presence of existing Recovery Service Protected File Share %q (Resource Group %q): %+v", fileShareName, resourceGroup, err2)
+				}
 			}
-		}
 
-		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError("azurerm_backup_protected_file_share", id.ID())
+			if !response.WasNotFound(existing.HttpResponse) {
+				return tf.ImportAsExistsError("azurerm_backup_protected_file_share", id.ID())
+			}
 		}
 	}
 
@@ -238,11 +242,16 @@ func resourceBackupProtectedFileShareCreateUpdate(d *pluginsdk.ResourceData, met
 		},
 	}
 
-	if err := client.CreateOrUpdateThenPoll(ctx, id, item); err != nil {
-		return fmt.Errorf("creating/updating Recovery Service Protected File Share %q (Resource Group %q): %+v", fileShareName, resourceGroup, err)
+	if d.IsNewResource() {
+		if err := client.CreateOrUpdateCallbackThenPoll(ctx, id, item, sdk.SetIDCallback(meta, &id, d)); err != nil {
+			return fmt.Errorf("creating %s: %+v", id, err)
+		}
+		d.SetId(id.ID())
+	} else {
+		if err := client.CreateOrUpdateThenPoll(ctx, id, item); err != nil {
+			return fmt.Errorf("updating %s: %+v", id, err)
+		}
 	}
-
-	d.SetId(id.ID())
 
 	return resourceBackupProtectedFileShareRead(d, meta)
 }

--- a/internal/services/recoveryservices/backup_protected_vm_resource.go
+++ b/internal/services/recoveryservices/backup_protected_vm_resource.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
@@ -119,7 +120,9 @@ func resourceRecoveryServicesBackupProtectedVMCreate(d *pluginsdk.ResourceData, 
 		}
 
 		if !isSoftDeleted {
-			return tf.ImportAsExistsError("azurerm_backup_protected_vm", id.ID())
+			if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				return tf.ImportAsExistsError("azurerm_backup_protected_vm", id.ID())
+			}
 		}
 	}
 
@@ -134,10 +137,9 @@ func resourceRecoveryServicesBackupProtectedVMCreate(d *pluginsdk.ResourceData, 
 		},
 	}
 
-	if err := client.CreateOrUpdateThenPoll(ctx, id, item); err != nil {
+	if err := client.CreateOrUpdateCallbackThenPoll(ctx, id, item, sdk.SetIDCallback(meta, &id, d)); err != nil {
 		return fmt.Errorf("creating %s: %+v", id, err)
 	}
-
 	d.SetId(id.ID())
 
 	// the protection state cannot be set during initial creation.

--- a/internal/services/recoveryservices/recovery_services_vault_resource.go
+++ b/internal/services/recoveryservices/recovery_services_vault_resource.go
@@ -27,6 +27,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -237,20 +238,22 @@ func resourceRecoveryServicesVaultCreate(d *pluginsdk.ResourceData, meta interfa
 	crossRegionRestore := d.Get("cross_region_restore_enabled").(bool)
 
 	if crossRegionRestore && storageMode != string(vaults.StandardTierStorageRedundancyGeoRedundant) {
-		return fmt.Errorf("cannot enable cross region restore when storage mode type is not %s. %s", string(vaults.StandardTierStorageRedundancyGeoRedundant), id.String())
+		return fmt.Errorf("cannot enable cross region restore when storage mode type is not %s. %s", string(vaults.StandardTierStorageRedundancyGeoRedundant), id)
 	}
 
 	location := d.Get("location").(string)
 	t := d.Get("tags").(map[string]interface{})
 
-	existing, err := client.Get(ctx, id)
-	if err != nil {
-		if !response.WasNotFound(existing.HttpResponse) {
-			return fmt.Errorf("checking for presence of existing Recovery Service %s: %+v", id.String(), err)
+	if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+		existing, err := client.Get(ctx, id)
+		if err != nil {
+			if !response.WasNotFound(existing.HttpResponse) {
+				return fmt.Errorf("checking for presence of existing Recovery Service %s: %+v", id, err)
+			}
 		}
-	}
-	if !response.WasNotFound(existing.HttpResponse) {
-		return tf.ImportAsExistsError("azurerm_recovery_services_vault", id.ID())
+		if !response.WasNotFound(existing.HttpResponse) {
+			return tf.ImportAsExistsError("azurerm_recovery_services_vault", id.ID())
+		}
 	}
 
 	expandedIdentity, err := identity.ExpandSystemAndUserAssignedMap(d.Get("identity").([]interface{}))
@@ -322,22 +325,21 @@ func resourceRecoveryServicesVaultCreate(d *pluginsdk.ResourceData, meta interfa
 		}
 	}
 
-	err = client.CreateOrUpdateThenPoll(ctx, id, vault, vaults.DefaultCreateOrUpdateOperationOptions())
-	if err != nil {
-		return fmt.Errorf("creating %s: %+v", id.String(), err)
+	if err := client.CreateOrUpdateCallbackThenPoll(ctx, id, vault, vaults.DefaultCreateOrUpdateOperationOptions(), sdk.SetIDCallback(meta, &id, d)); err != nil {
+		return fmt.Errorf("creating %s: %+v", id, err)
 	}
+	d.SetId(id.ID())
 
 	if requireAdditionalUpdate {
-		err := client.UpdateThenPoll(ctx, id, updatePatch, vaults.DefaultUpdateOperationOptions())
-		if err != nil {
-			return fmt.Errorf("updating Recovery Service %s: %+v, but recovery vault was created, a manually import might be required", id.String(), err)
+		if err := client.UpdateThenPoll(ctx, id, updatePatch, vaults.DefaultUpdateOperationOptions()); err != nil {
+			return fmt.Errorf("creating Recovery Service %s: %+v", id, err)
 		}
 	}
 
 	if !features.FivePointOh() {
 		defaultcfg, err := cfgsClient.Get(ctx, cfgId)
 		if err != nil {
-			return fmt.Errorf("retrieving backup config for %s: %+v", id.String(), err)
+			return fmt.Errorf("retrieving backup config for %s: %+v", id, err)
 		}
 
 		currentSoftDeleteState := backupresourcevaultconfigs.SoftDeleteFeatureStateEnabled
@@ -348,7 +350,7 @@ func resourceRecoveryServicesVaultCreate(d *pluginsdk.ResourceData, meta interfa
 		// Only non-AlwaysOn allows update, otherwise, API will throw `BMSUserErrorSoftDeleteStateAlwaysOn` error
 		if currentSoftDeleteState == backupresourcevaultconfigs.SoftDeleteFeatureStateAlwaysON {
 			if !d.Get("soft_delete_enabled").(bool) {
-				return fmt.Errorf("soft delete is set to AlwaysON for %s due to Azure's secure-by-default policy. `soft_delete_enabled` cannot be set to `false`. For more information, see: https://learn.microsoft.com/en-us/azure/backup/secure-by-default", id.String())
+				return fmt.Errorf("soft delete is set to AlwaysON for %s due to Azure's secure-by-default policy. `soft_delete_enabled` cannot be set to `false`. For more information, see: https://learn.microsoft.com/en-us/azure/backup/secure-by-default", id)
 			}
 		} else {
 			// an update on the vault will reset the vault config to default, so we handle it at last.
@@ -389,7 +391,7 @@ func resourceRecoveryServicesVaultCreate(d *pluginsdk.ResourceData, meta interfa
 			stateConf.Timeout = d.Timeout(pluginsdk.TimeoutCreate)
 
 			if _, err := stateConf.WaitForStateContext(ctx); err != nil {
-				return fmt.Errorf("waiting for on update for Recovery Service %s: %+v", id.String(), err)
+				return fmt.Errorf("waiting for on update for Recovery Service %s: %+v", id, err)
 			}
 		}
 	}
@@ -406,7 +408,6 @@ func resourceRecoveryServicesVaultCreate(d *pluginsdk.ResourceData, meta interfa
 		}
 	}
 
-	d.SetId(id.ID())
 	return resourceRecoveryServicesVaultRead(d, meta)
 }
 
@@ -426,10 +427,10 @@ func resourceRecoveryServicesVaultUpdate(d *pluginsdk.ResourceData, meta interfa
 	}
 	existing, err := client.Get(ctx, id)
 	if err != nil {
-		return fmt.Errorf("checking for presence of existing Recovery Service %s: %+v", id.String(), err)
+		return fmt.Errorf("checking for presence of existing Recovery Service %s: %+v", id, err)
 	}
 	if existing.Model == nil {
-		return fmt.Errorf("checking for presence of existing Recovery Service %s: `model` was nil", id.String())
+		return fmt.Errorf("checking for presence of existing Recovery Service %s: `model` was nil", id)
 	}
 	model := existing.Model
 
@@ -464,7 +465,7 @@ func resourceRecoveryServicesVaultUpdate(d *pluginsdk.ResourceData, meta interfa
 	crossRegionRestore := d.Get("cross_region_restore_enabled").(bool)
 
 	if crossRegionRestore && storageMode != string(vaults.StandardTierStorageRedundancyGeoRedundant) {
-		return fmt.Errorf("cannot enable cross region restore when storage mode type is not %s. %s", string(vaults.StandardTierStorageRedundancyGeoRedundant), id.String())
+		return fmt.Errorf("cannot enable cross region restore when storage mode type is not %s. %s", string(vaults.StandardTierStorageRedundancyGeoRedundant), id)
 	}
 
 	enhanchedSecurityState := backupresourcevaultconfigs.EnhancedSecurityStateEnabled
@@ -495,7 +496,7 @@ func resourceRecoveryServicesVaultUpdate(d *pluginsdk.ResourceData, meta interfa
 
 		err = client.CreateOrUpdateThenPoll(ctx, id, vault, vaults.DefaultCreateOrUpdateOperationOptions())
 		if err != nil {
-			return fmt.Errorf("updating Recovery Service %s: %+v", id.String(), err)
+			return fmt.Errorf("updating Recovery Service %s: %+v", id, err)
 		}
 	}
 
@@ -567,14 +568,14 @@ func resourceRecoveryServicesVaultUpdate(d *pluginsdk.ResourceData, meta interfa
 	if requireAdditionalUpdate {
 		err := client.UpdateThenPoll(ctx, id, additionalUpdatePatch, vaults.DefaultUpdateOperationOptions())
 		if err != nil {
-			return fmt.Errorf("updating Recovery Service %s: %+v, but recovery vault was created, a manually import might be required", id.String(), err)
+			return fmt.Errorf("updating Recovery Service %s: %+v, but recovery vault was created, a manually import might be required", id, err)
 		}
 	}
 
 	if !features.FivePointOh() {
 		defaultcfg, err := cfgsClient.Get(ctx, cfgId)
 		if err != nil {
-			return fmt.Errorf("retrieving backup config for %s: %+v", id.String(), err)
+			return fmt.Errorf("retrieving backup config for %s: %+v", id, err)
 		}
 
 		currentSoftDeleteState := backupresourcevaultconfigs.SoftDeleteFeatureStateEnabled
@@ -585,7 +586,7 @@ func resourceRecoveryServicesVaultUpdate(d *pluginsdk.ResourceData, meta interfa
 		// Only non-AlwaysOn allows update, otherwise, API will throw `BMSUserErrorSoftDeleteStateAlwaysOn` error
 		if currentSoftDeleteState == backupresourcevaultconfigs.SoftDeleteFeatureStateAlwaysON {
 			if !d.Get("soft_delete_enabled").(bool) {
-				return fmt.Errorf("soft delete is set to AlwaysON for %s due to Azure's secure-by-default policy. `soft_delete_enabled` cannot be set to `false`. For more information, see: https://learn.microsoft.com/en-us/azure/backup/secure-by-default", id.String())
+				return fmt.Errorf("soft delete is set to AlwaysON for %s due to Azure's secure-by-default policy. `soft_delete_enabled` cannot be set to `false`. For more information, see: https://learn.microsoft.com/en-us/azure/backup/secure-by-default", id)
 			}
 		} else {
 			// an update on vault will cause the vault config reset to default, so whether the config has change or not, it needs to be updated.
@@ -621,7 +622,7 @@ func resourceRecoveryServicesVaultUpdate(d *pluginsdk.ResourceData, meta interfa
 			stateConf.Timeout = d.Timeout(pluginsdk.TimeoutUpdate)
 
 			if _, err := stateConf.WaitForStateContext(ctx); err != nil {
-				return fmt.Errorf("waiting for on update for Recovery Service %s: %+v", id.String(), err)
+				return fmt.Errorf("waiting for on update for Recovery Service %s: %+v", id, err)
 			}
 		}
 	}
@@ -717,7 +718,7 @@ func resourceRecoveryServicesVaultRead(d *pluginsdk.ResourceData, meta interface
 		vaultSettingsId := replicationvaultsetting.NewReplicationVaultSettingID(id.SubscriptionId, id.ResourceGroupName, id.VaultName, "default")
 		vaultSetting, err := vaultSettingsClient.Get(ctx, vaultSettingsId)
 		if err != nil {
-			return fmt.Errorf("reading Recovery Service Vault Setting %s: %+v", id.String(), err)
+			return fmt.Errorf("reading Recovery Service Vault Setting %s: %+v", id, err)
 		}
 
 		classicVmwareReplicationEnabled := false
@@ -749,7 +750,7 @@ func resourceRecoveryServicesVaultDelete(d *pluginsdk.ResourceData, meta interfa
 	}
 
 	if meta.(*clients.Client).Features.RecoveryService.PurgeProtectedItemsFromVaultOnDestroy {
-		log.Printf("[DEBUG] Purging Protected Items from %s", id.String())
+		log.Printf("[DEBUG] Purging Protected Items from %s", id)
 
 		vaultId := backupprotecteditems.NewVaultID(id.SubscriptionId, id.ResourceGroupName, id.VaultName)
 
@@ -774,9 +775,8 @@ func resourceRecoveryServicesVaultDelete(d *pluginsdk.ResourceData, meta interfa
 		}
 	}
 
-	err = client.DeleteThenPoll(ctx, *id)
-	if err != nil {
-		return fmt.Errorf("deleting %s: %+v", id.String(), err)
+	if err := client.DeleteThenPoll(ctx, *id); err != nil {
+		return fmt.Errorf("deleting %s: %+v", id, err)
 	}
 
 	return nil
@@ -986,13 +986,13 @@ func resourceRecoveryServicesVaultSoftDeleteRefreshFunc(ctx context.Context, cfg
 			if strings.Contains(err.Error(), "ResourceNotYetSynced") {
 				return resp, "syncing", nil
 			}
-			return resp, "error", fmt.Errorf("refreshing Recovery Service Vault Cfg %s: %+v", id.String(), err)
+			return resp, "error", fmt.Errorf("refreshing Recovery Service Vault Cfg %s: %+v", id, err)
 		}
 
 		if resp.Model != nil && resp.Model.Properties != nil && resp.Model.Properties.SoftDeleteFeatureState != nil {
 			return resp.Model, string(*resp.Model.Properties.SoftDeleteFeatureState), nil
 		}
 
-		return resp, "error", fmt.Errorf("refreshing Recovery Service Vault Cfg %s: Properties is nil", id.String())
+		return resp, "error", fmt.Errorf("refreshing Recovery Service Vault Cfg %s: Properties is nil", id)
 	}
 }

--- a/internal/services/recoveryservices/recovery_services_vault_resource_guard_association_resource.go
+++ b/internal/services/recoveryservices/recovery_services_vault_resource_guard_association_resource.go
@@ -79,15 +79,17 @@ func (r VaultGuardProxyResource) Create() sdk.ResourceFunc {
 			name := "VaultProxy"
 			id := resourceguardproxy.NewBackupResourceGuardProxyID(vaultId.SubscriptionId, vaultId.ResourceGroupName, vaultId.VaultName, name)
 
-			existing, err := client.Get(ctx, id)
-			if err != nil {
-				if !response.WasNotFound(existing.HttpResponse) {
-					return fmt.Errorf("checking presence of %s:%+v", id, err)
+			if !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				existing, err := client.Get(ctx, id)
+				if err != nil {
+					if !response.WasNotFound(existing.HttpResponse) {
+						return fmt.Errorf("checking presence of %s:%+v", id, err)
+					}
 				}
-			}
 
-			if !response.WasNotFound(existing.HttpResponse) {
-				return tf.ImportAsExistsError("azurerm_recovery_services_vault_resource_guard_association", id.ID())
+				if !response.WasNotFound(existing.HttpResponse) {
+					return tf.ImportAsExistsError("azurerm_recovery_services_vault_resource_guard_association", id.ID())
+				}
 			}
 
 			proxy := resourceguardproxy.ResourceGuardProxyBaseResource{

--- a/internal/services/recoveryservices/site_recovery_fabric_resource.go
+++ b/internal/services/recoveryservices/site_recovery_fabric_resource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2024-04-01/replicationfabrics"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -69,7 +70,7 @@ func resourceSiteRecoveryFabricCreate(d *pluginsdk.ResourceData, meta interface{
 
 	id := replicationfabrics.NewReplicationFabricID(subscriptionId, resGroup, vaultName, name)
 
-	if d.IsNewResource() {
+	if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
 		existing, err := client.Get(ctx, id, replicationfabrics.DefaultGetOperationOptions())
 		if err != nil {
 			// NOTE: Bad Request due to https://github.com/Azure/azure-rest-api-specs/issues/12759
@@ -91,11 +92,9 @@ func resourceSiteRecoveryFabricCreate(d *pluginsdk.ResourceData, meta interface{
 		},
 	}
 
-	err := client.CreateThenPoll(ctx, id, parameters)
-	if err != nil {
+	if err := client.CreateCallbackThenPoll(ctx, id, parameters, sdk.SetIDCallback(meta, &id, d)); err != nil {
 		return fmt.Errorf("creating site recovery fabric %s (vault %s): %+v", name, vaultName, err)
 	}
-
 	d.SetId(id.ID())
 
 	return resourceSiteRecoveryFabricRead(d, meta)

--- a/internal/services/recoveryservices/site_recovery_hyperv_network_mapping_resource.go
+++ b/internal/services/recoveryservices/site_recovery_hyperv_network_mapping_resource.go
@@ -128,29 +128,32 @@ func (s HyperVNetworkMappingResource) Create() sdk.ResourceFunc {
 			}
 
 			id := replicationnetworkmappings.NewReplicationNetworkMappingID(parsedNetworkId.SubscriptionId, parsedNetworkId.ResourceGroupName, parsedNetworkId.VaultName, parsedNetworkId.ReplicationFabricName, parsedNetworkId.ReplicationNetworkName, plan.Name)
-			existing, err := client.Get(ctx, id)
-			if err != nil {
+			if !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				existing, err := client.Get(ctx, id)
+				if err != nil {
+					if !response.WasNotFound(existing.HttpResponse) {
+						return fmt.Errorf("checking presence of network mapping: %+v", err)
+					}
+				}
+
 				if !response.WasNotFound(existing.HttpResponse) {
-					return fmt.Errorf("checking presence of network mapping: %+v", err)
+					return tf.ImportAsExistsError("azurerm_site_recovery_hyperv_network_mapping", id.ID())
 				}
 			}
 
-			if !response.WasNotFound(existing.HttpResponse) {
-				return tf.ImportAsExistsError("azurerm_site_recovery_hyperv_network_mapping", id.ID())
-			}
-
-			err = client.CreateThenPoll(ctx, id, replicationnetworkmappings.CreateNetworkMappingInput{
+			payload := replicationnetworkmappings.CreateNetworkMappingInput{
 				Properties: replicationnetworkmappings.CreateNetworkMappingInputProperties{
 					RecoveryNetworkId:     plan.TargetNetworkId,
 					RecoveryFabricName:    pointer.To(HyperVNetworkMappingRecoveryFabricName),
 					FabricSpecificDetails: replicationnetworkmappings.VMmToAzureCreateNetworkMappingInput{},
 				},
-			})
-			if err != nil {
-				return fmt.Errorf("creating %s: %+v", id, err)
 			}
 
+			if err = client.CreateCallbackThenPoll(ctx, id, payload, metadata.SetIDCallback(&id)); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
 			metadata.SetID(id)
+
 			return nil
 		},
 	}

--- a/internal/services/recoveryservices/site_recovery_hyperv_replication_policy_association_resource.go
+++ b/internal/services/recoveryservices/site_recovery_hyperv_replication_policy_association_resource.go
@@ -112,7 +112,7 @@ func (h HyperVReplicationPolicyAssociationResource) Create() sdk.ResourceFunc {
 					ProviderSpecificInput:       replicationprotectioncontainermappings.BaseReplicationProviderSpecificContainerMappingInputImpl{},
 				},
 			}
-			if err := client.CreateThenPoll(ctx, id, param); err != nil {
+			if err := client.CreateCallbackThenPoll(ctx, id, param, metadata.SetIDCallback(&id)); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
 

--- a/internal/services/recoveryservices/site_recovery_hyperv_replication_policy_resource.go
+++ b/internal/services/recoveryservices/site_recovery_hyperv_replication_policy_resource.go
@@ -91,16 +91,18 @@ func (r ReplicationPolicyHyperVResource) Create() sdk.ResourceFunc {
 
 			id := replicationpolicies.NewReplicationPolicyID(parsedVaultId.SubscriptionId, parsedVaultId.ResourceGroupName, parsedVaultId.VaultName, plan.Name)
 
-			existing, err := client.Get(ctx, id)
-			if err != nil {
-				// NOTE: Bad Request due to https://github.com/Azure/azure-rest-api-specs/issues/12759
-				if !response.WasNotFound(existing.HttpResponse) && !wasBadRequestWithNotExist(existing.HttpResponse, err) {
-					return fmt.Errorf("checking presence %s: %+v", plan.Name, err)
+			if !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				existing, err := client.Get(ctx, id)
+				if err != nil {
+					// NOTE: Bad Request due to https://github.com/Azure/azure-rest-api-specs/issues/12759
+					if !response.WasNotFound(existing.HttpResponse) && !wasBadRequestWithNotExist(existing.HttpResponse, err) {
+						return fmt.Errorf("checking presence %s: %+v", plan.Name, err)
+					}
 				}
-			}
 
-			if existing.Model != nil {
-				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				if existing.Model != nil {
+					return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				}
 			}
 
 			parameters := replicationpolicies.CreatePolicyInput{
@@ -112,11 +114,9 @@ func (r ReplicationPolicyHyperVResource) Create() sdk.ResourceFunc {
 					},
 				},
 			}
-			err = client.CreateThenPoll(ctx, id, parameters)
-			if err != nil {
+			if err := client.CreateCallbackThenPoll(ctx, id, parameters, metadata.SetIDCallback(&id)); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
-
 			metadata.SetID(id)
 
 			return nil

--- a/internal/services/recoveryservices/site_recovery_network_mapping_resource.go
+++ b/internal/services/recoveryservices/site_recovery_network_mapping_resource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -105,7 +106,7 @@ func resourceSiteRecoveryNetworkMappingCreate(d *pluginsdk.ResourceData, meta in
 
 	id := replicationnetworkmappings.NewReplicationNetworkMappingID(subscriptionId, resGroup, vaultName, fabricName, parsedSourceNetworkId.VirtualNetworkName, name)
 
-	if d.IsNewResource() {
+	if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
 		existing, err := client.Get(ctx, id)
 		if err != nil {
 			if !response.WasNotFound(existing.HttpResponse) && !wasBadRequestWithNotExist(existing.HttpResponse, err) {
@@ -128,11 +129,9 @@ func resourceSiteRecoveryNetworkMappingCreate(d *pluginsdk.ResourceData, meta in
 		},
 	}
 
-	err = client.CreateThenPoll(ctx, id, parameters)
-	if err != nil {
+	if err := client.CreateCallbackThenPoll(ctx, id, parameters, sdk.SetIDCallback(meta, &id, d)); err != nil {
 		return fmt.Errorf("creating site recovery network mapping %s (vault %s): %+v", name, vaultName, err)
 	}
-
 	d.SetId(id.ID())
 
 	return resourceSiteRecoveryNetworkMappingRead(d, meta)

--- a/internal/services/recoveryservices/site_recovery_protection_container_mapping_resource.go
+++ b/internal/services/recoveryservices/site_recovery_protection_container_mapping_resource.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -134,7 +135,7 @@ func resourceSiteRecoveryContainerMappingCreate(d *pluginsdk.ResourceData, meta 
 
 	id := replicationprotectioncontainermappings.NewReplicationProtectionContainerMappingID(subscriptionId, resGroup, vaultName, fabricName, protectionContainerName, name)
 
-	if d.IsNewResource() {
+	if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
 		existing, err := client.Get(ctx, id)
 		if err != nil {
 			if !response.WasNotFound(existing.HttpResponse) {
@@ -165,8 +166,7 @@ func resourceSiteRecoveryContainerMappingCreate(d *pluginsdk.ResourceData, meta 
 		}
 	}
 
-	err := client.CreateThenPoll(ctx, id, parameters)
-	if err != nil {
+	if err := client.CreateCallbackThenPoll(ctx, id, parameters, sdk.SetIDCallback(meta, &id, d)); err != nil {
 		return fmt.Errorf("creating site recovery protection container mapping %s (vault %s): %+v", name, vaultName, err)
 	}
 	d.SetId(id.ID())

--- a/internal/services/recoveryservices/site_recovery_protection_container_resource.go
+++ b/internal/services/recoveryservices/site_recovery_protection_container_resource.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2024-04-01/replicationprotectioncontainers"
@@ -72,7 +74,7 @@ func resourceSiteRecoveryProtectionContainerCreate(d *pluginsdk.ResourceData, me
 
 	id := replicationprotectioncontainers.NewReplicationProtectionContainerID(subscriptionId, resGroup, vaultName, fabricName, name)
 
-	if d.IsNewResource() {
+	if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
 		existing, err := client.Get(ctx, id)
 		if err != nil {
 			if !response.WasNotFound(existing.HttpResponse) {
@@ -89,11 +91,9 @@ func resourceSiteRecoveryProtectionContainerCreate(d *pluginsdk.ResourceData, me
 		Properties: &replicationprotectioncontainers.CreateProtectionContainerInputProperties{},
 	}
 
-	err := client.CreateThenPoll(ctx, id, parameters)
-	if err != nil {
+	if err := client.CreateCallbackThenPoll(ctx, id, parameters, sdk.SetIDCallback(meta, &id, d)); err != nil {
 		return fmt.Errorf("creating site recovery protection container %s (fabric %s): %+v", name, fabricName, err)
 	}
-
 	d.SetId(id.ID())
 
 	return resourceSiteRecoveryProtectionContainerRead(d, meta)

--- a/internal/services/recoveryservices/site_recovery_replicated_vm_resource.go
+++ b/internal/services/recoveryservices/site_recovery_replicated_vm_resource.go
@@ -31,6 +31,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices/validate"
 	resourceParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/resource/parse"
@@ -449,7 +450,7 @@ func resourceSiteRecoveryReplicatedItemCreate(d *pluginsdk.ResourceData, meta in
 
 	id := replicationprotecteditems.NewReplicationProtectedItemID(subscriptionId, resGroup, vaultName, fabricName, sourceProtectionContainerName, name)
 
-	if d.IsNewResource() {
+	if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
 		existing, err := client.Get(ctx, id)
 		if err != nil {
 			if !response.WasNotFound(existing.HttpResponse) {
@@ -509,11 +510,9 @@ func resourceSiteRecoveryReplicatedItemCreate(d *pluginsdk.ResourceData, meta in
 		},
 	}
 
-	err := client.CreateThenPoll(ctx, id, parameters)
-	if err != nil {
+	if err := client.CreateCallbackThenPoll(ctx, id, parameters, sdk.SetIDCallback(meta, &id, d)); err != nil {
 		return fmt.Errorf("creating replicated vm %s (vault %s): %+v", name, vaultName, err)
 	}
-
 	d.SetId(id.ID())
 
 	// We are not allowed to configure the NIC on the initial setup, and the VM has to be replicated before

--- a/internal/services/recoveryservices/site_recovery_replication_policy_resource.go
+++ b/internal/services/recoveryservices/site_recovery_replication_policy_resource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2024-04-01/replicationpolicies"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -82,7 +83,7 @@ func resourceSiteRecoveryReplicationPolicyCreate(d *pluginsdk.ResourceData, meta
 
 	id := replicationpolicies.NewReplicationPolicyID(subscriptionId, resGroup, vaultName, name)
 
-	if d.IsNewResource() {
+	if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
 		existing, err := client.Get(ctx, id)
 		if err != nil {
 			// NOTE: Bad Request due to https://github.com/Azure/azure-rest-api-specs/issues/12759
@@ -110,11 +111,10 @@ func resourceSiteRecoveryReplicationPolicyCreate(d *pluginsdk.ResourceData, meta
 			},
 		},
 	}
-	err := client.CreateThenPoll(ctx, id, parameters)
-	if err != nil {
-		return fmt.Errorf("creating site recovery replication policy %s (vault %s): %+v", name, vaultName, err)
-	}
 
+	if err := client.CreateCallbackThenPoll(ctx, id, parameters, sdk.SetIDCallback(meta, &id, d)); err != nil {
+		return fmt.Errorf("creating %s: %+v", id, err)
+	}
 	d.SetId(id.ID())
 
 	return resourceSiteRecoveryReplicationPolicyRead(d, meta)

--- a/internal/services/recoveryservices/site_recovery_replication_recovery_plan_resource.go
+++ b/internal/services/recoveryservices/site_recovery_replication_recovery_plan_resource.go
@@ -341,16 +341,18 @@ func (r SiteRecoveryReplicationRecoveryPlanResource) Create() sdk.ResourceFunc {
 
 			id := replicationrecoveryplans.NewReplicationRecoveryPlanID(subscriptionId, vaultId.ResourceGroupName, vaultId.VaultName, model.Name)
 
-			existing, err := client.Get(ctx, id)
-			if err != nil {
-				// NOTE: Bad Request due to https://github.com/Azure/azure-rest-api-specs/issues/12759
-				if !response.WasNotFound(existing.HttpResponse) && !response.WasBadRequest(existing.HttpResponse) {
-					return fmt.Errorf("checking for presence of existing site recovery plan %q: %+v", id, err)
+			if !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				existing, err := client.Get(ctx, id)
+				if err != nil {
+					// NOTE: Bad Request due to https://github.com/Azure/azure-rest-api-specs/issues/12759
+					if !response.WasNotFound(existing.HttpResponse) && !response.WasBadRequest(existing.HttpResponse) {
+						return fmt.Errorf("checking for presence of existing site recovery plan %q: %+v", id, err)
+					}
 				}
-			}
 
-			if existing.Model != nil && existing.Model.Id != nil && *existing.Model.Id != "" {
-				return tf.ImportAsExistsError("azurerm_site_recovery_replication_recovery_plan", *existing.Model.Id)
+				if existing.Model != nil && existing.Model.Id != nil && *existing.Model.Id != "" {
+					return tf.ImportAsExistsError("azurerm_site_recovery_replication_recovery_plan", *existing.Model.Id)
+				}
 			}
 
 			// FailoverDeploymentModelClassic is used for other cloud service back up to Azure.
@@ -374,11 +376,9 @@ func (r SiteRecoveryReplicationRecoveryPlanResource) Create() sdk.ResourceFunc {
 				parameters.Properties.ProviderSpecificInput = expandA2ASettings(model.A2ASettings[0])
 			}
 
-			err = client.CreateThenPoll(ctx, id, parameters)
-			if err != nil {
-				return fmt.Errorf("creating site recovery replication plan %q: %+v", id, err)
+			if err := client.CreateCallbackThenPoll(ctx, id, parameters, metadata.SetIDCallback(&id)); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
 			}
-
 			metadata.SetID(id)
 
 			return nil

--- a/internal/services/recoveryservices/site_recovery_services_vault_hyperv_site_resource.go
+++ b/internal/services/recoveryservices/site_recovery_services_vault_hyperv_site_resource.go
@@ -83,12 +83,11 @@ func (r HyperVSiteResource) Create() sdk.ResourceFunc {
 				},
 			}
 
-			err = client.CreateThenPoll(ctx, id, parameters)
-			if err != nil {
+			if err := client.CreateCallbackThenPoll(ctx, id, parameters, metadata.SetIDCallback(&id)); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
-
 			metadata.SetID(id)
+
 			return nil
 		},
 	}

--- a/internal/services/recoveryservices/site_recovery_vmware_replicated_vm_resource.go
+++ b/internal/services/recoveryservices/site_recovery_vmware_replicated_vm_resource.go
@@ -75,15 +75,15 @@ type SiteRecoveryReplicatedVmVMwareModel struct {
 
 type VMWareReplicatedVmResource struct{}
 
-func (s VMWareReplicatedVmResource) ModelObject() interface{} {
+func (r VMWareReplicatedVmResource) ModelObject() interface{} {
 	return &SiteRecoveryReplicatedVmVMwareModel{}
 }
 
-func (s VMWareReplicatedVmResource) ResourceType() string {
+func (r VMWareReplicatedVmResource) ResourceType() string {
 	return "azurerm_site_recovery_vmware_replicated_vm"
 }
 
-func (s VMWareReplicatedVmResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+func (r VMWareReplicatedVmResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
 	return replicationprotecteditems.ValidateReplicationProtectedItemID
 }
 
@@ -92,7 +92,7 @@ var (
 	_ sdk.ResourceWithCustomizeDiff = VMWareReplicatedVmResource{}
 )
 
-func (s VMWareReplicatedVmResource) Arguments() map[string]*pluginsdk.Schema {
+func (r VMWareReplicatedVmResource) Arguments() map[string]*pluginsdk.Schema {
 	return map[string]*pluginsdk.Schema{
 		"name": {
 			Type:         pluginsdk.TypeString,
@@ -277,11 +277,11 @@ func resourceSiteRecoveryVMWareReplicatedVMNetworkInterfaceSchema() *pluginsdk.R
 	}
 }
 
-func (s VMWareReplicatedVmResource) Attributes() map[string]*pluginsdk.Schema {
+func (r VMWareReplicatedVmResource) Attributes() map[string]*pluginsdk.Schema {
 	return map[string]*pluginsdk.Schema{}
 }
 
-func (k VMWareReplicatedVmResource) CustomizeDiff() sdk.ResourceFunc {
+func (r VMWareReplicatedVmResource) CustomizeDiff() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
 			// these fields are not returned by API, and only used in creation.
@@ -318,7 +318,7 @@ func (k VMWareReplicatedVmResource) CustomizeDiff() sdk.ResourceFunc {
 	}
 }
 
-func (s VMWareReplicatedVmResource) Create() sdk.ResourceFunc {
+func (r VMWareReplicatedVmResource) Create() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Timeout: 120 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
@@ -352,10 +352,16 @@ func (s VMWareReplicatedVmResource) Create() sdk.ResourceFunc {
 			id := replicationprotecteditems.NewReplicationProtectedItemID(parsedContainerId.SubscriptionId, parsedContainerId.ResourceGroupName, parsedContainerId.VaultName, parsedContainerId.ReplicationFabricName, parsedContainerId.ReplicationProtectionContainerName, model.Name)
 			fabricId := replicationfabrics.NewReplicationFabricID(parsedContainerId.SubscriptionId, parsedContainerId.ResourceGroupName, parsedContainerId.VaultName, parsedContainerId.ReplicationFabricName)
 
-			existing, err := client.Get(ctx, id)
-			if err != nil {
+			if !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				existing, err := client.Get(ctx, id)
+				if err != nil {
+					if !response.WasNotFound(existing.HttpResponse) {
+						return fmt.Errorf("checking for presence of existing site recovery vmware replicated vm %q: %+v", id, err)
+					}
+				}
+
 				if !response.WasNotFound(existing.HttpResponse) {
-					return fmt.Errorf("checking for presence of existing site recovery vmware replicated vm %q: %+v", id, err)
+					return tf.ImportAsExistsError("azurerm_site_recovery_vmware_replicated_vm", *existing.Model.Id)
 				}
 			}
 
@@ -377,10 +383,6 @@ func (s VMWareReplicatedVmResource) Create() sdk.ResourceFunc {
 			runAsAccountId, err := fetchRunAsAccountsIdBySite(ctx, runAsAccountsClient, siteID, model.PhysicalServerCredentialName, model.ApplianceName)
 			if err != nil {
 				return fmt.Errorf("fetch run as account id %s: %+v", model.PhysicalServerCredentialName, err)
-			}
-
-			if existing.Model != nil {
-				return tf.ImportAsExistsError("azurerm_site_recovery_vmware_replicated_vm", *existing.Model.Id)
 			}
 
 			providerSpecificDetail := replicationprotecteditems.InMageRcmEnableProtectionInput{
@@ -470,17 +472,10 @@ func (s VMWareReplicatedVmResource) Create() sdk.ResourceFunc {
 				},
 			}
 
-			poller, err := client.Create(ctx, id, parameters)
-			if err != nil {
+			if err := client.CreateCallbackThenPoll(ctx, id, parameters, metadata.SetIDCallback(&id)); err != nil {
 				return fmt.Errorf("creating %q: %+v", id, err)
 			}
-			// once the PUT request returned successfully, an item has been created, even if it may fail in the poll process.
 			metadata.SetID(id)
-
-			err = poller.Poller.PollUntilDone(ctx)
-			if err != nil {
-				return fmt.Errorf("polling %q: %+v", id, err)
-			}
 
 			deadline, ok := ctx.Deadline()
 			if !ok {
@@ -544,8 +539,7 @@ func (s VMWareReplicatedVmResource) Create() sdk.ResourceFunc {
 				},
 			}
 
-			err = client.UpdateThenPoll(ctx, id, updateInput)
-			if err != nil {
+			if err := client.UpdateThenPoll(ctx, id, updateInput); err != nil {
 				return fmt.Errorf("creating %q: %+v", id, err)
 			}
 
@@ -554,7 +548,7 @@ func (s VMWareReplicatedVmResource) Create() sdk.ResourceFunc {
 	}
 }
 
-func (s VMWareReplicatedVmResource) Update() sdk.ResourceFunc {
+func (r VMWareReplicatedVmResource) Update() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Timeout: 90 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
@@ -715,7 +709,7 @@ func (s VMWareReplicatedVmResource) Update() sdk.ResourceFunc {
 	}
 }
 
-func (s VMWareReplicatedVmResource) Read() sdk.ResourceFunc {
+func (r VMWareReplicatedVmResource) Read() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Timeout: 5 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
@@ -836,7 +830,7 @@ func (s VMWareReplicatedVmResource) Read() sdk.ResourceFunc {
 	}
 }
 
-func (s VMWareReplicatedVmResource) Delete() sdk.ResourceFunc {
+func (r VMWareReplicatedVmResource) Delete() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Timeout: 90 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {

--- a/internal/services/recoveryservices/site_recovery_vmware_replication_policy_association_resource.go
+++ b/internal/services/recoveryservices/site_recovery_vmware_replication_policy_association_resource.go
@@ -103,15 +103,17 @@ func (s VMWareReplicationPolicyAssociationResource) Create() sdk.ResourceFunc {
 
 			id := replicationprotectioncontainermappings.NewReplicationProtectionContainerMappingID(parsedContainerId.SubscriptionId, parsedContainerId.ResourceGroupName, parsedContainerId.VaultName, parsedContainerId.ReplicationFabricName, parsedContainerId.ReplicationProtectionContainerName, model.Name)
 
-			existing, err := client.Get(ctx, id)
-			if err != nil {
-				if !response.WasNotFound(existing.HttpResponse) {
-					return fmt.Errorf("checking for presence of existing site recovery protection container mapping (%s): %+v", parsedContainerId, err)
+			if !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				existing, err := client.Get(ctx, id)
+				if err != nil {
+					if !response.WasNotFound(existing.HttpResponse) {
+						return fmt.Errorf("checking for presence of existing site recovery protection container mapping (%s): %+v", parsedContainerId, err)
+					}
 				}
-			}
 
-			if existing.Model != nil && existing.Model.Id != nil && *existing.Model.Id != "" {
-				return tf.ImportAsExistsError("azurerm_site_recovery_replication_policy_vmware_association", *existing.Model.Id)
+				if existing.Model != nil && existing.Model.Id != nil && *existing.Model.Id != "" {
+					return tf.ImportAsExistsError("azurerm_site_recovery_replication_policy_vmware_association", *existing.Model.Id)
+				}
 			}
 
 			parameters := replicationprotectioncontainermappings.CreateProtectionContainerMappingInput{
@@ -122,11 +124,9 @@ func (s VMWareReplicationPolicyAssociationResource) Create() sdk.ResourceFunc {
 				},
 			}
 
-			err = client.CreateThenPoll(ctx, id, parameters)
-			if err != nil {
+			if err := client.CreateCallbackThenPoll(ctx, id, parameters, metadata.SetIDCallback(&id)); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
-
 			metadata.SetID(id)
 
 			return nil

--- a/internal/services/recoveryservices/site_recovery_vmware_replication_policy_resource.go
+++ b/internal/services/recoveryservices/site_recovery_vmware_replication_policy_resource.go
@@ -98,16 +98,18 @@ func (r VMWareReplicationPolicyResource) Create() sdk.ResourceFunc {
 
 			client := metadata.Client.RecoveryServices.ReplicationPoliciesClient
 
-			existing, err := client.Get(ctx, id)
-			if err != nil {
-				// NOTE: Bad Request due to https://github.com/Azure/azure-rest-api-specs/issues/12759
-				if !response.WasNotFound(existing.HttpResponse) && !wasBadRequestWithNotExist(existing.HttpResponse, err) {
-					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+			if !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				existing, err := client.Get(ctx, id)
+				if err != nil {
+					// NOTE: Bad Request due to https://github.com/Azure/azure-rest-api-specs/issues/12759
+					if !response.WasNotFound(existing.HttpResponse) && !wasBadRequestWithNotExist(existing.HttpResponse, err) {
+						return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+					}
 				}
-			}
 
-			if !response.WasNotFound(existing.HttpResponse) {
-				return tf.ImportAsExistsError("azurerm_site_recovery_vmware_replication_policy", id.ID())
+				if !response.WasNotFound(existing.HttpResponse) {
+					return tf.ImportAsExistsError("azurerm_site_recovery_vmware_replication_policy", id.ID())
+				}
 			}
 
 			recoveryPoint := plan.RecoveryPointRetentionInMinutes
@@ -127,11 +129,9 @@ func (r VMWareReplicationPolicyResource) Create() sdk.ResourceFunc {
 				},
 			}
 
-			err = client.CreateThenPoll(ctx, id, parameters)
-			if err != nil {
-				return fmt.Errorf("creating %q: %+v", id, err)
+			if err := client.CreateCallbackThenPoll(ctx, id, parameters, metadata.SetIDCallback(&id)); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
 			}
-
 			metadata.SetID(id)
 
 			return nil

--- a/internal/services/redhatopenshift/redhat_openshift_cluster_resource.go
+++ b/internal/services/redhatopenshift/redhat_openshift_cluster_resource.go
@@ -391,15 +391,17 @@ func (r RedHatOpenShiftCluster) Create() sdk.ResourceFunc {
 
 			id := openshiftclusters.NewOpenShiftClusterID(subscriptionId, config.ResourceGroup, config.Name)
 
-			existing, err := client.Get(ctx, id)
-			if err != nil {
-				if !response.WasNotFound(existing.HttpResponse) {
-					return fmt.Errorf("checking for presence of existing %s: %s", id, err)
+			if !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				existing, err := client.Get(ctx, id)
+				if err != nil {
+					if !response.WasNotFound(existing.HttpResponse) {
+						return fmt.Errorf("checking for presence of existing %s: %s", id, err)
+					}
 				}
-			}
 
-			if !response.WasNotFound(existing.HttpResponse) {
-				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				if !response.WasNotFound(existing.HttpResponse) {
+					return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				}
 			}
 
 			parameters := openshiftclusters.OpenShiftCluster{
@@ -417,10 +419,9 @@ func (r RedHatOpenShiftCluster) Create() sdk.ResourceFunc {
 				Tags: pointer.To(config.Tags),
 			}
 
-			if err = client.CreateOrUpdateThenPoll(ctx, id, parameters); err != nil {
+			if err := client.CreateOrUpdateCallbackThenPoll(ctx, id, parameters, metadata.SetIDCallback(&id)); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
-
 			metadata.SetID(id)
 
 			return nil

--- a/internal/services/redis/redis_cache_access_policy_assignment_resource.go
+++ b/internal/services/redis/redis_cache_access_policy_assignment_resource.go
@@ -94,13 +94,15 @@ func (r RedisCacheAccessPolicyAssignmentResource) Create() sdk.ResourceFunc {
 			}
 			id := rediscacheaccesspolicyassignments.NewAccessPolicyAssignmentID(subscriptionId, redisId.ResourceGroupName, redisId.RedisName, model.Name)
 
-			existing, err := client.AccessPolicyAssignmentGet(ctx, id)
-			if err != nil && !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for existing %s: %+v", id, err)
-			}
+			if !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				existing, err := client.AccessPolicyAssignmentGet(ctx, id)
+				if err != nil && !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for existing %s: %+v", id, err)
+				}
 
-			if !response.WasNotFound(existing.HttpResponse) {
-				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				if !response.WasNotFound(existing.HttpResponse) {
+					return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				}
 			}
 
 			createInput := rediscacheaccesspolicyassignments.RedisCacheAccessPolicyAssignment{
@@ -115,11 +117,11 @@ func (r RedisCacheAccessPolicyAssignmentResource) Create() sdk.ResourceFunc {
 			locks.ByID(model.RedisCacheID)
 			defer locks.UnlockByID(model.RedisCacheID)
 
-			if err := client.AccessPolicyAssignmentCreateUpdateThenPoll(ctx, id, createInput); err != nil {
-				return fmt.Errorf("failed to create Redis Cache Access Policy Assignment %s in Redis Cache %s in resource group %s: %s", model.Name, redisId.RedisName, redisId.ResourceGroupName, err)
+			if err := client.AccessPolicyAssignmentCreateUpdateCallbackThenPoll(ctx, id, createInput, metadata.SetIDCallback(&id)); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
 			}
-
 			metadata.SetID(id)
+
 			return nil
 		},
 	}

--- a/internal/services/redis/redis_cache_access_policy_resource.go
+++ b/internal/services/redis/redis_cache_access_policy_resource.go
@@ -78,13 +78,15 @@ func (r RedisCacheAccessPolicyResource) Create() sdk.ResourceFunc {
 			}
 			id := rediscacheaccesspolicies.NewAccessPolicyID(subscriptionId, redisId.ResourceGroupName, redisId.RedisName, model.Name)
 
-			existing, err := client.AccessPolicyGet(ctx, id)
-			if err != nil && !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for existing %s: %+v", id, err)
-			}
+			if !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				existing, err := client.AccessPolicyGet(ctx, id)
+				if err != nil && !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for existing %s: %+v", id, err)
+				}
 
-			if !response.WasNotFound(existing.HttpResponse) {
-				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				if !response.WasNotFound(existing.HttpResponse) {
+					return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				}
 			}
 
 			policyTypeCustom := rediscacheaccesspolicies.AccessPolicyTypeCustom
@@ -100,11 +102,11 @@ func (r RedisCacheAccessPolicyResource) Create() sdk.ResourceFunc {
 			locks.ByID(model.RedisCacheID)
 			defer locks.UnlockByID(model.RedisCacheID)
 
-			if err := client.AccessPolicyCreateUpdateThenPoll(ctx, id, createInput); err != nil {
-				return fmt.Errorf("failed to create Redis Cache Access Policy %s in Redis Cache %s in resource group %s: %s", model.Name, redisId.RedisName, redisId.ResourceGroupName, err)
+			if err := client.AccessPolicyCreateUpdateCallbackThenPoll(ctx, id, createInput, metadata.SetIDCallback(&id)); err != nil {
+				return fmt.Errorf("creating %s: %s", id, err)
 			}
-
 			metadata.SetID(id)
+
 			return nil
 		},
 	}

--- a/internal/services/redis/redis_cache_resource.go
+++ b/internal/services/redis/redis_cache_resource.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/redis/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/redis/validate"
@@ -445,14 +446,17 @@ func resourceRedisCacheCreate(d *pluginsdk.ResourceData, meta interface{}) error
 	defer cancel()
 
 	id := redisresources.NewRediID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
-	existing, err := client.RedisGet(ctx, id)
-	if err != nil {
-		if !response.WasNotFound(existing.HttpResponse) {
-			return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+
+	if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+		existing, err := client.RedisGet(ctx, id)
+		if err != nil {
+			if !response.WasNotFound(existing.HttpResponse) {
+				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+			}
 		}
-	}
-	if !response.WasNotFound(existing.HttpResponse) {
-		return tf.ImportAsExistsError("azurerm_redis_cache", id.ID())
+		if !response.WasNotFound(existing.HttpResponse) {
+			return tf.ImportAsExistsError("azurerm_redis_cache", id.ID())
+		}
 	}
 
 	patchSchedule := expandRedisPatchSchedule(d)
@@ -537,10 +541,15 @@ func resourceRedisCacheCreate(d *pluginsdk.ResourceData, meta interface{}) error
 		}
 	}
 
-	if err := client.RedisCreateThenPoll(ctx, id, parameters); err != nil {
+	if err := client.RedisCreateCallbackThenPoll(ctx, id, parameters, sdk.SetIDCallback(meta, &id, d)); err != nil {
 		return fmt.Errorf("creating %s: %+v", id, err)
 	}
+	d.SetId(id.ID())
+	if err := pluginsdk.SetResourceIdentityData(d, &id); err != nil {
+		return err
+	}
 
+	// TODO: is this still required now that this is using polling methods from `go-azure-sdk`?
 	log.Printf("[DEBUG] Waiting for %s to become available", id)
 	deadline, ok := ctx.Deadline()
 	if !ok {
@@ -555,11 +564,6 @@ func resourceRedisCacheCreate(d *pluginsdk.ResourceData, meta interface{}) error
 	}
 	if _, err = stateConf.WaitForStateContext(ctx); err != nil {
 		return fmt.Errorf("waiting for %s to become available: %+v", id, err)
-	}
-
-	d.SetId(id.ID())
-	if err := pluginsdk.SetResourceIdentityData(d, &id); err != nil {
-		return err
 	}
 
 	if patchSchedule != nil {

--- a/internal/services/redis/redis_firewall_rule_resource.go
+++ b/internal/services/redis/redis_firewall_rule_resource.go
@@ -93,15 +93,18 @@ func resourceRedisFirewallRuleCreateUpdate(d *pluginsdk.ResourceData, meta inter
 	defer cancel()
 
 	id := redisfirewallrules.NewFirewallRuleID(subscriptionId, d.Get("resource_group_name").(string), d.Get("redis_cache_name").(string), d.Get("name").(string))
+
 	if d.IsNewResource() {
-		existing, err := client.FirewallRulesGet(ctx, id)
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+		if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+			existing, err := client.FirewallRulesGet(ctx, id)
+			if err != nil {
+				if !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+				}
 			}
-		}
-		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError("azurerm_redis_firewall_rule", id.ID())
+			if !response.WasNotFound(existing.HttpResponse) {
+				return tf.ImportAsExistsError("azurerm_redis_firewall_rule", id.ID())
+			}
 		}
 	}
 
@@ -113,12 +116,14 @@ func resourceRedisFirewallRuleCreateUpdate(d *pluginsdk.ResourceData, meta inter
 	}
 
 	if _, err := client.FirewallRulesCreateOrUpdate(ctx, id, payload); err != nil {
-		return fmt.Errorf("creating %s: %+v", id, err)
+		return fmt.Errorf("creating/updating %s: %+v", id, err)
 	}
 
-	d.SetId(id.ID())
-	if err := pluginsdk.SetResourceIdentityData(d, &id); err != nil {
-		return err
+	if d.IsNewResource() {
+		d.SetId(id.ID())
+		if err := pluginsdk.SetResourceIdentityData(d, &id); err != nil {
+			return err
+		}
 	}
 
 	return resourceRedisFirewallRuleRead(d, meta)

--- a/internal/services/redis/redis_linked_server_resource.go
+++ b/internal/services/redis/redis_linked_server_resource.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/redis/2024-11-01/linkedserver"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/redis/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -102,7 +103,8 @@ func resourceRedisLinkedServerCreate(d *pluginsdk.ResourceData, meta interface{}
 
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	id := linkedserver.NewLinkedServerID(subscriptionId, d.Get("resource_group_name").(string), d.Get("target_redis_cache_name").(string), cacheId.RedisName)
-	if d.IsNewResource() {
+
+	if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
 		existing, err := client.Get(ctx, id)
 		if err != nil {
 			if !response.WasNotFound(existing.HttpResponse) {
@@ -122,10 +124,12 @@ func resourceRedisLinkedServerCreate(d *pluginsdk.ResourceData, meta interface{}
 		},
 	}
 
-	if err := client.CreateThenPoll(ctx, id, payload); err != nil {
+	if err := client.CreateCallbackThenPoll(ctx, id, payload, sdk.SetIDCallback(meta, &id, d)); err != nil {
 		return fmt.Errorf("creating %s: %+v", id, err)
 	}
+	d.SetId(id.ID())
 
+	// TODO: is this still required now that this is using polling methods from `go-azure-sdk`?
 	deadline, ok := ctx.Deadline()
 	if !ok {
 		return fmt.Errorf("internal-error: context had no deadline")
@@ -142,7 +146,6 @@ func resourceRedisLinkedServerCreate(d *pluginsdk.ResourceData, meta interface{}
 		return fmt.Errorf("waiting for %s to become available: %+v", id, err)
 	}
 
-	d.SetId(id.ID())
 	return resourceRedisLinkedServerRead(d, meta)
 }
 

--- a/internal/services/redisenterprise/redis_enterprise_cluster_resource.go
+++ b/internal/services/redisenterprise/redis_enterprise_cluster_resource.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/redisenterprise/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/redisenterprise/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -112,7 +113,7 @@ func resourceRedisEnterpriseClusterCreate(d *pluginsdk.ResourceData, meta interf
 	defer cancel()
 
 	id := redisenterprise.NewRedisEnterpriseID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
-	if d.IsNewResource() {
+	if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
 		existing, err := client.Get(ctx, id)
 		if err != nil {
 			if !response.WasNotFound(existing.HttpResponse) {
@@ -156,10 +157,12 @@ func resourceRedisEnterpriseClusterCreate(d *pluginsdk.ResourceData, meta interf
 		}
 	}
 
-	if err := client.CreateThenPoll(ctx, id, parameters); err != nil {
-		return fmt.Errorf("waiting for creation of %s: %+v", id, err)
+	if err := client.CreateCallbackThenPoll(ctx, id, parameters, sdk.SetIDCallback(meta, &id, d)); err != nil {
+		return fmt.Errorf("creating %s: %+v", id, err)
 	}
+	d.SetId(id.ID())
 
+	// TODO: is this still required now that this is using polling methods from `go-azure-sdk`?
 	log.Printf("[DEBUG] Waiting for %s to become available..", id)
 	stateConf := &pluginsdk.StateChangeConf{
 		Pending:    []string{"Creating", "Updating", "Enabling", "Deleting", "Disabling"},
@@ -172,7 +175,6 @@ func resourceRedisEnterpriseClusterCreate(d *pluginsdk.ResourceData, meta interf
 		return fmt.Errorf("waiting for %s to become available: %+v", id, err)
 	}
 
-	d.SetId(id.ID())
 	return resourceRedisEnterpriseClusterRead(d, meta)
 }
 

--- a/internal/services/redisenterprise/redis_enterprise_database_resource.go
+++ b/internal/services/redisenterprise/redis_enterprise_database_resource.go
@@ -233,7 +233,8 @@ func resourceRedisEnterpriseDatabaseCreate(d *pluginsdk.ResourceData, meta inter
 	}
 
 	id := databases.NewDatabaseID(subscriptionId, clusterId.ResourceGroupName, clusterId.RedisEnterpriseName, d.Get("name").(string))
-	if d.IsNewResource() {
+
+	if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
 		existing, err := client.Get(ctx, id)
 		if err != nil {
 			if !response.WasNotFound(existing.HttpResponse) {
@@ -302,11 +303,12 @@ func resourceRedisEnterpriseDatabaseCreate(d *pluginsdk.ResourceData, meta inter
 		return fmt.Errorf("creating %s: %+v", id, err)
 	}
 
+	d.SetId(id.ID())
+
 	if err := future.Poller.PollUntilDone(ctx); err != nil {
 		return fmt.Errorf("waiting for creation of %s: %+v", id, err)
 	}
 
-	d.SetId(id.ID())
 	return resourceRedisEnterpriseDatabaseRead(d, meta)
 }
 

--- a/internal/services/relay/relay_hybrid_connection_authorization_rule_resource.go
+++ b/internal/services/relay/relay_hybrid_connection_authorization_rule_resource.go
@@ -70,15 +70,18 @@ func resourceRelayHybridConnectionAuthorizationRuleCreateUpdate(d *pluginsdk.Res
 	defer cancel()
 
 	resourceId := hybridconnections.NewHybridConnectionAuthorizationRuleID(subscriptionId, d.Get("resource_group_name").(string), d.Get("namespace_name").(string), d.Get("hybrid_connection_name").(string), d.Get("name").(string))
+
 	if d.IsNewResource() {
-		existing, err := client.GetAuthorizationRule(ctx, resourceId)
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for presence of existing %s: %+v", resourceId, err)
+		if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+			existing, err := client.GetAuthorizationRule(ctx, resourceId)
+			if err != nil {
+				if !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", resourceId, err)
+				}
 			}
-		}
-		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError("azurerm_relay_hybrid_connection_authorization_rule", resourceId.ID())
+			if !response.WasNotFound(existing.HttpResponse) {
+				return tf.ImportAsExistsError("azurerm_relay_hybrid_connection_authorization_rule", resourceId.ID())
+			}
 		}
 	}
 
@@ -93,7 +96,9 @@ func resourceRelayHybridConnectionAuthorizationRuleCreateUpdate(d *pluginsdk.Res
 		return fmt.Errorf("creating/updating %s: %+v", resourceId, err)
 	}
 
-	d.SetId(resourceId.ID())
+	if d.IsNewResource() {
+		d.SetId(resourceId.ID())
+	}
 
 	return resourceRelayHybridConnectionAuthorizationRuleRead(d, meta)
 }

--- a/internal/services/relay/relay_hybrid_connection_resource.go
+++ b/internal/services/relay/relay_hybrid_connection_resource.go
@@ -76,16 +76,19 @@ func resourceArmRelayHybridConnectionCreateUpdate(d *pluginsdk.ResourceData, met
 	defer cancel()
 
 	id := hybridconnections.NewHybridConnectionID(subscriptionId, d.Get("resource_group_name").(string), d.Get("relay_namespace_name").(string), d.Get("name").(string))
-	if d.IsNewResource() {
-		existing, err := client.Get(ctx, id)
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
-			}
-		}
 
-		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError("azurerm_relay_hybrid_connection", id.ID())
+	if d.IsNewResource() {
+		if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+			existing, err := client.Get(ctx, id)
+			if err != nil {
+				if !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+				}
+			}
+
+			if !response.WasNotFound(existing.HttpResponse) {
+				return tf.ImportAsExistsError("azurerm_relay_hybrid_connection", id.ID())
+			}
 		}
 	}
 
@@ -103,7 +106,10 @@ func resourceArmRelayHybridConnectionCreateUpdate(d *pluginsdk.ResourceData, met
 		return fmt.Errorf("creating/updating %s: %+v", id, err)
 	}
 
-	d.SetId(id.ID())
+	if d.IsNewResource() {
+		d.SetId(id.ID())
+	}
+
 	return resourceArmRelayHybridConnectionRead(d, meta)
 }
 

--- a/internal/services/relay/relay_namespace_authorization_rule_resource.go
+++ b/internal/services/relay/relay_namespace_authorization_rule_resource.go
@@ -64,15 +64,18 @@ func resourceRelayNamespaceAuthorizationRuleCreateUpdate(d *pluginsdk.ResourceDa
 	defer cancel()
 
 	resourceId := namespaces.NewAuthorizationRuleID(subscriptionId, d.Get("resource_group_name").(string), d.Get("namespace_name").(string), d.Get("name").(string))
+
 	if d.IsNewResource() {
-		existing, err := client.GetAuthorizationRule(ctx, resourceId)
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for presence of existing %s: %+v", resourceId, err)
+		if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+			existing, err := client.GetAuthorizationRule(ctx, resourceId)
+			if err != nil {
+				if !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", resourceId, err)
+				}
 			}
-		}
-		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError("azurerm_relay_namespace_authorization_rule", resourceId.ID())
+			if !response.WasNotFound(existing.HttpResponse) {
+				return tf.ImportAsExistsError("azurerm_relay_namespace_authorization_rule", resourceId.ID())
+			}
 		}
 	}
 
@@ -87,7 +90,9 @@ func resourceRelayNamespaceAuthorizationRuleCreateUpdate(d *pluginsdk.ResourceDa
 		return fmt.Errorf("creating/updating %s: %+v", resourceId, err)
 	}
 
-	d.SetId(resourceId.ID())
+	if d.IsNewResource() {
+		d.SetId(resourceId.ID())
+	}
 
 	return resourceRelayNamespaceAuthorizationRuleRead(d, meta)
 }

--- a/internal/services/relay/relay_namespace_resource.go
+++ b/internal/services/relay/relay_namespace_resource.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/relay/2021-11-01/namespaces"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
@@ -100,16 +101,19 @@ func resourceRelayNamespaceCreateUpdate(d *pluginsdk.ResourceData, meta interfac
 	defer cancel()
 
 	id := namespaces.NewNamespaceID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
-	if d.IsNewResource() {
-		existing, err := client.Get(ctx, id)
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
-			}
-		}
 
-		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError("azurerm_relay_namespace", id.ID())
+	if d.IsNewResource() {
+		if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+			existing, err := client.Get(ctx, id)
+			if err != nil {
+				if !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+				}
+			}
+
+			if !response.WasNotFound(existing.HttpResponse) {
+				return tf.ImportAsExistsError("azurerm_relay_namespace", id.ID())
+			}
 		}
 	}
 
@@ -124,11 +128,20 @@ func resourceRelayNamespaceCreateUpdate(d *pluginsdk.ResourceData, meta interfac
 		Tags:       tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
 
-	if err := client.CreateOrUpdateThenPoll(ctx, id, parameters); err != nil {
-		return fmt.Errorf("creating/updating %s: %+v", id, err)
+	if d.IsNewResource() {
+		if err := client.CreateOrUpdateCallbackThenPoll(ctx, id, parameters, sdk.SetIDCallback(meta, &id, d)); err != nil {
+			return fmt.Errorf("creating %s: %+v", id, err)
+		}
+	} else {
+		if err := client.CreateOrUpdateThenPoll(ctx, id, parameters); err != nil {
+			return fmt.Errorf("updating %s: %+v", id, err)
+		}
 	}
 
-	d.SetId(id.ID())
+	if d.IsNewResource() {
+		d.SetId(id.ID())
+	}
+
 	return resourceRelayNamespaceRead(d, meta)
 }
 

--- a/internal/services/resource/management_group_template_deployment_resource.go
+++ b/internal/services/resource/management_group_template_deployment_resource.go
@@ -124,14 +124,16 @@ func managementGroupTemplateDeploymentResourceCreate(d *pluginsdk.ResourceData, 
 
 	id := parse.NewManagementGroupTemplateDeploymentID(managementGroupId.Name, d.Get("name").(string))
 
-	existing, err := client.GetAtManagementGroupScope(ctx, id.ManagementGroupName, id.DeploymentName)
-	if err != nil {
-		if !utils.ResponseWasNotFound(existing.Response) {
-			return fmt.Errorf("checking for presence of existing Management Group Template Deployment %q: %+v", id.DeploymentName, err)
+	if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+		existing, err := client.GetAtManagementGroupScope(ctx, id.ManagementGroupName, id.DeploymentName)
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("checking for presence of existing Management Group Template Deployment %q: %+v", id.DeploymentName, err)
+			}
 		}
-	}
-	if existing.Properties != nil {
-		return tf.ImportAsExistsError("azurerm_management_group_template_deployment", id.ID())
+		if existing.Properties != nil {
+			return tf.ImportAsExistsError("azurerm_management_group_template_deployment", id.ID())
+		}
 	}
 
 	deployment := resources.ScopedDeployment{
@@ -177,12 +179,13 @@ func managementGroupTemplateDeploymentResourceCreate(d *pluginsdk.ResourceData, 
 		return fmt.Errorf("creating Management Group Template Deployment %q: %+v", id.DeploymentName, err)
 	}
 
+	d.SetId(id.ID())
+
 	log.Printf("[DEBUG] Waiting for deployment of Management Group Template Deployment %q..", id.DeploymentName)
 	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
 		return fmt.Errorf("waiting for creation of Management Group Template Deployment %q: %+v", id.DeploymentName, err)
 	}
 
-	d.SetId(id.ID())
 	return managementGroupTemplateDeploymentResourceRead(d, meta)
 }
 

--- a/internal/services/resource/management_lock_resource.go
+++ b/internal/services/resource/management_lock_resource.go
@@ -76,7 +76,8 @@ func resourceManagementLockCreate(d *pluginsdk.ResourceData, meta interface{}) e
 	defer cancel()
 
 	id := managementlocks.NewScopedLockID(d.Get("scope").(string), d.Get("name").(string))
-	if d.IsNewResource() {
+
+	if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
 		existing, err := client.GetByScope(ctx, id)
 		if err != nil {
 			if !response.WasNotFound(existing.HttpResponse) {

--- a/internal/services/resource/resource_deployment_script_azure_cli_resource.go
+++ b/internal/services/resource/resource_deployment_script_azure_cli_resource.go
@@ -55,13 +55,16 @@ func (r ResourceDeploymentScriptAzureCliResource) Create() sdk.ResourceFunc {
 			client := metadata.Client.Resource.DeploymentScriptsClient
 			subscriptionId := metadata.Client.Account.SubscriptionId
 			id := deploymentscripts.NewDeploymentScriptID(subscriptionId, model.ResourceGroupName, model.Name)
-			existing, err := client.Get(ctx, id)
-			if err != nil && !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for existing %s: %+v", id, err)
-			}
 
-			if !response.WasNotFound(existing.HttpResponse) {
-				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+			if !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				existing, err := client.Get(ctx, id)
+				if err != nil && !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for existing %s: %+v", id, err)
+				}
+
+				if !response.WasNotFound(existing.HttpResponse) {
+					return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				}
 			}
 
 			properties := &deploymentscripts.AzureCliScript{
@@ -110,11 +113,11 @@ func (r ResourceDeploymentScriptAzureCliResource) Create() sdk.ResourceFunc {
 				properties.Tags = &model.Tags
 			}
 
-			if err := client.CreateThenPoll(ctx, id, *properties); err != nil {
+			if err := client.CreateCallbackThenPoll(ctx, id, *properties, metadata.SetIDCallback(&id)); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
-
 			metadata.SetID(id)
+
 			return nil
 		},
 	}

--- a/internal/services/resource/resource_deployment_script_azure_power_shell_resource.go
+++ b/internal/services/resource/resource_deployment_script_azure_power_shell_resource.go
@@ -55,13 +55,16 @@ func (r ResourceDeploymentScriptAzurePowerShellResource) Create() sdk.ResourceFu
 			client := metadata.Client.Resource.DeploymentScriptsClient
 			subscriptionId := metadata.Client.Account.SubscriptionId
 			id := deploymentscripts.NewDeploymentScriptID(subscriptionId, model.ResourceGroupName, model.Name)
-			existing, err := client.Get(ctx, id)
-			if err != nil && !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for existing %s: %+v", id, err)
-			}
 
-			if !response.WasNotFound(existing.HttpResponse) {
-				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+			if !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				existing, err := client.Get(ctx, id)
+				if err != nil && !response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("checking for existing %s: %+v", id, err)
+				}
+
+				if !response.WasNotFound(existing.HttpResponse) {
+					return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				}
 			}
 
 			properties := &deploymentscripts.AzurePowerShellScript{
@@ -110,11 +113,11 @@ func (r ResourceDeploymentScriptAzurePowerShellResource) Create() sdk.ResourceFu
 				properties.Tags = &model.Tags
 			}
 
-			if err := client.CreateThenPoll(ctx, id, *properties); err != nil {
+			if err := client.CreateCallbackThenPoll(ctx, id, *properties, metadata.SetIDCallback(&id)); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
-
 			metadata.SetID(id)
+
 			return nil
 		},
 	}

--- a/internal/services/resource/resource_group_resource.go
+++ b/internal/services/resource/resource_group_resource.go
@@ -72,15 +72,17 @@ func resourceResourceGroupCreate(d *pluginsdk.ResourceData, meta interface{}) er
 
 	id := commonids.NewResourceGroupID(meta.(*clients.Client).Account.SubscriptionId, d.Get("name").(string))
 
-	existing, err := client.Get(ctx, id)
-	if err != nil {
-		if !response.WasNotFound(existing.HttpResponse) {
-			return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+	if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+		existing, err := client.Get(ctx, id)
+		if err != nil {
+			if !response.WasNotFound(existing.HttpResponse) {
+				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+			}
 		}
-	}
 
-	if !response.WasNotFound(existing.HttpResponse) {
-		return tf.ImportAsExistsError(resourceGroupResourceName, id.ID())
+		if !response.WasNotFound(existing.HttpResponse) {
+			return tf.ImportAsExistsError(resourceGroupResourceName, id.ID())
+		}
 	}
 
 	parameters := resourcegroups.ResourceGroup{
@@ -99,7 +101,7 @@ func resourceResourceGroupCreate(d *pluginsdk.ResourceData, meta interface{}) er
 	// custom poller to account for replication delays in the eventual consistency responses of newly created RG resources
 	pollerType := custompollers.NewResourceGroupCreatePoller(client, id)
 	poller := pollers.NewPoller(pollerType, 10*time.Second, pollers.DefaultNumberOfDroppedConnectionsToAllow)
-	if err = poller.PollUntilDone(ctx); err != nil {
+	if err := poller.PollUntilDone(ctx); err != nil {
 		return err
 	}
 

--- a/internal/services/resource/resource_group_template_deployment_resource.go
+++ b/internal/services/resource/resource_group_template_deployment_resource.go
@@ -145,14 +145,17 @@ func resourceGroupTemplateDeploymentResourceCreate(d *pluginsdk.ResourceData, me
 
 	id := parse.NewResourceGroupTemplateDeploymentID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
-	existing, err := client.Get(ctx, id.ResourceGroup, id.DeploymentName)
-	if err != nil {
-		if !utils.ResponseWasNotFound(existing.Response) {
-			return fmt.Errorf("checking for presence of existing Template Deployment %q (Resource Group %q): %+v", id.ResourceGroup, id.DeploymentName, err)
+	if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+		existing, err := client.Get(ctx, id.ResourceGroup, id.DeploymentName)
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("checking for presence of existing Template Deployment %q (Resource Group %q): %+v", id.ResourceGroup, id.DeploymentName, err)
+			}
 		}
-	}
-	if existing.Properties != nil {
-		return tf.ImportAsExistsError("azurerm_resource_group_template_deployment", id.ID())
+
+		if !utils.ResponseWasNotFound(existing.Response) {
+			return tf.ImportAsExistsError("azurerm_resource_group_template_deployment", id.ID())
+		}
 	}
 
 	deployment := resources.Deployment{
@@ -197,12 +200,13 @@ func resourceGroupTemplateDeploymentResourceCreate(d *pluginsdk.ResourceData, me
 		return fmt.Errorf("creating Template Deployment %q (Resource Group %q): %+v", id.DeploymentName, id.ResourceGroup, err)
 	}
 
+	d.SetId(id.ID())
+
 	log.Printf("[DEBUG] Waiting for deployment of Template Deployment %q (Resource Group %q)..", id.DeploymentName, id.ResourceGroup)
 	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
 		return fmt.Errorf("waiting for creation of Template Deployment %q (Resource Group %q): %+v", id.DeploymentName, id.ResourceGroup, err)
 	}
 
-	d.SetId(id.ID())
 	return resourceGroupTemplateDeploymentResourceRead(d, meta)
 }
 

--- a/internal/services/resource/resource_management_private_link_association_resource.go
+++ b/internal/services/resource/resource_management_private_link_association_resource.go
@@ -107,14 +107,16 @@ func (r ResourceManagementPrivateLinkAssociationResource) Create() sdk.ResourceF
 
 			id := privatelinkassociation.NewPrivateLinkAssociationID(managementGroupId.GroupId, name)
 
-			existing, err := client.Get(ctx, id)
-			if err != nil {
-				if !response.WasNotFound(existing.HttpResponse) {
-					return fmt.Errorf("checking for the presence of an existing %s: %+v", id, err)
+			if !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				existing, err := client.Get(ctx, id)
+				if err != nil {
+					if !response.WasNotFound(existing.HttpResponse) {
+						return fmt.Errorf("checking for the presence of an existing %s: %+v", id, err)
+					}
 				}
-			}
-			if !response.WasNotFound(existing.HttpResponse) {
-				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				if !response.WasNotFound(existing.HttpResponse) {
+					return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				}
 			}
 
 			payload := privatelinkassociation.PrivateLinkAssociationObject{

--- a/internal/services/resource/resource_management_private_link_resource.go
+++ b/internal/services/resource/resource_management_private_link_resource.go
@@ -72,14 +72,16 @@ func (r ResourceManagementPrivateLinkResource) Create() sdk.ResourceFunc {
 
 			id := resourcemanagementprivatelink.NewResourceManagementPrivateLinkID(subscriptionId, config.ResourceGroupName, config.Name)
 
-			existing, err := client.Get(ctx, id)
-			if err != nil {
-				if !response.WasNotFound(existing.HttpResponse) {
-					return fmt.Errorf("checking for the presence of an existing %s: %+v", id, err)
+			if !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				existing, err := client.Get(ctx, id)
+				if err != nil {
+					if !response.WasNotFound(existing.HttpResponse) {
+						return fmt.Errorf("checking for the presence of an existing %s: %+v", id, err)
+					}
 				}
-			}
-			if !response.WasNotFound(existing.HttpResponse) {
-				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				if !response.WasNotFound(existing.HttpResponse) {
+					return metadata.ResourceRequiresImport(r.ResourceType(), id)
+				}
 			}
 
 			payload := resourcemanagementprivatelink.ResourceManagementPrivateLinkLocation{

--- a/internal/services/resource/resource_provider_feature_registration_resource.go
+++ b/internal/services/resource/resource_provider_feature_registration_resource.go
@@ -95,8 +95,10 @@ func (r ResourceProviderFeatureRegistrationResource) Create() sdk.ResourceFunc {
 				return fmt.Errorf("retrieving %s: `registrationState` was nil", featureId)
 			}
 
-			if strings.EqualFold(registrationState, Registered) {
-				return metadata.ResourceRequiresImport(r.ResourceType(), featureId)
+			if !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				if strings.EqualFold(registrationState, Registered) {
+					return metadata.ResourceRequiresImport(r.ResourceType(), featureId)
+				}
 			}
 
 			if strings.EqualFold(registrationState, Pending) {
@@ -114,14 +116,18 @@ func (r ResourceProviderFeatureRegistrationResource) Create() sdk.ResourceFunc {
 				}
 			}
 
+			metadata.SetID(featureId)
+			if err := pluginsdk.SetResourceIdentityData(metadata.ResourceData, &featureId); err != nil {
+				return err
+			}
+
 			pollerType := custompollers.NewResourceProviderFeatureRegistrationPoller(client, featureId, Registered)
 			poller := pollers.NewPoller(pollerType, 10*time.Second, pollers.DefaultNumberOfDroppedConnectionsToAllow)
 			if err := poller.PollUntilDone(ctx); err != nil {
 				return fmt.Errorf("waiting for registration of %s: %+v", featureId, err)
 			}
 
-			metadata.SetID(featureId)
-			return pluginsdk.SetResourceIdentityData(metadata.ResourceData, &featureId)
+			return nil
 		},
 
 		Timeout: 30 * time.Minute,

--- a/internal/services/resource/resource_provider_registration_resource.go
+++ b/internal/services/resource/resource_provider_registration_resource.go
@@ -124,8 +124,11 @@ func (r ResourceProviderRegistrationResource) Create() sdk.ResourceFunc {
 			if registrationState == "" {
 				return fmt.Errorf("retrieving %s: `registrationState` was nil", resourceId)
 			}
-			if strings.EqualFold(registrationState, "Registered") {
-				return metadata.ResourceRequiresImport(r.ResourceType(), resourceId)
+
+			if !metadata.Client.Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+				if strings.EqualFold(registrationState, "Registered") {
+					return metadata.ResourceRequiresImport(r.ResourceType(), resourceId)
+				}
 			}
 
 			if metadata.ResourceData.HasChange("feature") {
@@ -141,6 +144,7 @@ func (r ResourceProviderRegistrationResource) Create() sdk.ResourceFunc {
 			if _, err := client.Register(ctx, resourceId, payload); err != nil {
 				return fmt.Errorf("registering %s: %+v", resourceId, err)
 			}
+			metadata.SetID(resourceId)
 
 			log.Printf("[DEBUG] Waiting for %s to finish registering..", resourceId)
 			pollerType := custompollers.NewResourceProviderRegistrationPollerDefault(client, resourceId, Registered)
@@ -150,7 +154,6 @@ func (r ResourceProviderRegistrationResource) Create() sdk.ResourceFunc {
 			}
 			log.Printf("[DEBUG] Registered Resource Provider %q.", resourceId)
 
-			metadata.SetID(resourceId)
 			return nil
 		},
 

--- a/internal/services/resource/subscription_template_deployment_resource.go
+++ b/internal/services/resource/subscription_template_deployment_resource.go
@@ -111,14 +111,17 @@ func subscriptionTemplateDeploymentResourceCreate(d *pluginsdk.ResourceData, met
 
 	id := parse.NewSubscriptionTemplateDeploymentID(subscriptionId, d.Get("name").(string))
 
-	existing, err := client.GetAtSubscriptionScope(ctx, id.DeploymentName)
-	if err != nil {
-		if !utils.ResponseWasNotFound(existing.Response) {
-			return fmt.Errorf("checking for presence of existing Subscription Template Deployment %q: %+v", id.DeploymentName, err)
+	if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+		existing, err := client.GetAtSubscriptionScope(ctx, id.DeploymentName)
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("checking for presence of existing Subscription Template Deployment %q: %+v", id.DeploymentName, err)
+			}
 		}
-	}
-	if existing.Properties != nil {
-		return tf.ImportAsExistsError("azurerm_subscription_template_deployment", id.ID())
+
+		if !utils.ResponseWasNotFound(existing.Response) {
+			return tf.ImportAsExistsError("azurerm_subscription_template_deployment", id.ID())
+		}
 	}
 
 	deployment := resources.Deployment{
@@ -164,12 +167,13 @@ func subscriptionTemplateDeploymentResourceCreate(d *pluginsdk.ResourceData, met
 		return fmt.Errorf("creating Subscription Template Deployment %q: %+v", id.DeploymentName, err)
 	}
 
+	d.SetId(id.ID())
+
 	log.Printf("[DEBUG] Waiting for deployment of Subscription Template Deployment %q..", id.DeploymentName)
 	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
 		return fmt.Errorf("waiting for creation of Subscription Template Deployment %q: %+v", id.DeploymentName, err)
 	}
 
-	d.SetId(id.ID())
 	return subscriptionTemplateDeploymentResourceRead(d, meta)
 }
 

--- a/internal/services/resource/tenant_template_deployment_resource.go
+++ b/internal/services/resource/tenant_template_deployment_resource.go
@@ -110,14 +110,16 @@ func tenantTemplateDeploymentResourceCreate(d *pluginsdk.ResourceData, meta inte
 
 	id := parse.NewTenantTemplateDeploymentID(d.Get("name").(string))
 
-	existing, err := client.GetAtTenantScope(ctx, id.DeploymentName)
-	if err != nil {
-		if !utils.ResponseWasNotFound(existing.Response) {
-			return fmt.Errorf("checking for presence of existing Tenant Template Deployment %q: %+v", id.DeploymentName, err)
+	if !meta.(*clients.Client).Features.SkipImportCheckOnCreateAndAllowOverwritingExistingResources {
+		existing, err := client.GetAtTenantScope(ctx, id.DeploymentName)
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("checking for presence of existing Tenant Template Deployment %q: %+v", id.DeploymentName, err)
+			}
 		}
-	}
-	if existing.Properties != nil {
-		return tf.ImportAsExistsError("azurerm_tenant_template_deployment", id.ID())
+		if !utils.ResponseWasNotFound(existing.Response) {
+			return tf.ImportAsExistsError("azurerm_tenant_template_deployment", id.ID())
+		}
 	}
 
 	deployment := resources.ScopedDeployment{
@@ -163,12 +165,13 @@ func tenantTemplateDeploymentResourceCreate(d *pluginsdk.ResourceData, meta inte
 		return fmt.Errorf("creating Tenant Template Deployment %q: %+v", id.DeploymentName, err)
 	}
 
+	d.SetId(id.ID())
+
 	log.Printf("[DEBUG] Waiting for deployment of Tenant Template Deployment %q..", id.DeploymentName)
 	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
 		return fmt.Errorf("waiting for creation of Tenant Template Deployment %q: %+v", id.DeploymentName, err)
 	}
 
-	d.SetId(id.ID())
 	return tenantTemplateDeploymentResourceRead(d, meta)
 }
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

> Note: This PR is dependent on #32318 and its prerequisites, once those are merged, I will rebase this PR so it contains only the resource changes


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<img width="492" height="210" alt="image" src="https://github.com/user-attachments/assets/e13db650-7dc0-4c9c-962c-3f9e3c5e0da2" />

<img width="482" height="208" alt="image" src="https://github.com/user-attachments/assets/60093210-a269-4f22-8ae3-4994e7667afe" />

<img width="529" height="198" alt="image" src="https://github.com/user-attachments/assets/bd917763-fdaf-4c07-ab4e-dc127a293784" />

<img width="469" height="199" alt="image" src="https://github.com/user-attachments/assets/f746afd3-08c6-45b6-9d66-096e342df043" />

<img width="523" height="198" alt="image" src="https://github.com/user-attachments/assets/75fd7bd4-b0f9-40d0-ac87-2ea5a7fb5154" />

<img width="579" height="198" alt="image" src="https://github.com/user-attachments/assets/40e9006a-02b3-43be-8408-926e1f314e9f" />

<img width="493" height="201" alt="image" src="https://github.com/user-attachments/assets/57c9145a-35b4-4ea3-8623-c5c3a9bba5d4" />

<img width="488" height="198" alt="image" src="https://github.com/user-attachments/assets/2b120701-5b7d-4c02-b79f-82e41ba4ba4c" />

<img width="553" height="197" alt="image" src="https://github.com/user-attachments/assets/1816bc5e-9a7d-4c6e-967a-8af4848d89cd" />

Failures due to post test destroy, creation succeeded, unrelated to these changes
<img width="434" height="196" alt="image" src="https://github.com/user-attachments/assets/31442074-1863-4d71-bbc3-cfb1744ffbb4" />

<img width="560" height="184" alt="image" src="https://github.com/user-attachments/assets/2dbd06df-3cbd-4001-8bb0-d1af5d9b6c1a" />

<img width="463" height="184" alt="image" src="https://github.com/user-attachments/assets/8b292894-145f-42bc-ae90-75cda9e42fe9" />

<img width="484" height="194" alt="image" src="https://github.com/user-attachments/assets/a03bc346-85a7-4063-838a-447cee00fd5f" />

<img width="504" height="191" alt="image" src="https://github.com/user-attachments/assets/82b457da-0563-4f07-b76d-c11671ae13be" />


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change




## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
