### PR TITLE
Tests: `loadbalancer` package - test fix for retired public IP sku

### DIFF
--- a/internal/services/loadbalancer/lb_backend_address_pool_resource_test.go
+++ b/internal/services/loadbalancer/lb_backend_address_pool_resource_test.go
@@ -267,7 +267,7 @@ func (r LoadBalancerBackendAddressPool) Destroy(ctx context.Context, client *cli
 }
 
 func (r LoadBalancerBackendAddressPool) basicSkuBasic(data acceptance.TestData) string {
-	template := r.template(data, "Basic")
+	template := r.template(data, "Standard")
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/internal/services/loadbalancer/lb_backend_address_pool_resource_test.go
+++ b/internal/services/loadbalancer/lb_backend_address_pool_resource_test.go
@@ -267,7 +267,7 @@ func (r LoadBalancerBackendAddressPool) Destroy(ctx context.Context, client *cli
 }
 
 func (r LoadBalancerBackendAddressPool) basicSkuBasic(data acceptance.TestData) string {
-	template := r.template(data, "Standard")
+	template := r.template(data)
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -295,7 +295,7 @@ resource "azurerm_lb_backend_address_pool" "import" {
 }
 
 func (r LoadBalancerBackendAddressPool) standardSkuBasic(data acceptance.TestData) string {
-	template := r.template(data, "Standard")
+	template := r.template(data)
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -311,7 +311,7 @@ resource "azurerm_lb_backend_address_pool" "test" {
 }
 
 func (r LoadBalancerBackendAddressPool) standardSkuBasicUpdate(data acceptance.TestData) string {
-	template := r.template(data, "Standard")
+	template := r.template(data)
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -339,12 +339,12 @@ resource "azurerm_lb_backend_address_pool" "import" {
 `, template)
 }
 
-func (LoadBalancerBackendAddressPool) template(data acceptance.TestData, sku string) string {
+func (LoadBalancerBackendAddressPool) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 locals {
   number   = %d
   location = %q
-  sku      = %q
+  sku      = "Standard"
 }
 
 resource "azurerm_resource_group" "test" {
@@ -378,7 +378,7 @@ resource "azurerm_lb" "test" {
     public_ip_address_id = azurerm_public_ip.test.id
   }
 }
-`, data.RandomInteger, data.Locations.Primary, sku)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (r LoadBalancerBackendAddressPool) gatewaySkuBasic(data acceptance.TestData) string {

--- a/internal/services/loadbalancer/lb_nat_rule_resource_test.go
+++ b/internal/services/loadbalancer/lb_nat_rule_resource_test.go
@@ -26,7 +26,7 @@ func TestAccAzureRMLoadBalancerNatRule_basic(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data, "Standard"),
+			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -122,7 +122,7 @@ func TestAccAzureRMLoadBalancerNatRule_update(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data, "Standard"),
+			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -136,7 +136,7 @@ func TestAccAzureRMLoadBalancerNatRule_update(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.basic(data, "Standard"),
+			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -151,7 +151,7 @@ func TestAccAzureRMLoadBalancerNatRule_requiresImport(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data, "Standard"),
+			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -166,9 +166,7 @@ func TestAccAzureRMLoadBalancerNatRule_disappears(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		data.DisappearsStep(acceptance.DisappearsStepData{
-			Config: func(data acceptance.TestData) string {
-				return r.basic(data, "Standard")
-			},
+			Config:       r.basic,
 			TestResource: r,
 		}),
 	})
@@ -289,7 +287,7 @@ func (r LoadBalancerNatRule) Destroy(ctx context.Context, client *clients.Client
 	return pointer.To(true), nil
 }
 
-func (r LoadBalancerNatRule) template(data acceptance.TestData, sku string) string {
+func (r LoadBalancerNatRule) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -305,24 +303,24 @@ resource "azurerm_public_ip" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Static"
-  sku                 = "%[3]s"
+  sku                 = "Standard"
 }
 
 resource "azurerm_lb" "test" {
   name                = "acctest-loadbalancer-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  sku                 = "%[3]s"
+  sku                 = "Standard"
 
   frontend_ip_configuration {
     name                 = "acctest-fe-%[1]d"
     public_ip_address_id = azurerm_public_ip.test.id
   }
 }
-`, data.RandomInteger, data.Locations.Primary, sku)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
-func (r LoadBalancerNatRule) basic(data acceptance.TestData, sku string) string {
+func (r LoadBalancerNatRule) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -335,7 +333,7 @@ resource "azurerm_lb_nat_rule" "test" {
   backend_port                   = 3389
   frontend_ip_configuration_name = azurerm_lb.test.frontend_ip_configuration.0.name
 }
-`, r.template(data, sku), data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }
 
 func (r LoadBalancerNatRule) complete(data acceptance.TestData) string {
@@ -358,7 +356,7 @@ resource "azurerm_lb_nat_rule" "test" {
 
   frontend_ip_configuration_name = azurerm_lb.test.frontend_ip_configuration.0.name
 }
-`, r.template(data, "Standard"), data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 	}
 	return fmt.Sprintf(`
 %s
@@ -378,7 +376,7 @@ resource "azurerm_lb_nat_rule" "test" {
 
   frontend_ip_configuration_name = azurerm_lb.test.frontend_ip_configuration.0.name
 }
-`, r.template(data, "Standard"), data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }
 
 func (r LoadBalancerNatRule) completeUpdate(data acceptance.TestData) string {
@@ -400,11 +398,11 @@ resource "azurerm_lb_nat_rule" "test" {
 
   frontend_ip_configuration_name = azurerm_lb.test.frontend_ip_configuration.0.name
 }
-`, r.template(data, "Standard"), data.RandomInteger)
+`, r.template(data), data.RandomInteger)
 }
 
 func (r LoadBalancerNatRule) requiresImport(data acceptance.TestData) string {
-	template := r.basic(data, "Standard")
+	template := r.basic(data)
 	return fmt.Sprintf(`
 %s
 
@@ -421,7 +419,7 @@ resource "azurerm_lb_nat_rule" "import" {
 }
 
 func (r LoadBalancerNatRule) multipleRules(data, data2 acceptance.TestData) string {
-	template := r.template(data, "Standard")
+	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
@@ -448,7 +446,7 @@ resource "azurerm_lb_nat_rule" "test2" {
 }
 
 func (r LoadBalancerNatRule) multipleRulesUpdate(data, data2 acceptance.TestData) string {
-	template := r.template(data, "Standard")
+	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 resource "azurerm_lb_nat_rule" "test" {
@@ -474,7 +472,7 @@ resource "azurerm_lb_nat_rule" "test2" {
 }
 
 func (r LoadBalancerNatRule) mapToBackendAddressPool(data acceptance.TestData) string {
-	template := r.template(data, "Standard")
+	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 resource "azurerm_virtual_network" "test" {

--- a/internal/services/loadbalancer/lb_nat_rule_resource_test.go
+++ b/internal/services/loadbalancer/lb_nat_rule_resource_test.go
@@ -26,7 +26,7 @@ func TestAccAzureRMLoadBalancerNatRule_basic(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data, "Basic"),
+			Config: r.basic(data, "Standard"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -151,7 +151,7 @@ func TestAccAzureRMLoadBalancerNatRule_requiresImport(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data, "Basic"),
+			Config: r.basic(data, "Standard"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -167,7 +167,7 @@ func TestAccAzureRMLoadBalancerNatRule_disappears(t *testing.T) {
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		data.DisappearsStep(acceptance.DisappearsStepData{
 			Config: func(data acceptance.TestData) string {
-				return r.basic(data, "Basic")
+				return r.basic(data, "Standard")
 			},
 			TestResource: r,
 		}),
@@ -404,7 +404,7 @@ resource "azurerm_lb_nat_rule" "test" {
 }
 
 func (r LoadBalancerNatRule) requiresImport(data acceptance.TestData) string {
-	template := r.basic(data, "Basic")
+	template := r.basic(data, "Standard")
 	return fmt.Sprintf(`
 %s
 
@@ -421,7 +421,7 @@ resource "azurerm_lb_nat_rule" "import" {
 }
 
 func (r LoadBalancerNatRule) multipleRules(data, data2 acceptance.TestData) string {
-	template := r.template(data, "Basic")
+	template := r.template(data, "Standard")
 	return fmt.Sprintf(`
 %s
 
@@ -448,7 +448,7 @@ resource "azurerm_lb_nat_rule" "test2" {
 }
 
 func (r LoadBalancerNatRule) multipleRulesUpdate(data, data2 acceptance.TestData) string {
-	template := r.template(data, "Basic")
+	template := r.template(data, "Standard")
 	return fmt.Sprintf(`
 %s
 resource "azurerm_lb_nat_rule" "test" {

--- a/internal/services/loadbalancer/lb_rule_resource_test.go
+++ b/internal/services/loadbalancer/lb_rule_resource_test.go
@@ -171,21 +171,21 @@ func TestAccAzureRMLoadBalancerRule_vmssBackendPoolUpdateRemoveLBRule(t *testing
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.vmssBackendPool(data, lbRuleName, "Standard"),
+			Config: r.vmssBackendPool(data, lbRuleName),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.vmssBackendPoolUpdate(data, lbRuleName, "Standard"),
+			Config: r.vmssBackendPoolUpdate(data, lbRuleName),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.vmssBackendPoolWithoutLBRule(data, "Standard"),
+			Config: r.vmssBackendPoolWithoutLBRule(data),
 		},
 	})
 }
@@ -275,7 +275,7 @@ func (r LoadBalancerRule) Destroy(ctx context.Context, client *clients.Client, s
 	return pointer.To(true), nil
 }
 
-func (r LoadBalancerRule) template(data acceptance.TestData, sku string) string {
+func (r LoadBalancerRule) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -291,21 +291,21 @@ resource "azurerm_public_ip" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Static"
-  sku                 = "%[3]s"
+  sku                 = "Standard"
 }
 
 resource "azurerm_lb" "test" {
   name                = "acctest-loadbalancer-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  sku                 = "%[3]s"
+  sku                 = "Standard"
 
   frontend_ip_configuration {
     name                 = "acctest-fe-%[1]d"
     public_ip_address_id = azurerm_public_ip.test.id
   }
 }
-`, data.RandomInteger, data.Locations.Primary, sku)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (r LoadBalancerRule) basic(data acceptance.TestData) string {
@@ -320,7 +320,7 @@ resource "azurerm_lb_rule" "test" {
   frontend_port                  = 3389
   backend_port                   = 3389
 }
-`, r.template(data, "Standard"), data.RandomInteger%100000000)
+`, r.template(data), data.RandomInteger%100000000)
 }
 
 func (r LoadBalancerRule) complete(data acceptance.TestData) string {
@@ -344,7 +344,7 @@ resource "azurerm_lb_rule" "test" {
 
   frontend_ip_configuration_name = azurerm_lb.test.frontend_ip_configuration.0.name
 }
-`, r.template(data, "Standard"), data.RandomInteger%100000000)
+`, r.template(data), data.RandomInteger%100000000)
 	}
 
 	return fmt.Sprintf(`
@@ -366,7 +366,7 @@ resource "azurerm_lb_rule" "test" {
 
   frontend_ip_configuration_name = azurerm_lb.test.frontend_ip_configuration.0.name
 }
-`, r.template(data, "Standard"), data.RandomInteger%100000000)
+`, r.template(data), data.RandomInteger%100000000)
 }
 
 func (r LoadBalancerRule) completeUpdate(data acceptance.TestData) string {
@@ -389,7 +389,7 @@ resource "azurerm_lb_rule" "test" {
 
   frontend_ip_configuration_name = azurerm_lb.test.frontend_ip_configuration.0.name
 }
-`, r.template(data, "Standard"), data.RandomInteger%100000000)
+`, r.template(data), data.RandomInteger%100000000)
 }
 
 func (r LoadBalancerRule) requiresImport(data acceptance.TestData) string {
@@ -410,7 +410,7 @@ resource "azurerm_lb_rule" "import" {
 
 // https://github.com/hashicorp/terraform/issues/9424
 func (r LoadBalancerRule) inconsistentRead(data acceptance.TestData) string {
-	template := r.template(data, "Standard")
+	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
@@ -438,7 +438,7 @@ resource "azurerm_lb_rule" "test" {
 }
 
 func (r LoadBalancerRule) multipleRules(data, data2 acceptance.TestData) string {
-	template := r.template(data, "Standard")
+	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
@@ -463,7 +463,7 @@ resource "azurerm_lb_rule" "test2" {
 }
 
 func (r LoadBalancerRule) multipleRulesUpdate(data, data2 acceptance.TestData) string {
-	template := r.template(data, "Standard")
+	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
@@ -487,8 +487,8 @@ resource "azurerm_lb_rule" "test2" {
 `, template, data.RandomInteger%100000000, data2.RandomInteger%100000000)
 }
 
-func (r LoadBalancerRule) vmssBackendPoolWithoutLBRule(data acceptance.TestData, sku string) string {
-	template := r.template(data, sku)
+func (r LoadBalancerRule) vmssBackendPoolWithoutLBRule(data acceptance.TestData) string {
+	template := r.template(data)
 	return fmt.Sprintf(`
 %[1]s
 
@@ -551,8 +551,8 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
 `, template, data.RandomInteger)
 }
 
-func (r LoadBalancerRule) vmssBackendPool(data acceptance.TestData, lbRuleName, sku string) string {
-	template := r.vmssBackendPoolWithoutLBRule(data, sku)
+func (r LoadBalancerRule) vmssBackendPool(data acceptance.TestData, lbRuleName string) string {
+	template := r.vmssBackendPoolWithoutLBRule(data)
 	return fmt.Sprintf(`
 %s
 
@@ -568,8 +568,8 @@ resource "azurerm_lb_rule" "test" {
 `, template, lbRuleName)
 }
 
-func (r LoadBalancerRule) vmssBackendPoolUpdate(data acceptance.TestData, lbRuleName, sku string) string {
-	template := r.vmssBackendPoolWithoutLBRule(data, sku)
+func (r LoadBalancerRule) vmssBackendPoolUpdate(data acceptance.TestData, lbRuleName string) string {
+	template := r.vmssBackendPoolWithoutLBRule(data)
 	return fmt.Sprintf(`
 %s
 resource "azurerm_lb_rule" "test" {

--- a/internal/services/loadbalancer/lb_rule_resource_test.go
+++ b/internal/services/loadbalancer/lb_rule_resource_test.go
@@ -410,7 +410,7 @@ resource "azurerm_lb_rule" "import" {
 
 // https://github.com/hashicorp/terraform/issues/9424
 func (r LoadBalancerRule) inconsistentRead(data acceptance.TestData) string {
-	template := r.template(data, "Basic")
+	template := r.template(data, "Standard")
 	return fmt.Sprintf(`
 %s
 
@@ -438,7 +438,7 @@ resource "azurerm_lb_rule" "test" {
 }
 
 func (r LoadBalancerRule) multipleRules(data, data2 acceptance.TestData) string {
-	template := r.template(data, "Basic")
+	template := r.template(data, "Standard")
 	return fmt.Sprintf(`
 %s
 
@@ -463,7 +463,7 @@ resource "azurerm_lb_rule" "test2" {
 }
 
 func (r LoadBalancerRule) multipleRulesUpdate(data, data2 acceptance.TestData) string {
-	template := r.template(data, "Basic")
+	template := r.template(data, "Standard")
 	return fmt.Sprintf(`
 %s
 

--- a/internal/services/loadbalancer/loadbalancer_nat_pool_resource_test.go
+++ b/internal/services/loadbalancer/loadbalancer_nat_pool_resource_test.go
@@ -26,7 +26,7 @@ func TestAccAzureRMLoadBalancerNatPool_basic(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data, "Standard"),
+			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -41,7 +41,7 @@ func TestAccAzureRMLoadBalancerNatPool_complete(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.complete(data, "Standard"),
+			Config: r.complete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -56,20 +56,20 @@ func TestAccAzureRMLoadBalancerNatPool_update(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data, "Standard"),
+			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.complete(data, "Standard"),
+			Config: r.complete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		{
-			Config: r.basic(data, "Standard"),
+			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -84,7 +84,7 @@ func TestAccAzureRMLoadBalancerNatPool_requiresImport(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data, "Standard"),
+			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -99,9 +99,7 @@ func TestAccAzureRMLoadBalancerNatPool_disappears(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		data.DisappearsStep(acceptance.DisappearsStepData{
-			Config: func(data acceptance.TestData) string {
-				return r.basic(data, "Standard")
-			},
+			Config:       r.basic,
 			TestResource: r,
 		}),
 	})
@@ -205,7 +203,7 @@ func (r LoadBalancerNatPool) Destroy(ctx context.Context, client *clients.Client
 	return pointer.To(true), nil
 }
 
-func (r LoadBalancerNatPool) basic(data acceptance.TestData, sku string) string {
+func (r LoadBalancerNatPool) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -221,14 +219,14 @@ resource "azurerm_public_ip" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Static"
-  sku                 = "%[3]s"
+  sku                 = "Standard"
 }
 
 resource "azurerm_lb" "test" {
   name                = "arm-test-loadbalancer-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  sku                 = "%[3]s"
+  sku                 = "Standard"
 
   frontend_ip_configuration {
     name                 = "one-%[1]d"
@@ -246,10 +244,10 @@ resource "azurerm_lb_nat_pool" "test" {
   backend_port                   = 3389
   frontend_ip_configuration_name = "one-%[1]d"
 }
-`, data.RandomInteger, data.Locations.Primary, sku)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
-func (r LoadBalancerNatPool) complete(data acceptance.TestData, sku string) string {
+func (r LoadBalancerNatPool) complete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -263,13 +261,13 @@ resource "azurerm_public_ip" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Static"
-  sku                 = "%[3]s"
+  sku                 = "Standard"
 }
 resource "azurerm_lb" "test" {
   name                = "arm-test-loadbalancer-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  sku                 = "%[3]s"
+  sku                 = "Standard"
 
   frontend_ip_configuration {
     name                 = "one-%[1]d"
@@ -289,11 +287,11 @@ resource "azurerm_lb_nat_pool" "test" {
   tcp_reset_enabled              = true
   idle_timeout_in_minutes        = 10
 }
-`, data.RandomInteger, data.Locations.Primary, sku)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (r LoadBalancerNatPool) requiresImport(data acceptance.TestData) string {
-	template := r.basic(data, "Standard")
+	template := r.basic(data)
 	return fmt.Sprintf(`
 %s
 

--- a/internal/services/loadbalancer/loadbalancer_nat_pool_resource_test.go
+++ b/internal/services/loadbalancer/loadbalancer_nat_pool_resource_test.go
@@ -26,7 +26,7 @@ func TestAccAzureRMLoadBalancerNatPool_basic(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data, "Basic"),
+			Config: r.basic(data, "Standard"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -84,7 +84,7 @@ func TestAccAzureRMLoadBalancerNatPool_requiresImport(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data, "Basic"),
+			Config: r.basic(data, "Standard"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -100,7 +100,7 @@ func TestAccAzureRMLoadBalancerNatPool_disappears(t *testing.T) {
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		data.DisappearsStep(acceptance.DisappearsStepData{
 			Config: func(data acceptance.TestData) string {
-				return r.basic(data, "Basic")
+				return r.basic(data, "Standard")
 			},
 			TestResource: r,
 		}),
@@ -293,7 +293,7 @@ resource "azurerm_lb_nat_pool" "test" {
 }
 
 func (r LoadBalancerNatPool) requiresImport(data acceptance.TestData) string {
-	template := r.basic(data, "Basic")
+	template := r.basic(data, "Standard")
 	return fmt.Sprintf(`
 %s
 

--- a/internal/services/loadbalancer/loadbalancer_rule_data_source_test.go
+++ b/internal/services/loadbalancer/loadbalancer_rule_data_source_test.go
@@ -106,7 +106,7 @@ data "azurerm_lb_rule" "test" {
   name            = azurerm_lb_rule.test.name
   loadbalancer_id = azurerm_lb_rule.test.loadbalancer_id
 }
-`, r.template(data, "Standard"), data.RandomStringOfLength(8), data.RandomStringOfLength(8), data.RandomStringOfLength(8))
+`, r.template(data), data.RandomStringOfLength(8), data.RandomStringOfLength(8), data.RandomStringOfLength(8))
 	}
 
 	return fmt.Sprintf(`
@@ -146,5 +146,5 @@ data "azurerm_lb_rule" "test" {
   name            = azurerm_lb_rule.test.name
   loadbalancer_id = azurerm_lb_rule.test.loadbalancer_id
 }
-`, r.template(data, "Standard"), data.RandomStringOfLength(8), data.RandomStringOfLength(8), data.RandomStringOfLength(8))
+`, r.template(data), data.RandomStringOfLength(8), data.RandomStringOfLength(8), data.RandomStringOfLength(8))
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

TEST FIX: The SKU "Basic" for the `azurerm_public_ip` and `azurerm_lb` resource has been fully retired from Azure, in the `loadbalancer` test cases this SKU has been replaced with "Standard" to allow all tests to pass again.

NOTE: removal of "Basic" sku had resulted in "Standard" being the only sku used, the linter caught that if that sku value was a test parameter it is now no longer needed, so these params have been removed as well.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
