### PR TITLE
`azurerm_mssql_managed_instance_transparent_data_encryption` - support versionless `key_vault_key_id`

### DIFF
--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_transparent_data_encryption_resource.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_transparent_data_encryption_resource.go
@@ -311,7 +311,9 @@ func resourceMsSqlManagedInstanceTransparentDataEncryptionKeyVaultName(keyVaultU
 	return strings.Split(parsedURL.Host, ".")[0], nil
 }
 
-func msSqlManagedInstanceTransparentDataEncryptionKeyVaultKeyDiffSuppress(_, oldValue, newValue string, d *schema.ResourceData) bool {
+// If versionless KV key is used in config/state, suppress the diff with versioned key. 
+// This is needed because backend API will return back a versioned key if it's given versionless one
+func diffSuppressKeyVaultVersionedKey(_, oldValue, newValue string, d *schema.ResourceData) bool {
 	if d == nil || !d.Get("auto_rotation_enabled").(bool) {
 		return false
 	}

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_transparent_data_encryption_resource.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_transparent_data_encryption_resource.go
@@ -56,7 +56,7 @@ func resourceMsSqlManagedInstanceTransparentDataEncryption() *pluginsdk.Resource
 			"key_vault_key_id": {
 				Type:             pluginsdk.TypeString,
 				Optional:         true,
-				DiffSuppressFunc: msSqlManagedInstanceTransparentDataEncryptionKeyVaultKeyDiffSuppress,
+				DiffSuppressFunc: diffSuppressKeyVaultVersionedKey,
 				ValidateFunc:     keyvault.ValidateNestedItemID(keyvault.VersionTypeAny, keyvault.NestedItemTypeKey),
 			},
 
@@ -73,7 +73,7 @@ func resourceMsSqlManagedInstanceTransparentDataEncryption() *pluginsdk.Resource
 			Type:     pluginsdk.TypeString,
 			Optional: true,
 			DiffSuppressFunc: func(_, oldValue, newValue string, d *schema.ResourceData) bool {
-				if msSqlManagedInstanceTransparentDataEncryptionKeyVaultKeyDiffSuppress("", oldValue, newValue, d) {
+				if diffSuppressKeyVaultVersionedKey("", oldValue, newValue, d) {
 					return true
 				}
 
@@ -96,7 +96,7 @@ func resourceMsSqlManagedInstanceTransparentDataEncryption() *pluginsdk.Resource
 			Type:     pluginsdk.TypeString,
 			Optional: true,
 			DiffSuppressFunc: func(_, oldValue, newValue string, d *schema.ResourceData) bool {
-				if msSqlManagedInstanceTransparentDataEncryptionKeyVaultKeyDiffSuppress("", oldValue, newValue, d) {
+				if diffSuppressKeyVaultVersionedKey("", oldValue, newValue, d) {
 					return true
 				}
 
@@ -311,7 +311,7 @@ func resourceMsSqlManagedInstanceTransparentDataEncryptionKeyVaultName(keyVaultU
 	return strings.Split(parsedURL.Host, ".")[0], nil
 }
 
-// If versionless KV key is used in config/state, suppress the diff with versioned key. 
+// If versionless KV key is used in config/state, suppress the diff with versioned key.
 // This is needed because backend API will return back a versioned key if it's given versionless one
 func diffSuppressKeyVaultVersionedKey(_, oldValue, newValue string, d *schema.ResourceData) bool {
 	if d == nil || !d.Get("auto_rotation_enabled").(bool) {

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_transparent_data_encryption_resource.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_transparent_data_encryption_resource.go
@@ -316,16 +316,16 @@ func msSqlManagedInstanceTransparentDataEncryptionKeyVaultKeyDiffSuppress(_, old
 		return false
 	}
 
-	return msSqlManagedInstanceTransparentDataEncryptionSameKeyIgnoringVersion(oldValue, newValue)
-}
-
-func msSqlManagedInstanceTransparentDataEncryptionSameKeyIgnoringVersion(oldValue, newValue string) bool {
-	oldId, err := keyvault.ParseNestedItemID(oldValue, keyvault.VersionTypeAny, keyvault.NestedItemTypeKey)
+	newId, err := keyvault.ParseNestedItemID(newValue, keyvault.VersionTypeAny, keyvault.NestedItemTypeKey)
 	if err != nil {
 		return false
 	}
 
-	newId, err := keyvault.ParseNestedItemID(newValue, keyvault.VersionTypeAny, keyvault.NestedItemTypeKey)
+	if newId.Version != "" {
+		return false
+	}
+
+	oldId, err := keyvault.ParseNestedItemID(oldValue, keyvault.VersionTypeAny, keyvault.NestedItemTypeKey)
 	if err != nil {
 		return false
 	}

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_transparent_data_encryption_resource.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_transparent_data_encryption_resource.go
@@ -4,6 +4,7 @@
 package mssqlmanagedinstance
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
@@ -53,9 +54,10 @@ func resourceMsSqlManagedInstanceTransparentDataEncryption() *pluginsdk.Resource
 			},
 
 			"key_vault_key_id": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				ValidateFunc: keyvault.ValidateNestedItemID(keyvault.VersionTypeVersioned, keyvault.NestedItemTypeKey),
+				Type:             pluginsdk.TypeString,
+				Optional:         true,
+				DiffSuppressFunc: msSqlManagedInstanceTransparentDataEncryptionKeyVaultKeyDiffSuppress,
+				ValidateFunc:     keyvault.ValidateNestedItemID(keyvault.VersionTypeAny, keyvault.NestedItemTypeKey),
 			},
 
 			"auto_rotation_enabled": {
@@ -71,6 +73,10 @@ func resourceMsSqlManagedInstanceTransparentDataEncryption() *pluginsdk.Resource
 			Type:     pluginsdk.TypeString,
 			Optional: true,
 			DiffSuppressFunc: func(_, oldValue, newValue string, d *schema.ResourceData) bool {
+				if msSqlManagedInstanceTransparentDataEncryptionKeyVaultKeyDiffSuppress("", oldValue, newValue, d) {
+					return true
+				}
+
 				if newValue == "" {
 					// If using `managed_hsm_key_id`, `key_vault_key_id` will also be set
 					// ignore diff if the 2 are equal.
@@ -82,7 +88,7 @@ func resourceMsSqlManagedInstanceTransparentDataEncryption() *pluginsdk.Resource
 
 				return false
 			},
-			ValidateFunc:  keyvault.ValidateNestedItemID(keyvault.VersionTypeVersioned, keyvault.NestedItemTypeKey),
+			ValidateFunc:  keyvault.ValidateNestedItemID(keyvault.VersionTypeAny, keyvault.NestedItemTypeKey),
 			ConflictsWith: []string{"managed_hsm_key_id"},
 		}
 
@@ -90,6 +96,10 @@ func resourceMsSqlManagedInstanceTransparentDataEncryption() *pluginsdk.Resource
 			Type:     pluginsdk.TypeString,
 			Optional: true,
 			DiffSuppressFunc: func(_, oldValue, newValue string, d *schema.ResourceData) bool {
+				if msSqlManagedInstanceTransparentDataEncryptionKeyVaultKeyDiffSuppress("", oldValue, newValue, d) {
+					return true
+				}
+
 				if newValue == "" {
 					// If using `key_vault_key_id` with MHSM key, `managed_hsm_key_id` will also be set
 					// ignore diff if the 2 are equal.
@@ -101,7 +111,7 @@ func resourceMsSqlManagedInstanceTransparentDataEncryption() *pluginsdk.Resource
 
 				return false
 			},
-			ValidateFunc:  keyvault.ValidateNestedItemID(keyvault.VersionTypeVersioned, keyvault.NestedItemTypeKey),
+			ValidateFunc:  keyvault.ValidateNestedItemID(keyvault.VersionTypeAny, keyvault.NestedItemTypeKey),
 			ConflictsWith: []string{"key_vault_key_id"},
 		}
 	}
@@ -140,7 +150,12 @@ func resourceMsSqlManagedInstanceTransparentDataEncryptionCreateUpdate(d *plugin
 
 	var key *keyvault.NestedItemID
 	if v, ok := d.GetOk("key_vault_key_id"); ok {
-		key, err = keyvault.ParseNestedItemID(v.(string), keyvault.VersionTypeVersioned, keyvault.NestedItemTypeKey)
+		key, err = keyvault.ParseNestedItemID(v.(string), keyvault.VersionTypeAny, keyvault.NestedItemTypeKey)
+		if err != nil {
+			return err
+		}
+
+		key, err = resourceMsSqlManagedInstanceTransparentDataEncryptionVersionedKey(ctx, key, "key_vault_key_id", d.Get("auto_rotation_enabled").(bool), meta)
 		if err != nil {
 			return err
 		}
@@ -148,7 +163,12 @@ func resourceMsSqlManagedInstanceTransparentDataEncryptionCreateUpdate(d *plugin
 
 	if !features.FivePointOh() {
 		if !pluginsdk.IsExplicitlyNullInConfig(d, "managed_hsm_key_id") {
-			key, err = keyvault.ParseNestedItemID(d.Get("managed_hsm_key_id").(string), keyvault.VersionTypeVersioned, keyvault.NestedItemTypeKey)
+			key, err = keyvault.ParseNestedItemID(d.Get("managed_hsm_key_id").(string), keyvault.VersionTypeAny, keyvault.NestedItemTypeKey)
+			if err != nil {
+				return err
+			}
+
+			key, err = resourceMsSqlManagedInstanceTransparentDataEncryptionVersionedKey(ctx, key, "managed_hsm_key_id", d.Get("auto_rotation_enabled").(bool), meta)
 			if err != nil {
 				return err
 			}
@@ -289,4 +309,68 @@ func resourceMsSqlManagedInstanceTransparentDataEncryptionKeyVaultName(keyVaultU
 	}
 
 	return strings.Split(parsedURL.Host, ".")[0], nil
+}
+
+func msSqlManagedInstanceTransparentDataEncryptionKeyVaultKeyDiffSuppress(_, oldValue, newValue string, d *schema.ResourceData) bool {
+	if d == nil || !d.Get("auto_rotation_enabled").(bool) {
+		return false
+	}
+
+	return msSqlManagedInstanceTransparentDataEncryptionSameKeyIgnoringVersion(oldValue, newValue)
+}
+
+func msSqlManagedInstanceTransparentDataEncryptionSameKeyIgnoringVersion(oldValue, newValue string) bool {
+	oldId, err := keyvault.ParseNestedItemID(oldValue, keyvault.VersionTypeAny, keyvault.NestedItemTypeKey)
+	if err != nil {
+		return false
+	}
+
+	newId, err := keyvault.ParseNestedItemID(newValue, keyvault.VersionTypeAny, keyvault.NestedItemTypeKey)
+	if err != nil {
+		return false
+	}
+
+	return strings.EqualFold(oldId.KeyVaultBaseURL, newId.KeyVaultBaseURL) && strings.EqualFold(oldId.Name, newId.Name)
+}
+
+func resourceMsSqlManagedInstanceTransparentDataEncryptionVersionedKey(ctx context.Context, id *keyvault.NestedItemID, fieldName string, autoRotationEnabled bool, meta interface{}) (*keyvault.NestedItemID, error) {
+	if id.Version != "" {
+		return id, nil
+	}
+
+	if !autoRotationEnabled {
+		return nil, fmt.Errorf("`%s` must be a versioned Key Vault Key ID when `auto_rotation_enabled` is false", fieldName)
+	}
+
+	var keyUrl string
+	if id.IsManagedHSM() {
+		resp, err := meta.(*clients.Client).ManagedHSMs.DataPlaneKeysClient.GetKey(ctx, id.KeyVaultBaseURL, id.Name, "")
+		if err != nil {
+			return nil, err
+		}
+
+		if resp.Key != nil {
+			keyUrl = pointer.From(resp.Key.Kid)
+		}
+	} else {
+		resp, err := meta.(*clients.Client).KeyVault.ManagementClient.GetKey(ctx, id.KeyVaultBaseURL, id.Name, "")
+		if err != nil {
+			return nil, err
+		}
+
+		if resp.Key != nil {
+			keyUrl = pointer.From(resp.Key.Kid)
+		}
+	}
+
+	if keyUrl == "" {
+		return nil, fmt.Errorf("retrieving latest version for Key Vault Key %q at %q: empty key ID returned", id.Name, id.KeyVaultBaseURL)
+	}
+
+	versionedId, err := keyvault.ParseNestedItemID(keyUrl, keyvault.VersionTypeVersioned, keyvault.NestedItemTypeKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return versionedId, nil
 }

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_transparent_data_encryption_resource_test.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_transparent_data_encryption_resource_test.go
@@ -68,6 +68,22 @@ func TestAccMsSqlManagedInstanceTransparentDataEncryption_autoRotate(t *testing.
 	})
 }
 
+func TestAccMsSqlManagedInstanceTransparentDataEncryption_autoRotateVersionless(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mssql_managed_instance_transparent_data_encryption", "test")
+	r := MsSqlManagedInstanceTransparentDataEncryptionResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.autoRotateVersionless(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("key_vault_key_id").Exists(),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccMsSqlManagedInstanceTransparentDataEncryption_systemManaged(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_managed_instance_transparent_data_encryption", "test")
 	r := MsSqlManagedInstanceTransparentDataEncryptionResource{}
@@ -365,6 +381,68 @@ resource "azurerm_key_vault_key" "generated" {
 resource "azurerm_mssql_managed_instance_transparent_data_encryption" "test" {
   managed_instance_id   = azurerm_mssql_managed_instance.test.id
   key_vault_key_id      = azurerm_key_vault_key.generated.id
+  auto_rotation_enabled = true
+}
+`, r.serverUAMI(data), data.RandomStringOfLength(5))
+}
+
+func (r MsSqlManagedInstanceTransparentDataEncryptionResource) autoRotateVersionless(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_key_vault" "test" {
+  name                        = "acctestsqlserver%[2]s"
+  location                    = azurerm_resource_group.test.location
+  resource_group_name         = azurerm_resource_group.test.name
+  enabled_for_disk_encryption = true
+  tenant_id                   = data.azurerm_client_config.current.tenant_id
+  soft_delete_retention_days  = 7
+  purge_protection_enabled    = false
+
+  sku_name = "standard"
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    key_permissions = [
+      "Get", "List", "Create", "Delete", "Update", "Purge", "GetRotationPolicy", "SetRotationPolicy"
+    ]
+  }
+
+  access_policy {
+    tenant_id = azurerm_user_assigned_identity.test.tenant_id
+    object_id = azurerm_user_assigned_identity.test.principal_id
+
+    key_permissions = [
+      "Get", "WrapKey", "UnwrapKey", "List", "Create", "GetRotationPolicy", "SetRotationPolicy"
+    ]
+  }
+}
+
+resource "azurerm_key_vault_key" "generated" {
+  name         = "keyVault"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "RSA"
+  key_size     = 2048
+
+  key_opts = [
+    "decrypt",
+    "encrypt",
+    "sign",
+    "unwrapKey",
+    "verify",
+    "wrapKey",
+  ]
+
+  depends_on = [
+    azurerm_key_vault.test,
+  ]
+}
+
+resource "azurerm_mssql_managed_instance_transparent_data_encryption" "test" {
+  managed_instance_id   = azurerm_mssql_managed_instance.test.id
+  key_vault_key_id      = azurerm_key_vault_key.generated.versionless_id
   auto_rotation_enabled = true
 }
 `, r.serverUAMI(data), data.RandomStringOfLength(5))

--- a/website/docs/r/mssql_managed_instance_transparent_data_encryption.html.markdown
+++ b/website/docs/r/mssql_managed_instance_transparent_data_encryption.html.markdown
@@ -185,9 +185,11 @@ The following arguments are supported:
 
 ---
 
-* `key_vault_key_id` - (Optional) To use customer managed keys from Azure Key Vault, provide the AKV Key ID. To use service managed keys, omit this field.
+* `key_vault_key_id` - (Optional) To use customer managed keys from Azure Key Vault, provide the AKV Key ID. To use service managed keys, omit this field. When `auto_rotation_enabled` is `true`, this can be either a versioned or versionless Key Vault Key ID. When `auto_rotation_enabled` is `false`, this must be a versioned Key Vault Key ID.
 
 ~> **Note:** In order to use customer managed keys, the identity of the MSSQL Managed Instance must have the following permissions on the key vault: 'get', 'wrapKey' and 'unwrapKey'
+
+~> **Note:** When using a versionless `key_vault_key_id`, the principal running Terraform must have permission to read the latest key version from Key Vault.
 
 ~> **Note:** If `managed_instance_id` denotes a secondary instance deployed for disaster recovery purposes, then the `key_vault_key_id` should be the same key used for the primary instance's transparent data encryption. Both primary and secondary instances should be encrypted with same key material.
 

--- a/website/docs/r/mssql_managed_instance_transparent_data_encryption.html.markdown
+++ b/website/docs/r/mssql_managed_instance_transparent_data_encryption.html.markdown
@@ -185,11 +185,11 @@ The following arguments are supported:
 
 ---
 
-* `key_vault_key_id` - (Optional) To use customer managed keys from Azure Key Vault, provide the AKV Key ID. To use service managed keys, omit this field. When `auto_rotation_enabled` is `true`, this can be either a versioned or versionless Key Vault Key ID. When `auto_rotation_enabled` is `false`, this must be a versioned Key Vault Key ID.
+* `key_vault_key_id` - (Optional) To use customer managed keys from Azure Key Vault, provide the AKV Key ID. To use service managed keys, omit this field.
 
 ~> **Note:** In order to use customer managed keys, the identity of the MSSQL Managed Instance must have the following permissions on the key vault: 'get', 'wrapKey' and 'unwrapKey'
 
-~> **Note:** When using a versionless `key_vault_key_id`, the principal running Terraform must have permission to read the latest key version from Key Vault.
+~> **Note:** When `auto_rotation_enabled` is `true`, `key_vault_key_id` can be either a versioned or versionless Key Vault Key ID. When using a versionless `key_vault_key_id`, the principal running Terraform must have permission to read the latest key version from Key Vault. When `auto_rotation_enabled` is `false`, `key_vault_key_id` must be a versioned Key Vault Key ID.
 
 ~> **Note:** If `managed_instance_id` denotes a secondary instance deployed for disaster recovery purposes, then the `key_vault_key_id` should be the same key used for the primary instance's transparent data encryption. Both primary and secondary instances should be encrypted with same key material.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

As this resource supports auto-rotate key, it shall be able to accept versionless key id. Otherwise, a versioned key id with `auto_rotation_enabled=true` does not make sense. And it will cause dirft when the key is rotated.

At the configuration boundary, `key_vault_key_id` now accepts both versioned and versionless Key Vault key IDs when `auto_rotation_enabled` is `true`. If the configured ID is versionless, the provider resolves it to the latest versioned key URI before calling the Azure SQL MI API.  But the identity used by Terraform will require unwarp permission.

This also suppresses version-only diffs when `auto_rotation_enabled` is `true` and the new value is a versionless value. That handles the existing drift case where Azure rotates the TDE protector to a newer key version and the read API returns the new versioned URI.

When `auto_rotation_enabled` is `false`, versionless IDs are rejected because SQL MI TDE is expected to use a specific key version in that mode.

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<img width="1452" height="1178" alt="image" src="https://github.com/user-attachments/assets/f12b7b48-8710-413e-8293-fb3f63afc4b8" />

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_mssql_managed_instance_transparent_data_encryption` - support versionless `key_vault_key_id` [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #32382


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

review code and PR description

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
