### PR TITLE
`azurerm_cosmosdb_account` - Fix edge case for multi-location/consistency update

### DIFF
--- a/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/internal/services/cosmos/cosmosdb_account_resource.go
@@ -1064,6 +1064,21 @@ func resourceCosmosDbAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 		"tags", "automatic_failover_enabled", "analytical_storage_enabled",
 		"local_authentication_disabled", "partition_merge_enabled", "minimal_tls_version", "burst_capacity_enabled")
 
+	// Azure rejects an update that sets `ConsistencyPolicy=Strong` while `EnableMultipleWriteLocations=true`,
+	// because Strong consistency is incompatible with multi-region writes. When both fields change in the same
+	// apply (consistency -> Strong, multi-write true -> false), the consistency change must be deferred until
+	// after multi-write has been disabled, otherwise the initial batched update fails.
+	// This relies on `consistency_policy` being part of `updateRequired`.
+	deferStrongConsistency := false
+	if d.HasChange("consistency_policy") && d.HasChange("multiple_write_locations_enabled") {
+		oldMW, newMW := d.GetChange("multiple_write_locations_enabled")
+		if oldMW.(bool) && !newMW.(bool) {
+			if newPolicy := expandAzureRmCosmosDBAccountConsistencyPolicy(d); newPolicy != nil && newPolicy.DefaultConsistencyLevel == cosmosdb.DefaultConsistencyLevelStrong {
+				deferStrongConsistency = true
+			}
+		}
+	}
+
 	// Incident : #383341730
 	// Azure Bug: #2209567 'Updating identities and default identity at the same time fails silently'
 	//
@@ -1151,6 +1166,10 @@ func resourceCosmosDbAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 		}
 	}
 
+	if deferStrongConsistency {
+		account.Properties.ConsistencyPolicy = existing.Model.Properties.ConsistencyPolicy
+	}
+
 	// Only do this update if a value has changed above...
 	if updateRequired {
 		if err = resourceCosmosDbAccountApiCreateOrUpdate(client, ctx, *id, account); err != nil {
@@ -1165,6 +1184,15 @@ func resourceCosmosDbAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 		// Update the database...
 		if err = resourceCosmosDbAccountApiCreateOrUpdate(client, ctx, *id, account); err != nil {
 			return fmt.Errorf("updating %q EnableMultipleWriteLocations: %+v", id, err)
+		}
+	}
+
+	// Apply the deferred Strong consistency change now that multi-region writes are disabled.
+	if deferStrongConsistency {
+		account.Properties.ConsistencyPolicy = expandAzureRmCosmosDBAccountConsistencyPolicy(d)
+
+		if err = resourceCosmosDbAccountApiCreateOrUpdate(client, ctx, *id, account); err != nil {
+			return fmt.Errorf("updating %q ConsistencyPolicy: %+v", id, err)
 		}
 	}
 

--- a/internal/services/cosmos/cosmosdb_account_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_account_resource_test.go
@@ -1485,6 +1485,32 @@ func TestAccCosmosDBAccount_withoutMaxAgeInSeconds(t *testing.T) {
 	})
 }
 
+func TestAccCosmosDBAccount_updateConsistencyToStrongDisablingMultipleWriteLocations(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_account", "test")
+	r := CosmosDBAccountResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.multiMasterBoundedStaleness(data),
+			Check: acceptance.ComposeAggregateTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("multiple_write_locations_enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("consistency_policy.0.consistency_level").HasValue("Session"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.singleWriteStrong(data),
+			Check: acceptance.ComposeAggregateTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("multiple_write_locations_enabled").HasValue("false"),
+				check.That(data.ResourceName).Key("consistency_policy.0.consistency_level").HasValue("Strong"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r CosmosDBAccountResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := cosmosdb.ParseDatabaseAccountID(state.ID)
 	if err != nil {
@@ -4853,4 +4879,80 @@ resource "azurerm_cosmosdb_account" "test" {
   network_acl_bypass_for_azure_services = true
 }
 `, r.completePreReqs(data), data.RandomInteger, string(kind), string(consistency), data.Locations.Secondary, data.Locations.Ternary)
+}
+
+func (CosmosDBAccountResource) multiMasterBoundedStaleness(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-cosmos-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_cosmosdb_account" "test" {
+  name                = "acctest-ca-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  offer_type          = "Standard"
+  kind                = "GlobalDocumentDB"
+
+  multiple_write_locations_enabled = true
+
+  consistency_policy {
+    consistency_level       = "Session"
+    max_interval_in_seconds = 300
+    max_staleness_prefix    = 100000
+  }
+
+  geo_location {
+    location          = azurerm_resource_group.test.location
+    failover_priority = 0
+  }
+
+  geo_location {
+    location          = "%[3]s"
+    failover_priority = 1
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.Locations.Secondary)
+}
+
+func (CosmosDBAccountResource) singleWriteStrong(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-cosmos-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_cosmosdb_account" "test" {
+  name                = "acctest-ca-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  offer_type          = "Standard"
+  kind                = "GlobalDocumentDB"
+
+  multiple_write_locations_enabled = false
+
+  consistency_policy {
+    consistency_level = "Strong"
+  }
+
+  geo_location {
+    location          = azurerm_resource_group.test.location
+    failover_priority = 0
+  }
+
+  geo_location {
+    location          = "%[3]s"
+    failover_priority = 1
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.Locations.Secondary)
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Issue occurs when updating `azurerm_cosmosdb_account` resource by setting `multiple_write_locations_enabled` from `true` to `false` and `consistency_policy.0.consistency_level` from other to `Strong` in one single apply.

The root cause is because the existing code does a multi-step update: it calls the ARM API with `consistency_level` as `Strong` in the first step, which causes conflict with ` multiple_write_locations_enabled` as `true`.

The PR introduces a deferred update step for `consistency_level` for this special edge case after `multiple_write_locations_enabled` update.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

Run a full test set to cover all acc tests. 

<img width="1047" height="759" alt="image" src="https://github.com/user-attachments/assets/4b367c4e-bf14-4647-aa67-5246e688d2a3" />

`TestAccCosmosDBAccount_updateConsistencyToStrongDisablingMultipleWriteLocations` run with different default/alt locations as it failed with 5000 miles location distance restriction when creating the replicas with default env vars.

<img width="806" height="430" alt="image" src="https://github.com/user-attachments/assets/71554fb1-9cb4-4836-8229-7792ed8832a2" />

Update 27/05/2026:

Full test run link: https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_COSMOS/673881

<img width="1006" height="790" alt="image" src="https://github.com/user-attachments/assets/3a8b27e3-5b23-4ea9-96da-840c95906449" />


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #32374


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
