### PR TITLE
`azurerm_network_service_tags` - add cache for listing service tags per location

### DIFF
--- a/internal/services/network/client/service_tags_cache.go
+++ b/internal/services/network/client/service_tags_cache.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2014, 2025
 // SPDX-License-Identifier: MPL-2.0
 
 package client

--- a/internal/services/network/client/service_tags_cache.go
+++ b/internal/services/network/client/service_tags_cache.go
@@ -1,0 +1,46 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package client
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/servicetags"
+)
+
+var (
+	serviceTagsCache = map[string]*servicetags.ServiceTagsListResult{}
+	serviceTagsMu    sync.Mutex
+)
+
+func serviceTagsCacheKey(locationName string) string {
+	return strings.ToLower(locationName)
+}
+
+func (c *Client) CachedServiceTagsList(ctx context.Context, locationId servicetags.LocationId) (servicetags.ServiceTagsListOperationResponse, error) {
+	cacheKey := serviceTagsCacheKey(locationId.LocationName)
+
+	serviceTagsMu.Lock()
+	defer serviceTagsMu.Unlock()
+
+	if cached, ok := serviceTagsCache[cacheKey]; ok {
+		return servicetags.ServiceTagsListOperationResponse{
+			Model: cached,
+		}, nil
+	}
+
+	resp, err := c.ServiceTags.ServiceTagsList(ctx, locationId)
+	if err != nil {
+		return resp, fmt.Errorf("listing network service tags for %s: %+v", locationId, err)
+	}
+
+	if resp.Model != nil {
+		serviceTagsCache[cacheKey] = resp.Model
+	}
+
+	return resp, nil
+}

--- a/internal/services/network/network_service_tags_data_source.go
+++ b/internal/services/network/network_service_tags_data_source.go
@@ -68,13 +68,13 @@ func dataSourceNetworkServiceTags() *pluginsdk.Resource {
 }
 
 func dataSourceNetworkServiceTagsRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.ServiceTags
+	client := meta.(*clients.Client).Network
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	locationId := servicetags.NewLocationID(subscriptionId, location.Normalize(d.Get("location").(string)))
-	resp, err := client.ServiceTagsList(ctx, locationId)
+	resp, err := client.CachedServiceTagsList(ctx, locationId)
 	if err != nil {
 		return fmt.Errorf("listing network service tags: %+v", err)
 	}


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR adds an in-memory cache for the ServiceTagsList API call used by the azurerm_network_service_tags data source.

When a Terraform configuration references azurerm_network_service_tags multiple times for the same location, each instance makes a separate API call to list service tags, resulting in 429 Too Many Requests. Since service tags are read-only reference data that doesn't change within a single Terraform run, these redundant calls waste time and can contribute to API throttling.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_NETWORK/666781?buildTab=tests


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_network_service_tags ` - add caching for services tags per location [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #32362 


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
