### PR TITLE
[Contributor Documentation] - Clarify acceptance test `fmt.Sprintf` helper usage

### DIFF
--- a/contributing/topics/guide-new-resource.md
+++ b/contributing/topics/guide-new-resource.md
@@ -655,7 +655,7 @@ func (r ResourceGroupExampleResource) Update() sdk.ResourceFunc {
             if existing.Model.Properties == nil {
                return fmt.Errorf("retrieving %s: `properties` was nil", id)
             }
-            
+
             ...
             return nil
         },
@@ -942,9 +942,10 @@ There's a more detailed breakdown of how this works [in the Acceptance Testing r
 
 1. Test Terraform Configurations are defined as methods on the struct `ResourceGroupExampleResource` so that they're easily accessible (this helps to avoid them being unintentionally used in other resources).
 2. The `acceptance.TestData` object contains a number of helpers, including both random integers, strings and the Azure Locations where resources should be provisioned - which are used to ensure when tests are run in parallel that we provision unique resources for testing purposes.
-3. The `ApplyStep`'s apply the Terraform Configuration specified and then assert there's no changes after (e.g. `terraform apply` and then checking that `terraform plan` shows no changes).
-4. The `ImportStep` takes the Resource ID for the Resource and runs `terraform import azurerm_resource_group_example.test {resourceId}`, checking that the fields defined in the state match the fields returned from the Read function.
-5. We append `_test` to the Go package name (e.g. `resource_test`) since we need to be able to access both the `resource` package and the `acceptance` package (which is a circular reference, otherwise).
+3. When one config helper is only used once inside `fmt.Sprintf`, pass it directly as the argument (for example `r.basic(data)`) instead of assigning a temporary variable first.
+4. The `ApplyStep`'s apply the Terraform Configuration specified and then assert there's no changes after (e.g. `terraform apply` and then checking that `terraform plan` shows no changes).
+5. The `ImportStep` takes the Resource ID for the Resource and runs `terraform import azurerm_resource_group_example.test {resourceId}`, checking that the fields defined in the state match the fields returned from the Read function.
+6. We append `_test` to the Go package name (e.g. `resource_test`) since we need to be able to access both the `resource` package and the `acceptance` package (which is a circular reference, otherwise).
 
 At this point we should be able to run this test.
 

--- a/contributing/topics/reference-acceptance-testing.md
+++ b/contributing/topics/reference-acceptance-testing.md
@@ -187,36 +187,35 @@ A Data Source generally has one or two Required properties and a number of Compu
 
 Since the Data Source primarily exposes Computed-only fields which aren't specified in the Terraform Configuration, we typically assert that these computed fields have a/an expected value - which differs from the Acceptance Tests for the Resource where we'll use an Import step to confirm that the Terraform Configuration matches the imported state.
 
+When one config helper is only being threaded into `fmt.Sprintf` once, pass it directly as the argument instead of assigning a temporary variable first.
+
 ```go
-func TestAccExampleDataSource_complete(t *testing.T) {
+func TestAccExampleDataSource_basic(t *testing.T) {
         data := acceptance.BuildTestData(t, "data.azurerm_example_resource", "test")
         r := ExampleDataSource{}
 
-        data.ResourceTest(t, r, []acceptance.TestStep{
+        data.DataSourceTest(t, []acceptance.TestStep{
                 {
-                        Config: r.complete(data),
+                        Config: r.basic(data),
                         Check: acceptance.ComposeTestCheckFunc(
                             check.That(data.ResourceName).Key("example_property").HasValue("bar"),
                             check.That(data.ResourceName).Key("example_optional_bool").HasValue("false"),
                             check.That(data.ResourceName).Key("example_optional_string").HasValue("foo"),
                         ),
                 },
-                data.ImportStep(),
         })
 }
 
-func (ExampleDataSource) complete(data acceptance.TestData) string {
-	template := ExampleResource{}.basic(data)
+func (ExampleDataSource) basic(data acceptance.TestData) string {
     return fmt.Sprintf(`
 %[1]s
 
 data "azurerm_example_resource" "test" {
   name = azurerm_example_resource.test.name
 }
-`, template)
+`, ExampleResource{}.complete(data))
 }
 ```
-
 
 ---
 
@@ -325,8 +324,7 @@ func TestAccExampleResource_basic(t *testing.T) {
 }
 
 func (r ExampleResource) requiresImport(data acceptance.TestData) string {
-	template := r.basic(data)
-    return fmt.Sprintf(`
+        return fmt.Sprintf(`
 %[1]s
 
 resource "azurerm_example_resource" "import" {
@@ -334,7 +332,7 @@ resource "azurerm_example_resource" "import" {
   location         = azurerm_example_resource.example.location
   example_property = azurerm_example_resource.example.example_property
 }
-`, template)
+`, r.basic(data))
 }
 ```
 


### PR DESCRIPTION
## Community Note
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR updates the contributor documentation for acceptance-test config builders.

The main goal is to document the narrower style change we discussed without rewriting the existing contributor guidance more broadly than necessary. In particular, this keeps the original acceptance-testing guidance that a data source test may reuse the associated Resource `complete` configuration, while updating the examples to avoid assigning a one-use temporary variable just to pass a helper into `fmt.Sprintf`.

The documentation changes are:

- clarify in the acceptance testing reference that when a helper config is only passed once into `fmt.Sprintf`, it should be passed directly rather than first being assigned to a temporary variable
- update the acceptance testing examples to use the direct-call pattern
- keep the existing contributor guidance around data source tests reusing the associated Resource `complete` configuration
- align the new resource guide summary bullets with the same `fmt.Sprintf` helper-usage guidance

This is a docs-only update to contributor guidance. No provider behavior is changed.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them.
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

Docs-only change. I did not run acceptance or unit tests because this PR only updates contributor documentation examples and explanatory text.


## Change Log

None - contributor docs only


This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

N/A


## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

Extent of AI usage:
- drafting and refining contributor documentation wording
- reviewing existing acceptance-test examples for consistency with provider patterns
- iterating on the PR description


## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

No changes to security controls.