### PR TITLE
test: `azurerm_application_gateway` - `waf_configuration` property removed from tests due to retirement

### DIFF
--- a/internal/services/network/application_gateway_resource_test.go
+++ b/internal/services/network/application_gateway_resource_test.go
@@ -36,7 +36,6 @@ func TestAccApplicationGateway_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("sku.0.name").HasValue("Standard_v2"),
 				check.That(data.ResourceName).Key("sku.0.tier").HasValue("Standard_v2"),
 				check.That(data.ResourceName).Key("sku.0.capacity").HasValue("2"),
-				check.That(data.ResourceName).Key("waf_configuration.#").HasValue("0"),
 			),
 		},
 		data.ImportStep(),
@@ -56,7 +55,6 @@ func TestAccApplicationGateway_autoscaleConfiguration(t *testing.T) {
 				check.That(data.ResourceName).Key("sku.0.tier").HasValue("Standard_v2"),
 				check.That(data.ResourceName).Key("autoscale_configuration.0.min_capacity").HasValue("0"),
 				check.That(data.ResourceName).Key("autoscale_configuration.0.max_capacity").HasValue("10"),
-				check.That(data.ResourceName).Key("waf_configuration.#").HasValue("0"),
 			),
 		},
 		{
@@ -67,7 +65,6 @@ func TestAccApplicationGateway_autoscaleConfiguration(t *testing.T) {
 				check.That(data.ResourceName).Key("sku.0.tier").HasValue("Standard_v2"),
 				check.That(data.ResourceName).Key("autoscale_configuration.0.min_capacity").HasValue("4"),
 				check.That(data.ResourceName).Key("autoscale_configuration.0.max_capacity").HasValue("12"),
-				check.That(data.ResourceName).Key("waf_configuration.#").HasValue("0"),
 			),
 		},
 		data.ImportStep(),
@@ -86,7 +83,6 @@ func TestAccApplicationGateway_autoscaleConfigurationNoMaxCapacity(t *testing.T)
 				check.That(data.ResourceName).Key("sku.0.name").HasValue("Standard_v2"),
 				check.That(data.ResourceName).Key("sku.0.tier").HasValue("Standard_v2"),
 				check.That(data.ResourceName).Key("autoscale_configuration.0.min_capacity").HasValue("2"),
-				check.That(data.ResourceName).Key("waf_configuration.#").HasValue("0"),
 			),
 		},
 		data.ImportStep(),
@@ -136,7 +132,6 @@ func TestAccApplicationGateway_zones(t *testing.T) {
 				check.That(data.ResourceName).Key("sku.0.tier").HasValue("Standard_v2"),
 				check.That(data.ResourceName).Key("zones.#").HasValue("2"),
 				check.That(data.ResourceName).Key("sku.0.capacity").HasValue("2"),
-				check.That(data.ResourceName).Key("waf_configuration.#").HasValue("0"),
 			),
 		},
 		data.ImportStep(),
@@ -705,13 +700,7 @@ func TestAccApplicationGateway_webApplicationFirewall(t *testing.T) {
 				check.That(data.ResourceName).Key("sku.0.name").HasValue("WAF_v2"),
 				check.That(data.ResourceName).Key("sku.0.tier").HasValue("WAF_v2"),
 				check.That(data.ResourceName).Key("sku.0.capacity").HasValue("1"),
-				check.That(data.ResourceName).Key("waf_configuration.0.enabled").HasValue("true"),
-				check.That(data.ResourceName).Key("waf_configuration.0.firewall_mode").HasValue("Detection"),
-				check.That(data.ResourceName).Key("waf_configuration.0.rule_set_type").HasValue("OWASP"),
-				check.That(data.ResourceName).Key("waf_configuration.0.rule_set_version").HasValue("3.0"),
-				check.That(data.ResourceName).Key("waf_configuration.0.file_upload_limit_mb").HasValue("100"),
-				check.That(data.ResourceName).Key("waf_configuration.0.request_body_check").HasValue("true"),
-				check.That(data.ResourceName).Key("waf_configuration.0.max_request_body_size_kb").HasValue("100"),
+				check.That(data.ResourceName).Key("firewall_policy_id").IsNotEmpty(),
 			),
 		},
 	})
@@ -737,123 +726,11 @@ func TestAccApplicationGateway_connectionDraining(t *testing.T) {
 				check.That(data.ResourceName).Key("sku.0.name").HasValue("Standard_v2"),
 				check.That(data.ResourceName).Key("sku.0.tier").HasValue("Standard_v2"),
 				check.That(data.ResourceName).Key("sku.0.capacity").HasValue("2"),
-				check.That(data.ResourceName).Key("waf_configuration.#").HasValue("0"),
 				acceptance.TestCheckNoResourceAttr(data.ResourceName, "backend_http_settings.0.connection_draining.0.enabled"),
 				acceptance.TestCheckNoResourceAttr(data.ResourceName, "backend_http_settings.0.connection_draining.0.drain_timeout_sec"),
 			),
 		},
 		data.ImportStep(),
-	})
-}
-
-func TestAccApplicationGateway_webApplicationFirewall_disabledRuleGroups(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_application_gateway", "test")
-	r := ApplicationGatewayResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.webApplicationFirewall_disabledRuleGroups(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("sku.0.name").HasValue("WAF_v2"),
-				check.That(data.ResourceName).Key("sku.0.tier").HasValue("WAF_v2"),
-				check.That(data.ResourceName).Key("sku.0.capacity").HasValue("1"),
-				check.That(data.ResourceName).Key("waf_configuration.0.enabled").HasValue("true"),
-				check.That(data.ResourceName).Key("waf_configuration.0.firewall_mode").HasValue("Detection"),
-				check.That(data.ResourceName).Key("waf_configuration.0.rule_set_type").HasValue("OWASP"),
-				check.That(data.ResourceName).Key("waf_configuration.0.rule_set_version").HasValue("3.0"),
-				check.That(data.ResourceName).Key("waf_configuration.0.request_body_check").HasValue("true"),
-				check.That(data.ResourceName).Key("waf_configuration.0.max_request_body_size_kb").HasValue("128"),
-				check.That(data.ResourceName).Key("waf_configuration.0.file_upload_limit_mb").HasValue("100"),
-				check.That(data.ResourceName).Key("waf_configuration.0.disabled_rule_group.0.rule_group_name").HasValue("REQUEST-921-PROTOCOL-ATTACK"),
-				check.That(data.ResourceName).Key("waf_configuration.0.disabled_rule_group.0.rules.0").HasValue("921110"),
-				check.That(data.ResourceName).Key("waf_configuration.0.disabled_rule_group.0.rules.1").HasValue("921151"),
-				check.That(data.ResourceName).Key("waf_configuration.0.disabled_rule_group.0.rules.2").HasValue("921180"),
-				check.That(data.ResourceName).Key("waf_configuration.0.disabled_rule_group.1.rule_group_name").HasValue("REQUEST-930-APPLICATION-ATTACK-LFI"),
-				check.That(data.ResourceName).Key("waf_configuration.0.disabled_rule_group.1.rules.0").HasValue("930120"),
-				check.That(data.ResourceName).Key("waf_configuration.0.disabled_rule_group.1.rules.1").HasValue("930130"),
-				check.That(data.ResourceName).Key("waf_configuration.0.disabled_rule_group.2.rule_group_name").HasValue("REQUEST-942-APPLICATION-ATTACK-SQLI"),
-			),
-		},
-		{
-			Config: r.webApplicationFirewall_disabledRuleGroups_enabled_some_rules(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("sku.0.name").HasValue("WAF_v2"),
-				check.That(data.ResourceName).Key("sku.0.tier").HasValue("WAF_v2"),
-				check.That(data.ResourceName).Key("sku.0.capacity").HasValue("1"),
-				check.That(data.ResourceName).Key("waf_configuration.0.enabled").HasValue("true"),
-				check.That(data.ResourceName).Key("waf_configuration.0.firewall_mode").HasValue("Detection"),
-				check.That(data.ResourceName).Key("waf_configuration.0.rule_set_type").HasValue("OWASP"),
-				check.That(data.ResourceName).Key("waf_configuration.0.rule_set_version").HasValue("3.0"),
-				check.That(data.ResourceName).Key("waf_configuration.0.request_body_check").HasValue("true"),
-				check.That(data.ResourceName).Key("waf_configuration.0.max_request_body_size_kb").HasValue("128"),
-				check.That(data.ResourceName).Key("waf_configuration.0.file_upload_limit_mb").HasValue("100"),
-				check.That(data.ResourceName).Key("waf_configuration.0.disabled_rule_group.0.rule_group_name").HasValue("REQUEST-921-PROTOCOL-ATTACK"),
-				check.That(data.ResourceName).Key("waf_configuration.0.disabled_rule_group.0.rules.0").HasValue("921110"),
-				check.That(data.ResourceName).Key("waf_configuration.0.disabled_rule_group.0.rules.1").HasValue("921151"),
-				check.That(data.ResourceName).Key("waf_configuration.0.disabled_rule_group.0.rules.2").HasValue("921180"),
-				check.That(data.ResourceName).Key("waf_configuration.0.disabled_rule_group.1.rule_group_name").HasValue("REQUEST-942-APPLICATION-ATTACK-SQLI"),
-			),
-		},
-	})
-}
-
-func TestAccApplicationGateway_webApplicationFirewall_exclusions(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_application_gateway", "test")
-	r := ApplicationGatewayResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.webApplicationFirewall_exclusions_many(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("sku.0.name").HasValue("WAF_v2"),
-				check.That(data.ResourceName).Key("sku.0.tier").HasValue("WAF_v2"),
-				check.That(data.ResourceName).Key("sku.0.capacity").HasValue("1"),
-				check.That(data.ResourceName).Key("waf_configuration.0.enabled").HasValue("true"),
-				check.That(data.ResourceName).Key("waf_configuration.0.firewall_mode").HasValue("Detection"),
-				check.That(data.ResourceName).Key("waf_configuration.0.rule_set_type").HasValue("OWASP"),
-				check.That(data.ResourceName).Key("waf_configuration.0.rule_set_version").HasValue("3.0"),
-				check.That(data.ResourceName).Key("waf_configuration.0.request_body_check").HasValue("true"),
-				check.That(data.ResourceName).Key("waf_configuration.0.max_request_body_size_kb").HasValue("128"),
-				check.That(data.ResourceName).Key("waf_configuration.0.file_upload_limit_mb").HasValue("750"),
-				check.That(data.ResourceName).Key("waf_configuration.0.exclusion.0.match_variable").HasValue("RequestArgNames"),
-				check.That(data.ResourceName).Key("waf_configuration.0.exclusion.0.selector_match_operator").HasValue("Equals"),
-				check.That(data.ResourceName).Key("waf_configuration.0.exclusion.0.selector").HasValue("displayNameHtml"),
-				check.That(data.ResourceName).Key("waf_configuration.0.exclusion.1.match_variable").HasValue("RequestCookieNames"),
-				check.That(data.ResourceName).Key("waf_configuration.0.exclusion.1.selector_match_operator").HasValue("EndsWith"),
-				check.That(data.ResourceName).Key("waf_configuration.0.exclusion.1.selector").HasValue("username"),
-				check.That(data.ResourceName).Key("waf_configuration.0.exclusion.2.match_variable").HasValue("RequestHeaderNames"),
-				check.That(data.ResourceName).Key("waf_configuration.0.exclusion.2.selector_match_operator").HasValue("StartsWith"),
-				check.That(data.ResourceName).Key("waf_configuration.0.exclusion.2.selector").HasValue("ORIGIN"),
-				check.That(data.ResourceName).Key("waf_configuration.0.exclusion.3.match_variable").HasValue("RequestHeaderNames"),
-				check.That(data.ResourceName).Key("waf_configuration.0.exclusion.3.selector_match_operator").HasValue("Contains"),
-				check.That(data.ResourceName).Key("waf_configuration.0.exclusion.3.selector").HasValue("ORIGIN"),
-				check.That(data.ResourceName).Key("waf_configuration.0.exclusion.4.match_variable").HasValue("RequestHeaderNames"),
-				check.That(data.ResourceName).Key("waf_configuration.0.exclusion.4.selector_match_operator").HasValue(""),
-				check.That(data.ResourceName).Key("waf_configuration.0.exclusion.4.selector").HasValue(""),
-			),
-		},
-		{
-			Config: r.webApplicationFirewall_exclusions_one(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("sku.0.name").HasValue("WAF_v2"),
-				check.That(data.ResourceName).Key("sku.0.tier").HasValue("WAF_v2"),
-				check.That(data.ResourceName).Key("sku.0.capacity").HasValue("1"),
-				check.That(data.ResourceName).Key("waf_configuration.0.enabled").HasValue("true"),
-				check.That(data.ResourceName).Key("waf_configuration.0.firewall_mode").HasValue("Detection"),
-				check.That(data.ResourceName).Key("waf_configuration.0.rule_set_type").HasValue("OWASP"),
-				check.That(data.ResourceName).Key("waf_configuration.0.rule_set_version").HasValue("3.0"),
-				check.That(data.ResourceName).Key("waf_configuration.0.request_body_check").HasValue("true"),
-				check.That(data.ResourceName).Key("waf_configuration.0.max_request_body_size_kb").HasValue("128"),
-				check.That(data.ResourceName).Key("waf_configuration.0.file_upload_limit_mb").HasValue("750"),
-				check.That(data.ResourceName).Key("waf_configuration.0.exclusion.0.match_variable").HasValue("RequestArgNames"),
-				check.That(data.ResourceName).Key("waf_configuration.0.exclusion.0.selector_match_operator").HasValue("Equals"),
-				check.That(data.ResourceName).Key("waf_configuration.0.exclusion.0.selector").HasValue("displayNameHtml"),
-			),
-		},
 	})
 }
 
@@ -2782,10 +2659,29 @@ resource "azurerm_key_vault_certificate" "test" {
   }
 }
 
+resource "azurerm_web_application_firewall_policy" "test" {
+  name                = "acctest-wafp-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  managed_rules {
+    managed_rule_set {
+      type    = "OWASP"
+      version = "3.2"
+    }
+  }
+
+  policy_settings {
+    enabled = true
+    mode    = "Detection"
+  }
+}
+
 resource "azurerm_application_gateway" "test" {
   name                = "acctestag-%[2]d"
   resource_group_name = "${azurerm_resource_group.test.name}"
   location            = "${azurerm_resource_group.test.location}"
+  firewall_policy_id  = azurerm_web_application_firewall_policy.test.id
 
   sku {
     name     = "WAF_v2"
@@ -2796,16 +2692,6 @@ resource "azurerm_application_gateway" "test" {
   gateway_ip_configuration {
     name      = "my-gateway-ip-configuration"
     subnet_id = "${azurerm_subnet.test.id}"
-  }
-
-  waf_configuration {
-    enabled                  = true
-    firewall_mode            = "Detection"
-    rule_set_type            = "OWASP"
-    rule_set_version         = "3.0"
-    file_upload_limit_mb     = 100
-    request_body_check       = true
-    max_request_body_size_kb = 100
   }
 
   identity {
@@ -2967,10 +2853,29 @@ resource "azurerm_key_vault_certificate" "test2" {
   }
 }
 
+resource "azurerm_web_application_firewall_policy" "test" {
+  name                = "acctest-wafp-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  managed_rules {
+    managed_rule_set {
+      type    = "OWASP"
+      version = "3.2"
+    }
+  }
+
+  policy_settings {
+    enabled = true
+    mode    = "Detection"
+  }
+}
+
 resource "azurerm_application_gateway" "test" {
   name                = "acctestag-%[2]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
+  firewall_policy_id  = azurerm_web_application_firewall_policy.test.id
 
   sku {
     name     = "WAF_v2"
@@ -2981,16 +2886,6 @@ resource "azurerm_application_gateway" "test" {
   gateway_ip_configuration {
     name      = "my-gateway-ip-configuration"
     subnet_id = azurerm_subnet.test.id
-  }
-
-  waf_configuration {
-    enabled                  = true
-    firewall_mode            = "Detection"
-    rule_set_type            = "OWASP"
-    rule_set_version         = "3.0"
-    file_upload_limit_mb     = 100
-    request_body_check       = true
-    max_request_body_size_kb = 100
   }
 
   identity {
@@ -3140,10 +3035,29 @@ resource "azurerm_public_ip" "teststd" {
   sku                 = "Standard"
 }
 
+resource "azurerm_web_application_firewall_policy" "test" {
+  name                = "acctest-wafp-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  managed_rules {
+    managed_rule_set {
+      type    = "OWASP"
+      version = "3.2"
+    }
+  }
+
+  policy_settings {
+    enabled = true
+    mode    = "Detection"
+  }
+}
+
 resource "azurerm_application_gateway" "test" {
   name                = "acctestag-%[2]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
+  firewall_policy_id  = azurerm_web_application_firewall_policy.test.id
 
   sku {
     name     = "WAF_v2"
@@ -3154,16 +3068,6 @@ resource "azurerm_application_gateway" "test" {
   gateway_ip_configuration {
     name      = "my-gateway-ip-configuration"
     subnet_id = azurerm_subnet.test.id
-  }
-
-  waf_configuration {
-    enabled                  = true
-    firewall_mode            = "Detection"
-    rule_set_type            = "OWASP"
-    rule_set_version         = "3.0"
-    file_upload_limit_mb     = 100
-    request_body_check       = true
-    max_request_body_size_kb = 100
   }
 
   frontend_port {
@@ -3598,10 +3502,29 @@ resource "azurerm_public_ip" "teststd" {
   sku                 = "Standard"
 }
 
+resource "azurerm_web_application_firewall_policy" "test" {
+  name                = "acctest-wafp-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  managed_rules {
+    managed_rule_set {
+      type    = "OWASP"
+      version = "3.2"
+    }
+  }
+
+  policy_settings {
+    enabled = true
+    mode    = "Detection"
+  }
+}
+
 resource "azurerm_application_gateway" "test" {
   name                = "acctestag-%[2]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
+  firewall_policy_id  = azurerm_web_application_firewall_policy.test.id
 
   sku {
     name     = "WAF_v2"
@@ -3622,16 +3545,6 @@ resource "azurerm_application_gateway" "test" {
   frontend_ip_configuration {
     name                 = local.frontend_ip_configuration_name
     public_ip_address_id = azurerm_public_ip.teststd.id
-  }
-
-  waf_configuration {
-    enabled                  = true
-    firewall_mode            = "Detection"
-    rule_set_type            = "OWASP"
-    rule_set_version         = "3.0"
-    file_upload_limit_mb     = 100
-    request_body_check       = true
-    max_request_body_size_kb = 100
   }
 
   backend_address_pool {
@@ -4875,10 +4788,29 @@ resource "azurerm_key_vault_certificate" "test" {
   }
 }
 
+resource "azurerm_web_application_firewall_policy" "test" {
+  name                = "acctest-wafp-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  managed_rules {
+    managed_rule_set {
+      type    = "OWASP"
+      version = "3.2"
+    }
+  }
+
+  policy_settings {
+    enabled = true
+    mode    = "Detection"
+  }
+}
+
 resource "azurerm_application_gateway" "test" {
   name                = "acctestag-%[2]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
+  firewall_policy_id  = azurerm_web_application_firewall_policy.test.id
 
   sku {
     name     = "WAF_v2"
@@ -4889,16 +4821,6 @@ resource "azurerm_application_gateway" "test" {
   gateway_ip_configuration {
     name      = "my-gateway-ip-configuration"
     subnet_id = azurerm_subnet.test.id
-  }
-
-  waf_configuration {
-    enabled                  = true
-    firewall_mode            = "Detection"
-    rule_set_type            = "OWASP"
-    rule_set_version         = "3.0"
-    file_upload_limit_mb     = 100
-    request_body_check       = true
-    max_request_body_size_kb = 100
   }
 
   identity {
@@ -5035,10 +4957,29 @@ resource "azurerm_key_vault_certificate" "test" {
   }
 }
 
+resource "azurerm_web_application_firewall_policy" "test" {
+  name                = "acctest-wafp-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  managed_rules {
+    managed_rule_set {
+      type    = "OWASP"
+      version = "3.2"
+    }
+  }
+
+  policy_settings {
+    enabled = true
+    mode    = "Detection"
+  }
+}
+
 resource "azurerm_application_gateway" "test" {
   name                = "acctestag-%[2]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
+  firewall_profile_id = azurerm_web_application_firewall_policy.test.id
 
   sku {
     name     = "WAF_v2"
@@ -5049,16 +4990,6 @@ resource "azurerm_application_gateway" "test" {
   gateway_ip_configuration {
     name      = "my-gateway-ip-configuration"
     subnet_id = azurerm_subnet.test.id
-  }
-
-  waf_configuration {
-    enabled                  = true
-    firewall_mode            = "Detection"
-    rule_set_type            = "OWASP"
-    rule_set_version         = "3.0"
-    file_upload_limit_mb     = 100
-    request_body_check       = true
-    max_request_body_size_kb = 100
   }
 
   identity {
@@ -5583,25 +5514,34 @@ locals {
   request_routing_rule_name      = "${azurerm_virtual_network.test.name}-rqrt"
 }
 
-resource "azurerm_application_gateway" "test" {
-  name                = "acctestag-%d"
+resource "azurerm_web_application_firewall_policy" "test" {
+  name                = "acctest-wafp-%[2]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
+
+  managed_rules {
+    managed_rule_set {
+      type    = "OWASP"
+      version = "3.2"
+    }
+  }
+
+  policy_settings {
+    enabled = true
+    mode    = "Detection"
+  }
+}
+
+resource "azurerm_application_gateway" "test" {
+  name                = "acctestag-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  firewall_policy_id  = azurerm_web_application_firewall_policy.test.id
 
   sku {
     name     = "WAF_v2"
     tier     = "WAF_v2"
     capacity = 1
-  }
-
-  waf_configuration {
-    enabled                  = true
-    firewall_mode            = "Detection"
-    rule_set_type            = "OWASP"
-    rule_set_version         = "3.0"
-    file_upload_limit_mb     = 100
-    request_body_check       = true
-    max_request_body_size_kb = 100
   }
 
   gateway_ip_configuration {
@@ -5725,419 +5665,6 @@ resource "azurerm_application_gateway" "test" {
   }
 }
 `, r.template(data), data.RandomInteger)
-}
-
-func (r ApplicationGatewayResource) webApplicationFirewall_disabledRuleGroups(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%s
-
-# since these variables are re-used - a locals block makes this more maintainable
-locals {
-  backend_address_pool_name      = "${azurerm_virtual_network.test.name}-beap"
-  frontend_port_name             = "${azurerm_virtual_network.test.name}-feport"
-  frontend_ip_configuration_name = "${azurerm_virtual_network.test.name}-feip"
-  http_setting_name              = "${azurerm_virtual_network.test.name}-be-htst"
-  listener_name                  = "${azurerm_virtual_network.test.name}-httplstn"
-  request_routing_rule_name      = "${azurerm_virtual_network.test.name}-rqrt"
-}
-
-resource "azurerm_public_ip" "test_standard" {
-  name                = "acctest-pubip-%d-standard"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  sku                 = "Standard"
-  allocation_method   = "Static"
-}
-
-resource "azurerm_application_gateway" "test" {
-  name                = "acctestag-%d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-
-  sku {
-    name     = "WAF_v2"
-    tier     = "WAF_v2"
-    capacity = 1
-  }
-
-  waf_configuration {
-    enabled                  = true
-    firewall_mode            = "Detection"
-    rule_set_type            = "OWASP"
-    rule_set_version         = "3.0"
-    request_body_check       = true
-    max_request_body_size_kb = 128
-    file_upload_limit_mb     = 100
-
-    disabled_rule_group {
-      rule_group_name = "REQUEST-921-PROTOCOL-ATTACK"
-      rules           = [921110, 921151, 921180]
-    }
-
-    disabled_rule_group {
-      rule_group_name = "REQUEST-930-APPLICATION-ATTACK-LFI"
-      rules           = [930120, 930130]
-    }
-
-    disabled_rule_group {
-      rule_group_name = "REQUEST-942-APPLICATION-ATTACK-SQLI"
-    }
-  }
-
-  gateway_ip_configuration {
-    name      = "my-gateway-ip-configuration"
-    subnet_id = azurerm_subnet.test.id
-  }
-
-  frontend_port {
-    name = local.frontend_port_name
-    port = 80
-  }
-
-  frontend_ip_configuration {
-    name                 = local.frontend_ip_configuration_name
-    public_ip_address_id = azurerm_public_ip.test_standard.id
-  }
-
-  backend_address_pool {
-    name = local.backend_address_pool_name
-  }
-
-  backend_http_settings {
-    name                  = local.http_setting_name
-    cookie_based_affinity = "Disabled"
-    port                  = 80
-    protocol              = "Http"
-    request_timeout       = 1
-  }
-
-  http_listener {
-    name                           = local.listener_name
-    frontend_ip_configuration_name = local.frontend_ip_configuration_name
-    frontend_port_name             = local.frontend_port_name
-    protocol                       = "Http"
-  }
-
-  request_routing_rule {
-    name                       = local.request_routing_rule_name
-    rule_type                  = "Basic"
-    http_listener_name         = local.listener_name
-    backend_address_pool_name  = local.backend_address_pool_name
-    backend_http_settings_name = local.http_setting_name
-    priority                   = 10
-  }
-}
-`, r.template(data), data.RandomInteger, data.RandomInteger)
-}
-
-func (r ApplicationGatewayResource) webApplicationFirewall_disabledRuleGroups_enabled_some_rules(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%s
-
-# since these variables are re-used - a locals block makes this more maintainable
-locals {
-  backend_address_pool_name      = "${azurerm_virtual_network.test.name}-beap"
-  frontend_port_name             = "${azurerm_virtual_network.test.name}-feport"
-  frontend_ip_configuration_name = "${azurerm_virtual_network.test.name}-feip"
-  http_setting_name              = "${azurerm_virtual_network.test.name}-be-htst"
-  listener_name                  = "${azurerm_virtual_network.test.name}-httplstn"
-  request_routing_rule_name      = "${azurerm_virtual_network.test.name}-rqrt"
-}
-
-resource "azurerm_public_ip" "test_standard" {
-  name                = "acctest-pubip-%d-standard"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  sku                 = "Standard"
-  allocation_method   = "Static"
-}
-
-resource "azurerm_application_gateway" "test" {
-  name                = "acctestag-%d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-
-  sku {
-    name     = "WAF_v2"
-    tier     = "WAF_v2"
-    capacity = 1
-  }
-
-  waf_configuration {
-    enabled                  = true
-    firewall_mode            = "Detection"
-    rule_set_type            = "OWASP"
-    rule_set_version         = "3.0"
-    request_body_check       = true
-    max_request_body_size_kb = 128
-    file_upload_limit_mb     = 100
-
-    disabled_rule_group {
-      rule_group_name = "REQUEST-921-PROTOCOL-ATTACK"
-      rules           = [921110, 921151, 921180]
-    }
-
-    disabled_rule_group {
-      rule_group_name = "REQUEST-942-APPLICATION-ATTACK-SQLI"
-    }
-  }
-
-  gateway_ip_configuration {
-    name      = "my-gateway-ip-configuration"
-    subnet_id = azurerm_subnet.test.id
-  }
-
-  frontend_port {
-    name = local.frontend_port_name
-    port = 80
-  }
-
-  frontend_ip_configuration {
-    name                 = local.frontend_ip_configuration_name
-    public_ip_address_id = azurerm_public_ip.test_standard.id
-  }
-
-  backend_address_pool {
-    name = local.backend_address_pool_name
-  }
-
-  backend_http_settings {
-    name                  = local.http_setting_name
-    cookie_based_affinity = "Disabled"
-    port                  = 80
-    protocol              = "Http"
-    request_timeout       = 1
-  }
-
-  http_listener {
-    name                           = local.listener_name
-    frontend_ip_configuration_name = local.frontend_ip_configuration_name
-    frontend_port_name             = local.frontend_port_name
-    protocol                       = "Http"
-  }
-
-  request_routing_rule {
-    name                       = local.request_routing_rule_name
-    rule_type                  = "Basic"
-    http_listener_name         = local.listener_name
-    backend_address_pool_name  = local.backend_address_pool_name
-    backend_http_settings_name = local.http_setting_name
-    priority                   = 10
-  }
-}
-`, r.template(data), data.RandomInteger, data.RandomInteger)
-}
-
-func (r ApplicationGatewayResource) webApplicationFirewall_exclusions_many(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%s
-
-# since these variables are re-used - a locals block makes this more maintainable
-locals {
-  backend_address_pool_name      = "${azurerm_virtual_network.test.name}-beap"
-  frontend_port_name             = "${azurerm_virtual_network.test.name}-feport"
-  frontend_ip_configuration_name = "${azurerm_virtual_network.test.name}-feip"
-  http_setting_name              = "${azurerm_virtual_network.test.name}-be-htst"
-  listener_name                  = "${azurerm_virtual_network.test.name}-httplstn"
-  request_routing_rule_name      = "${azurerm_virtual_network.test.name}-rqrt"
-}
-
-resource "azurerm_public_ip" "test_standard" {
-  name                = "acctest-pubip-%d-standard"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  sku                 = "Standard"
-  allocation_method   = "Static"
-}
-
-resource "azurerm_application_gateway" "test" {
-  name                = "acctestag-%d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-
-  sku {
-    name     = "WAF_v2"
-    tier     = "WAF_v2"
-    capacity = 1
-  }
-
-  waf_configuration {
-    enabled                  = true
-    firewall_mode            = "Detection"
-    rule_set_type            = "OWASP"
-    rule_set_version         = "3.0"
-    request_body_check       = true
-    max_request_body_size_kb = 128
-    file_upload_limit_mb     = 750
-
-    exclusion {
-      match_variable          = "RequestArgNames"
-      selector_match_operator = "Equals"
-      selector                = "displayNameHtml"
-    }
-
-    exclusion {
-      match_variable          = "RequestCookieNames"
-      selector_match_operator = "EndsWith"
-      selector                = "username"
-    }
-
-    exclusion {
-      match_variable          = "RequestHeaderNames"
-      selector_match_operator = "StartsWith"
-      selector                = "ORIGIN"
-    }
-
-    exclusion {
-      match_variable          = "RequestHeaderNames"
-      selector_match_operator = "Contains"
-      selector                = "ORIGIN"
-    }
-
-    exclusion {
-      match_variable = "RequestHeaderNames"
-    }
-  }
-
-  gateway_ip_configuration {
-    name      = "my-gateway-ip-configuration"
-    subnet_id = azurerm_subnet.test.id
-  }
-
-  frontend_port {
-    name = local.frontend_port_name
-    port = 80
-  }
-
-  frontend_ip_configuration {
-    name                 = local.frontend_ip_configuration_name
-    public_ip_address_id = azurerm_public_ip.test_standard.id
-  }
-
-  backend_address_pool {
-    name = local.backend_address_pool_name
-  }
-
-  backend_http_settings {
-    name                  = local.http_setting_name
-    cookie_based_affinity = "Disabled"
-    port                  = 80
-    protocol              = "Http"
-    request_timeout       = 1
-  }
-
-  http_listener {
-    name                           = local.listener_name
-    frontend_ip_configuration_name = local.frontend_ip_configuration_name
-    frontend_port_name             = local.frontend_port_name
-    protocol                       = "Http"
-  }
-
-  request_routing_rule {
-    name                       = local.request_routing_rule_name
-    rule_type                  = "Basic"
-    http_listener_name         = local.listener_name
-    backend_address_pool_name  = local.backend_address_pool_name
-    backend_http_settings_name = local.http_setting_name
-    priority                   = 10
-  }
-}
-`, r.template(data), data.RandomInteger, data.RandomInteger)
-}
-
-func (r ApplicationGatewayResource) webApplicationFirewall_exclusions_one(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%s
-
-# since these variables are re-used - a locals block makes this more maintainable
-locals {
-  backend_address_pool_name      = "${azurerm_virtual_network.test.name}-beap"
-  frontend_port_name             = "${azurerm_virtual_network.test.name}-feport"
-  frontend_ip_configuration_name = "${azurerm_virtual_network.test.name}-feip"
-  http_setting_name              = "${azurerm_virtual_network.test.name}-be-htst"
-  listener_name                  = "${azurerm_virtual_network.test.name}-httplstn"
-  request_routing_rule_name      = "${azurerm_virtual_network.test.name}-rqrt"
-}
-
-resource "azurerm_public_ip" "test_standard" {
-  name                = "acctest-pubip-%d-standard"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  sku                 = "Standard"
-  allocation_method   = "Static"
-}
-
-resource "azurerm_application_gateway" "test" {
-  name                = "acctestag-%d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-
-  sku {
-    name     = "WAF_v2"
-    tier     = "WAF_v2"
-    capacity = 1
-  }
-
-  waf_configuration {
-    enabled                  = true
-    firewall_mode            = "Detection"
-    rule_set_type            = "OWASP"
-    rule_set_version         = "3.0"
-    request_body_check       = true
-    max_request_body_size_kb = 128
-    file_upload_limit_mb     = 750
-
-    exclusion {
-      match_variable          = "RequestArgNames"
-      selector_match_operator = "Equals"
-      selector                = "displayNameHtml"
-    }
-  }
-
-  gateway_ip_configuration {
-    name      = "my-gateway-ip-configuration"
-    subnet_id = azurerm_subnet.test.id
-  }
-
-  frontend_port {
-    name = local.frontend_port_name
-    port = 80
-  }
-
-  frontend_ip_configuration {
-    name                 = local.frontend_ip_configuration_name
-    public_ip_address_id = azurerm_public_ip.test_standard.id
-  }
-
-  backend_address_pool {
-    name = local.backend_address_pool_name
-  }
-
-  backend_http_settings {
-    name                  = local.http_setting_name
-    cookie_based_affinity = "Disabled"
-    port                  = 80
-    protocol              = "Http"
-    request_timeout       = 1
-  }
-
-  http_listener {
-    name                           = local.listener_name
-    frontend_ip_configuration_name = local.frontend_ip_configuration_name
-    frontend_port_name             = local.frontend_port_name
-    protocol                       = "Http"
-  }
-
-  request_routing_rule {
-    name                       = local.request_routing_rule_name
-    rule_type                  = "Basic"
-    http_listener_name         = local.listener_name
-    backend_address_pool_name  = local.backend_address_pool_name
-    backend_http_settings_name = local.http_setting_name
-    priority                   = 10
-  }
-}
-`, r.template(data), data.RandomInteger, data.RandomInteger)
 }
 
 func (r ApplicationGatewayResource) sslPolicy_policyType_predefined(data acceptance.TestData) string {

--- a/internal/services/network/application_gateway_resource_test.go
+++ b/internal/services/network/application_gateway_resource_test.go
@@ -4979,7 +4979,7 @@ resource "azurerm_application_gateway" "test" {
   name                = "acctestag-%[2]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  firewall_policy_id = azurerm_web_application_firewall_policy.test.id
+  firewall_policy_id  = azurerm_web_application_firewall_policy.test.id
 
   sku {
     name     = "WAF_v2"

--- a/internal/services/network/application_gateway_resource_test.go
+++ b/internal/services/network/application_gateway_resource_test.go
@@ -4979,7 +4979,7 @@ resource "azurerm_application_gateway" "test" {
   name                = "acctestag-%[2]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  firewall_profile_id = azurerm_web_application_firewall_policy.test.id
+  firewall_policy_id = azurerm_web_application_firewall_policy.test.id
 
   sku {
     name     = "WAF_v2"


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

In `azurerm_application_gateway`, the option to also configure a `waf_configuration` has now been officially retired from Azure for new resource creation:
https://learn.microsoft.com/en-us/azure/web-application-firewall/ag/upgrade-ag-waf-policy?tabs=portal#retirement-timelines

> No creation of new WAF configuration deployments: March 15, 2025. The ability to create new WAF configuration deployments on the Application Gateway WAF V2 SKU has been fully discontinued on March 15, 2025.

The `waf_configuration` option for existing resources is still valid, so this is a TEST ONLY change as creating new resources with this option is now failing and we will not be able to test.

**NOTE**: The removal of using this option in these tests consist of the following scenarios:
1. For gateways of type `WAF_V2` that need a rule for the test, but are not directly testing the rule, I have swapped out the old `waf_configuration` block with the preferred `azurerm_web_application_firewall_policy`.
2. The tests that were specifically designed to test the functionality of the `waf_configuration` block itself have been completely removed, as these types of tests are all covered in the `azurerm_web_application_firewall_policy` package.


## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
