### PR TITLE
list and identity implementation - azurerm_key_vault_access_policy

### DIFF
--- a/internal/services/keyvault/key_vault_access_policy_resource.go
+++ b/internal/services/keyvault/key_vault_access_policy_resource.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-02-01/vaults"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
@@ -23,6 +24,8 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
+
+const keyVaultAccessPolicyResourceName = "azurerm_key_vault_access_policy"
 
 func resourceKeyVaultAccessPolicy() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
@@ -35,6 +38,27 @@ func resourceKeyVaultAccessPolicy() *pluginsdk.Resource {
 			_, err := parse.AccessPolicyID(id)
 			return err
 		}),
+
+		// NOTE: Resource Identity is implemented manually because `parse.AccessPolicyId` is a custom ID
+		// type that does not implement `resourceids.ResourceId`, so the auto-generation helpers cannot be used.
+		Identity: &schema.ResourceIdentity{
+			SchemaFunc: func() map[string]*schema.Schema {
+				return map[string]*schema.Schema{
+					"key_vault_id": {
+						Type:              schema.TypeString,
+						RequiredForImport: true,
+					},
+					"object_id": {
+						Type:              schema.TypeString,
+						RequiredForImport: true,
+					},
+					"application_id": {
+						Type:              schema.TypeString,
+						RequiredForImport: true,
+					},
+				}
+			},
+		},
 
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
@@ -180,6 +204,9 @@ func resourceKeyVaultAccessPolicyCreate(d *pluginsdk.ResourceData, meta interfac
 	}
 
 	d.SetId(id.ID())
+	if err := setKeyVaultAccessPolicyIdentityData(d, &id); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -288,31 +315,55 @@ func resourceKeyVaultAccessPolicyRead(d *pluginsdk.ResourceData, meta interface{
 		return nil
 	}
 
+	return resourceKeyVaultAccessPolicyFlatten(d, id, accessPolicy)
+}
+
+func resourceKeyVaultAccessPolicyFlatten(d *pluginsdk.ResourceData, id *parse.AccessPolicyId, accessPolicy *vaults.AccessPolicyEntry) error {
 	d.Set("key_vault_id", id.KeyVaultId().ID())
 	d.Set("application_id", id.ApplicationId())
 	d.Set("object_id", id.ObjectID())
-	d.Set("tenant_id", accessPolicy.TenantId)
 
-	certificatePermissions := flattenCertificatePermissions(accessPolicy.Permissions.Certificates)
-	if err := d.Set("certificate_permissions", certificatePermissions); err != nil {
-		return fmt.Errorf("setting `certificate_permissions`: %+v", err)
+	if accessPolicy != nil {
+		d.Set("tenant_id", accessPolicy.TenantId)
+
+		certificatePermissions := flattenCertificatePermissions(accessPolicy.Permissions.Certificates)
+		if err := d.Set("certificate_permissions", certificatePermissions); err != nil {
+			return fmt.Errorf("setting `certificate_permissions`: %+v", err)
+		}
+
+		keyPermissions := flattenKeyPermissions(accessPolicy.Permissions.Keys)
+		if err := d.Set("key_permissions", keyPermissions); err != nil {
+			return fmt.Errorf("setting `key_permissions`: %+v", err)
+		}
+
+		secretPermissions := flattenSecretPermissions(accessPolicy.Permissions.Secrets)
+		if err := d.Set("secret_permissions", secretPermissions); err != nil {
+			return fmt.Errorf("setting `secret_permissions`: %+v", err)
+		}
+
+		storagePermissions := flattenStoragePermissions(accessPolicy.Permissions.Storage)
+		if err := d.Set("storage_permissions", storagePermissions); err != nil {
+			return fmt.Errorf("setting `storage_permissions`: %+v", err)
+		}
 	}
 
-	keyPermissions := flattenKeyPermissions(accessPolicy.Permissions.Keys)
-	if err := d.Set("key_permissions", keyPermissions); err != nil {
-		return fmt.Errorf("setting `key_permissions`: %+v", err)
-	}
+	return setKeyVaultAccessPolicyIdentityData(d, id)
+}
 
-	secretPermissions := flattenSecretPermissions(accessPolicy.Permissions.Secrets)
-	if err := d.Set("secret_permissions", secretPermissions); err != nil {
-		return fmt.Errorf("setting `secret_permissions`: %+v", err)
+func setKeyVaultAccessPolicyIdentityData(d *pluginsdk.ResourceData, id *parse.AccessPolicyId) error {
+	identity, err := d.Identity()
+	if err != nil {
+		return fmt.Errorf("getting identity: %+v", err)
 	}
-
-	storagePermissions := flattenStoragePermissions(accessPolicy.Permissions.Storage)
-	if err := d.Set("storage_permissions", storagePermissions); err != nil {
-		return fmt.Errorf("setting `storage_permissions`: %+v", err)
+	if err := identity.Set("key_vault_id", id.KeyVaultId().ID()); err != nil {
+		return fmt.Errorf("setting `key_vault_id` in resource identity: %+v", err)
 	}
-
+	if err := identity.Set("object_id", id.ObjectID()); err != nil {
+		return fmt.Errorf("setting `object_id` in resource identity: %+v", err)
+	}
+	if err := identity.Set("application_id", id.ApplicationId()); err != nil {
+		return fmt.Errorf("setting `application_id` in resource identity: %+v", err)
+	}
 	return nil
 }
 

--- a/internal/services/keyvault/key_vault_access_policy_resource_identity_test.go
+++ b/internal/services/keyvault/key_vault_access_policy_resource_identity_test.go
@@ -1,0 +1,42 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package keyvault_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	customstatecheck "github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/statecheck"
+)
+
+// NOTE: Resource Identity is implemented manually for `azurerm_key_vault_access_policy` because the resource
+// uses a custom parse.AccessPolicyId type that does not implement resourceids.ResourceId.
+// This means the go:generate tool cannot be used and identity-based import is not supported.
+
+func TestAccKeyVaultAccessPolicy_resourceIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_key_vault_access_policy", "test")
+	r := KeyVaultAccessPolicyResource{}
+
+	checkedFields := map[string]struct{}{
+		"key_vault_id":   {},
+		"object_id":      {},
+		"application_id": {},
+	}
+
+	data.ResourceIdentityTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			ConfigStateChecks: []statecheck.StateCheck{
+				customstatecheck.ExpectAllIdentityFieldsAreChecked("azurerm_key_vault_access_policy.test", checkedFields),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_key_vault_access_policy.test", tfjsonpath.New("key_vault_id"), tfjsonpath.New("key_vault_id")),
+				statecheck.ExpectIdentityValueMatchesStateAtPath("azurerm_key_vault_access_policy.test", tfjsonpath.New("object_id"), tfjsonpath.New("object_id")),
+				statecheck.ExpectIdentityValue("azurerm_key_vault_access_policy.test", tfjsonpath.New("application_id"), knownvalue.StringExact("")),
+			},
+		},
+		data.ImportBlockWithIDStep(false),
+	}, false)
+}

--- a/internal/services/keyvault/key_vault_access_policy_resource_list.go
+++ b/internal/services/keyvault/key_vault_access_policy_resource_list.go
@@ -1,0 +1,114 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package keyvault
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-azure-helpers/framework/typehelpers"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-02-01/vaults"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type KeyVaultAccessPolicyListResource struct{}
+
+type KeyVaultAccessPolicyListModel struct {
+	KeyVaultId types.String `tfsdk:"key_vault_id"`
+}
+
+var _ sdk.FrameworkListWrappedResource = new(KeyVaultAccessPolicyListResource)
+
+func (KeyVaultAccessPolicyListResource) ResourceFunc() *pluginsdk.Resource {
+	return resourceKeyVaultAccessPolicy()
+}
+
+func (r KeyVaultAccessPolicyListResource) Metadata(_ context.Context, _ resource.MetadataRequest, response *resource.MetadataResponse) {
+	response.TypeName = keyVaultAccessPolicyResourceName
+}
+
+func (r KeyVaultAccessPolicyListResource) ListResourceConfigSchema(_ context.Context, _ list.ListResourceSchemaRequest, response *list.ListResourceSchemaResponse) {
+	response.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"key_vault_id": schema.StringAttribute{
+				Required: true,
+				Validators: []validator.String{
+					typehelpers.WrappedStringValidator{
+						Func: commonids.ValidateKeyVaultID,
+					},
+				},
+			},
+		},
+	}
+}
+
+func (KeyVaultAccessPolicyListResource) List(ctx context.Context, request list.ListRequest, stream *list.ListResultsStream, metadata sdk.ResourceMetadata) {
+	client := metadata.Client.KeyVault.VaultsClient
+
+	var data KeyVaultAccessPolicyListModel
+	diags := request.Config.Get(ctx, &data)
+	if diags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	keyVaultId, err := commonids.ParseKeyVaultID(data.KeyVaultId.ValueString())
+	if err != nil {
+		sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("parsing `key_vault_id` for `%s`", keyVaultAccessPolicyResourceName), err)
+		return
+	}
+
+	resp, err := client.Get(ctx, *keyVaultId)
+	if err != nil {
+		sdk.SetResponseErrorDiagnostic(stream, fmt.Sprintf("retrieving Key Vault for `%s`", keyVaultAccessPolicyResourceName), err)
+		return
+	}
+
+	var accessPolicies []vaults.AccessPolicyEntry
+	if resp.Model != nil && resp.Model.Properties.AccessPolicies != nil {
+		accessPolicies = *resp.Model.Properties.AccessPolicies
+	}
+
+	stream.Results = func(push func(list.ListResult) bool) {
+		for _, policy := range accessPolicies {
+			appId := ""
+			if policy.ApplicationId != nil {
+				appId = pointer.From(policy.ApplicationId)
+			}
+
+			id := parse.NewAccessPolicyId(*keyVaultId, policy.ObjectId, appId)
+
+			result := request.NewListResult(ctx)
+			result.DisplayName = fmt.Sprintf("%s/%s", keyVaultId.VaultName, policy.ObjectId)
+
+			rd := resourceKeyVaultAccessPolicy().Data(&terraform.InstanceState{})
+			rd.SetId(id.ID())
+
+			if err := resourceKeyVaultAccessPolicyFlatten(rd, &id, &policy); err != nil {
+				sdk.SetErrorDiagnosticAndPushListResult(result, push, fmt.Sprintf("encoding `%s` resource data", keyVaultAccessPolicyResourceName), err)
+				return
+			}
+
+			sdk.EncodeListResult(ctx, rd, &result)
+			if result.Diagnostics.HasError() {
+				push(result)
+				return
+			}
+
+			if !push(result) {
+				return
+			}
+		}
+	}
+}

--- a/internal/services/keyvault/key_vault_access_policy_resource_list_test.go
+++ b/internal/services/keyvault/key_vault_access_policy_resource_list_test.go
@@ -1,0 +1,103 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package keyvault_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider/framework"
+)
+
+func TestAccKeyVaultAccessPolicy_list_basic(t *testing.T) {
+	r := KeyVaultAccessPolicyResource{}
+	listResourceAddress := "azurerm_key_vault_access_policy.list"
+
+	data := acceptance.BuildTestData(t, "azurerm_key_vault_access_policy", "test0")
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		ProtoV5ProviderFactories: framework.ProtoV5ProviderFactoriesInit(context.Background(), "azurerm"),
+		Steps: []resource.TestStep{
+			{
+				Config: r.basicList(data),
+			},
+			{
+				Query:  true,
+				Config: r.basicListQuery(data),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLengthAtLeast(listResourceAddress, 3),
+				},
+			},
+		},
+	})
+}
+
+func (r KeyVaultAccessPolicyResource) basicList(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_user_assigned_identity" "test" {
+  count               = 3
+  name                = "acctest-uai-%[1]d-${count.index}"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_key_vault" "test" {
+  name                       = "acctestkv-%[3]s"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "standard"
+  soft_delete_retention_days = 7
+}
+
+resource "azurerm_key_vault_access_policy" "test" {
+  count = 3
+
+  key_vault_id = azurerm_key_vault.test.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = azurerm_user_assigned_identity.test[count.index].principal_id
+
+  key_permissions = [
+    "Get",
+    "List",
+  ]
+
+  secret_permissions = [
+    "Get",
+    "Set",
+  ]
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func (r KeyVaultAccessPolicyResource) basicListQuery(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+list "azurerm_key_vault_access_policy" "list" {
+  provider = azurerm
+  config {
+    key_vault_id = "/subscriptions/%[1]s/resourceGroups/acctestRG-%[2]d/providers/Microsoft.KeyVault/vaults/acctestkv-%[3]s"
+  }
+}
+`, data.Subscriptions.Primary, data.RandomInteger, data.RandomString)
+}

--- a/internal/services/keyvault/registration.go
+++ b/internal/services/keyvault/registration.go
@@ -95,5 +95,7 @@ func (r Registration) EphemeralResources() []func() ephemeral.EphemeralResource 
 }
 
 func (r Registration) ListResources() []sdk.FrameworkListWrappedResource {
-	return []sdk.FrameworkListWrappedResource{}
+	return []sdk.FrameworkListWrappedResource{
+		KeyVaultAccessPolicyListResource{},
+	}
 }

--- a/website/docs/list-resources/key_vault_access_policy.html.markdown
+++ b/website/docs/list-resources/key_vault_access_policy.html.markdown
@@ -1,0 +1,30 @@
+---
+subcategory: "Key Vault"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_key_vault_access_policy"
+description: |-
+  Lists Key Vault Access Policy resources.
+---
+
+# List resource: azurerm_key_vault_access_policy
+
+Lists Key Vault Access Policy resources for a given Key Vault.
+
+## Example Usage
+
+### List all Access Policies for a Key Vault
+
+```hcl
+list "azurerm_key_vault_access_policy" "example" {
+  provider = azurerm
+  config {
+    key_vault_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example-rg/providers/Microsoft.KeyVault/vaults/example-kv"
+  }
+}
+```
+
+## Argument Reference
+
+This list resource supports the following arguments:
+
+* `key_vault_id` - (Required) The ID of the Key Vault whose Access Policies should be listed.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Note : Resource Identity is implemented manually because parse.AccessPolicyId is a custom union ID type that does not implement resourceids.ResourceId, which is required by the generator tooling. This is a known generator limitation per the contributing guide.

List and identity implementation for azurerm_key_vault_access_policy

Teamcity run: https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_KEYVAULT/668794?buildTab=tests

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
