### PR TITLE
provider: remove antiquated lifecycle logging patterns 

### DIFF
--- a/internal/services/aadb2c/aadb2c_directory_resource.go
+++ b/internal/services/aadb2c/aadb2c_directory_resource.go
@@ -152,7 +152,6 @@ func (r AadB2cDirectoryResource) Create() sdk.ResourceFunc {
 
 			id := tenants.NewB2CDirectoryID(subscriptionId, model.ResourceGroup, model.DomainName)
 
-			metadata.Logger.Infof("Import check for %s", id)
 			existing, err := client.Get(ctx, id)
 			if err != nil && !response.WasNotFound(existing.HttpResponse) {
 				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
@@ -162,7 +161,6 @@ func (r AadB2cDirectoryResource) Create() sdk.ResourceFunc {
 				return metadata.ResourceRequiresImport(r.ResourceType(), id)
 			}
 
-			metadata.Logger.Infof("Domain name availability check for %s", id)
 			availabilityResult, err := client.CheckNameAvailability(ctx, commonids.NewSubscriptionID(subscriptionId), tenants.CheckNameAvailabilityRequest{
 				Name:        &model.DomainName,
 				CountryCode: &model.CountryCode,
@@ -183,8 +181,6 @@ func (r AadB2cDirectoryResource) Create() sdk.ResourceFunc {
 					return fmt.Errorf("checking availability of `domain_name`: the specified domain %q is unavailable: %s", model.DomainName, reason)
 				}
 			}
-
-			metadata.Logger.Infof("Creating %s", id)
 
 			properties := tenants.CreateTenant{
 				Location: tenants.Location(model.DataResidencyLocation),
@@ -222,13 +218,10 @@ func (r AadB2cDirectoryResource) Update() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("Decoding state for %s", id)
 			var state AadB2cDirectoryModel
 			if err := metadata.Decode(&state); err != nil {
 				return err
 			}
-
-			metadata.Logger.Infof("Updating %s", id)
 
 			properties := tenants.UpdateTenant{
 				Sku: tenants.Sku{
@@ -258,7 +251,6 @@ func (r AadB2cDirectoryResource) Read() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("Reading %s", id)
 			resp, err := client.Get(ctx, *id)
 			if err != nil {
 				if response.WasNotFound(resp.HttpResponse) {
@@ -321,8 +313,6 @@ func (r AadB2cDirectoryResource) Delete() sdk.ResourceFunc {
 			if err != nil {
 				return err
 			}
-
-			metadata.Logger.Infof("Deleting %s", id)
 
 			if err := client.DeleteThenPoll(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s: %+v", id, err)

--- a/internal/services/analysisservices/analysis_services_server_resource.go
+++ b/internal/services/analysisservices/analysis_services_server_resource.go
@@ -6,7 +6,6 @@ package analysisservices
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
@@ -151,8 +150,6 @@ func resourceAnalysisServicesServerCreate(d *pluginsdk.ResourceData, meta interf
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Azure ARM Analysis Services Server creation.")
-
 	id := servers.NewServerID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
 	server, err := client.GetDetails(ctx, id)
@@ -262,8 +259,6 @@ func resourceAnalysisServicesServerUpdate(d *pluginsdk.ResourceData, meta interf
 	client := meta.(*clients.Client).AnalysisServices.Servers
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for Azure ARM Analysis Services Server update.")
 
 	id, err := servers.ParseServerID(d.Id())
 	if err != nil {

--- a/internal/services/apimanagement/api_management_custom_domain_resource.go
+++ b/internal/services/apimanagement/api_management_custom_domain_resource.go
@@ -245,8 +245,6 @@ func apiManagementCustomDomainDelete(d *pluginsdk.ResourceData, meta interface{}
 		return fmt.Errorf("waiting for %s to become ready: %+v", *id, err)
 	}
 
-	log.Printf("[DEBUG] Deleting %s", *id)
-
 	if resp.Model != nil {
 		resp.Model.Properties.HostnameConfigurations = nil
 	}

--- a/internal/services/apimanagement/api_management_gateway_certificate_authority_resource.go
+++ b/internal/services/apimanagement/api_management_gateway_certificate_authority_resource.go
@@ -145,7 +145,6 @@ func resourceApiManagementGatewayCertificateAuthorityDelete(d *pluginsdk.Resourc
 		return err
 	}
 
-	log.Printf("[DEBUG] Deleting %s", *id)
 	if resp, err := client.Delete(ctx, *id, gatewaycertificateauthority.DeleteOperationOptions{}); err != nil {
 		if !response.WasNotFound(resp.HttpResponse) {
 			return fmt.Errorf("deleting %s: %+v", *id, err)

--- a/internal/services/apimanagement/api_management_gateway_host_name_configuration_resource.go
+++ b/internal/services/apimanagement/api_management_gateway_host_name_configuration_resource.go
@@ -184,7 +184,6 @@ func resourceApiManagementGatewayHostNameConfigurationDelete(d *pluginsdk.Resour
 		return err
 	}
 
-	log.Printf("[DEBUG] Deleting %s", *id)
 	if resp, err := client.Delete(ctx, *id, gatewayhostnameconfiguration.DeleteOperationOptions{}); err != nil {
 		if !response.WasNotFound(resp.HttpResponse) {
 			return fmt.Errorf("deleting %s: %+v", *id, err)

--- a/internal/services/apimanagement/api_management_product_resource.go
+++ b/internal/services/apimanagement/api_management_product_resource.go
@@ -204,7 +204,6 @@ func resourceApiManagementProductDelete(d *pluginsdk.ResourceData, meta interfac
 		return err
 	}
 
-	log.Printf("[DEBUG] Deleting %s", *id)
 	if resp, err := client.Delete(ctx, *id, product.DeleteOperationOptions{DeleteSubscriptions: pointer.To(true)}); err != nil {
 		if !response.WasNotFound(resp.HttpResponse) {
 			return fmt.Errorf("deleting %s: %+v", *id, err)

--- a/internal/services/apimanagement/api_management_product_resource.go
+++ b/internal/services/apimanagement/api_management_product_resource.go
@@ -91,8 +91,6 @@ func resourceApiManagementProductCreateUpdate(d *pluginsdk.ResourceData, meta in
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for API Management Product creation.")
-
 	id := product.NewProductID(subscriptionId, d.Get("resource_group_name").(string), d.Get("api_management_name").(string), d.Get("product_id").(string))
 
 	displayName := d.Get("display_name").(string)

--- a/internal/services/apimanagement/api_management_product_tag_resource.go
+++ b/internal/services/apimanagement/api_management_product_tag_resource.go
@@ -124,7 +124,6 @@ func resourceApiManagementProductTagDelete(d *pluginsdk.ResourceData, meta inter
 		return err
 	}
 
-	log.Printf("[DEBUG] Deleting %s", *id)
 	resp, err := client.TagDetachFromProduct(ctx, *id)
 	if err != nil {
 		if !response.WasNotFound(resp.HttpResponse) {

--- a/internal/services/apimanagement/api_management_resource.go
+++ b/internal/services/apimanagement/api_management_resource.go
@@ -753,7 +753,6 @@ func resourceApiManagementServiceCreate(d *pluginsdk.ResourceData, meta interfac
 	defer cancel()
 
 	sku := expandAzureRmApiManagementSkuName(d.Get("sku_name").(string))
-	log.Printf("[INFO] preparing arguments for API Management Service creation.")
 
 	id := apimanagementservice.NewServiceID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
@@ -1036,8 +1035,6 @@ func resourceApiManagementServiceUpdate(d *pluginsdk.ResourceData, meta interfac
 	sku := expandAzureRmApiManagementSkuName(d.Get("sku_name").(string))
 	virtualNetworkType := d.Get("virtual_network_type").(string)
 	virtualNetworkConfiguration := expandAzureRmApiManagementVirtualNetworkConfigurations(d)
-
-	log.Printf("[INFO] preparing arguments for API Management Service creation.")
 
 	id := apimanagementservice.NewServiceID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 

--- a/internal/services/apimanagement/api_management_resource.go
+++ b/internal/services/apimanagement/api_management_resource.go
@@ -1496,7 +1496,6 @@ func apiManagementRefreshFunc(ctx context.Context, client *apimanagementservice.
 		resp, err := client.Get(ctx, id)
 		if err != nil {
 			if response.WasNotFound(resp.HttpResponse) {
-				log.Printf("[DEBUG] Retrieving API Management %q (Resource Group: %q) returned 404.", id.ServiceName, id.ResourceGroupName)
 				return nil, "NotFound", nil
 			}
 

--- a/internal/services/apimanagement/api_management_resource.go
+++ b/internal/services/apimanagement/api_management_resource.go
@@ -940,7 +940,6 @@ func resourceApiManagementServiceCreate(d *pluginsdk.ResourceData, meta interfac
 			if err != nil {
 				return fmt.Errorf("parsing API ID: %+v", err)
 			}
-			log.Printf("[DEBUG] Deleting %s", apiId)
 			if delResp, err := apiClient.Delete(ctx, *apiId, api.DeleteOperationOptions{DeleteRevisions: pointer.To(true)}); err != nil {
 				if !response.WasNotFound(delResp.HttpResponse) {
 					return fmt.Errorf("deleting %s: %+v", *apiId, err)
@@ -963,7 +962,6 @@ func resourceApiManagementServiceCreate(d *pluginsdk.ResourceData, meta interfac
 			if err != nil {
 				return fmt.Errorf("parsing product ID: %+v", err)
 			}
-			log.Printf("[DEBUG] Deleting %s", productId)
 			if delResp, err := productsClient.Delete(ctx, *productId, product.DeleteOperationOptions{DeleteSubscriptions: pointer.To(true)}); err != nil {
 				if !response.WasNotFound(delResp.HttpResponse) {
 					return fmt.Errorf("deleting %s: %+v", *productId, err)
@@ -1431,7 +1429,6 @@ func resourceApiManagementServiceDelete(d *pluginsdk.ResourceData, meta interfac
 		return fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	log.Printf("[DEBUG] Deleting %s", *id)
 	resp, err := client.Delete(ctx, *id)
 	if err != nil {
 		return fmt.Errorf("deleting %s: %v", *id, err)

--- a/internal/services/apimanagement/api_management_user_resource.go
+++ b/internal/services/apimanagement/api_management_user_resource.go
@@ -104,8 +104,6 @@ func resourceApiManagementUserCreateUpdate(d *pluginsdk.ResourceData, meta inter
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for API Management User creation.")
-
 	id := user.NewUserID(subscriptionId, d.Get("resource_group_name").(string), d.Get("api_management_name").(string), d.Get("user_id").(string))
 
 	firstName := d.Get("first_name").(string)

--- a/internal/services/apimanagement/api_management_user_resource.go
+++ b/internal/services/apimanagement/api_management_user_resource.go
@@ -207,7 +207,6 @@ func resourceApiManagementUserDelete(d *pluginsdk.ResourceData, meta interface{}
 		return err
 	}
 
-	log.Printf("[DEBUG] Deleting %s", *id)
 	resp, err := client.Delete(ctx, *id, user.DeleteOperationOptions{AppType: pointer.To(user.AppTypeDeveloperPortal), DeleteSubscriptions: pointer.To(true), Notify: pointer.To(false)})
 	if err != nil {
 		if !response.WasNotFound(resp.HttpResponse) {

--- a/internal/services/appconfiguration/app_configuration_feature_resource.go
+++ b/internal/services/appconfiguration/app_configuration_feature_resource.go
@@ -247,7 +247,6 @@ func (k FeatureResource) Create() sdk.ResourceFunc {
 
 			// from https://learn.microsoft.com/en-us/azure/azure-app-configuration/concept-enable-rbac#azure-built-in-roles-for-azure-app-configuration
 			// allow some time for role permission to be propagated
-			metadata.Logger.Infof("[DEBUG] Waiting for App Configuration Feature %q read permission to be propagated", featureKey)
 			stateConf := &pluginsdk.StateChangeConf{
 				Pending:                   []string{"Forbidden"},
 				Target:                    []string{"Error", "Exists", "NotFound"},
@@ -344,7 +343,6 @@ func (k FeatureResource) Create() sdk.ResourceFunc {
 			}
 
 			// https://github.com/Azure/AppConfiguration/issues/763
-			metadata.Logger.Infof("[DEBUG] Waiting for App Configuration Feature %q to be provisioned", model.Key)
 			stateConf = &pluginsdk.StateChangeConf{
 				Pending:                   []string{"NotFound", "Forbidden"},
 				Target:                    []string{"Exists"},

--- a/internal/services/appconfiguration/app_configuration_key_resource.go
+++ b/internal/services/appconfiguration/app_configuration_key_resource.go
@@ -173,7 +173,6 @@ func (k KeyResource) Create() sdk.ResourceFunc {
 
 			// from https://learn.microsoft.com/en-us/azure/azure-app-configuration/concept-enable-rbac#azure-built-in-roles-for-azure-app-configuration
 			// allow some time for role permission to be propagated
-			metadata.Logger.Infof("[DEBUG] Waiting for App Configuration Key %q read permission to be propagated", model.Key)
 			stateConf := &pluginsdk.StateChangeConf{
 				Pending:                   []string{"Forbidden"},
 				Target:                    []string{"Error", "Exists", "NotFound"},
@@ -230,7 +229,6 @@ func (k KeyResource) Create() sdk.ResourceFunc {
 			}
 
 			// https://github.com/Azure/AppConfiguration/issues/763
-			metadata.Logger.Infof("[DEBUG] Waiting for App Configuration Key %q to be provisioned", model.Key)
 			stateConf = &pluginsdk.StateChangeConf{
 				Pending:                   []string{"NotFound", "Forbidden"},
 				Target:                    []string{"Exists"},

--- a/internal/services/appconfiguration/app_configuration_resource.go
+++ b/internal/services/appconfiguration/app_configuration_resource.go
@@ -1021,7 +1021,6 @@ func resourceConfigurationStoreNameAvailabilityRefreshFunc(ctx context.Context, 
 
 func deleteReplicas(ctx context.Context, replicaClient *replicas.ReplicasClient, operationClient *operations.OperationsClient, configurationStoreReplicaIds []replicas.ReplicaId) error {
 	for _, configurationStoreReplicaId := range configurationStoreReplicaIds {
-		log.Printf("[DEBUG] Deleting Replica %q", configurationStoreReplicaId)
 		if err := replicaClient.DeleteThenPoll(ctx, configurationStoreReplicaId); err != nil {
 			return fmt.Errorf("deleting replica %q: %+v", configurationStoreReplicaId, err)
 		}

--- a/internal/services/appconfiguration/app_configuration_resource.go
+++ b/internal/services/appconfiguration/app_configuration_resource.go
@@ -328,7 +328,6 @@ func resourceAppConfigurationCreate(d *pluginsdk.ResourceData, meta interface{})
 			}
 			// if the soft deleted is not found, skip the recovering
 		} else {
-			log.Printf("[DEBUG] Soft Deleted App Configuration exists, marked for recover")
 			recoverSoftDeleted = true
 		}
 	}

--- a/internal/services/appconfiguration/app_configuration_resource.go
+++ b/internal/services/appconfiguration/app_configuration_resource.go
@@ -300,8 +300,6 @@ func resourceAppConfigurationCreate(d *pluginsdk.ResourceData, meta interface{})
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Azure ARM App Configuration creation.")
-
 	name := d.Get("name").(string)
 	resourceGroup := d.Get("resource_group_name").(string)
 	resourceId := configurationstores.NewConfigurationStoreID(subscriptionId, resourceGroup, name)
@@ -415,7 +413,6 @@ func resourceAppConfigurationUpdate(d *pluginsdk.ResourceData, meta interface{})
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Azure ARM App Configuration update.")
 	id, err := configurationstores.ParseConfigurationStoreID(d.Id())
 	if err != nil {
 		return err

--- a/internal/services/applicationinsights/application_insights_smart_detection_rule_resource.go
+++ b/internal/services/applicationinsights/application_insights_smart_detection_rule_resource.go
@@ -100,8 +100,6 @@ func resourceApplicationInsightsSmartDetectionRuleUpdate(d *pluginsdk.ResourceDa
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for AzureRM Application Insights Smart Detection Rule update.")
-
 	// The Smart Detection Rule name from the UI doesn't match what the API accepts.
 	// We'll have the user submit what the name looks like in the UI and convert it behind the scenes to match what the API accepts
 	name := convertUiNameToApiName(d.Get("name"))

--- a/internal/services/applicationinsights/application_insights_smart_detection_rule_resource.go
+++ b/internal/services/applicationinsights/application_insights_smart_detection_rule_resource.go
@@ -139,8 +139,6 @@ func resourceApplicationInsightsSmartDetectionRuleRead(d *pluginsdk.ResourceData
 		return err
 	}
 
-	log.Printf("[DEBUG] Reading AzureRM Application Insights Smart Detection Rule %s", id)
-
 	resp, err := client.ProactiveDetectionConfigurationsGet(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {

--- a/internal/services/applicationinsights/application_insights_web_test_resource.go
+++ b/internal/services/applicationinsights/application_insights_web_test_resource.go
@@ -298,8 +298,6 @@ func resourceApplicationInsightsWebTestsRead(d *pluginsdk.ResourceData, meta int
 		return err
 	}
 
-	log.Printf("[DEBUG] Reading AzureRM Application Insights %q", *id)
-
 	resp, err := client.WebTestsGet(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {

--- a/internal/services/applicationinsights/application_insights_web_test_resource.go
+++ b/internal/services/applicationinsights/application_insights_web_test_resource.go
@@ -146,8 +146,6 @@ func resourceApplicationInsightsWebTestsCreate(d *pluginsdk.ResourceData, meta i
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for AzureRM Application Insights WebTest creation.")
-
 	appInsightsId, err := components.ParseComponentID(d.Get("application_insights_id").(string))
 	if err != nil {
 		return err

--- a/internal/services/appservice/app_service_environment_v3_resource.go
+++ b/internal/services/appservice/app_service_environment_v3_resource.go
@@ -449,7 +449,6 @@ func (r AppServiceEnvironmentV3Resource) Update() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Info("Decoding state...")
 			var state AppServiceEnvironmentV3Model
 			if err := metadata.Decode(&state); err != nil {
 				return err
@@ -464,8 +463,6 @@ func (r AppServiceEnvironmentV3Resource) Update() sdk.ResourceFunc {
 			if model == nil {
 				return fmt.Errorf("retrieving %s: model was nil", *id)
 			}
-
-			metadata.Logger.Infof("updating %s", id)
 
 			if metadata.ResourceData.HasChange("cluster_setting") {
 				model.Properties.ClusterSettings = expandClusterSettingsModel(state.ClusterSetting)

--- a/internal/services/appservice/function_app_flex_consumption_resource.go
+++ b/internal/services/appservice/function_app_flex_consumption_resource.go
@@ -779,8 +779,6 @@ func (r FunctionAppFlexConsumptionResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("deleting %s", *id)
-
 			delOptions := webapps.DeleteOperationOptions{
 				DeleteEmptyServerFarm: pointer.To(false),
 				DeleteMetrics:         pointer.To(false),

--- a/internal/services/appservice/function_app_function_resource.go
+++ b/internal/services/appservice/function_app_function_resource.go
@@ -348,8 +348,6 @@ func (r FunctionAppFunctionResource) Delete() sdk.ResourceFunc {
 			}
 			appId := commonids.NewAppServiceID(id.SubscriptionId, id.ResourceGroupName, id.SiteName)
 
-			metadata.Logger.Infof("deleting %s", *id)
-
 			deadline, ok := ctx.Deadline()
 			if !ok {
 				return fmt.Errorf("internal-error: context had no deadline")

--- a/internal/services/appservice/linux_function_app_resource.go
+++ b/internal/services/appservice/linux_function_app_resource.go
@@ -872,8 +872,6 @@ func (r LinuxFunctionAppResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("deleting Linux %s", *id)
-
 			delOptions := webapps.DeleteOperationOptions{
 				DeleteEmptyServerFarm: pointer.To(false),
 				DeleteMetrics:         pointer.To(false),

--- a/internal/services/appservice/linux_function_app_resource.go
+++ b/internal/services/appservice/linux_function_app_resource.go
@@ -1264,7 +1264,7 @@ func (r LinuxFunctionAppResource) CustomizeDiff() sdk.ResourceFunc {
 				}
 				if aspModel := asp.Model; aspModel != nil {
 					if aspModel.Properties != nil && aspModel.Properties.HostingEnvironmentProfile != nil &&
-						aspModel.Properties.HostingEnvironmentProfile.Id != nil && *(aspModel.Properties.HostingEnvironmentProfile.Id) != "" && !newValue.(bool) {
+						aspModel.Properties.HostingEnvironmentProfile.Id != nil && *aspModel.Properties.HostingEnvironmentProfile.Id != "" && !newValue.(bool) {
 						return fmt.Errorf("`vnet_image_pull_enabled` cannot be disabled for app running in an app service environment")
 					}
 					if sku := aspModel.Sku; sku != nil {

--- a/internal/services/appservice/linux_function_app_slot_resource.go
+++ b/internal/services/appservice/linux_function_app_slot_resource.go
@@ -831,7 +831,6 @@ func (r LinuxFunctionAppSlotResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("deleting Linux %s", *id)
 			delOpts := webapps.DeleteSlotOperationOptions{
 				DeleteEmptyServerFarm: pointer.To(false),
 				DeleteMetrics:         pointer.To(false),

--- a/internal/services/appservice/linux_function_app_slot_resource.go
+++ b/internal/services/appservice/linux_function_app_slot_resource.go
@@ -1237,7 +1237,7 @@ func (r LinuxFunctionAppSlotResource) CustomizeDiff() sdk.ResourceFunc {
 					return fmt.Errorf("retrieving %s: %+v", functionAppId, err)
 				}
 				if functionAppModel := functionApp.Model; functionAppModel != nil && functionAppModel.Properties != nil {
-					if ase := functionAppModel.Properties.HostingEnvironmentProfile; ase != nil && ase.Id != nil && *(ase.Id) != "" && !newValue.(bool) {
+					if ase := functionAppModel.Properties.HostingEnvironmentProfile; ase != nil && ase.Id != nil && *ase.Id != "" && !newValue.(bool) {
 						return fmt.Errorf("`vnet_image_pull_enabled` cannot be disabled for app slot running in an app service environment")
 					}
 				}

--- a/internal/services/appservice/linux_web_app_resource.go
+++ b/internal/services/appservice/linux_web_app_resource.go
@@ -1081,7 +1081,7 @@ func (r LinuxWebAppResource) CustomizeDiff() sdk.ResourceFunc {
 				}
 				if aspModel := asp.Model; aspModel != nil {
 					if aspModel.Properties != nil && aspModel.Properties.HostingEnvironmentProfile != nil &&
-						aspModel.Properties.HostingEnvironmentProfile.Id != nil && *(aspModel.Properties.HostingEnvironmentProfile.Id) != "" && !newValue.(bool) {
+						aspModel.Properties.HostingEnvironmentProfile.Id != nil && *aspModel.Properties.HostingEnvironmentProfile.Id != "" && !newValue.(bool) {
 						return fmt.Errorf("`vnet_image_pull_enabled` cannot be disabled for app running in an app service environment")
 					}
 				}

--- a/internal/services/appservice/linux_web_app_resource.go
+++ b/internal/services/appservice/linux_web_app_resource.go
@@ -715,7 +715,6 @@ func (r LinuxWebAppResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("deleting %s", *id)
 			delOptions := webapps.DeleteOperationOptions{
 				DeleteEmptyServerFarm: pointer.To(false),
 				DeleteMetrics:         pointer.To(false),

--- a/internal/services/appservice/linux_web_app_slot_resource.go
+++ b/internal/services/appservice/linux_web_app_slot_resource.go
@@ -687,8 +687,6 @@ func (r LinuxWebAppSlotResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("deleting %s", *id)
-
 			delOpts := webapps.DeleteSlotOperationOptions{
 				DeleteEmptyServerFarm: pointer.To(false),
 				DeleteMetrics:         pointer.To(false),

--- a/internal/services/appservice/linux_web_app_slot_resource.go
+++ b/internal/services/appservice/linux_web_app_slot_resource.go
@@ -999,7 +999,7 @@ func (r LinuxWebAppSlotResource) CustomizeDiff() sdk.ResourceFunc {
 					return fmt.Errorf("retrieving %s: %+v", functionAppId, err)
 				}
 				if webAppModel := webApp.Model; webAppModel != nil && webAppModel.Properties != nil {
-					if ase := webAppModel.Properties.HostingEnvironmentProfile; ase != nil && ase.Id != nil && *(ase.Id) != "" && !newValue.(bool) {
+					if ase := webAppModel.Properties.HostingEnvironmentProfile; ase != nil && ase.Id != nil && *ase.Id != "" && !newValue.(bool) {
 						return fmt.Errorf("`vnet_image_pull_enabled` cannot be disabled for app slot running in an app service environment")
 					}
 				}

--- a/internal/services/appservice/service_plan_resource.go
+++ b/internal/services/appservice/service_plan_resource.go
@@ -84,7 +84,8 @@ func (r ServicePlanResource) Arguments() map[string]*pluginsdk.Schema {
 			Required: true,
 			ValidateFunc: validation.StringInSlice(
 				helpers.AllKnownServicePlanSkus(),
-				false),
+				false,
+			),
 			DiffSuppressFunc: suppress.CaseDifference,
 		},
 

--- a/internal/services/appservice/service_plan_resource.go
+++ b/internal/services/appservice/service_plan_resource.go
@@ -263,7 +263,6 @@ func (r ServicePlanResource) Delete() sdk.ResourceFunc {
 			}
 
 			client := metadata.Client.AppService.ServicePlanClient
-			metadata.Logger.Infof("deleting %s", id)
 
 			if _, err := client.Delete(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s: %v", id, err)

--- a/internal/services/appservice/windows_function_app_resource.go
+++ b/internal/services/appservice/windows_function_app_resource.go
@@ -870,8 +870,6 @@ func (r WindowsFunctionAppResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("deleting Windows %s", *id)
-
 			delOptions := webapps.DeleteOperationOptions{
 				DeleteEmptyServerFarm: pointer.To(false),
 				DeleteMetrics:         pointer.To(false),

--- a/internal/services/appservice/windows_function_app_resource.go
+++ b/internal/services/appservice/windows_function_app_resource.go
@@ -1274,7 +1274,7 @@ func (r WindowsFunctionAppResource) CustomizeDiff() sdk.ResourceFunc {
 				}
 				if aspModel := asp.Model; aspModel != nil {
 					if aspModel.Properties != nil && aspModel.Properties.HostingEnvironmentProfile != nil &&
-						aspModel.Properties.HostingEnvironmentProfile.Id != nil && *(aspModel.Properties.HostingEnvironmentProfile.Id) != "" && !newValue.(bool) {
+						aspModel.Properties.HostingEnvironmentProfile.Id != nil && *aspModel.Properties.HostingEnvironmentProfile.Id != "" && !newValue.(bool) {
 						return fmt.Errorf("`vnet_image_pull_enabled` cannot be disabled for app running in an app service environment")
 					}
 					if sku := aspModel.Sku; sku != nil {

--- a/internal/services/appservice/windows_function_app_slot_resource.go
+++ b/internal/services/appservice/windows_function_app_slot_resource.go
@@ -849,8 +849,6 @@ func (r WindowsFunctionAppSlotResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("deleting Windows %s", *id)
-
 			delOpts := webapps.DeleteSlotOperationOptions{
 				DeleteEmptyServerFarm: pointer.To(false),
 				DeleteMetrics:         pointer.To(false),

--- a/internal/services/appservice/windows_function_app_slot_resource.go
+++ b/internal/services/appservice/windows_function_app_slot_resource.go
@@ -1248,7 +1248,7 @@ func (r WindowsFunctionAppSlotResource) CustomizeDiff() sdk.ResourceFunc {
 					return fmt.Errorf("retrieving %s: %+v", functionAppId, err)
 				}
 				if functionAppModel := functionApp.Model; functionAppModel != nil && functionAppModel.Properties != nil {
-					if ase := functionAppModel.Properties.HostingEnvironmentProfile; ase != nil && ase.Id != nil && *(ase.Id) != "" && !newValue.(bool) {
+					if ase := functionAppModel.Properties.HostingEnvironmentProfile; ase != nil && ase.Id != nil && *ase.Id != "" && !newValue.(bool) {
 						return fmt.Errorf("`vnet_image_pull_enabled` cannot be disabled for app slot running in an app service environment")
 					}
 				}

--- a/internal/services/appservice/windows_web_app_resource.go
+++ b/internal/services/appservice/windows_web_app_resource.go
@@ -775,8 +775,6 @@ func (r WindowsWebAppResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("deleting %s", *id)
-
 			delOptions := webapps.DeleteOperationOptions{
 				DeleteEmptyServerFarm: pointer.To(false),
 				DeleteMetrics:         pointer.To(false),

--- a/internal/services/appservice/windows_web_app_slot_resource.go
+++ b/internal/services/appservice/windows_web_app_slot_resource.go
@@ -746,8 +746,6 @@ func (r WindowsWebAppSlotResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("deleting %s", *id)
-
 			delOpts := webapps.DeleteSlotOperationOptions{
 				DeleteEmptyServerFarm: pointer.To(false),
 				DeleteMetrics:         pointer.To(false),

--- a/internal/services/arcresourcebridge/arc_resource_bridge_appliance_resource.go
+++ b/internal/services/arcresourcebridge/arc_resource_bridge_appliance_resource.go
@@ -167,7 +167,6 @@ func (r ArcResourceBridgeApplianceResource) Update() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("Decoding state for %s", *id)
 			var model ApplianceModel
 			if err := metadata.Decode(&model); err != nil {
 				return fmt.Errorf("decoding: %+v", err)

--- a/internal/services/automation/automation_certificate_resource.go
+++ b/internal/services/automation/automation_certificate_resource.go
@@ -5,7 +5,6 @@ package automation
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -89,8 +88,6 @@ func resourceAutomationCertificateCreate(d *pluginsdk.ResourceData, meta interfa
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for AzureRM Automation Certificate creation.")
 
 	id := certificate.NewCertificateID(subscriptionId, d.Get("resource_group_name").(string), d.Get("automation_account_name").(string), d.Get("name").(string))
 

--- a/internal/services/automation/automation_connection_certificate_resource.go
+++ b/internal/services/automation/automation_connection_certificate_resource.go
@@ -5,7 +5,6 @@ package automation
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -81,8 +80,6 @@ func resourceAutomationConnectionCertificateCreate(d *pluginsdk.ResourceData, me
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for AzureRM Automation Connection creation.")
 
 	id := connection.NewConnectionID(subscriptionId, d.Get("resource_group_name").(string), d.Get("automation_account_name").(string), d.Get("name").(string))
 

--- a/internal/services/automation/automation_connection_classic_certificate_resource.go
+++ b/internal/services/automation/automation_connection_classic_certificate_resource.go
@@ -5,7 +5,6 @@ package automation
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -88,8 +87,6 @@ func resourceAutomationConnectionClassicCertificateCreate(d *pluginsdk.ResourceD
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for AzureRM Automation Connection creation.")
-
 	id := connection.NewConnectionID(subscriptionId, d.Get("resource_group_name").(string), d.Get("automation_account_name").(string), d.Get("name").(string))
 
 	existing, err := client.Get(ctx, id)
@@ -131,8 +128,6 @@ func resourceAutomationConnectionClassicCertificateUpdate(d *pluginsdk.ResourceD
 	client := meta.(*clients.Client).Automation.Connection
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for AzureRM Automation Connection update.")
 
 	id, err := connection.ParseConnectionID(d.Id())
 	if err != nil {

--- a/internal/services/automation/automation_connection_resource.go
+++ b/internal/services/automation/automation_connection_resource.go
@@ -5,7 +5,6 @@ package automation
 
 import (
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
@@ -88,8 +87,6 @@ func resourceAutomationConnectionCreate(d *pluginsdk.ResourceData, meta interfac
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for AzureRM Automation Connection creation.")
-
 	id := connection.NewConnectionID(subscriptionId, d.Get("resource_group_name").(string), d.Get("automation_account_name").(string), d.Get("name").(string))
 
 	existing, err := client.Get(ctx, id)
@@ -148,8 +145,6 @@ func resourceAutomationConnectionUpdate(d *pluginsdk.ResourceData, meta interfac
 	client := meta.(*clients.Client).Automation.Connection
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for AzureRM Automation Connection update.")
 
 	id, err := connection.ParseConnectionID(d.Id())
 	if err != nil {

--- a/internal/services/automation/automation_connection_service_principal_resource.go
+++ b/internal/services/automation/automation_connection_service_principal_resource.go
@@ -5,7 +5,6 @@ package automation
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -94,8 +93,6 @@ func resourceAutomationConnectionServicePrincipalCreate(d *pluginsdk.ResourceDat
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for AzureRM Automation Connection creation.")
-
 	id := connection.NewConnectionID(subscriptionId, d.Get("resource_group_name").(string), d.Get("automation_account_name").(string), d.Get("name").(string))
 
 	existing, err := client.Get(ctx, id)
@@ -138,8 +135,6 @@ func resourceAutomationConnectionServicePrincipalUpdate(d *pluginsdk.ResourceDat
 	client := meta.(*clients.Client).Automation.Connection
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for AzureRM Automation Connection update.")
 
 	id, err := connection.ParseConnectionID(d.Id())
 	if err != nil {

--- a/internal/services/automation/automation_credential_resource.go
+++ b/internal/services/automation/automation_credential_resource.go
@@ -5,7 +5,6 @@ package automation
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -79,8 +78,6 @@ func resourceAutomationCredentialCreate(d *pluginsdk.ResourceData, meta interfac
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for AzureRM Automation Credential creation.")
-
 	id := credential.NewCredentialID(subscriptionId, d.Get("resource_group_name").(string), d.Get("automation_account_name").(string), d.Get("name").(string))
 
 	existing, err := client.Get(ctx, id)
@@ -118,8 +115,6 @@ func resourceAutomationCredentialUpdate(d *pluginsdk.ResourceData, meta interfac
 	client := meta.(*clients.Client).Automation.Credential
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for AzureRM Automation Credential update.")
 
 	id, err := credential.ParseCredentialID(d.Id())
 	if err != nil {

--- a/internal/services/automation/automation_dsc_configuration_resource.go
+++ b/internal/services/automation/automation_dsc_configuration_resource.go
@@ -6,7 +6,6 @@ package automation
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"regexp"
 	"time"
 
@@ -98,8 +97,6 @@ func resourceAutomationDscConfigurationCreate(d *pluginsdk.ResourceData, meta in
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for AzureRM Automation Dsc Configuration creation.")
-
 	id := dscconfiguration.NewConfigurationID(subscriptionId, d.Get("resource_group_name").(string), d.Get("automation_account_name").(string), d.Get("name").(string))
 
 	existing, err := client.Get(ctx, id)
@@ -139,8 +136,6 @@ func resourceAutomationDscConfigurationUpdate(d *pluginsdk.ResourceData, meta in
 	client := meta.(*clients.Client).Automation.DscConfiguration
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for AzureRM Automation Dsc Configuration update.")
 
 	id, err := dscconfiguration.ParseConfigurationID(d.Id())
 	if err != nil {

--- a/internal/services/automation/automation_dsc_nodeconfiguration_resource.go
+++ b/internal/services/automation/automation_dsc_nodeconfiguration_resource.go
@@ -5,7 +5,6 @@ package automation
 
 import (
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
@@ -76,8 +75,6 @@ func resourceAutomationDscNodeConfigurationCreate(d *pluginsdk.ResourceData, met
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for AzureRM Automation Dsc Node Configuration creation.")
 
 	id := dscnodeconfiguration.NewNodeConfigurationID(subscriptionId, d.Get("resource_group_name").(string), d.Get("automation_account_name").(string), d.Get("name").(string))
 

--- a/internal/services/automation/automation_job_schedule_resource.go
+++ b/internal/services/automation/automation_job_schedule_resource.go
@@ -6,7 +6,6 @@ package automation
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
@@ -111,8 +110,6 @@ func resourceAutomationJobScheduleCreate(d *pluginsdk.ResourceData, meta interfa
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for AzureRM Automation Job Schedule creation.")
 
 	resourceGroup := d.Get("resource_group_name").(string)
 	accountName := d.Get("automation_account_name").(string)

--- a/internal/services/automation/automation_module_resource.go
+++ b/internal/services/automation/automation_module_resource.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
@@ -97,8 +96,6 @@ func resourceAutomationModuleCreate(d *pluginsdk.ResourceData, meta interface{})
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for AzureRM Automation Module creation.")
 
 	id := module.NewModuleID(subscriptionId, d.Get("resource_group_name").(string), d.Get("automation_account_name").(string), d.Get("name").(string))
 

--- a/internal/services/automation/automation_runbook_resource.go
+++ b/internal/services/automation/automation_runbook_resource.go
@@ -6,7 +6,6 @@ package automation
 import (
 	"context"
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -295,7 +294,6 @@ func resourceAutomationRunbookCreateUpdate(d *pluginsdk.ResourceData, meta inter
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for AzureRM Automation Runbook creation.")
 	subscriptionID := meta.(*clients.Client).Account.SubscriptionId
 
 	id := runbook.NewRunbookID(subscriptionID, d.Get("resource_group_name").(string), d.Get("automation_account_name").(string), d.Get("name").(string))

--- a/internal/services/automation/automation_schedule_resource.go
+++ b/internal/services/automation/automation_schedule_resource.go
@@ -6,7 +6,6 @@ package automation
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
@@ -219,8 +218,6 @@ func resourceAutomationScheduleCreate(d *pluginsdk.ResourceData, meta interface{
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for AzureRM Automation Schedule creation.")
-
 	id := schedule.NewScheduleID(subscriptionId, d.Get("resource_group_name").(string), d.Get("automation_account_name").(string), d.Get("name").(string))
 
 	existing, err := client.Get(ctx, id)
@@ -297,8 +294,6 @@ func resourceAutomationScheduleUpdate(d *pluginsdk.ResourceData, meta interface{
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for AzureRM Automation Schedule update.")
 
 	id := schedule.NewScheduleID(subscriptionId, d.Get("resource_group_name").(string), d.Get("automation_account_name").(string), d.Get("name").(string))
 

--- a/internal/services/azurestackhci/stack_hci_deployment_setting_resource.go
+++ b/internal/services/azurestackhci/stack_hci_deployment_setting_resource.go
@@ -824,14 +824,10 @@ func (StackHCIDeploymentSettingResource) Delete() sdk.ResourceFunc {
 			applianceName := fmt.Sprintf("%s-arcbridge", id.ClusterName)
 			applianceId := appliances.NewApplianceID(id.SubscriptionId, id.ResourceGroupName, applianceName)
 
-			log.Printf("[DEBUG] Deleting Arc Resource Bridge Appliance generated during deployment: %s", applianceId.ID())
-
 			applianceClient := metadata.Client.ArcResourceBridge.AppliancesClient
 			if err := applianceClient.DeleteThenPoll(ctx, applianceId); err != nil {
 				return fmt.Errorf("deleting Arc Resource Bridge Appliance generated during deployment: deleting %s: %+v", applianceId, err)
 			}
-
-			log.Printf("[DEBUG] Deleting Custom Location and Stack HCI Storage Paths generated during deployment")
 
 			var customLocationName string
 			if resp.Model != nil && resp.Model.Properties != nil &&
@@ -844,7 +840,6 @@ func (StackHCIDeploymentSettingResource) Delete() sdk.ResourceFunc {
 				customLocationId := customlocations.NewCustomLocationID(id.SubscriptionId, id.ResourceGroupName, customLocationName)
 
 				// we need to delete the Storage Paths before the Custom Location, otherwise the Custom Location cannot be deleted if there is any Resource in it
-				log.Printf("[DEBUG] Deleting Stack HCI Storage Paths under Custom Location %s", customLocationId.ID())
 
 				storageContainerClient := metadata.Client.AzureStackHCI.StorageContainers
 				resourceGroupId := commonids.NewResourceGroupID(id.SubscriptionId, id.ResourceGroupName)

--- a/internal/services/azurestackhci/stack_hci_deployment_setting_resource.go
+++ b/internal/services/azurestackhci/stack_hci_deployment_setting_resource.go
@@ -6,7 +6,6 @@ package azurestackhci
 import (
 	"context"
 	"fmt"
-	"log"
 	"regexp"
 	"strings"
 	"time"

--- a/internal/services/batch/batch_account_resource.go
+++ b/internal/services/batch/batch_account_resource.go
@@ -203,8 +203,6 @@ func resourceBatchAccountCreate(d *pluginsdk.ResourceData, meta interface{}) err
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Azure Batch account creation.")
-
 	id := batchaccount.NewBatchAccountID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 	location := location.Normalize(d.Get("location").(string))
 	storageAccountId := d.Get("storage_account_id").(string)
@@ -400,8 +398,6 @@ func resourceBatchAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 	client := meta.(*clients.Client).Batch.AccountClient
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for Azure Batch account update.")
 
 	id, err := batchaccount.ParseBatchAccountID(d.Id())
 	if err != nil {

--- a/internal/services/batch/batch_certificate_resource.go
+++ b/internal/services/batch/batch_certificate_resource.go
@@ -110,8 +110,6 @@ func resourceBatchCertificateCreate(d *pluginsdk.ResourceData, meta interface{})
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Azure Batch certificate creation.")
-
 	cert := d.Get("certificate").(string)
 	format := d.Get("format").(string)
 	password := d.Get("password").(string)
@@ -217,8 +215,6 @@ func resourceBatchCertificateUpdate(d *pluginsdk.ResourceData, meta interface{})
 	client := meta.(*clients.Client).Batch.CertificateClient
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for Azure Batch certificate update.")
 
 	id, err := certificate.ParseCertificateID(d.Id())
 	if err != nil {

--- a/internal/services/batch/batch_pool_resource.go
+++ b/internal/services/batch/batch_pool_resource.go
@@ -669,7 +669,8 @@ func resourceBatchPool() *pluginsdk.Resource {
 				ValidateFunc: validation.StringInSlice(
 					[]string{
 						string(pool.DiffDiskPlacementCacheDisk),
-					}, false),
+					}, false,
+				),
 			},
 			"inter_node_communication": {
 				Type:     pluginsdk.TypeString,

--- a/internal/services/batch/batch_pool_resource.go
+++ b/internal/services/batch/batch_pool_resource.go
@@ -1114,7 +1114,6 @@ func resourceBatchUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	}
 
 	if d.HasChange("metadata") {
-		log.Printf("[DEBUG] Updating the MetaData for %s", *id)
 		metaDataRaw := d.Get("metadata").(map[string]interface{})
 
 		parameters.Properties.Metadata = ExpandBatchMetaData(metaDataRaw)

--- a/internal/services/cdn/cdn_endpoint_resource.go
+++ b/internal/services/cdn/cdn_endpoint_resource.go
@@ -226,8 +226,6 @@ func resourceCdnEndpointCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Azure ARM CDN EndPoint creation.")
-
 	id := parse.NewEndpointID(subscriptionId, d.Get("resource_group_name").(string), d.Get("profile_name").(string), d.Get("name").(string))
 	existing, err := endpointsClient.Get(ctx, id.ResourceGroup, id.ProfileName, id.Name)
 	if err != nil {
@@ -334,8 +332,6 @@ func resourceCdnEndpointUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 	profilesClient := meta.(*clients.Client).Cdn.ProfilesClient
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for Azure ARM CDN EndPoint update.")
 
 	id, err := parse.EndpointID(d.Id())
 	if err != nil {

--- a/internal/services/cdn/cdn_frontdoor_custom_domain_association_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_custom_domain_association_resource.go
@@ -5,7 +5,6 @@ package cdn
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
@@ -66,8 +65,6 @@ func resourceCdnFrontDoorCustomDomainAssociationCreate(d *pluginsdk.ResourceData
 	client := meta.(*clients.Client).Cdn.AFDCustomDomainsClient
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for CDN FrontDoor Route <-> CDN FrontDoor Custom Domain Association creation")
 
 	cdId, err := parse.FrontDoorCustomDomainID(d.Get("cdn_frontdoor_custom_domain_id").(string))
 	if err != nil {

--- a/internal/services/cognitive/ai_services_resource.go
+++ b/internal/services/cognitive/ai_services_resource.go
@@ -604,7 +604,6 @@ func (AIServices) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			log.Printf("[DEBUG] Retrieving %s..", *id)
 			account, err := client.AccountsGet(ctx, *id)
 			if err != nil || account.Model == nil || account.Model.Location == nil {
 				return fmt.Errorf("retrieving %s: %+v", *id, err)

--- a/internal/services/cognitive/ai_services_resource.go
+++ b/internal/services/cognitive/ai_services_resource.go
@@ -735,7 +735,7 @@ func expandNetworkACLs(input []NetworkACLs) (*cognitiveservicesaccounts.NetworkR
 		networkRules = append(networkRules, rule)
 	}
 
-	bypass := cognitiveservicesaccounts.ByPassSelection((v.Bypass))
+	bypass := cognitiveservicesaccounts.ByPassSelection(v.Bypass)
 
 	ruleSet := cognitiveservicesaccounts.NetworkRuleSet{
 		Bypass:              &bypass,

--- a/internal/services/cognitive/ai_services_resource.go
+++ b/internal/services/cognitive/ai_services_resource.go
@@ -612,7 +612,6 @@ func (AIServices) Delete() sdk.ResourceFunc {
 
 			deletedAzureAIServicesId := cognitiveservicesaccounts.NewDeletedAccountID(id.SubscriptionId, *account.Model.Location, id.ResourceGroupName, id.AccountName)
 
-			log.Printf("[DEBUG] Deleting %s..", *id)
 			if err := client.AccountsDeleteThenPoll(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}

--- a/internal/services/cognitive/cognitive_account_resource.go
+++ b/internal/services/cognitive/cognitive_account_resource.go
@@ -745,7 +745,6 @@ func resourceCognitiveAccountDelete(d *pluginsdk.ResourceData, meta interface{})
 
 	deletedAccountId := cognitiveservicesaccounts.NewDeletedAccountID(id.SubscriptionId, *account.Model.Location, id.ResourceGroupName, id.AccountName)
 
-	log.Printf("[DEBUG] Deleting %s..", *id)
 	if err := accountsClient.AccountsDeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %s: %+v", *id, err)
 	}

--- a/internal/services/cognitive/cognitive_account_resource.go
+++ b/internal/services/cognitive/cognitive_account_resource.go
@@ -737,7 +737,6 @@ func resourceCognitiveAccountDelete(d *pluginsdk.ResourceData, meta interface{})
 	}
 
 	// first we need to retrieve it, since we need the location to be able to purge it
-	log.Printf("[DEBUG] Retrieving %s..", *id)
 	account, err := accountsClient.AccountsGet(ctx, *id)
 	if err != nil || account.Model == nil || account.Model.Location == nil {
 		return fmt.Errorf("retrieving %s: %+v", *id, err)

--- a/internal/services/compute/gallery_application_version_resource.go
+++ b/internal/services/compute/gallery_application_version_resource.go
@@ -445,7 +445,6 @@ func (r GalleryApplicationVersionResource) Delete() sdk.ResourceFunc {
 				return fmt.Errorf("deleting %s: %+v", id, err)
 			}
 
-			metadata.Logger.Infof("Waiting for %s to be eventually deleted", *id)
 			timeout, _ := ctx.Deadline()
 			stateConf := &pluginsdk.StateChangeConf{
 				Pending: []string{"Exists"},

--- a/internal/services/compute/linux_virtual_machine_resource.go
+++ b/internal/services/compute/linux_virtual_machine_resource.go
@@ -1799,8 +1799,6 @@ func resourceLinuxVirtualMachineDelete(d *pluginsdk.ResourceData, meta interface
 		return fmt.Errorf("deleting Linux %s: %+v", id, err)
 	}
 
-	log.Printf("[DEBUG] Deleted Linux %s", id)
-
 	deleteOSDisk := meta.(*clients.Client).Features.VirtualMachine.DeleteOSDiskOnDeletion
 	if deleteOSDisk {
 		disksClient := meta.(*clients.Client).Compute.DisksClient
@@ -1821,7 +1819,6 @@ func resourceLinuxVirtualMachineDelete(d *pluginsdk.ResourceData, meta interface
 				return fmt.Errorf("deleting %s for Linux %s: %+v", diskId, id, err)
 			}
 
-			log.Printf("[DEBUG] Deleted %s for Linux %s", diskId, id)
 		} else {
 			log.Printf("[DEBUG] Skipping Deleting OS Disk from Linux %s - cannot determine OS Disk ID.", id)
 		}

--- a/internal/services/compute/linux_virtual_machine_resource.go
+++ b/internal/services/compute/linux_virtual_machine_resource.go
@@ -1163,7 +1163,6 @@ func resourceLinuxVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interface
 	locks.ByName(id.VirtualMachineName, VirtualMachineResourceName)
 	defer locks.UnlockByName(id.VirtualMachineName, VirtualMachineResourceName)
 
-	log.Printf("[DEBUG] Retrieving Linux %s", id)
 	options := virtualmachines.DefaultGetOperationOptions()
 	options.Expand = pointer.To(virtualmachines.InstanceViewTypesUserData)
 	existing, err := client.Get(ctx, *id, options)
@@ -1171,7 +1170,6 @@ func resourceLinuxVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interface
 		return fmt.Errorf("retrieving Linux %s: %+v", id, err)
 	}
 
-	log.Printf("[DEBUG] Retrieving InstanceView for Linux %s.", id)
 	instanceView, err := client.InstanceView(ctx, *id)
 	if err != nil {
 		return fmt.Errorf("retrieving InstanceView for Linux %s: %+v", id, err)
@@ -1749,7 +1747,6 @@ func resourceLinuxVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interface
 			return fmt.Errorf("updating Linux %s: %+v", id, err)
 		}
 
-		log.Printf("[DEBUG] Updated Linux %s", id)
 	}
 
 	// if we've shut it down and it was turned off, let's boot it back up
@@ -1778,7 +1775,6 @@ func resourceLinuxVirtualMachineDelete(d *pluginsdk.ResourceData, meta interface
 	locks.ByName(id.VirtualMachineName, VirtualMachineResourceName)
 	defer locks.UnlockByName(id.VirtualMachineName, VirtualMachineResourceName)
 
-	log.Printf("[DEBUG] Retrieving Linux %s", id)
 	options := virtualmachines.DefaultGetOperationOptions()
 	options.Expand = pointer.To(virtualmachines.InstanceViewTypesUserData)
 	existing, err := client.Get(ctx, *id, options)

--- a/internal/services/compute/linux_virtual_machine_resource.go
+++ b/internal/services/compute/linux_virtual_machine_resource.go
@@ -1743,7 +1743,6 @@ func resourceLinuxVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interface
 		if err := client.UpdateThenPoll(ctx, *id, update, virtualmachines.DefaultUpdateOperationOptions()); err != nil {
 			return fmt.Errorf("updating Linux %s: %+v", id, err)
 		}
-
 	}
 
 	// if we've shut it down and it was turned off, let's boot it back up

--- a/internal/services/compute/linux_virtual_machine_resource.go
+++ b/internal/services/compute/linux_virtual_machine_resource.go
@@ -1710,7 +1710,6 @@ func resourceLinuxVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interface
 	if d.HasChange("os_disk.0.disk_encryption_set_id") {
 		if diskEncryptionSetId := d.Get("os_disk.0.disk_encryption_set_id").(string); diskEncryptionSetId != "" {
 			diskName := d.Get("os_disk.0.name").(string)
-			log.Printf("[DEBUG] Updating encryption settings of OS Disk %q for Linux %s to %q..", diskName, id, diskEncryptionSetId)
 
 			encryptionType, err := retrieveDiskEncryptionSetEncryptionType(ctx, meta.(*clients.Client).Compute.DiskEncryptionSetsClient, diskEncryptionSetId)
 			if err != nil {
@@ -1735,14 +1734,12 @@ func resourceLinuxVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interface
 				return fmt.Errorf("updating encryption settings of OS Disk %q for Linux Virtual Machine %q (Resource Group %q): %+v", diskName, id.DiskName, id.ResourceGroupName, err)
 			}
 
-			log.Printf("[DEBUG] Updating encryption settings of OS Disk %q for Linux Virtual Machine %q (Resource Group %q) to %q.", diskName, id.DiskName, id.ResourceGroupName, diskEncryptionSetId)
 		} else {
 			return fmt.Errorf("once a customer-managed key is used, you can’t change the selection back to a platform-managed key")
 		}
 	}
 
 	if shouldUpdate {
-		log.Printf("[DEBUG] Updating Linux %s", id)
 		if err := client.UpdateThenPoll(ctx, *id, update, virtualmachines.DefaultUpdateOperationOptions()); err != nil {
 			return fmt.Errorf("updating Linux %s: %+v", id, err)
 		}

--- a/internal/services/compute/linux_virtual_machine_resource.go
+++ b/internal/services/compute/linux_virtual_machine_resource.go
@@ -1790,8 +1790,6 @@ func resourceLinuxVirtualMachineDelete(d *pluginsdk.ResourceData, meta interface
 		return fmt.Errorf("retrieving Linux %s: %+v", id, err)
 	}
 
-	log.Printf("[DEBUG] Deleting Linux %s", id)
-
 	// Force Delete is in an opt-in Preview and can only be specified (true/false) if the feature is enabled
 	// as such we default this to `nil` which matches the previous behaviour (where this isn't sent) and
 	// conditionally set this if required
@@ -1809,7 +1807,6 @@ func resourceLinuxVirtualMachineDelete(d *pluginsdk.ResourceData, meta interface
 
 	deleteOSDisk := meta.(*clients.Client).Features.VirtualMachine.DeleteOSDiskOnDeletion
 	if deleteOSDisk {
-		log.Printf("[DEBUG] Deleting OS Disk from Linux %s", id)
 		disksClient := meta.(*clients.Client).Compute.DisksClient
 		managedDiskId := ""
 		if props := existing.Model.Properties; props != nil && props.StorageProfile != nil && props.StorageProfile.OsDisk != nil {

--- a/internal/services/compute/linux_virtual_machine_resource.go
+++ b/internal/services/compute/linux_virtual_machine_resource.go
@@ -1733,7 +1733,6 @@ func resourceLinuxVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interface
 			if err != nil {
 				return fmt.Errorf("updating encryption settings of OS Disk %q for Linux Virtual Machine %q (Resource Group %q): %+v", diskName, id.DiskName, id.ResourceGroupName, err)
 			}
-
 		} else {
 			return fmt.Errorf("once a customer-managed key is used, you can’t change the selection back to a platform-managed key")
 		}
@@ -1814,7 +1813,6 @@ func resourceLinuxVirtualMachineDelete(d *pluginsdk.ResourceData, meta interface
 			if err := disksClient.DeleteThenPoll(ctx, *diskId); err != nil {
 				return fmt.Errorf("deleting %s for Linux %s: %+v", diskId, id, err)
 			}
-
 		} else {
 			log.Printf("[DEBUG] Skipping Deleting OS Disk from Linux %s - cannot determine OS Disk ID.", id)
 		}

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource.go
@@ -1146,8 +1146,6 @@ func resourceLinuxVirtualMachineScaleSetDelete(d *pluginsdk.ResourceData, meta i
 		return fmt.Errorf("deleting Linux %s: %+v", id, err)
 	}
 
-	log.Printf("[DEBUG] Deleted Linux %s", id)
-
 	return nil
 }
 

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource.go
@@ -464,7 +464,6 @@ func resourceLinuxVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta i
 		props.Properties.ZoneBalance = pointer.To(v.(bool))
 	}
 
-	log.Printf("[DEBUG] Creating Linux %s", id)
 	if err := client.CreateOrUpdateThenPoll(ctx, id, props, virtualmachinescalesets.DefaultCreateOrUpdateOperationOptions()); err != nil {
 		return fmt.Errorf("creating Linux %s: %+v", id, err)
 	}
@@ -1140,7 +1139,6 @@ func resourceLinuxVirtualMachineScaleSetDelete(d *pluginsdk.ResourceData, meta i
 		log.Printf("[DEBUG] Unable to scale instances to `0` since the `sku` block is nil - trying to delete anyway")
 	}
 
-	log.Printf("[DEBUG] Deleting Linux %s", id)
 	// @ArcturusZhang (mimicking from linux_virtual_machine_pluginsdk.go): sending `nil` here omits this value from being sent
 	// which matches the previous behaviour - we're only splitting this out so it's clear why
 	// TODO: support force deletion once it's out of Preview, if applicable

--- a/internal/services/compute/managed_disk_resource.go
+++ b/internal/services/compute/managed_disk_resource.go
@@ -321,8 +321,6 @@ func resourceManagedDiskCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Azure ARM Managed Disk creation.")
-
 	name := d.Get("name").(string)
 	resourceGroup := d.Get("resource_group_name").(string)
 
@@ -606,8 +604,6 @@ func resourceManagedDiskUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 	skusClient := meta.(*clients.Client).Compute.SkusClient
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for Azure ARM Managed Disk update.")
 
 	name := d.Get("name").(string)
 	resourceGroup := d.Get("resource_group_name").(string)

--- a/internal/services/compute/managed_disk_sas_token_resource.go
+++ b/internal/services/compute/managed_disk_sas_token_resource.go
@@ -85,7 +85,6 @@ func resourceManagedDiskSasTokenCreate(d *pluginsdk.ResourceData, meta interface
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for AzureRM Disk Export.")
 	durationInSeconds := int64(d.Get("duration_in_seconds").(int))
 	access := disks.AccessLevel(d.Get("access_level").(string))
 

--- a/internal/services/compute/marketplace_agreement_resource.go
+++ b/internal/services/compute/marketplace_agreement_resource.go
@@ -77,8 +77,6 @@ func resourceMarketplaceAgreementCreate(d *pluginsdk.ResourceData, meta interfac
 
 	id := agreements.NewPlanID(subscriptionId, d.Get("publisher").(string), d.Get("offer").(string), d.Get("plan").(string))
 
-	log.Printf("[DEBUG] retrieving %s", id)
-
 	agreementId := agreements.NewOfferPlanID(id.SubscriptionId, id.PublisherId, id.OfferId, id.PlanId)
 	term, err := client.MarketplaceAgreementsGet(ctx, agreementId)
 	if err != nil {

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
@@ -1549,7 +1549,6 @@ func resourceOrchestratedVirtualMachineScaleSetDelete(d *pluginsdk.ResourceData,
 	if err = client.DeleteThenPoll(ctx, *id, virtualmachinescalesets.DefaultDeleteOperationOptions()); err != nil {
 		return fmt.Errorf("deleting Orchestrated %s: %w", id, err)
 	}
-	log.Printf("[DEBUG] Deleted Orchestrated %s", id)
 
 	return nil
 }

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
@@ -794,7 +794,6 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 	}
 
 	log.Printf("[DEBUG] Orchestrated %s was created", id)
-	log.Printf("[DEBUG] Retrieving Orchestrated %s.", id)
 
 	d.SetId(id.ID())
 

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
@@ -789,7 +789,6 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 		props.Properties.VirtualMachineProfile = &virtualMachineProfile
 	}
 
-	log.Printf("[DEBUG] Creating Orchestrated %s.", id)
 	if err := client.CreateOrUpdateThenPoll(ctx, id, props, virtualmachinescalesets.DefaultCreateOrUpdateOperationOptions()); err != nil {
 		return fmt.Errorf("creating Orchestrated %s: %w", id, err)
 	}
@@ -1546,7 +1545,6 @@ func resourceOrchestratedVirtualMachineScaleSetDelete(d *pluginsdk.ResourceData,
 		log.Printf("[DEBUG] Unable to scale instances to `0` since the `sku` block is nil - trying to delete anyway")
 	}
 
-	log.Printf("[DEBUG] Deleting Orchestrated %s", id)
 	// @ArcturusZhang (mimicking from windows_virtual_machine_pluginsdk.go): sending `nil` here omits this value from being sent
 	// which matches the previous behaviour - we're only splitting this out so it's clear why
 	if err = client.DeleteThenPoll(ctx, *id, virtualmachinescalesets.DefaultDeleteOperationOptions()); err != nil {

--- a/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/orchestrated_virtual_machine_scale_set_resource.go
@@ -390,7 +390,7 @@ func resourceOrchestratedVirtualMachineScaleSet() *pluginsdk.Resource {
 					}
 
 					if auxiliaryMode != "" {
-						networkApiVersion := (virtualmachinescalesets.NetworkApiVersion)(diff.Get("network_api_version").(string))
+						networkApiVersion := virtualmachinescalesets.NetworkApiVersion(diff.Get("network_api_version").(string))
 						if networkApiVersion == virtualmachinescalesets.NetworkApiVersionTwoZeroTwoZeroNegativeOneOneNegativeZeroOne {
 							return fmt.Errorf("`auxiliary_mode` and `auxiliary_sku` can be set only when `network_api_version` is later than `2020-11-01`")
 						}
@@ -469,7 +469,7 @@ func resourceOrchestratedVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData,
 	}
 
 	networkProfile := &virtualmachinescalesets.VirtualMachineScaleSetNetworkProfile{
-		NetworkApiVersion: pointer.To((virtualmachinescalesets.NetworkApiVersion)(d.Get("network_api_version").(string))),
+		NetworkApiVersion: pointer.To(virtualmachinescalesets.NetworkApiVersion(d.Get("network_api_version").(string))),
 	}
 
 	if v, ok := d.GetOk("proximity_placement_group_id"); ok {
@@ -1568,7 +1568,7 @@ func expandOrchestratedVirtualMachineScaleSetSkuProfile(input []interface{}) *vi
 	}
 
 	return &virtualmachinescalesets.SkuProfile{
-		AllocationStrategy: pointer.To((virtualmachinescalesets.AllocationStrategy)(v["allocation_strategy"].(string))),
+		AllocationStrategy: pointer.To(virtualmachinescalesets.AllocationStrategy(v["allocation_strategy"].(string))),
 		VMSizes:            pointer.To(vmSizes),
 	}
 }

--- a/internal/services/compute/shared_image_resource.go
+++ b/internal/services/compute/shared_image_resource.go
@@ -292,7 +292,6 @@ func resourceSharedImageCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Shared Image creation.")
 	id := galleryimages.NewGalleryImageID(subscriptionId, d.Get("resource_group_name").(string), d.Get("gallery_name").(string), d.Get("name").(string))
 
 	existing, err := client.Get(ctx, id)

--- a/internal/services/compute/shared_image_resource.go
+++ b/internal/services/compute/shared_image_resource.go
@@ -506,7 +506,7 @@ func resourceSharedImageRead(d *pluginsdk.ResourceData, meta interface{}) error 
 
 			d.Set("os_type", string(props.OsType))
 
-			architecture := string((galleryimages.ArchitectureXSixFour))
+			architecture := string(galleryimages.ArchitectureXSixFour)
 			if props.Architecture != nil {
 				architecture = string(*props.Architecture)
 			}

--- a/internal/services/compute/snapshot_resource.go
+++ b/internal/services/compute/snapshot_resource.go
@@ -6,6 +6,7 @@ package compute
 import (
 	"context"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"

--- a/internal/services/compute/snapshot_resource.go
+++ b/internal/services/compute/snapshot_resource.go
@@ -6,7 +6,6 @@ package compute
 import (
 	"context"
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -233,7 +232,6 @@ func resourceSnapshotRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			log.Printf("[INFO] Error reading Snapshot %q - removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}

--- a/internal/services/compute/snapshot_resource.go
+++ b/internal/services/compute/snapshot_resource.go
@@ -232,6 +232,7 @@ func resourceSnapshotRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
+			log.Printf("[INFO] Error reading Snapshot %q - removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}

--- a/internal/services/compute/windows_virtual_machine_resource.go
+++ b/internal/services/compute/windows_virtual_machine_resource.go
@@ -1863,8 +1863,6 @@ func resourceWindowsVirtualMachineDelete(d *pluginsdk.ResourceData, meta interfa
 		return fmt.Errorf("deleting Windows %s: %+v", id, err)
 	}
 
-	log.Printf("[DEBUG] Deleted Windows %s", id)
-
 	deleteOSDisk := meta.(*clients.Client).Features.VirtualMachine.DeleteOSDiskOnDeletion
 	if deleteOSDisk {
 		disksClient := meta.(*clients.Client).Compute.DisksClient
@@ -1895,7 +1893,6 @@ func resourceWindowsVirtualMachineDelete(d *pluginsdk.ResourceData, meta interfa
 				}
 			}
 
-			log.Printf("[DEBUG] Deleted OS Disk from Windows %s.", id)
 		} else {
 			log.Printf("[DEBUG] Skipping Deleting OS Disk from Windows %s - cannot determine OS Disk ID.", id)
 		}

--- a/internal/services/compute/windows_virtual_machine_resource.go
+++ b/internal/services/compute/windows_virtual_machine_resource.go
@@ -1812,7 +1812,6 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 		if err := client.UpdateThenPoll(ctx, *id, update, virtualmachines.DefaultUpdateOperationOptions()); err != nil {
 			return fmt.Errorf("updating Windows %s: %+v", id, err)
 		}
-
 	}
 
 	// if we've shut it down and it was turned off, let's boot it back up

--- a/internal/services/compute/windows_virtual_machine_resource.go
+++ b/internal/services/compute/windows_virtual_machine_resource.go
@@ -1856,8 +1856,6 @@ func resourceWindowsVirtualMachineDelete(d *pluginsdk.ResourceData, meta interfa
 		return fmt.Errorf("retrieving Windows %s: %+v", id, err)
 	}
 
-	log.Printf("[DEBUG] Deleting Windows %s", id)
-
 	// Force Delete is in an opt-in Preview and can only be specified (true/false) if the feature is enabled
 	// as such we default this to `nil` which matches the previous behaviour (where this isn't sent) and
 	// conditionally set this if required
@@ -1873,7 +1871,6 @@ func resourceWindowsVirtualMachineDelete(d *pluginsdk.ResourceData, meta interfa
 
 	deleteOSDisk := meta.(*clients.Client).Features.VirtualMachine.DeleteOSDiskOnDeletion
 	if deleteOSDisk {
-		log.Printf("[DEBUG] Deleting OS Disk from Windows %s", id)
 		disksClient := meta.(*clients.Client).Compute.DisksClient
 		managedDiskId := ""
 		if model := existing.Model; model != nil {

--- a/internal/services/compute/windows_virtual_machine_resource.go
+++ b/internal/services/compute/windows_virtual_machine_resource.go
@@ -1224,7 +1224,6 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 	locks.ByName(id.VirtualMachineName, VirtualMachineResourceName)
 	defer locks.UnlockByName(id.VirtualMachineName, VirtualMachineResourceName)
 
-	log.Printf("[DEBUG] Retrieving Windows %s", id)
 	options := virtualmachines.DefaultGetOperationOptions()
 	options.Expand = pointer.To(virtualmachines.InstanceViewTypesUserData)
 	existing, err := client.Get(ctx, *id, options)
@@ -1232,7 +1231,6 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 		return fmt.Errorf("retrieving Windows %s: %+v", id, err)
 	}
 
-	log.Printf("[DEBUG] Retrieving InstanceView for Windows %s", id)
 	instanceView, err := client.InstanceView(ctx, *id)
 	if err != nil {
 		return fmt.Errorf("retrieving InstanceView for Windows %s: %+v", id, err)
@@ -1818,7 +1816,6 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 			return fmt.Errorf("updating Windows %s: %+v", id, err)
 		}
 
-		log.Printf("[DEBUG] Updated Windows %s.", id)
 	}
 
 	// if we've shut it down and it was turned off, let's boot it back up
@@ -1846,7 +1843,6 @@ func resourceWindowsVirtualMachineDelete(d *pluginsdk.ResourceData, meta interfa
 	locks.ByName(id.VirtualMachineName, VirtualMachineResourceName)
 	defer locks.UnlockByName(id.VirtualMachineName, VirtualMachineResourceName)
 
-	log.Printf("[DEBUG] Retrieving Windows %s", id)
 	existing, err := client.Get(ctx, *id, virtualmachines.DefaultGetOperationOptions())
 	if err != nil {
 		if response.WasNotFound(existing.HttpResponse) {

--- a/internal/services/compute/windows_virtual_machine_resource.go
+++ b/internal/services/compute/windows_virtual_machine_resource.go
@@ -1802,7 +1802,6 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 			if err != nil {
 				return fmt.Errorf("updating encryption settings of OS Disk %q for Windows Virtual Machine %q (Resource Group %q): %+v", diskName, id.DiskName, id.ResourceGroupName, err)
 			}
-
 		} else {
 			return fmt.Errorf("once a customer-managed key is used, you can’t change the selection back to a platform-managed key")
 		}
@@ -1888,7 +1887,6 @@ func resourceWindowsVirtualMachineDelete(d *pluginsdk.ResourceData, meta interfa
 					return fmt.Errorf("OS Disk %s for Windows %s: %+v", diskId, id, err)
 				}
 			}
-
 		} else {
 			log.Printf("[DEBUG] Skipping Deleting OS Disk from Windows %s - cannot determine OS Disk ID.", id)
 		}

--- a/internal/services/compute/windows_virtual_machine_resource.go
+++ b/internal/services/compute/windows_virtual_machine_resource.go
@@ -1779,7 +1779,6 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 	if d.HasChange("os_disk.0.disk_encryption_set_id") {
 		if diskEncryptionSetId := d.Get("os_disk.0.disk_encryption_set_id").(string); diskEncryptionSetId != "" {
 			diskName := d.Get("os_disk.0.name").(string)
-			log.Printf("[DEBUG] Updating encryption settings of OS Disk %q for Windows %s to %q..", diskName, id, diskEncryptionSetId)
 
 			encryptionType, err := retrieveDiskEncryptionSetEncryptionType(ctx, meta.(*clients.Client).Compute.DiskEncryptionSetsClient, diskEncryptionSetId)
 			if err != nil {
@@ -1804,14 +1803,12 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 				return fmt.Errorf("updating encryption settings of OS Disk %q for Windows Virtual Machine %q (Resource Group %q): %+v", diskName, id.DiskName, id.ResourceGroupName, err)
 			}
 
-			log.Printf("[DEBUG] Updating encryption settings of OS Disk %q for Windows Virtual Machine %q (Resource Group %q) to %q.", diskName, id.DiskName, id.ResourceGroupName, diskEncryptionSetId)
 		} else {
 			return fmt.Errorf("once a customer-managed key is used, you can’t change the selection back to a platform-managed key")
 		}
 	}
 
 	if shouldUpdate {
-		log.Printf("[DEBUG] Updating Windows %s", id)
 		if err := client.UpdateThenPoll(ctx, *id, update, virtualmachines.DefaultUpdateOperationOptions()); err != nil {
 			return fmt.Errorf("updating Windows %s: %+v", id, err)
 		}

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource.go
@@ -471,7 +471,6 @@ func resourceWindowsVirtualMachineScaleSetCreate(d *pluginsdk.ResourceData, meta
 		props.Properties.ZoneBalance = pointer.To(v.(bool))
 	}
 
-	log.Printf("[DEBUG] Creating Windows %s.", id)
 	if err := client.CreateOrUpdateThenPoll(ctx, id, props, virtualmachinescalesets.DefaultCreateOrUpdateOperationOptions()); err != nil {
 		return fmt.Errorf("creating Windows %s: %+v", id, err)
 	}
@@ -1169,7 +1168,6 @@ func resourceWindowsVirtualMachineScaleSetDelete(d *pluginsdk.ResourceData, meta
 		log.Printf("[DEBUG] Unable to scale instances to `0` since the `sku` block is nil - trying to delete anyway")
 	}
 
-	log.Printf("[DEBUG] Deleting Windows %s", id)
 	// @ArcturusZhang (mimicking from windows_virtual_machine_pluginsdk.go): sending `nil` here omits this value from being sent
 	// which matches the previous behaviour - we're only splitting this out so it's clear why
 	// TODO: support force deletion once it's out of Preview, if applicable

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource.go
@@ -1174,7 +1174,6 @@ func resourceWindowsVirtualMachineScaleSetDelete(d *pluginsdk.ResourceData, meta
 	if err := client.DeleteThenPoll(ctx, *id, virtualmachinescalesets.DefaultDeleteOperationOptions()); err != nil {
 		return fmt.Errorf("deleting Windows %s: %+v", id, err)
 	}
-	log.Printf("[DEBUG] Deleted Windows %s", id)
 
 	return nil
 }

--- a/internal/services/containers/container_registry_agent_pool_resource.go
+++ b/internal/services/containers/container_registry_agent_pool_resource.go
@@ -97,7 +97,6 @@ func resourceContainerRegistryAgentPoolCreate(d *pluginsdk.ResourceData, meta in
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	log.Printf("[INFO] preparing arguments for Container Registry Agent Pool creation.")
 
 	id := agentpools.NewAgentPoolID(subscriptionId, d.Get("resource_group_name").(string), d.Get("container_registry_name").(string), d.Get("name").(string))
 
@@ -143,7 +142,6 @@ func resourceContainerRegistryAgentPoolUpdate(d *pluginsdk.ResourceData, meta in
 	client := meta.(*clients.Client).Containers.ContainerRegistryClient_v2019_06_01_preview.AgentPools
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	log.Printf("[INFO] preparing arguments for Container Registry Agent Pool creation.")
 
 	id, err := agentpools.ParseAgentPoolID(d.Id())
 	if err != nil {

--- a/internal/services/containers/container_registry_cache_rule_resource.go
+++ b/internal/services/containers/container_registry_cache_rule_resource.go
@@ -98,7 +98,8 @@ func (r ContainerRegistryCacheRule) Create() sdk.ResourceFunc {
 				return err
 			}
 
-			id := cacherules.NewCacheRuleID(subscriptionId,
+			id := cacherules.NewCacheRuleID(
+				subscriptionId,
 				registryId.ResourceGroupName,
 				registryId.RegistryName,
 				metadata.ResourceData.Get("name").(string),

--- a/internal/services/containers/container_registry_cache_rule_resource.go
+++ b/internal/services/containers/container_registry_cache_rule_resource.go
@@ -93,8 +93,6 @@ func (r ContainerRegistryCacheRule) Create() sdk.ResourceFunc {
 				return err
 			}
 
-			log.Printf("[INFO] preparing arguments for Container Registry Cache Rule creation.")
-
 			registryId, err := registries.ParseRegistryID(metadata.ResourceData.Get("container_registry_id").(string))
 			if err != nil {
 				return err
@@ -195,8 +193,6 @@ func (r ContainerRegistryCacheRule) Update() sdk.ResourceFunc {
 			if err := metadata.Decode(&config); err != nil {
 				return err
 			}
-
-			log.Printf("[INFO] preparing arguments for Container Registry Cache Rule update.")
 
 			id, err := cacherules.ParseCacheRuleID(metadata.ResourceData.Id())
 			if err != nil {

--- a/internal/services/containers/container_registry_credential_set_resource.go
+++ b/internal/services/containers/container_registry_credential_set_resource.go
@@ -118,7 +118,8 @@ func (r ContainerRegistryCredentialSetResource) Create() sdk.ResourceFunc {
 				return err
 			}
 
-			id := credentialsets.NewCredentialSetID(subscriptionId,
+			id := credentialsets.NewCredentialSetID(
+				subscriptionId,
 				registryId.ResourceGroupName,
 				registryId.RegistryName,
 				config.Name,

--- a/internal/services/containers/container_registry_credential_set_resource.go
+++ b/internal/services/containers/container_registry_credential_set_resource.go
@@ -6,7 +6,6 @@ package containers
 import (
 	"context"
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -113,8 +112,6 @@ func (r ContainerRegistryCredentialSetResource) Create() sdk.ResourceFunc {
 			if err := metadata.Decode(&config); err != nil {
 				return err
 			}
-
-			log.Printf("[INFO] preparing arguments for Container Registry Credential Set creation.")
 
 			registryId, err := registries.ParseRegistryID(config.ContainerRegistryId)
 			if err != nil {

--- a/internal/services/containers/container_registry_resource.go
+++ b/internal/services/containers/container_registry_resource.go
@@ -356,7 +356,6 @@ func resourceContainerRegistryCreate(d *pluginsdk.ResourceData, meta interface{}
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	log.Printf("[INFO] preparing arguments for  Container Registry creation.")
 
 	id := registries.NewRegistryID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 

--- a/internal/services/containers/container_registry_resource.go
+++ b/internal/services/containers/container_registry_resource.go
@@ -670,7 +670,6 @@ func applyContainerRegistrySku(d *pluginsdk.ResourceData, meta interface{}, sku 
 
 func applyGeoReplicationLocations(ctx context.Context, meta interface{}, registryId registries.RegistryId, oldGeoReplications []replications.Replication, newGeoReplications []replications.Replication) error {
 	replicationClient := meta.(*clients.Client).Containers.ContainerRegistryClient.Replications
-	log.Printf("[INFO] preparing to apply geo-replications for Container Registry.")
 
 	oldReplications := map[string]replications.Replication{}
 	for _, replication := range oldGeoReplications {

--- a/internal/services/containers/container_registry_scope_map_resource.go
+++ b/internal/services/containers/container_registry_scope_map_resource.go
@@ -118,7 +118,6 @@ func resourceContainerRegistryScopeMapUpdate(d *pluginsdk.ResourceData, meta int
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for AzureRM Container Registry scope map update.")
 	id, err := scopemaps.ParseScopeMapID(d.Id())
 	if err != nil {
 		return err

--- a/internal/services/containers/container_registry_token_resource.go
+++ b/internal/services/containers/container_registry_token_resource.go
@@ -125,7 +125,6 @@ func resourceContainerRegistryTokenUpdate(d *pluginsdk.ResourceData, meta interf
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for AzureRM Container Registry token update.")
 	id, err := tokens.ParseTokenID(d.Id())
 	if err != nil {
 		return err

--- a/internal/services/containers/container_registry_webhook_resource.go
+++ b/internal/services/containers/container_registry_webhook_resource.go
@@ -122,7 +122,6 @@ func resourceContainerRegistryWebhookCreate(d *pluginsdk.ResourceData, meta inte
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	log.Printf("[INFO] preparing arguments for Container Registry Webhook creation.")
 
 	id := webhooks.NewWebHookID(subscriptionId, d.Get("resource_group_name").(string), d.Get("registry_name").(string), d.Get("name").(string))
 
@@ -158,8 +157,6 @@ func resourceContainerRegistryWebhookUpdate(d *pluginsdk.ResourceData, meta inte
 	client := meta.(*clients.Client).Containers.ContainerRegistryClient.WebHooks
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for Container Registry Webhook update.")
 
 	id, err := webhooks.ParseWebHookID(d.Id())
 	if err != nil {

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -520,7 +520,6 @@ func resourceKubernetesClusterNodePoolCreate(d *pluginsdk.ResourceData, meta int
 
 	id := agentpools.NewAgentPoolID(clusterId.SubscriptionId, clusterId.ResourceGroupName, clusterId.ManagedClusterName, d.Get("name").(string))
 
-	log.Printf("[DEBUG] Retrieving %s...", *clusterId)
 	cluster, err := clustersClient.Get(ctx, *clusterId)
 	if err != nil {
 		if response.WasNotFound(cluster.HttpResponse) {
@@ -794,7 +793,6 @@ func resourceKubernetesClusterNodePoolUpdate(d *pluginsdk.ResourceData, meta int
 
 	d.Partial(true)
 
-	log.Printf("[DEBUG] Retrieving existing %s..", *id)
 	existing, err := client.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(existing.HttpResponse) {

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -1092,7 +1092,6 @@ func resourceKubernetesClusterNodePoolUpdate(d *pluginsdk.ResourceData, meta int
 
 		log.Printf("[DEBUG] Cycled Node Pool..")
 	} else {
-		log.Printf("[DEBUG] Updating existing %s..", *id)
 		err = client.CreateOrUpdateThenPoll(ctx, *id, *existing.Model, agentpools.DefaultCreateOrUpdateOperationOptions())
 		if err != nil {
 			return fmt.Errorf("updating Node Pool %s: %+v", *id, err)

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -2157,7 +2157,6 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 	}
 
 	if d.HasChange("service_principal") && !d.HasChange("identity") {
-		log.Printf("[DEBUG] Updating the Service Principal for %s..", *id)
 		servicePrincipals := d.Get("service_principal").([]interface{})
 		// we'll be rotating the Service Principal - removing the SP block is handled by the validate function
 		servicePrincipalRaw := servicePrincipals[0].(map[string]interface{})
@@ -2210,7 +2209,6 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 
 		props.AadProfile = azureADProfile
 		if props.AadProfile == nil || (props.AadProfile.Managed == nil || !*props.AadProfile.Managed) {
-			log.Printf("[DEBUG] Updating the RBAC AAD profile")
 			props.AadProfile = &managedclusters.ManagedClusterAADProfile{}
 			err = clusterClient.ResetAADProfileThenPoll(ctx, *id, *props.AadProfile)
 			if err != nil {
@@ -2663,7 +2661,6 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 			existing.Model.Properties.SecurityProfile.Defender = nil
 		}
 
-		log.Printf("[DEBUG] Updating %s..", *id)
 		err = clusterClient.CreateOrUpdateThenPoll(ctx, *id, *existing.Model, managedclusters.DefaultCreateOrUpdateOperationOptions())
 		if err != nil {
 			return fmt.Errorf("updating %s: %+v", *id, err)
@@ -2817,7 +2814,6 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 
 			log.Printf("[DEBUG] Cycled Default Node Pool..")
 		} else {
-			log.Printf("[DEBUG] Updating of Default Node Pool..")
 
 			if err := nodePoolsClient.CreateOrUpdateThenPoll(ctx, defaultNodePoolId, agentProfile, agentpools.DefaultCreateOrUpdateOperationOptions()); err != nil {
 				return fmt.Errorf("updating Default Node Pool %s %+v", defaultNodePoolId, err)

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -2669,7 +2669,6 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 		if err != nil {
 			return fmt.Errorf("updating %s: %+v", *id, err)
 		}
-
 	}
 
 	// then roll the version of Kubernetes if necessary

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -1803,8 +1803,6 @@ func resourceKubernetesClusterCreate(d *pluginsdk.ResourceData, meta interface{}
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Managed Kubernetes Cluster create.")
-
 	id := commonids.NewKubernetesClusterID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 	existing, err := client.Get(ctx, id)
 	if err != nil {

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -2170,7 +2170,6 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 		if err != nil {
 			return fmt.Errorf("updating Service Principal for %s: %+v", *id, err)
 		}
-		log.Printf("[DEBUG] Updated the Service Principal for %s.", *id)
 
 		// since we're patching it, re-retrieve the latest version of the cluster
 		existing, err = clusterClient.Get(ctx, *id)
@@ -2664,7 +2663,6 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 			return fmt.Errorf("updating %s: %+v", *id, err)
 		}
 
-		log.Printf("[DEBUG] Updated %s..", *id)
 	}
 
 	// then roll the version of Kubernetes if necessary
@@ -2817,7 +2815,6 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 				return fmt.Errorf("updating Default Node Pool %s %+v", defaultNodePoolId, err)
 			}
 
-			log.Printf("[DEBUG] Updated Default Node Pool.")
 		}
 	}
 

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -56,7 +56,8 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 			func(id string) error {
 				_, err := commonids.ParseKubernetesClusterID(id)
 				return err
-			}),
+			},
+		),
 
 		CustomizeDiff: pluginsdk.CustomDiffInSequence(
 			// The behaviour of the API requires this, but this could be removed when https://github.com/Azure/azure-rest-api-specs/issues/27373 has been addressed
@@ -555,7 +556,8 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 									string(managedclusters.NginxIngressControllerTypeInternal),
 									string(managedclusters.NginxIngressControllerTypeExternal),
 									string(managedclusters.NginxIngressControllerTypeNone),
-								}, false),
+								}, false,
+							),
 						},
 
 						"web_app_routing_identity": {
@@ -881,7 +883,8 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 							Optional: true,
 							ValidateFunc: validation.StringInSlice(
 								maintenanceconfigurations.PossibleValuesForWeekDay(),
-								false),
+								false,
+							),
 						},
 
 						"duration": {
@@ -895,7 +898,8 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 							Optional: true,
 							ValidateFunc: validation.StringInSlice(
 								maintenanceconfigurations.PossibleValuesForType(),
-								false),
+								false,
+							),
 						},
 
 						"day_of_month": {
@@ -972,7 +976,8 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 							Optional: true,
 							ValidateFunc: validation.StringInSlice(
 								maintenanceconfigurations.PossibleValuesForWeekDay(),
-								false),
+								false,
+							),
 						},
 
 						"duration": {
@@ -986,7 +991,8 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 							Optional: true,
 							ValidateFunc: validation.StringInSlice(
 								maintenanceconfigurations.PossibleValuesForType(),
-								false),
+								false,
+							),
 						},
 
 						"day_of_month": {
@@ -1153,7 +1159,8 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 							Default:  string(managedclusters.NetworkDataplaneAzure),
 							ValidateFunc: validation.StringInSlice(
 								managedclusters.PossibleValuesForNetworkDataplane(),
-								false),
+								false,
+							),
 						},
 
 						"network_plugin_mode": {
@@ -2810,11 +2817,9 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 
 			log.Printf("[DEBUG] Cycled Default Node Pool..")
 		} else {
-
 			if err := nodePoolsClient.CreateOrUpdateThenPoll(ctx, defaultNodePoolId, agentProfile, agentpools.DefaultCreateOrUpdateOperationOptions()); err != nil {
 				return fmt.Errorf("updating Default Node Pool %s %+v", defaultNodePoolId, err)
 			}
-
 		}
 	}
 

--- a/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/internal/services/cosmos/cosmosdb_account_resource.go
@@ -1221,7 +1221,6 @@ func resourceCosmosDbAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 		// Looks like you have to always remove all the identities first before you can
 		// reassign/modify them, else it will append any new/changed identities
 		// resulting in a diff...
-		log.Printf("[INFO] Updating AzureRM Cosmos DB Account: Setting 'Identity' to 'None'")
 
 		// can't set this back to account, because that will hit the bug...
 		identityVal := cosmosdb.DatabaseAccountUpdateParameters{

--- a/internal/services/cosmos/cosmosdb_cassandra_cluster_resource.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_cluster_resource.go
@@ -6,7 +6,6 @@ package cosmos
 import (
 	"context"
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"

--- a/internal/services/cosmos/cosmosdb_cassandra_cluster_resource.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_cluster_resource.go
@@ -6,6 +6,7 @@ package cosmos
 import (
 	"context"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"

--- a/internal/services/cosmos/cosmosdb_cassandra_datacenter_resource.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_datacenter_resource.go
@@ -6,7 +6,6 @@ package cosmos
 import (
 	"context"
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"

--- a/internal/services/cosmos/cosmosdb_cassandra_datacenter_resource.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_datacenter_resource.go
@@ -6,6 +6,7 @@ package cosmos
 import (
 	"context"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"

--- a/internal/services/dashboard/dashboard_grafana_managed_private_endpoint_resource.go
+++ b/internal/services/dashboard/dashboard_grafana_managed_private_endpoint_resource.go
@@ -242,8 +242,6 @@ func (r ManagedPrivateEndpointResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("deleting %s", *id)
-
 			if err := client.ManagedPrivateEndpointsDeleteThenPoll(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}

--- a/internal/services/databricks/databricks_virtual_network_peering_resource.go
+++ b/internal/services/databricks/databricks_virtual_network_peering_resource.go
@@ -5,7 +5,6 @@ package databricks
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -129,7 +128,6 @@ func resourceDatabricksVirtualNetworkPeeringCreate(d *pluginsdk.ResourceData, me
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Azure ARM databricks virtual network peering creation.")
 	var id vnetpeering.VirtualNetworkPeeringId
 
 	// I need to include the workspace ID in the properties because I need the name
@@ -263,8 +261,6 @@ func resourceDatabricksVirtualNetworkPeeringUpdate(d *pluginsdk.ResourceData, me
 	client := meta.(*clients.Client).DataBricks.VnetPeeringClient
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for Azure ARM databricks virtual network peering update.")
 
 	id, err := vnetpeering.ParseVirtualNetworkPeeringID(d.Id())
 	if err != nil {

--- a/internal/services/desktopvirtualization/virtual_desktop_application_group_resource.go
+++ b/internal/services/desktopvirtualization/virtual_desktop_application_group_resource.go
@@ -108,8 +108,6 @@ func resourceVirtualDesktopApplicationGroupCreateUpdate(d *pluginsdk.ResourceDat
 	client := meta.(*clients.Client).DesktopVirtualization.ApplicationGroupsClient
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 
-	log.Printf("[INFO] preparing arguments for Virtual Desktop Application Group creation")
-
 	name := d.Get("name").(string)
 	resourceGroup := d.Get("resource_group_name").(string)
 

--- a/internal/services/desktopvirtualization/virtual_desktop_application_resource.go
+++ b/internal/services/desktopvirtualization/virtual_desktop_application_resource.go
@@ -123,8 +123,6 @@ func resourceVirtualDesktopApplicationCreateUpdate(d *pluginsdk.ResourceData, me
 	client := meta.(*clients.Client).DesktopVirtualization.ApplicationsClient
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 
-	log.Printf("[INFO] preparing arguments for Virtual Desktop Application creation")
-
 	applicationGroup, _ := applicationgroup.ParseApplicationGroupID(d.Get("application_group_id").(string))
 	id := application.NewApplicationID(subscriptionId, applicationGroup.ResourceGroupName, applicationGroup.ApplicationGroupName, d.Get("name").(string))
 

--- a/internal/services/desktopvirtualization/virtual_desktop_scaling_plan_host_pool_association_resource.go
+++ b/internal/services/desktopvirtualization/virtual_desktop_scaling_plan_host_pool_association_resource.go
@@ -67,7 +67,6 @@ func resourceVirtualDesktopScalingPlanHostPoolAssociationCreate(d *pluginsdk.Res
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Virtual Desktop Scaling Plan <-> Host Pool Association creation.")
 	scalingPlanId, err := scalingplan.ParseScalingPlanID(d.Get("scaling_plan_id").(string))
 	if err != nil {
 		return err

--- a/internal/services/desktopvirtualization/virtual_desktop_scaling_plan_resource.go
+++ b/internal/services/desktopvirtualization/virtual_desktop_scaling_plan_resource.go
@@ -254,8 +254,6 @@ func resourceVirtualDesktopScalingPlanCreate(d *pluginsdk.ResourceData, meta int
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Virtual Desktop Scaling Plan create")
-
 	id := scalingplan.NewScalingPlanID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 	if d.IsNewResource() {
 		existing, err := client.Get(ctx, id)
@@ -302,8 +300,6 @@ func resourceVirtualDesktopScalingPlanUpdate(d *pluginsdk.ResourceData, meta int
 	client := meta.(*clients.Client).DesktopVirtualization.ScalingPlansClient
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for Virtual Desktop Scaling Plan update")
 
 	id, err := scalingplan.ParseScalingPlanID(d.Id())
 	if err != nil {

--- a/internal/services/desktopvirtualization/virtual_desktop_workspace_application_group_association_resource.go
+++ b/internal/services/desktopvirtualization/virtual_desktop_workspace_application_group_association_resource.go
@@ -66,7 +66,6 @@ func resourceVirtualDesktopWorkspaceApplicationGroupAssociationCreate(d *plugins
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Virtual Desktop Workspace <-> Application Group Association creation.")
 	workspaceId, err := workspace.ParseWorkspaceID(d.Get("workspace_id").(string))
 	if err != nil {
 		return err

--- a/internal/services/desktopvirtualization/virtual_desktop_workspace_resource.go
+++ b/internal/services/desktopvirtualization/virtual_desktop_workspace_resource.go
@@ -91,8 +91,6 @@ func resourceArmDesktopVirtualizationWorkspaceCreateUpdate(d *pluginsdk.Resource
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Virtual Desktop Workspace create/update")
-
 	id := workspace.NewWorkspaceID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 	if d.IsNewResource() {
 		existing, err := client.Get(ctx, id)

--- a/internal/services/devtestlabs/dev_test_lab_resource.go
+++ b/internal/services/devtestlabs/dev_test_lab_resource.go
@@ -104,8 +104,6 @@ func resourceDevTestLabCreateUpdate(d *pluginsdk.ResourceData, meta interface{})
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for DevTest Lab creation")
-
 	id := labs.NewLabID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
 	if d.IsNewResource() {

--- a/internal/services/devtestlabs/dev_test_linux_virtual_machine_resource.go
+++ b/internal/services/devtestlabs/dev_test_linux_virtual_machine_resource.go
@@ -162,8 +162,6 @@ func resourceArmDevTestLinuxVirtualMachineCreateUpdate(d *pluginsdk.ResourceData
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for DevTest Linux Virtual Machine creation")
-
 	id := virtualmachines.NewVirtualMachineID(subscriptionId, d.Get("resource_group_name").(string), d.Get("lab_name").(string), d.Get("name").(string))
 
 	if d.IsNewResource() {

--- a/internal/services/devtestlabs/dev_test_policy_resource.go
+++ b/internal/services/devtestlabs/dev_test_policy_resource.go
@@ -117,8 +117,6 @@ func resourceArmDevTestPolicyCreateUpdate(d *pluginsdk.ResourceData, meta interf
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for DevTest Policy creation")
-
 	id := policies.NewPolicyID(subscriptionId, d.Get("resource_group_name").(string), d.Get("lab_name").(string), d.Get("policy_set_name").(string), d.Get("name").(string))
 
 	if d.IsNewResource() {

--- a/internal/services/devtestlabs/dev_test_virtual_network_resource.go
+++ b/internal/services/devtestlabs/dev_test_virtual_network_resource.go
@@ -305,7 +305,8 @@ func resourceArmDevTestVirtualNetworkDelete(d *pluginsdk.ResourceData, meta inte
 func ValidateDevTestVirtualNetworkName() pluginsdk.SchemaValidateFunc {
 	return validation.StringMatch(
 		regexp.MustCompile("^[A-Za-z0-9_-]+$"),
-		"Virtual Network Name can only include alphanumeric characters, underscores, hyphens.")
+		"Virtual Network Name can only include alphanumeric characters, underscores, hyphens.",
+	)
 }
 
 func expandDevTestVirtualNetworkSubnets(input []interface{}, subscriptionId, resourceGroupName, virtualNetworkName string) *[]virtualnetworks.SubnetOverride {

--- a/internal/services/devtestlabs/dev_test_virtual_network_resource.go
+++ b/internal/services/devtestlabs/dev_test_virtual_network_resource.go
@@ -150,8 +150,6 @@ func resourceArmDevTestVirtualNetworkCreate(d *pluginsdk.ResourceData, meta inte
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for DevTest Virtual Network creation")
-
 	id := virtualnetworks.NewVirtualNetworkID(subscriptionId, d.Get("resource_group_name").(string), d.Get("lab_name").(string), d.Get("name").(string))
 
 	existing, err := client.Get(ctx, id, virtualnetworks.GetOperationOptions{})
@@ -236,7 +234,6 @@ func resourceArmDevTestVirtualNetworkUpdate(d *pluginsdk.ResourceData, meta inte
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for DevTest Virtual Network creation")
 	id, err := virtualnetworks.ParseVirtualNetworkID(d.Id())
 	if err != nil {
 		return err

--- a/internal/services/devtestlabs/dev_test_windows_virtual_machine_resource.go
+++ b/internal/services/devtestlabs/dev_test_windows_virtual_machine_resource.go
@@ -155,8 +155,6 @@ func resourceArmDevTestWindowsVirtualMachineCreateUpdate(d *pluginsdk.ResourceDa
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for DevTest Windows Virtual Machine creation")
-
 	id := virtualmachines.NewVirtualMachineID(subscriptionId, d.Get("resource_group_name").(string), d.Get("lab_name").(string), d.Get("name").(string))
 
 	if d.IsNewResource() {

--- a/internal/services/dynatrace/dynatrace_monitor_resource.go
+++ b/internal/services/dynatrace/dynatrace_monitor_resource.go
@@ -327,8 +327,6 @@ func (r MonitorsResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("deleting %s", *id)
-
 			if resp, err := client.Delete(ctx, *id); err != nil {
 				if !response.WasNotFound(resp.HttpResponse) {
 					return fmt.Errorf("deleting %s: %+v", *id, err)

--- a/internal/services/dynatrace/dynatrace_tag_rules_resource.go
+++ b/internal/services/dynatrace/dynatrace_tag_rules_resource.go
@@ -268,8 +268,6 @@ func (r TagRulesResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("deleting %s", *id)
-
 			if _, err := client.Delete(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}

--- a/internal/services/eventhub/eventhub_authorization_rule_resource.go
+++ b/internal/services/eventhub/eventhub_authorization_rule_resource.go
@@ -81,8 +81,6 @@ func resourceEventHubAuthorizationRuleCreateUpdate(d *pluginsdk.ResourceData, me
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for AzureRM EventHub Authorization Rule creation.")
-
 	id := eventhubs.NewEventhubAuthorizationRuleID(subscriptionId, d.Get("resource_group_name").(string), d.Get("namespace_name").(string), d.Get("eventhub_name").(string), d.Get("name").(string))
 	if d.IsNewResource() {
 		existing, err := eventhubsClient.GetAuthorizationRule(ctx, id)

--- a/internal/services/eventhub/eventhub_cluster_resource.go
+++ b/internal/services/eventhub/eventhub_cluster_resource.go
@@ -5,7 +5,6 @@ package eventhub
 
 import (
 	"fmt"
-	"log"
 	"net/http"
 	"regexp"
 	"strconv"
@@ -78,7 +77,6 @@ func resourceEventHubClusterCreateUpdate(d *pluginsdk.ResourceData, meta interfa
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	log.Printf("[INFO] preparing arguments for Azure ARM EventHub Cluster creation.")
 
 	id := eventhubsclusters.NewClusterID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 	if d.IsNewResource() {

--- a/internal/services/eventhub/eventhub_consumer_group_resource.go
+++ b/internal/services/eventhub/eventhub_consumer_group_resource.go
@@ -79,13 +79,11 @@ func (r ConsumerGroupResource) Attributes() map[string]*pluginsdk.Schema {
 func (r ConsumerGroupResource) Create() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
-			metadata.Logger.Info("Decoding state..")
 			var state ConsumerGroupObject
 			if err := metadata.Decode(&state); err != nil {
 				return err
 			}
 
-			metadata.Logger.Infof("creating Consumer Group %q..", state.Name)
 			client := metadata.Client.Eventhub.ConsumerGroupClient
 			subscriptionId := metadata.Client.Account.SubscriptionId
 
@@ -124,13 +122,11 @@ func (r ConsumerGroupResource) Update() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Info("Decoding state..")
 			var state ConsumerGroupObject
 			if err := metadata.Decode(&state); err != nil {
 				return err
 			}
 
-			metadata.Logger.Infof("updating Consumer Group %q..", state.Name)
 			client := metadata.Client.Eventhub.ConsumerGroupClient
 
 			parameters := consumergroups.ConsumerGroup{
@@ -159,7 +155,6 @@ func (r ConsumerGroupResource) Read() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("retrieving Consumer Group %q..", id.ConsumerGroupName)
 			resp, err := client.Get(ctx, *id)
 			if err != nil {
 				if response.WasNotFound(resp.HttpResponse) {
@@ -194,7 +189,6 @@ func (r ConsumerGroupResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("deleting Consumer Group %q..", id.ConsumerGroupName)
 			if resp, err := client.Delete(ctx, *id); err != nil {
 				if !response.WasNotFound(resp.HttpResponse) {
 					return fmt.Errorf("deleting %s: %+v", id, err)

--- a/internal/services/eventhub/eventhub_namespace_authorization_rule_resource.go
+++ b/internal/services/eventhub/eventhub_namespace_authorization_rule_resource.go
@@ -73,8 +73,6 @@ func resourceEventHubNamespaceAuthorizationRuleCreateUpdate(d *pluginsdk.Resourc
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for AzureRM EventHub Namespace Authorization Rule creation.")
-
 	id := authorizationrulesnamespaces.NewAuthorizationRuleID(subscriptionId, d.Get("resource_group_name").(string), d.Get("namespace_name").(string), d.Get("name").(string))
 	if d.IsNewResource() {
 		existing, err := client.NamespacesGetAuthorizationRule(ctx, id)

--- a/internal/services/eventhub/eventhub_namespace_disaster_recovery_config_resource.go
+++ b/internal/services/eventhub/eventhub_namespace_disaster_recovery_config_resource.go
@@ -6,7 +6,6 @@ package eventhub
 import (
 	"context"
 	"fmt"
-	"log"
 	"strconv"
 	"time"
 
@@ -74,8 +73,6 @@ func resourceEventHubNamespaceDisasterRecoveryConfigCreate(d *pluginsdk.Resource
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for AzureRM EventHub Namespace Disaster Recovery Configs creation.")
 
 	id := disasterrecoveryconfigs.NewDisasterRecoveryConfigID(subscriptionId, d.Get("resource_group_name").(string), d.Get("namespace_name").(string), d.Get("name").(string))
 

--- a/internal/services/eventhub/eventhub_namespace_resource.go
+++ b/internal/services/eventhub/eventhub_namespace_resource.go
@@ -283,7 +283,6 @@ func resourceEventHubNamespaceCreate(d *pluginsdk.ResourceData, meta interface{}
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	log.Printf("[INFO] preparing arguments for AzureRM EventHub Namespace creation.")
 
 	id := namespaces.NewNamespaceID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 	existing, err := client.Get(ctx, id)
@@ -386,7 +385,6 @@ func resourceEventHubNamespaceUpdate(d *pluginsdk.ResourceData, meta interface{}
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	log.Printf("[INFO] preparing arguments for AzureRM EventHub Namespace update.")
 
 	id := namespaces.NewNamespaceID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 

--- a/internal/services/eventhub/eventhub_namespace_schema_group_resource.go
+++ b/internal/services/eventhub/eventhub_namespace_schema_group_resource.go
@@ -5,7 +5,6 @@ package eventhub
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
@@ -81,7 +80,6 @@ func resourceEventHubNamespaceSchemaRegistryCreate(d *pluginsdk.ResourceData, me
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	log.Printf("[INFO] preparing arguments for AzureRM EventHub Namespace Schema Registry creation.")
 
 	namespaceId, err := namespaces.ParseNamespaceID(d.Get("namespace_id").(string))
 	if err != nil {

--- a/internal/services/eventhub/eventhub_resource.go
+++ b/internal/services/eventhub/eventhub_resource.go
@@ -6,7 +6,6 @@ package eventhub
 import (
 	"context"
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -265,8 +264,6 @@ func resourceEventHubCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Azure ARM EventHub creation.")
-
 	namespaceName := ""
 	resourceGroupName := ""
 	if v := d.Get("namespace_id").(string); v != "" {
@@ -332,8 +329,6 @@ func resourceEventHubUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for Azure ARM EventHub update.")
 
 	id, err := eventhubs.ParseEventhubID(d.Id())
 	if err != nil {

--- a/internal/services/extendedlocation/extended_custom_location_resource.go
+++ b/internal/services/extendedlocation/extended_custom_location_resource.go
@@ -239,8 +239,6 @@ func (r CustomLocationResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("deleting %s", *id)
-
 			if err := client.DeleteThenPoll(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s: %+v", id, err)
 			}

--- a/internal/services/extendedlocation/extended_location_custom_location_resource.go
+++ b/internal/services/extendedlocation/extended_location_custom_location_resource.go
@@ -246,8 +246,6 @@ func (r ExtendedLocationCustomLocationResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("deleting %s", *id)
-
 			if err := client.DeleteThenPoll(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s: %+v", id, err)
 			}

--- a/internal/services/firewall/firewall_resource.go
+++ b/internal/services/firewall/firewall_resource.go
@@ -238,8 +238,6 @@ func resourceFirewallCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for AzureRM Azure Firewall creation")
-
 	id := azurefirewalls.NewAzureFirewallID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
 	existing, err := client.Get(ctx, id)

--- a/internal/services/frontdoor/frontdoor_firewall_policy_resource.go
+++ b/internal/services/frontdoor/frontdoor_firewall_policy_resource.go
@@ -453,8 +453,6 @@ func resourceFrontDoorFirewallPolicyCreateUpdate(d *pluginsdk.ResourceData, meta
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing args for Front Door Firewall Policy")
-
 	name := d.Get("name").(string)
 	resourceGroup := d.Get("resource_group_name").(string)
 	id := webapplicationfirewallpolicies.NewFrontDoorWebApplicationFirewallPolicyID(subscriptionId, resourceGroup, name)

--- a/internal/services/healthcare/healthcare_dicom_service_resource.go
+++ b/internal/services/healthcare/healthcare_dicom_service_resource.go
@@ -217,7 +217,6 @@ func resourceHealthcareApisDicomServiceCreate(d *pluginsdk.ResourceData, meta in
 	client := meta.(*clients.Client).HealthCare.HealthcareWorkspaceDicomServiceClient
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	log.Printf("[INFO] preparing arguments for AzureRM Healthcare Dicom Service creation.")
 
 	workspace, err := workspaces.ParseWorkspaceID(d.Get("workspace_id").(string))
 	if err != nil {

--- a/internal/services/healthcare/healthcare_fhir_service_resource.go
+++ b/internal/services/healthcare/healthcare_fhir_service_resource.go
@@ -233,7 +233,6 @@ func resourceHealthcareApisFhirServiceCreate(d *pluginsdk.ResourceData, meta int
 	client := meta.(*clients.Client).HealthCare.HealthcareWorkspaceFhirServiceClient
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	log.Printf("[INFO] preparing arguments for AzureRM Healthcare Fhir Service creation.")
 
 	workspaceId, err := workspaces.ParseWorkspaceID(d.Get("workspace_id").(string))
 	if err != nil {

--- a/internal/services/healthcare/healthcare_medtech_service_fhir_destination_resource.go
+++ b/internal/services/healthcare/healthcare_medtech_service_fhir_destination_resource.go
@@ -96,7 +96,6 @@ func resourceHealthcareApisMedTechServiceFhirDestinationCreate(d *pluginsdk.Reso
 	client := meta.(*clients.Client).HealthCare.HealthcareWorkspaceIotConnectorsClient
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	log.Printf("[INFO] preparing arguments for AzureRM Healthcare Med Tech Service Fhir Destination creation.")
 
 	medTechService, err := iotconnectors.ParseIotConnectorID(d.Get("medtech_service_id").(string))
 	if err != nil {

--- a/internal/services/healthcare/healthcare_medtech_service_resource.go
+++ b/internal/services/healthcare/healthcare_medtech_service_resource.go
@@ -106,7 +106,6 @@ func resourceHealthcareApisMedTechServiceCreate(d *pluginsdk.ResourceData, meta 
 	client := meta.(*clients.Client).HealthCare.HealthcareWorkspaceIotConnectorsClient
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	log.Printf("[INFO] preparing arguments for AzureRM Healthcare MedTech Service creation.")
 
 	workspace, err := workspaces.ParseWorkspaceID(d.Get("workspace_id").(string))
 	if err != nil {

--- a/internal/services/healthcare/healthcare_workspace_resource.go
+++ b/internal/services/healthcare/healthcare_workspace_resource.go
@@ -5,7 +5,6 @@ package healthcare
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
@@ -79,7 +78,6 @@ func resourceHealthcareApisWorkspaceCreate(d *pluginsdk.ResourceData, meta inter
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	log.Printf("[INFO] preparing arguments for AzureRM Healthcare Workspace creation.")
 
 	id := workspaces.NewWorkspaceID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 	if d.IsNewResource() {

--- a/internal/services/iothub/iothub_consumer_group_resource.go
+++ b/internal/services/iothub/iothub_consumer_group_resource.go
@@ -5,7 +5,6 @@ package iothub
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
@@ -74,7 +73,6 @@ func resourceIotHubConsumerGroupCreate(d *pluginsdk.ResourceData, meta interface
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	log.Printf("[INFO] preparing arguments for AzureRM IoTHub Consumer Group creation.")
 
 	id := parse.NewConsumerGroupID(subscriptionId, d.Get("resource_group_name").(string), d.Get("iothub_name").(string), d.Get("eventhub_endpoint_name").(string), d.Get("name").(string))
 

--- a/internal/services/iothub/iothub_dps_resource.go
+++ b/internal/services/iothub/iothub_dps_resource.go
@@ -416,7 +416,6 @@ func iothubdpsStateStatusCodeRefreshFunc(ctx context.Context, client *iotdpsreso
 		if res.HttpResponse != nil {
 			statusCode = strconv.Itoa(res.HttpResponse.StatusCode)
 		}
-		log.Printf("Retrieving IoT Device Provisioning Service %q returned Status %q", id, statusCode)
 
 		if err != nil {
 			if response.WasNotFound(res.HttpResponse) {

--- a/internal/services/kusto/kusto_cluster_resource.go
+++ b/internal/services/kusto/kusto_cluster_resource.go
@@ -6,7 +6,6 @@ package kusto
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
@@ -337,8 +336,6 @@ func resourceKustoClusterCreate(d *pluginsdk.ResourceData, meta interface{}) err
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for Azure Kusto Cluster creation.")
 
 	id := commonids.NewKustoClusterID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 	existing, err := client.Get(ctx, id)

--- a/internal/services/kusto/kusto_eventgrid_data_connection_resource.go
+++ b/internal/services/kusto/kusto_eventgrid_data_connection_resource.go
@@ -96,7 +96,8 @@ func resourceKustoEventGridDataConnection() *pluginsdk.Resource {
 				ForceNew: true,
 				ValidateFunc: validation.Any(
 					eventhubValidate.ValidateEventHubConsumerName(),
-					validation.StringInSlice([]string{"$Default"}, false)),
+					validation.StringInSlice([]string{"$Default"}, false),
+				),
 			},
 
 			"blob_storage_event_type": {

--- a/internal/services/kusto/kusto_eventgrid_data_connection_resource.go
+++ b/internal/services/kusto/kusto_eventgrid_data_connection_resource.go
@@ -5,7 +5,6 @@ package kusto
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -191,8 +190,6 @@ func resourceKustoEventGridDataConnectionCreateUpdate(d *pluginsdk.ResourceData,
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for Azure Kusto Event Grid Data Connection creation.")
 
 	id := dataconnections.NewDataConnectionID(subscriptionId, d.Get("resource_group_name").(string), d.Get("cluster_name").(string), d.Get("database_name").(string), d.Get("name").(string))
 	if d.IsNewResource() {

--- a/internal/services/kusto/kusto_eventhub_data_connection_resource.go
+++ b/internal/services/kusto/kusto_eventhub_data_connection_resource.go
@@ -105,7 +105,8 @@ func resourceKustoEventHubDataConnection() *pluginsdk.Resource {
 				ForceNew: true,
 				ValidateFunc: validation.Any(
 					eventhubValidate.ValidateEventHubConsumerName(),
-					validation.StringInSlice([]string{"$Default"}, false)),
+					validation.StringInSlice([]string{"$Default"}, false),
+				),
 			},
 
 			"table_name": {

--- a/internal/services/kusto/kusto_eventhub_data_connection_resource.go
+++ b/internal/services/kusto/kusto_eventhub_data_connection_resource.go
@@ -5,7 +5,6 @@ package kusto
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -159,8 +158,6 @@ func resourceKustoEventHubDataConnectionCreate(d *pluginsdk.ResourceData, meta i
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for Azure Kusto Event Hub Data Connection creation.")
 
 	id := dataconnections.NewDataConnectionID(subscriptionId, d.Get("resource_group_name").(string), d.Get("cluster_name").(string), d.Get("database_name").(string), d.Get("name").(string))
 

--- a/internal/services/kusto/kusto_iothub_data_connection_resource.go
+++ b/internal/services/kusto/kusto_iothub_data_connection_resource.go
@@ -5,7 +5,6 @@ package kusto
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -150,8 +149,6 @@ func resourceKustoIotHubDataConnectionCreate(d *pluginsdk.ResourceData, meta int
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for Azure Kusto Iot Hub Data Connection creation.")
 
 	id := dataconnections.NewDataConnectionID(subscriptionId, d.Get("resource_group_name").(string), d.Get("cluster_name").(string), d.Get("database_name").(string), d.Get("name").(string))
 	resp, err := client.Get(ctx, id)

--- a/internal/services/legacy/virtual_machine_resource.go
+++ b/internal/services/legacy/virtual_machine_resource.go
@@ -969,7 +969,6 @@ func resourceVirtualMachineDelete(d *pluginsdk.ResourceData, meta interface{}) e
 
 		// delete Data disks if opted in
 		if deleteDataDisks {
-
 			dataDisks := storageProfile.DataDisks
 			if dataDisks == nil {
 				return fmt.Errorf("deleting Data Disks for %s: `dataDisks` was nil", id)

--- a/internal/services/legacy/virtual_machine_resource.go
+++ b/internal/services/legacy/virtual_machine_resource.go
@@ -615,7 +615,6 @@ func resourceVirtualMachineCreateUpdate(d *pluginsdk.ResourceData, meta interfac
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Azure ARM Virtual Machine creation.")
 	id := virtualmachines.NewVirtualMachineID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
 	if d.IsNewResource() {

--- a/internal/services/legacy/virtual_machine_resource.go
+++ b/internal/services/legacy/virtual_machine_resource.go
@@ -948,7 +948,6 @@ func resourceVirtualMachineDelete(d *pluginsdk.ResourceData, meta interface{}) e
 		}
 
 		if deleteOsDisk {
-			log.Printf("[INFO] delete_os_disk_on_termination is enabled, deleting disk from %s", id)
 			osDisk := storageProfile.OsDisk
 			if osDisk == nil {
 				return fmt.Errorf("deleting OS Disk for %s - `osDisk` was nil", id)
@@ -970,7 +969,6 @@ func resourceVirtualMachineDelete(d *pluginsdk.ResourceData, meta interface{}) e
 
 		// delete Data disks if opted in
 		if deleteDataDisks {
-			log.Printf("[INFO] delete_data_disks_on_termination is enabled, deleting each data disk from %s", id)
 
 			dataDisks := storageProfile.DataDisks
 			if dataDisks == nil {

--- a/internal/services/legacy/virtual_machine_resource.go
+++ b/internal/services/legacy/virtual_machine_resource.go
@@ -10,7 +10,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"log"
 	"strings"
 	"time"
 

--- a/internal/services/legacy/virtual_machine_scale_set_resource.go
+++ b/internal/services/legacy/virtual_machine_scale_set_resource.go
@@ -784,8 +784,6 @@ func resourceVirtualMachineScaleSetCreateUpdate(d *pluginsdk.ResourceData, meta 
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Azure ARM Virtual Machine Scale Set creation.")
-
 	id := virtualmachinescalesets.NewVirtualMachineScaleSetID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
 	if d.IsNewResource() {

--- a/internal/services/loadbalancer/lb_backend_address_pool_address_resource.go
+++ b/internal/services/loadbalancer/lb_backend_address_pool_address_resource.go
@@ -183,7 +183,6 @@ func (r BackendAddressPoolAddressResource) Create() sdk.ResourceFunc {
 					addresses = *pool.Model.Properties.LoadBalancerBackendAddresses
 				}
 
-				metadata.Logger.Infof("checking for existing %s..", id)
 				for _, address := range addresses {
 					if address.Name == nil {
 						continue
@@ -221,12 +220,10 @@ func (r BackendAddressPoolAddressResource) Create() sdk.ResourceFunc {
 
 				pool.Model.Properties.LoadBalancerBackendAddresses = &addresses
 
-				metadata.Logger.Infof("adding %s..", id)
 				err = lbClient.LoadBalancerBackendAddressPoolsCreateOrUpdateThenPoll(ctx, *poolId, *pool.Model)
 				if err != nil {
 					return fmt.Errorf("updating %s: %+v", id, err)
 				}
-				metadata.Logger.Infof("waiting for update %s..", id)
 
 				metadata.SetID(id)
 			}
@@ -386,7 +383,6 @@ func (r BackendAddressPoolAddressResource) Delete() sdk.ResourceFunc {
 				}
 			}
 
-			metadata.Logger.Infof("removing %s..", *id)
 			pool.Model.Properties.LoadBalancerBackendAddresses = &newAddresses
 
 			err = lbClient.LoadBalancerBackendAddressPoolsCreateOrUpdateThenPoll(ctx, poolId, *pool.Model)

--- a/internal/services/loadbalancer/lb_resource.go
+++ b/internal/services/loadbalancer/lb_resource.go
@@ -270,8 +270,6 @@ func resourceArmLoadBalancerCreate(d *pluginsdk.ResourceData, meta interface{}) 
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Azure ARM Load Balancer creation.")
-
 	id := loadbalancers.NewLoadBalancerID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
 	// Casting because of a bug in provider ID generation due to a data issue that needs investigation.

--- a/internal/services/loganalytics/log_analytics_linked_service_resource.go
+++ b/internal/services/loganalytics/log_analytics_linked_service_resource.go
@@ -6,7 +6,6 @@ package loganalytics
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
@@ -69,8 +68,6 @@ func resourceLogAnalyticsLinkedServiceCreateUpdate(d *pluginsdk.ResourceData, me
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for AzureRM Log Analytics Linked Services creation.")
 
 	var workspaceId string
 	resourceGroup := d.Get("resource_group_name").(string)

--- a/internal/services/loganalytics/log_analytics_workspace_resource.go
+++ b/internal/services/loganalytics/log_analytics_workspace_resource.go
@@ -253,7 +253,6 @@ func resourceLogAnalyticsWorkspaceCreate(d *pluginsdk.ResourceData, meta interfa
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	log.Printf("[INFO] preparing arguments for AzureRM Log Analytics Workspace creation.")
 
 	var isLACluster bool
 
@@ -429,7 +428,6 @@ func resourceLogAnalyticsWorkspaceUpdate(d *pluginsdk.ResourceData, meta interfa
 	client := meta.(*clients.Client).LogAnalytics.WorkspaceClient
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	log.Printf("[INFO] preparing arguments for AzureRM Log Analytics Workspace update.")
 
 	id, err := workspaces.ParseWorkspaceID(d.Id())
 	if err != nil {

--- a/internal/services/loganalytics/log_analytics_workspace_table_resource.go
+++ b/internal/services/loganalytics/log_analytics_workspace_table_resource.go
@@ -6,7 +6,6 @@ package loganalytics
 import (
 	"context"
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -114,7 +113,6 @@ func (r LogAnalyticsWorkspaceTableResource) Create() sdk.ResourceFunc {
 			client := metadata.Client.LogAnalytics.TablesClient
 
 			tableName := model.Name
-			log.Printf("[INFO] preparing arguments for AzureRM Log Analytics Workspace Table %s update.", tableName)
 
 			workspaceId, err := workspaces.ParseWorkspaceID(model.WorkspaceId)
 			if err != nil {

--- a/internal/services/logic/logic_app_standard_resource.go
+++ b/internal/services/logic/logic_app_standard_resource.go
@@ -693,8 +693,6 @@ func (r LogicAppResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("deleting Linux %s", *id)
-
 			delOptions := webapps.DeleteOperationOptions{
 				DeleteMetrics:         pointer.To(true),
 				DeleteEmptyServerFarm: pointer.To(false),

--- a/internal/services/logic/logic_app_workflow_resource.go
+++ b/internal/services/logic/logic_app_workflow_resource.go
@@ -283,8 +283,6 @@ func resourceLogicAppWorkflowCreate(d *pluginsdk.ResourceData, meta interface{})
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Logic App Workflow creation.")
-
 	id := workflows.NewWorkflowID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
 	if d.IsNewResource() {

--- a/internal/services/managedredis/managed_redis_resource.go
+++ b/internal/services/managedredis/managed_redis_resource.go
@@ -553,7 +553,6 @@ func (r ManagedRedisResource) Update() sdk.ResourceFunc {
 						"default_database.0.geo_replication_group_name",
 						"default_database.0.module",
 					) {
-						log.Printf("[INFO] re-creating database %s to apply updates to immutable properties, data will be lost and Managed Redis will be unavailable during this operation", dbId)
 
 						if err := dbClient.DeleteThenPoll(ctx, dbId); err != nil {
 							return fmt.Errorf("deleting database %s for re-creation: %+v", dbId, err)

--- a/internal/services/managedredis/managed_redis_resource.go
+++ b/internal/services/managedredis/managed_redis_resource.go
@@ -553,7 +553,6 @@ func (r ManagedRedisResource) Update() sdk.ResourceFunc {
 						"default_database.0.geo_replication_group_name",
 						"default_database.0.module",
 					) {
-
 						if err := dbClient.DeleteThenPoll(ctx, dbId); err != nil {
 							return fmt.Errorf("deleting database %s for re-creation: %+v", dbId, err)
 						}

--- a/internal/services/managementgroup/management_group_resource.go
+++ b/internal/services/managementgroup/management_group_resource.go
@@ -211,7 +211,6 @@ func resourceManagementGroupCreateUpdate(d *pluginsdk.ResourceData, meta interfa
 	}
 
 	// then add the new ones
-	log.Printf("[DEBUG] Preparing to assign Subscriptions to Management Group %q", groupName)
 	for _, subscriptionId := range subscriptionIds {
 		log.Printf("[DEBUG] Assigning Subscription ID %q to management group %q", subscriptionId, groupName)
 		if _, err := client.SubscriptionsCreate(ctx, managementgroups.NewSubscriptionID(groupName, subscriptionId), managementgroups.SubscriptionsCreateOperationOptions{

--- a/internal/services/managementgroup/management_group_resource.go
+++ b/internal/services/managementgroup/management_group_resource.go
@@ -130,8 +130,6 @@ func resourceManagementGroupCreateUpdate(d *pluginsdk.ResourceData, meta interfa
 		}
 	}
 
-	log.Printf("[INFO] Creating Management Group %q", groupName)
-
 	properties := managementgroups.CreateManagementGroupRequest{
 		Name: pointer.To(groupName),
 		Properties: &managementgroups.CreateManagementGroupProperties{

--- a/internal/services/maps/maps_account_resource.go
+++ b/internal/services/maps/maps_account_resource.go
@@ -5,7 +5,6 @@ package maps
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -140,8 +139,6 @@ func resourceMapsAccountCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for AzureRM Maps Account creation.")
-
 	id := accounts.NewAccountID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
 	existing, err := client.Get(ctx, id)
@@ -209,8 +206,6 @@ func resourceMapsAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 	client := meta.(*clients.Client).Maps.AccountsClient
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for AzureRM Maps Account creation.")
 
 	id, err := accounts.ParseAccountID(d.Id())
 	if err != nil {

--- a/internal/services/mongocluster/mongo_cluster_resource.go
+++ b/internal/services/mongocluster/mongo_cluster_resource.go
@@ -472,7 +472,6 @@ func (r MongoClusterResource) Update() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Info("Decoding state...")
 			var state MongoClusterResourceModel
 			if err := metadata.Decode(&state); err != nil {
 				return fmt.Errorf("decoding: %+v", err)
@@ -490,8 +489,6 @@ func (r MongoClusterResource) Update() sdk.ResourceFunc {
 				return fmt.Errorf("retrieving %s: `properties` was nil", *id)
 			}
 			payload := existing.Model
-
-			metadata.Logger.Infof("updating %s", *id)
 
 			// Set SystemData to nil as the API returns `The property '#/systemData' of type null did not match the following type: object in schema 25debcc2-6915-5536-9566-a2ecd765b755"}}` error.
 			// https://github.com/Azure/azure-rest-api-specs/issues/31377 has been filed to track it.
@@ -516,14 +513,12 @@ func (r MongoClusterResource) Update() sdk.ResourceFunc {
 				}
 				oldComputeTier, newComputeTier := metadata.ResourceData.GetChange("compute_tier")
 				if (oldComputeTier == "Free" || oldComputeTier == "M25") && newComputeTier != "Free" && newComputeTier != "M25" {
-					metadata.Logger.Infof("updating compute tier for %s", *id)
 					if err := client.CreateOrUpdateThenPoll(ctx, *id, *payload); err != nil {
 						return fmt.Errorf("updating %s: %+v", *id, err)
 					}
 				}
 			}
 
-			metadata.Logger.Infof("updating other configurations for %s", *id)
 			if metadata.ResourceData.HasChange("administrator_password") {
 				payload.Properties.Administrator = &mongoclusters.AdministratorProperties{
 					UserName: pointer.To(state.AdministratorUserName),

--- a/internal/services/monitor/monitor_data_collection_endpoint_resource.go
+++ b/internal/services/monitor/monitor_data_collection_endpoint_resource.go
@@ -114,7 +114,6 @@ func (r DataCollectionEndpointResource) ModelObject() interface{} {
 func (r DataCollectionEndpointResource) Create() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
-			metadata.Logger.Info("Decoding state..")
 			var state DataCollectionEndpoint
 			if err := metadata.Decode(&state); err != nil {
 				return err
@@ -124,7 +123,6 @@ func (r DataCollectionEndpointResource) Create() sdk.ResourceFunc {
 			subscriptionId := metadata.Client.Account.SubscriptionId
 
 			id := datacollectionendpoints.NewDataCollectionEndpointID(subscriptionId, state.ResourceGroupName, state.Name)
-			metadata.Logger.Infof("creating %s", id)
 
 			existing, err := client.Get(ctx, id)
 			if err != nil && !response.WasNotFound(existing.HttpResponse) {
@@ -233,7 +231,6 @@ func (r DataCollectionEndpointResource) Update() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("updating %s..", *id)
 			client := metadata.Client.Monitor.DataCollectionEndpointsClient
 			resp, err := client.Get(ctx, *id)
 			if err != nil {
@@ -288,7 +285,6 @@ func (r DataCollectionEndpointResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("deleting %s..", *id)
 			resp, err := client.Delete(ctx, *id)
 			if err != nil && !response.WasNotFound(resp.HttpResponse) {
 				return fmt.Errorf("deleting %s: %+v", *id, err)

--- a/internal/services/monitor/monitor_data_collection_endpoint_resource.go
+++ b/internal/services/monitor/monitor_data_collection_endpoint_resource.go
@@ -68,7 +68,8 @@ func (r DataCollectionEndpointResource) Arguments() map[string]*pluginsdk.Schema
 			Type:     pluginsdk.TypeString,
 			Optional: true,
 			ValidateFunc: validation.StringInSlice(
-				datacollectionendpoints.PossibleValuesForKnownDataCollectionEndpointResourceKind(), false),
+				datacollectionendpoints.PossibleValuesForKnownDataCollectionEndpointResourceKind(), false,
+			),
 		},
 
 		"tags": commonschema.Tags(),

--- a/internal/services/monitor/monitor_data_collection_rule_association_resource.go
+++ b/internal/services/monitor/monitor_data_collection_rule_association_resource.go
@@ -88,7 +88,6 @@ func (r DataCollectionRuleAssociationResource) ModelObject() interface{} {
 func (r DataCollectionRuleAssociationResource) Create() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
-			metadata.Logger.Info("Decoding state..")
 			var model DataCollectionRuleAssociationModel
 			if err := metadata.Decode(&model); err != nil {
 				return err
@@ -97,7 +96,6 @@ func (r DataCollectionRuleAssociationResource) Create() sdk.ResourceFunc {
 			client := metadata.Client.Monitor.DataCollectionRuleAssociationsClient
 
 			id := datacollectionruleassociations.NewScopedDataCollectionRuleAssociationID(model.TargetResourceId, model.Name)
-			metadata.Logger.Infof("creating %s", id)
 
 			existing, err := client.Get(ctx, id)
 			if err != nil && !response.WasNotFound(existing.HttpResponse) {
@@ -181,7 +179,6 @@ func (r DataCollectionRuleAssociationResource) Update() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("updating %s..", *id)
 			client := metadata.Client.Monitor.DataCollectionRuleAssociationsClient
 			resp, err := client.Get(ctx, *id)
 			if err != nil {
@@ -238,7 +235,6 @@ func (r DataCollectionRuleAssociationResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("deleting %s..", *id)
 			resp, err := client.Delete(ctx, *id)
 			if err != nil && !response.WasNotFound(resp.HttpResponse) {
 				return fmt.Errorf("deleting %s: %+v", *id, err)

--- a/internal/services/monitor/monitor_data_collection_rule_resource.go
+++ b/internal/services/monitor/monitor_data_collection_rule_resource.go
@@ -766,7 +766,8 @@ func (r DataCollectionRuleResource) Arguments() map[string]*pluginsdk.Schema {
 										Type: pluginsdk.TypeString,
 										ValidateFunc: validation.StringInSlice(
 											datacollectionrules.PossibleValuesForKnownSyslogDataSourceFacilityNames(),
-											false),
+											false,
+										),
 									},
 								},
 								"log_levels": {
@@ -776,7 +777,8 @@ func (r DataCollectionRuleResource) Arguments() map[string]*pluginsdk.Schema {
 									Elem: &pluginsdk.Schema{
 										Type: pluginsdk.TypeString,
 										ValidateFunc: validation.StringInSlice(
-											datacollectionrules.PossibleValuesForKnownSyslogDataSourceLogLevels(), false),
+											datacollectionrules.PossibleValuesForKnownSyslogDataSourceLogLevels(), false,
+										),
 									},
 								},
 								// lintignore:S013
@@ -866,7 +868,8 @@ func (r DataCollectionRuleResource) Arguments() map[string]*pluginsdk.Schema {
 					"AgentDirectToStore",
 					"WorkspaceTransforms",
 				},
-				false),
+				false,
+			),
 		},
 
 		"stream_declaration": {

--- a/internal/services/monitor/monitor_data_collection_rule_resource.go
+++ b/internal/services/monitor/monitor_data_collection_rule_resource.go
@@ -930,7 +930,6 @@ func (r DataCollectionRuleResource) ModelObject() interface{} {
 func (r DataCollectionRuleResource) Create() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
-			metadata.Logger.Info("Decoding state..")
 			var state DataCollectionRule
 			if err := metadata.Decode(&state); err != nil {
 				return err
@@ -940,7 +939,6 @@ func (r DataCollectionRuleResource) Create() sdk.ResourceFunc {
 			subscriptionId := metadata.Client.Account.SubscriptionId
 
 			id := datacollectionrules.NewDataCollectionRuleID(subscriptionId, state.ResourceGroupName, state.Name)
-			metadata.Logger.Infof("creating %s", id)
 
 			existing, err := client.Get(ctx, id)
 			if err != nil && !response.WasNotFound(existing.HttpResponse) {
@@ -999,11 +997,9 @@ func (r DataCollectionRuleResource) Read() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("retrieving %s", *id)
 			resp, err := client.Get(ctx, *id)
 			if err != nil {
 				if response.WasNotFound(resp.HttpResponse) {
-					metadata.Logger.Infof("%s was not found - removing from state!", *id)
 					return metadata.MarkAsGone(id)
 				}
 				return fmt.Errorf("retrieving %s: %+v", *id, err)
@@ -1068,7 +1064,6 @@ func (r DataCollectionRuleResource) Update() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("updating %s..", *id)
 			client := metadata.Client.Monitor.DataCollectionRulesClient
 			resp, err := client.Get(ctx, *id)
 			if err != nil {
@@ -1153,7 +1148,6 @@ func (r DataCollectionRuleResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("deleting %s..", *id)
 			resp, err := client.Delete(ctx, *id, datacollectionrules.DefaultDeleteOperationOptions())
 			if err != nil && !response.WasNotFound(resp.HttpResponse) {
 				return fmt.Errorf("deleting %s: %+v", *id, err)

--- a/internal/services/monitor/monitor_diagnostic_setting_resource.go
+++ b/internal/services/monitor/monitor_diagnostic_setting_resource.go
@@ -229,7 +229,6 @@ func resourceMonitorDiagnosticSettingCreate(d *pluginsdk.ResourceData, meta inte
 	client := meta.(*clients.Client).Monitor.DiagnosticSettingsClient
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	log.Printf("[INFO] preparing arguments for Azure ARM Diagnostic Settings.")
 
 	id := diagnosticsettings.NewScopedDiagnosticSettingID(d.Get("target_resource_id").(string), d.Get("name").(string))
 	resourceId := fmt.Sprintf("%s|%s", id.ResourceUri, id.DiagnosticSettingName)
@@ -351,7 +350,6 @@ func resourceMonitorDiagnosticSettingUpdate(d *pluginsdk.ResourceData, meta inte
 	client := meta.(*clients.Client).Monitor.DiagnosticSettingsClient
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	log.Printf("[INFO] preparing arguments for Azure ARM Diagnostic Settings.")
 
 	id, err := ParseMonitorDiagnosticId(d.Id())
 	if err != nil {

--- a/internal/services/mssql/mssql_database_extended_auditing_policy_resource.go
+++ b/internal/services/mssql/mssql_database_extended_auditing_policy_resource.go
@@ -5,7 +5,6 @@ package mssql
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -92,8 +91,6 @@ func resourceMsSqlDatabaseExtendedAuditingPolicyCreateUpdate(d *pluginsdk.Resour
 	client := meta.(*clients.Client).MSSQL.BlobAuditingPoliciesClient
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for MsSql Database Extended Auditing Policy creation.")
 
 	dbId, err := commonids.ParseSqlDatabaseID(d.Get("database_id").(string))
 	if err != nil {

--- a/internal/services/mssql/mssql_database_resource.go
+++ b/internal/services/mssql/mssql_database_resource.go
@@ -1225,7 +1225,7 @@ func resourceMssqlDatabaseSetFlatten(d *pluginsdk.ResourceData, id *commonids.Sq
 
 			// when `max_size_gb` is below 1GB, the API only accepts 100MB and 500MB. 100MB is 104857600, and 500MB is 524288000.
 			// directly set `max_size_gb` when API returns `104857600` or `524288000`.
-			size := float64((pointer.From(props.MaxSizeBytes)) / int64(1073741824))
+			size := float64(pointer.From(props.MaxSizeBytes) / int64(1073741824))
 			switch pointer.From(props.MaxSizeBytes) {
 			case 104857600:
 				size = 0.1

--- a/internal/services/mssql/mssql_database_resource.go
+++ b/internal/services/mssql/mssql_database_resource.go
@@ -198,8 +198,6 @@ func resourceMsSqlDatabaseCreate(d *pluginsdk.ResourceData, meta interface{}) er
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for MsSql Database creation")
-
 	if strings.HasPrefix(d.Get("sku_name").(string), "GP_S_") && d.Get("license_type").(string) != "" {
 		return fmt.Errorf("serverless databases do not support license type")
 	}
@@ -683,8 +681,6 @@ func resourceMsSqlDatabaseUpdate(d *pluginsdk.ResourceData, meta interface{}) er
 
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for MsSql Database update")
 
 	name := d.Get("name").(string)
 	skuName := d.Get("sku_name").(string)

--- a/internal/services/mssql/mssql_database_resource.go
+++ b/internal/services/mssql/mssql_database_resource.go
@@ -898,7 +898,6 @@ func resourceMsSqlDatabaseUpdate(d *pluginsdk.ResourceData, meta interface{}) er
 						return fmt.Errorf("updating SKU of Replication Partner Database %s: %+v", partnerDatabaseId, err)
 					}
 
-					log.Printf("[INFO] SKU of Replication Partner Database updated successfully to %q", skuName)
 				}
 			}
 		}

--- a/internal/services/mssql/mssql_database_resource.go
+++ b/internal/services/mssql/mssql_database_resource.go
@@ -888,7 +888,6 @@ func resourceMsSqlDatabaseUpdate(d *pluginsdk.ResourceData, meta interface{}) er
 
 				// See: https://docs.microsoft.com/en-us/azure/azure-sql/database/active-geo-replication-overview#configuring-secondary-database
 				if partnerDatabase.Sku != nil && partnerDatabase.Sku.Name != "" && helper.CompareDatabaseSkuServiceTiers(skuName, partnerDatabase.Sku.Name) {
-					log.Printf("[INFO] Updating SKU of Replication Partner Database from %q to %q", partnerDatabase.Sku.Name, skuName)
 					err := client.UpdateThenPoll(ctx, *partnerDatabaseId, databases.DatabaseUpdate{
 						Sku: &databases.Sku{
 							Name: skuName,

--- a/internal/services/mssql/mssql_database_resource.go
+++ b/internal/services/mssql/mssql_database_resource.go
@@ -896,7 +896,6 @@ func resourceMsSqlDatabaseUpdate(d *pluginsdk.ResourceData, meta interface{}) er
 					if err != nil {
 						return fmt.Errorf("updating SKU of Replication Partner Database %s: %+v", partnerDatabaseId, err)
 					}
-
 				}
 			}
 		}

--- a/internal/services/mssql/mssql_database_vulnerability_assessment_rule_baseline_resource.go
+++ b/internal/services/mssql/mssql_database_vulnerability_assessment_rule_baseline_resource.go
@@ -96,8 +96,6 @@ func resourceMsSqlDatabaseVulnerabilityAssessmentRuleBaselineCreateUpdate(d *plu
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Azure ARM Vulnerability Assessment Rule Baselines creation.")
-
 	vulnerabilityAssessmentId, err := parse.ServerVulnerabilityAssessmentID(d.Get("server_vulnerability_assessment_id").(string))
 	if err != nil {
 		return err

--- a/internal/services/mssql/mssql_elasticpool_resource.go
+++ b/internal/services/mssql/mssql_elasticpool_resource.go
@@ -6,7 +6,6 @@ package mssql
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
@@ -255,8 +254,6 @@ func resourceMsSqlElasticPoolCreateUpdate(d *pluginsdk.ResourceData, meta interf
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for MSSQL ElasticPool creation.")
 
 	id := commonids.NewSqlElasticPoolID(subscriptionId, d.Get("resource_group_name").(string), d.Get("server_name").(string), d.Get("name").(string))
 

--- a/internal/services/mssql/mssql_failover_group_resource.go
+++ b/internal/services/mssql/mssql_failover_group_resource.go
@@ -251,13 +251,10 @@ func (r MsSqlFailoverGroupResource) Update() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Info("Decoding state...")
 			var state MsSqlFailoverGroupModel
 			if err := metadata.Decode(&state); err != nil {
 				return err
 			}
-
-			metadata.Logger.Infof("updating %s", id)
 
 			readOnlyFailoverPolicy := failovergroups.ReadOnlyEndpointFailoverPolicyDisabled
 			if state.ReadonlyEndpointFailurePolicyEnabled {

--- a/internal/services/mssql/mssql_job_agent_resource.go
+++ b/internal/services/mssql/mssql_job_agent_resource.go
@@ -5,7 +5,6 @@ package mssql
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
@@ -85,8 +84,6 @@ func resourceMsSqlJobAgentCreate(d *pluginsdk.ResourceData, meta interface{}) er
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Job Agent creation.")
-
 	databaseId := d.Get("database_id").(string)
 	dbId, err := commonids.ParseSqlDatabaseID(databaseId)
 	if err != nil {
@@ -140,8 +137,6 @@ func resourceMsSqlJobAgentUpdate(d *pluginsdk.ResourceData, meta interface{}) er
 	client := meta.(*clients.Client).MSSQL.JobAgentsClient
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for Job Agent update.")
 
 	databaseId := d.Get("database_id").(string)
 	dbId, err := commonids.ParseSqlDatabaseID(databaseId)

--- a/internal/services/mssql/mssql_job_credential_resource.go
+++ b/internal/services/mssql/mssql_job_credential_resource.go
@@ -5,7 +5,6 @@ package mssql
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -87,8 +86,6 @@ func resourceMsSqlJobCredentialCreate(d *pluginsdk.ResourceData, meta interface{
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Job Credential creation.")
-
 	jaId, err := jobcredentials.ParseJobAgentID(d.Get("job_agent_id").(string))
 	if err != nil {
 		return err
@@ -135,8 +132,6 @@ func resourceMsSqlJobCredentialUpdate(d *pluginsdk.ResourceData, meta interface{
 	client := meta.(*clients.Client).MSSQL.JobCredentialsClient
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for Job Credential update.")
 
 	jaId, err := jobcredentials.ParseJobAgentID(d.Get("job_agent_id").(string))
 	if err != nil {

--- a/internal/services/mssql/mssql_server_dns_alias_resource.go
+++ b/internal/services/mssql/mssql_server_dns_alias_resource.go
@@ -136,7 +136,6 @@ func (m ServerDNSAliasResource) Delete() sdk.ResourceFunc {
 			if err != nil {
 				return err
 			}
-			metadata.Logger.Infof("deleting %s", id)
 			client := metadata.Client.MSSQL.ServerDNSAliasClient
 			err = client.DeleteThenPoll(ctx, *id)
 			if err != nil {

--- a/internal/services/mssql/mssql_server_extended_auditing_policy_resource.go
+++ b/internal/services/mssql/mssql_server_extended_auditing_policy_resource.go
@@ -5,7 +5,6 @@ package mssql
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -120,8 +119,6 @@ func resourceMsSqlServerExtendedAuditingPolicyCreateUpdate(d *pluginsdk.Resource
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for MsSql Server Extended Auditing Policy creation.")
 
 	serverId, err := commonids.ParseSqlServerID(d.Get("server_id").(string))
 	if err != nil {

--- a/internal/services/mssql/mssql_server_microsoft_support_auditing_policy_resource.go
+++ b/internal/services/mssql/mssql_server_microsoft_support_auditing_policy_resource.go
@@ -5,7 +5,6 @@ package mssql
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -88,8 +87,6 @@ func resourceMsSqlServerMicrosoftSupportAuditingPolicyCreateUpdate(d *pluginsdk.
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for MsSql Server Microsoft Support Auditing Policy creation.")
 
 	serverId, err := commonids.ParseSqlServerID(d.Get("server_id").(string))
 	if err != nil {

--- a/internal/services/mssql/mssql_server_security_alert_policy_resource.go
+++ b/internal/services/mssql/mssql_server_security_alert_policy_resource.go
@@ -211,8 +211,6 @@ func resourceMsSqlServerSecurityAlertPolicyRead(d *pluginsdk.ResourceData, meta 
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] reading mssql server security alert policy")
-
 	id, err := parse.ServerSecurityAlertPolicyID(d.Id())
 	if err != nil {
 		return err
@@ -395,8 +393,6 @@ func resourceMsSqlServerSecurityAlertPolicyDelete(d *pluginsdk.ResourceData, met
 	client := meta.(*clients.Client).MSSQL.ServerSecurityAlertPoliciesClient
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] deleting mssql server security alert policy")
 
 	id, err := parse.ServerSecurityAlertPolicyID(d.Id())
 	if err != nil {

--- a/internal/services/mssql/mssql_server_security_alert_policy_resource.go
+++ b/internal/services/mssql/mssql_server_security_alert_policy_resource.go
@@ -121,8 +121,6 @@ func resourceMsSqlServerSecurityAlertPolicyCreate(d *pluginsdk.ResourceData, met
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for mssql server security alert policy creation")
-
 	payload := serversecurityalertpolicies.ServerSecurityAlertPolicy{}
 	resourceGroupName := d.Get("resource_group_name").(string)
 	serverName := d.Get("server_name").(string)
@@ -300,8 +298,6 @@ func resourceMsSqlServerSecurityAlertPolicyUpdate(d *pluginsdk.ResourceData, met
 	client := meta.(*clients.Client).MSSQL.ServerSecurityAlertPoliciesClient
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for mssql server security alert policy update")
 
 	id, err := parse.ServerSecurityAlertPolicyID(d.Id())
 	if err != nil {

--- a/internal/services/mssql/mssql_server_vulnerability_assessment_resource.go
+++ b/internal/services/mssql/mssql_server_vulnerability_assessment_resource.go
@@ -200,8 +200,6 @@ func resourceMsSqlServerVulnerabilityAssessmentRead(d *pluginsdk.ResourceData, m
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] reading mssql server vulnerability assessment")
-
 	id, err := parse.ServerVulnerabilityAssessmentID(d.Id())
 	if err != nil {
 		return err
@@ -399,8 +397,6 @@ func resourceMsSqlServerVulnerabilityAssessmentDelete(d *pluginsdk.ResourceData,
 	client := meta.(*clients.Client).MSSQL.ServerVulnerabilityAssessmentsClient
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] deleting mssql server vulnerability assessment")
 
 	id, err := parse.ServerVulnerabilityAssessmentID(d.Id())
 	if err != nil {

--- a/internal/services/mssql/mssql_server_vulnerability_assessment_resource.go
+++ b/internal/services/mssql/mssql_server_vulnerability_assessment_resource.go
@@ -134,8 +134,6 @@ func resourceMsSqlServerVulnerabilityAssessmentCreate(d *pluginsdk.ResourceData,
 		return fmt.Errorf("security alert policy for SQL server %q must be enabled before configuring vulnerability assessment", serverId.ServerName)
 	}
 
-	log.Printf("[INFO] preparing arguments for mssql server vulnerability assessment creation")
-
 	id := parse.NewServerVulnerabilityAssessmentID(serverId.SubscriptionId, serverId.ResourceGroupName, serverId.ServerName, "default")
 
 	payload := servervulnerabilityassessments.ServerVulnerabilityAssessment{}
@@ -317,8 +315,6 @@ func resourceMsSqlServerVulnerabilityAssessmentUpdate(d *pluginsdk.ResourceData,
 	if alert.Model.Properties.State != serversecurityalertpolicies.SecurityAlertsPolicyStateEnabled {
 		return fmt.Errorf("security alert policy for SQL server %q must be enabled before updating vulnerability assessment", serverId.ServerName)
 	}
-
-	log.Printf("[INFO] preparing arguments for mssql server vulnerability assessment update")
 
 	payload := servervulnerabilityassessments.ServerVulnerabilityAssessment{}
 	result, err := client.Get(ctx, serverId)

--- a/internal/services/mssqlmanagedinstance/mssql_managed_database_resource.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_database_resource.go
@@ -257,7 +257,6 @@ func (r MsSqlManagedDatabaseResource) Create() sdk.ResourceFunc {
 				return fmt.Errorf("checking for existence and region of Managed Instance for %s: %+v", id, err)
 			}
 
-			metadata.Logger.Infof("Import check for %s", id)
 			existing, err := client.Get(ctx, id)
 			if err != nil && !response.WasNotFound(existing.HttpResponse) {
 				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
@@ -284,8 +283,6 @@ func (r MsSqlManagedDatabaseResource) Create() sdk.ResourceFunc {
 					parameters.Properties.SourceDatabaseId = pointer.To(restorePointInTime.SourceDatabaseId)
 				}
 			}
-
-			metadata.Logger.Infof("Creating %s", id)
 
 			err = client.CreateOrUpdateThenPoll(ctx, id, parameters)
 			if err != nil {
@@ -399,7 +396,6 @@ func (r MsSqlManagedDatabaseResource) Read() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("Decoding state for %s", id)
 			var state MsSqlManagedDatabaseModel
 			if err := metadata.Decode(&state); err != nil {
 				return err

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_active_directory_administrator_resource.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_active_directory_administrator_resource.go
@@ -106,7 +106,6 @@ func (r MsSqlManagedInstanceActiveDirectoryAdministratorResource) Create() sdk.R
 			id := parse.NewManagedInstanceAzureActiveDirectoryAdministratorID(managedInstanceId.SubscriptionId,
 				managedInstanceId.ResourceGroupName, managedInstanceId.ManagedInstanceName, string(managedinstanceadministrators.ManagedInstanceAdministratorTypeActiveDirectory))
 
-			metadata.Logger.Infof("Import check for %s", id)
 			existing, err := client.Get(ctx, *managedInstanceId)
 			if err != nil && !response.WasNotFound(existing.HttpResponse) {
 				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
@@ -124,8 +123,6 @@ func (r MsSqlManagedInstanceActiveDirectoryAdministratorResource) Create() sdk.R
 					TenantId:          &model.TenantId,
 				},
 			}
-
-			metadata.Logger.Infof("Creating %s", id)
 
 			err = client.CreateOrUpdateThenPoll(ctx, *managedInstanceId, parameters)
 			if err != nil {
@@ -162,7 +159,6 @@ func (r MsSqlManagedInstanceActiveDirectoryAdministratorResource) Update() sdk.R
 				return err
 			}
 
-			metadata.Logger.Infof("Decoding state for %s", id)
 			var state MsSqlManagedInstanceActiveDirectoryAdministratorModel
 			if err := metadata.Decode(&state); err != nil {
 				return err
@@ -181,8 +177,6 @@ func (r MsSqlManagedInstanceActiveDirectoryAdministratorResource) Update() sdk.R
 					TenantId:          &state.TenantId,
 				},
 			}
-
-			metadata.Logger.Infof("Updating %s", id)
 
 			err = client.CreateOrUpdateThenPoll(ctx, *managedInstanceId, parameters)
 			if err != nil {
@@ -217,7 +211,6 @@ func (r MsSqlManagedInstanceActiveDirectoryAdministratorResource) Read() sdk.Res
 				return err
 			}
 
-			metadata.Logger.Infof("Decoding state for %s", id)
 			var state MsSqlManagedInstanceActiveDirectoryAdministratorModel
 			if err := metadata.Decode(&state); err != nil {
 				return err

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_failover_group_resource.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_failover_group_resource.go
@@ -182,7 +182,6 @@ func (r MsSqlManagedInstanceFailoverGroupResource) Create() sdk.ResourceFunc {
 				return fmt.Errorf("checking for existence and region of Partner of %q: %+v", id, err)
 			}
 
-			metadata.Logger.Infof("Import check for %s", id)
 			existing, err := client.Get(ctx, id)
 			if err != nil && !response.WasNotFound(existing.HttpResponse) {
 				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
@@ -225,8 +224,6 @@ func (r MsSqlManagedInstanceFailoverGroupResource) Create() sdk.ResourceFunc {
 				}
 			}
 
-			metadata.Logger.Infof("Creating %s", id)
-
 			err = client.CreateOrUpdateThenPoll(ctx, id, parameters)
 			if err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
@@ -250,7 +247,6 @@ func (r MsSqlManagedInstanceFailoverGroupResource) Update() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("Decoding state for %s", id)
 			var state MsSqlManagedInstanceFailoverGroupModel
 			if err := metadata.Decode(&state); err != nil {
 				return err
@@ -305,8 +301,6 @@ func (r MsSqlManagedInstanceFailoverGroupResource) Update() sdk.ResourceFunc {
 				}
 			}
 
-			metadata.Logger.Infof("Updating %s", id)
-
 			err = client.CreateOrUpdateThenPoll(ctx, *id, parameters)
 			if err != nil {
 				return fmt.Errorf("updating %s: %+v", id, err)
@@ -328,7 +322,6 @@ func (r MsSqlManagedInstanceFailoverGroupResource) Read() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("Decoding state for %s", id)
 			var state MsSqlManagedInstanceFailoverGroupModel
 			if err := metadata.Decode(&state); err != nil {
 				return err

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_resource.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_resource.go
@@ -437,7 +437,6 @@ func (r MsSqlManagedInstanceResource) Create() sdk.ResourceFunc {
 
 			id := commonids.NewSqlManagedInstanceID(subscriptionId, model.ResourceGroupName, model.Name)
 
-			metadata.Logger.Infof("Import check for %s", id)
 			existing, err := client.Get(ctx, id, managedinstances.GetOperationOptions{})
 			if err != nil && !response.WasNotFound(existing.HttpResponse) {
 				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
@@ -503,8 +502,6 @@ func (r MsSqlManagedInstanceResource) Create() sdk.ResourceFunc {
 				}
 			}
 
-			metadata.Logger.Infof("Creating %s", id)
-
 			err = client.CreateOrUpdateThenPoll(ctx, id, parameters)
 			if err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
@@ -529,7 +526,6 @@ func (r MsSqlManagedInstanceResource) Update() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("Decoding state for %s", *id)
 			var state MsSqlManagedInstanceModel
 			if err := metadata.Decode(&state); err != nil {
 				return err
@@ -732,7 +728,6 @@ func (r MsSqlManagedInstanceResource) Read() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("Decoding state for %s", id)
 			var state MsSqlManagedInstanceModel
 			if err := metadata.Decode(&state); err != nil {
 				return err

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_security_alert_policy_resource.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_security_alert_policy_resource.go
@@ -242,8 +242,6 @@ func resourceMsSqlManagedInstanceSecurityAlertPolicyRead(d *pluginsdk.ResourceDa
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] reading managed instance security alert policy")
-
 	id, err := parse.ManagedInstancesSecurityAlertPolicyID(d.Id())
 	if err != nil {
 		return err

--- a/internal/services/mssqlmanagedinstance/mssql_managed_instance_security_alert_policy_resource.go
+++ b/internal/services/mssqlmanagedinstance/mssql_managed_instance_security_alert_policy_resource.go
@@ -116,8 +116,6 @@ func resourceMsSqlManagedInstanceSecurityAlertPolicyCreate(d *pluginsdk.Resource
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for managed instance security alert policy creation.")
-
 	alertPolicy := expandManagedServerSecurityAlertPolicy(d)
 
 	managedInstanceId := commonids.NewSqlManagedInstanceID(subscriptionId, d.Get("resource_group_name").(string), d.Get("managed_instance_name").(string))

--- a/internal/services/mysql/mysql_flexible_server_configuration_resource.go
+++ b/internal/services/mysql/mysql_flexible_server_configuration_resource.go
@@ -74,8 +74,6 @@ func resourceMySQLFlexibleServerConfigurationCreate(d *pluginsdk.ResourceData, m
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for AzureRM MySQL Configuration creation.")
-
 	payload := configurations.Configuration{
 		Properties: &configurations.ConfigurationProperties{
 			Value: pointer.To(d.Get("value").(string)),
@@ -106,8 +104,6 @@ func resourceMySQLFlexibleServerConfigurationUpdate(d *pluginsdk.ResourceData, m
 	client := meta.(*clients.Client).MySQL.FlexibleServers.Configurations
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for AzureRM MySQL Configuration update.")
 
 	id, err := configurations.ParseConfigurationID(d.Id())
 	if err != nil {

--- a/internal/services/netapp/netapp_account_encryption_resource.go
+++ b/internal/services/netapp/netapp_account_encryption_resource.go
@@ -203,7 +203,7 @@ func (r NetAppAccountEncryptionResource) Read() sdk.ResourceFunc {
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
 			client := metadata.Client.NetApp.AccountClient
 
-			id, err := netappaccounts.ParseNetAppAccountID((metadata.ResourceData.Id()))
+			id, err := netappaccounts.ParseNetAppAccountID(metadata.ResourceData.Id())
 			if err != nil {
 				return err
 			}

--- a/internal/services/netapp/netapp_account_encryption_resource.go
+++ b/internal/services/netapp/netapp_account_encryption_resource.go
@@ -116,8 +116,6 @@ func (r NetAppAccountEncryptionResource) Create() sdk.ResourceFunc {
 				return fmt.Errorf("error parsing account id %s: %+v", model.NetAppAccountID, err)
 			}
 
-			metadata.Logger.Infof("Import check for %s", accountID.ID())
-
 			locks.ByID(accountID.ID())
 			defer locks.UnlockByID(accountID.ID())
 
@@ -172,13 +170,10 @@ func (r NetAppAccountEncryptionResource) Update() sdk.ResourceFunc {
 			locks.ByID(id.ID())
 			defer locks.UnlockByID(id.ID())
 
-			metadata.Logger.Infof("Decoding state for %s", id)
 			var state netAppModels.NetAppAccountEncryption
 			if err := metadata.Decode(&state); err != nil {
 				return fmt.Errorf("decoding: %+v", err)
 			}
-
-			metadata.Logger.Infof("Updating %s", id)
 
 			update := netappaccounts.NetAppAccountPatch{
 				Properties: &netappaccounts.AccountProperties{},
@@ -213,7 +208,6 @@ func (r NetAppAccountEncryptionResource) Read() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("Decoding state for %s", id)
 			var state netAppModels.NetAppAccountEncryption
 			if err := metadata.Decode(&state); err != nil {
 				return fmt.Errorf("decoding: %+v", err)
@@ -285,13 +279,10 @@ func (r NetAppAccountEncryptionResource) Delete() sdk.ResourceFunc {
 			locks.ByID(id.ID())
 			defer locks.UnlockByID(id.ID())
 
-			metadata.Logger.Infof("Decoding state for %s", id)
 			var state netAppModels.NetAppAccountEncryption
 			if err := metadata.Decode(&state); err != nil {
 				return fmt.Errorf("decoding: %+v", err)
 			}
-
-			metadata.Logger.Infof("Updating %s", id)
 
 			update := netappaccounts.NetAppAccountPatch{
 				Properties: pointer.To(netappaccounts.AccountProperties{}),

--- a/internal/services/netapp/netapp_backup_policy_resource.go
+++ b/internal/services/netapp/netapp_backup_policy_resource.go
@@ -114,7 +114,6 @@ func (r NetAppBackupPolicyResource) Create() sdk.ResourceFunc {
 				return fmt.Errorf("one or more issues found while performing deeper validations for %s:\n%+v", id, errorList)
 			}
 
-			metadata.Logger.Infof("Import check for %s", id)
 			existing, err := client.Get(ctx, id)
 			if err != nil {
 				if !response.WasNotFound(existing.HttpResponse) {
@@ -160,7 +159,6 @@ func (r NetAppBackupPolicyResource) Update() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("Decoding state for %s", id)
 			var state netAppModels.NetAppBackupPolicyModel
 			if err := metadata.Decode(&state); err != nil {
 				return fmt.Errorf("decoding: %+v", err)
@@ -191,8 +189,6 @@ func (r NetAppBackupPolicyResource) Update() sdk.ResourceFunc {
 				update.Properties.Enabled = pointer.To(state.Enabled)
 			}
 
-			metadata.Logger.Infof("Updating %s", id)
-
 			if err := client.UpdateThenPoll(ctx, pointer.From(id), update); err != nil {
 				return fmt.Errorf("updating %s: %+v", id, err)
 			}
@@ -213,7 +209,6 @@ func (r NetAppBackupPolicyResource) Read() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("Decoding state for %s", id)
 			var state netAppModels.NetAppBackupPolicyModel
 			if err := metadata.Decode(&state); err != nil {
 				return fmt.Errorf("decoding: %+v", err)

--- a/internal/services/netapp/netapp_backup_vault_resource.go
+++ b/internal/services/netapp/netapp_backup_vault_resource.go
@@ -126,7 +126,6 @@ func (r NetAppBackupVaultResource) Update() sdk.ResourceFunc {
 			}
 
 			if metadata.ResourceData.HasChange("tags") {
-
 				update := backupvaults.BackupVaultPatch{
 					Tags: pointer.To(state.Tags),
 				}

--- a/internal/services/netapp/netapp_backup_vault_resource.go
+++ b/internal/services/netapp/netapp_backup_vault_resource.go
@@ -81,7 +81,6 @@ func (r NetAppBackupVaultResource) Create() sdk.ResourceFunc {
 
 			id := backupvaults.NewBackupVaultID(subscriptionId, model.ResourceGroupName, model.AccountName, model.Name)
 
-			metadata.Logger.Infof("Import check for %s", id)
 			existing, err := client.Get(ctx, id)
 			if err != nil {
 				if !response.WasNotFound(existing.HttpResponse) {
@@ -121,14 +120,12 @@ func (r NetAppBackupVaultResource) Update() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("Decoding state for %s", id)
 			var state netAppModels.NetAppBackupVaultModel
 			if err := metadata.Decode(&state); err != nil {
 				return fmt.Errorf("decoding: %+v", err)
 			}
 
 			if metadata.ResourceData.HasChange("tags") {
-				metadata.Logger.Infof("Updating %s", id)
 
 				update := backupvaults.BackupVaultPatch{
 					Tags: pointer.To(state.Tags),
@@ -155,7 +152,6 @@ func (r NetAppBackupVaultResource) Read() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("Decoding state for %s", id)
 			var state netAppModels.NetAppBackupVaultModel
 			if err := metadata.Decode(&state); err != nil {
 				return fmt.Errorf("decoding: %+v", err)

--- a/internal/services/netapp/netapp_volume_group_oracle_resource.go
+++ b/internal/services/netapp/netapp_volume_group_oracle_resource.go
@@ -480,7 +480,7 @@ func (r NetAppVolumeGroupOracleResource) Update() sdk.ResourceFunc {
 							exportPolicyRuleRaw := metadata.ResourceData.Get(fmt.Sprintf("%v.export_policy_rule", volumeItem)).([]interface{})
 
 							// Validating export policy rules
-							volumeProtocolRaw := (metadata.ResourceData.Get(fmt.Sprintf("%v.protocols", volumeItem)).([]interface{}))[0]
+							volumeProtocolRaw := metadata.ResourceData.Get(fmt.Sprintf("%v.protocols", volumeItem)).([]interface{})[0]
 							volumeProtocol := volumeProtocolRaw.(string)
 
 							errors := make([]error, 0)

--- a/internal/services/netapp/netapp_volume_group_oracle_resource.go
+++ b/internal/services/netapp/netapp_volume_group_oracle_resource.go
@@ -382,7 +382,6 @@ func (r NetAppVolumeGroupOracleResource) Create() sdk.ResourceFunc {
 
 			id := volumegroups.NewVolumeGroupID(subscriptionId, model.ResourceGroupName, model.AccountName, model.Name)
 
-			metadata.Logger.Infof("Import check for %s", id)
 			existing, err := client.Get(ctx, id)
 			if err != nil && !response.WasNotFound(existing.HttpResponse) {
 				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
@@ -446,13 +445,10 @@ func (r NetAppVolumeGroupOracleResource) Update() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("Decoding state for %s", id)
 			var state netAppModels.NetAppVolumeGroupOracleModel
 			if err := metadata.Decode(&state); err != nil {
 				return fmt.Errorf("decoding: %+v", err)
 			}
-
-			metadata.Logger.Infof("Updating %s", id)
 
 			if metadata.ResourceData.HasChange("volume") {
 				for i := 0; i < metadata.ResourceData.Get("volume.#").(int); i++ {
@@ -583,7 +579,6 @@ func (r NetAppVolumeGroupOracleResource) Read() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("Decoding state for %s", id)
 			var state netAppModels.NetAppVolumeGroupOracleModel
 			if err := metadata.Decode(&state); err != nil {
 				return fmt.Errorf("decoding: %+v", err)

--- a/internal/services/netapp/netapp_volume_group_sap_hana_resource.go
+++ b/internal/services/netapp/netapp_volume_group_sap_hana_resource.go
@@ -400,7 +400,6 @@ func (r NetAppVolumeGroupSAPHanaResource) Create() sdk.ResourceFunc {
 
 			id := volumegroups.NewVolumeGroupID(subscriptionId, model.ResourceGroupName, model.AccountName, model.Name)
 
-			metadata.Logger.Infof("Import check for %s", id)
 			existing, err := client.Get(ctx, id)
 			if err != nil && !response.WasNotFound(existing.HttpResponse) {
 				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
@@ -464,13 +463,10 @@ func (r NetAppVolumeGroupSAPHanaResource) Update() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("Decoding state for %s", id)
 			var state netAppModels.NetAppVolumeGroupSAPHanaModel
 			if err := metadata.Decode(&state); err != nil {
 				return fmt.Errorf("decoding: %+v", err)
 			}
-
-			metadata.Logger.Infof("Updating %s", id)
 
 			if metadata.ResourceData.HasChange("volume") {
 				// Iterating over each volume and performing individual patch
@@ -602,7 +598,6 @@ func (r NetAppVolumeGroupSAPHanaResource) Read() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("Decoding state for %s", id)
 			var state netAppModels.NetAppVolumeGroupSAPHanaModel
 			if err := metadata.Decode(&state); err != nil {
 				return fmt.Errorf("decoding: %+v", err)

--- a/internal/services/netapp/netapp_volume_group_sap_hana_resource.go
+++ b/internal/services/netapp/netapp_volume_group_sap_hana_resource.go
@@ -499,7 +499,7 @@ func (r NetAppVolumeGroupSAPHanaResource) Update() sdk.ResourceFunc {
 							exportPolicyRuleRaw := metadata.ResourceData.Get(fmt.Sprintf("%v.export_policy_rule", volumeItem)).([]interface{})
 
 							// Validating export policy rules
-							volumeProtocolRaw := (metadata.ResourceData.Get(fmt.Sprintf("%v.protocols", volumeItem)).([]interface{}))[0]
+							volumeProtocolRaw := metadata.ResourceData.Get(fmt.Sprintf("%v.protocols", volumeItem)).([]interface{})[0]
 							volumeProtocol := volumeProtocolRaw.(string)
 
 							errors := make([]error, 0)

--- a/internal/services/netapp/netapp_volume_quota_rule_resource.go
+++ b/internal/services/netapp/netapp_volume_quota_rule_resource.go
@@ -159,7 +159,6 @@ func (r NetAppVolumeQuotaRuleResource) Update() sdk.ResourceFunc {
 			}
 
 			if metadata.ResourceData.HasChange("quota_size_in_kib") {
-
 				update := volumequotarules.VolumeQuotaRulePatch{
 					Properties: &volumequotarules.VolumeQuotaRulesProperties{},
 				}

--- a/internal/services/netapp/netapp_volume_quota_rule_resource.go
+++ b/internal/services/netapp/netapp_volume_quota_rule_resource.go
@@ -101,7 +101,6 @@ func (r NetAppVolumeQuotaRuleResource) Create() sdk.ResourceFunc {
 
 			id := volumequotarules.NewVolumeQuotaRuleID(subscriptionId, volumeID.ResourceGroupName, volumeID.NetAppAccountName, volumeID.CapacityPoolName, volumeID.VolumeName, model.Name)
 
-			metadata.Logger.Infof("Import check for %s", id)
 			existing, err := client.Get(ctx, id)
 			if err != nil {
 				if !response.WasNotFound(existing.HttpResponse) {
@@ -154,14 +153,12 @@ func (r NetAppVolumeQuotaRuleResource) Update() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("Decoding state for %s", id)
 			var state netAppModels.NetAppVolumeQuotaRuleModel
 			if err := metadata.Decode(&state); err != nil {
 				return fmt.Errorf("decoding: %+v", err)
 			}
 
 			if metadata.ResourceData.HasChange("quota_size_in_kib") {
-				metadata.Logger.Infof("Updating %s", id)
 
 				update := volumequotarules.VolumeQuotaRulePatch{
 					Properties: &volumequotarules.VolumeQuotaRulesProperties{},
@@ -195,7 +192,6 @@ func (r NetAppVolumeQuotaRuleResource) Read() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("Decoding state for %s", id)
 			var state netAppModels.NetAppVolumeQuotaRuleModel
 			if err := metadata.Decode(&state); err != nil {
 				return fmt.Errorf("decoding: %+v", err)

--- a/internal/services/network/application_security_group_resource.go
+++ b/internal/services/network/application_security_group_resource.go
@@ -169,7 +169,6 @@ func resourceApplicationSecurityGroupDelete(d *pluginsdk.ResourceData, meta inte
 		return err
 	}
 
-	log.Printf("[DEBUG] Deleting %s..", *id)
 	if err := client.DeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %s: %+v", *id, err)
 	}

--- a/internal/services/network/custom_ip_prefix_resource.go
+++ b/internal/services/network/custom_ip_prefix_resource.go
@@ -434,8 +434,6 @@ func (r CustomIpPrefixResource) updateCommissionedState(ctx context.Context, id 
 
 	initialState := existing.Model.Properties.CommissionedState
 
-	log.Printf("[DEBUG] Updating CommissionedState for %s from current value %q to desired value %q..", id, *initialState, desiredState)
-
 	// stateTree is a map of desired state, to a map of current state, to the list of transition states needed to get there
 	stateTree := map[customipprefixes.CommissionedState]map[customipprefixes.CommissionedState][]customipprefixes.CommissionedState{
 		customipprefixes.CommissionedStateDeprovisioned: {

--- a/internal/services/network/custom_ip_prefix_resource.go
+++ b/internal/services/network/custom_ip_prefix_resource.go
@@ -284,7 +284,6 @@ func (r CustomIpPrefixResource) Update() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Info("Decoding state...")
 			var state CustomIpPrefixModel
 			if err := metadata.Decode(&state); err != nil {
 				return err
@@ -582,7 +581,6 @@ func (r CustomIpPrefixResource) setCommissionedState(ctx context.Context, id cus
 	existing.Model.Properties.CommissionedState = pointer.To(desiredState)
 	existing.Model.Properties.NoInternetAdvertise = noInternetAdvertise
 
-	log.Printf("[DEBUG] Updating the CommissionedState field to %q for %s..", desiredState, id)
 	if err := r.client.CreateOrUpdateThenPoll(ctx, id, *existing.Model); err != nil {
 		return fmt.Errorf("updating CommissionedState to %q for %s: %+v", desiredState, id, err)
 	}

--- a/internal/services/network/express_route_circuit_peering_resource.go
+++ b/internal/services/network/express_route_circuit_peering_resource.go
@@ -5,7 +5,6 @@ package network
 
 import (
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
@@ -244,8 +243,6 @@ func resourceExpressRouteCircuitPeeringCreate(d *pluginsdk.ResourceData, meta in
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Express Route Peering create.")
-
 	id := commonids.NewExpressRouteCircuitPeeringID(subscriptionId, d.Get("resource_group_name").(string), d.Get("express_route_circuit_name").(string), d.Get("peering_type").(string))
 
 	locks.ByName(id.CircuitName, expressRouteCircuitResourceName)
@@ -352,8 +349,6 @@ func resourceExpressRouteCircuitPeeringUpdate(d *pluginsdk.ResourceData, meta in
 	client := meta.(*clients.Client).Network.ExpressRouteCircuitPeerings
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for Express Route Peering update.")
 
 	id, err := commonids.ParseExpressRouteCircuitPeeringID(d.Id())
 	if err != nil {

--- a/internal/services/network/express_route_circuit_resource.go
+++ b/internal/services/network/express_route_circuit_resource.go
@@ -173,8 +173,6 @@ func resourceExpressRouteCircuitCreate(d *pluginsdk.ResourceData, meta interface
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Azure ARM ExpressRoute Circuit creation.")
-
 	id := expressroutecircuits.NewExpressRouteCircuitID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
 	locks.ByName(id.ExpressRouteCircuitName, expressRouteCircuitResourceName)
@@ -261,8 +259,6 @@ func resourceExpressRouteCircuitUpdate(d *pluginsdk.ResourceData, meta interface
 	client := meta.(*clients.Client).Network.ExpressRouteCircuits
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for Azure ARM ExpressRoute Circuit update.")
 
 	id, err := expressroutecircuits.ParseExpressRouteCircuitID(d.Id())
 	if err != nil {

--- a/internal/services/network/network_interface_application_security_group_association_resource.go
+++ b/internal/services/network/network_interface_application_security_group_association_resource.go
@@ -65,8 +65,6 @@ func resourceNetworkInterfaceApplicationSecurityGroupAssociationCreate(d *plugin
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Network Interface <-> Application Security Group Association creation.")
-
 	applicationSecurityGroupId, err := applicationsecuritygroups.ParseApplicationSecurityGroupID(d.Get("application_security_group_id").(string))
 	if err != nil {
 		return err

--- a/internal/services/network/network_manager_deployment_resource.go
+++ b/internal/services/network/network_manager_deployment_resource.go
@@ -94,7 +94,6 @@ func (r ManagerDeploymentResource) Attributes() map[string]*pluginsdk.Schema {
 func (r ManagerDeploymentResource) Create() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
-			metadata.Logger.Info("Decoding state..")
 			var state ManagerDeploymentModel
 			if err := metadata.Decode(&state); err != nil {
 				return err
@@ -112,8 +111,6 @@ func (r ManagerDeploymentResource) Create() sdk.ResourceFunc {
 
 			locks.ByID(id.ID())
 			defer locks.UnlockByID(id.ID())
-
-			metadata.Logger.Infof("creating %s", *id)
 
 			listParam := networkmanagers.NetworkManagerDeploymentStatusParameter{
 				Regions:         &[]string{normalizedLocation},
@@ -168,8 +165,6 @@ func (r ManagerDeploymentResource) Read() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("retrieving %s", *id)
-
 			listParam := networkmanagers.NetworkManagerDeploymentStatusParameter{
 				Regions:         &[]string{id.Location},
 				DeploymentTypes: &[]networkmanagers.ConfigurationType{networkmanagers.ConfigurationType(id.ScopeAccess)},
@@ -180,7 +175,6 @@ func (r ManagerDeploymentResource) Read() sdk.ResourceFunc {
 			resp, err := client.NetworkManagerDeploymentStatusList(ctx, networkManagerId, listParam)
 			if err != nil {
 				if response.WasNotFound(resp.HttpResponse) {
-					metadata.Logger.Infof("%s was not found - removing from state!", *id)
 					return metadata.MarkAsGone(id)
 				}
 				return fmt.Errorf("retrieving %s: %+v", *id, err)
@@ -191,7 +185,6 @@ func (r ManagerDeploymentResource) Read() sdk.ResourceFunc {
 			}
 
 			if resp.Model.Value == nil || len(*resp.Model.Value) == 0 || (*resp.Model.Value)[0].ConfigurationIds == nil || len(*(*resp.Model.Value)[0].ConfigurationIds) == 0 {
-				metadata.Logger.Infof("%s was not found - removing from state!", *id)
 				return metadata.MarkAsGone(id)
 			}
 
@@ -222,7 +215,6 @@ func (r ManagerDeploymentResource) Update() sdk.ResourceFunc {
 			locks.ByID(id.ID())
 			defer locks.UnlockByID(id.ID())
 
-			metadata.Logger.Infof("updating %s..", *id)
 			client := metadata.Client.Network.NetworkManagers
 
 			listParam := networkmanagers.NetworkManagerDeploymentStatusParameter{
@@ -235,7 +227,6 @@ func (r ManagerDeploymentResource) Update() sdk.ResourceFunc {
 			resp, err := client.NetworkManagerDeploymentStatusList(ctx, networkManagerId, listParam)
 			if err != nil {
 				if response.WasNotFound(resp.HttpResponse) {
-					metadata.Logger.Infof("%s was not found - removing from state!", *id)
 					return metadata.MarkAsGone(id)
 				}
 				return fmt.Errorf("retrieving %s: %+v", *id, err)
@@ -246,7 +237,6 @@ func (r ManagerDeploymentResource) Update() sdk.ResourceFunc {
 			}
 
 			if resp.Model.Value == nil || len(*resp.Model.Value) == 0 || *(*resp.Model.Value)[0].ConfigurationIds == nil || len(*(*resp.Model.Value)[0].ConfigurationIds) == 0 {
-				metadata.Logger.Infof("%s was not found - removing from state!", *id)
 				return metadata.MarkAsGone(id)
 			}
 
@@ -305,7 +295,6 @@ func (r ManagerDeploymentResource) Delete() sdk.ResourceFunc {
 			locks.ByID(id.ID())
 			defer locks.UnlockByID(id.ID())
 
-			metadata.Logger.Infof("deleting %s..", *id)
 			input := networkmanagers.NetworkManagerCommit{
 				ConfigurationIds: &[]string{},
 				TargetLocations:  []string{id.Location},

--- a/internal/services/network/network_manager_resource.go
+++ b/internal/services/network/network_manager_resource.go
@@ -170,7 +170,6 @@ func (r ManagerResource) Create() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Timeout: 30 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
-			metadata.Logger.Info("Decoding state..")
 			var state ManagerModel
 			if err := metadata.Decode(&state); err != nil {
 				return err
@@ -180,7 +179,6 @@ func (r ManagerResource) Create() sdk.ResourceFunc {
 			subscriptionId := metadata.Client.Account.SubscriptionId
 
 			id := networkmanagers.NewNetworkManagerID(subscriptionId, state.ResourceGroupName, state.Name)
-			metadata.Logger.Infof("creating %s", id)
 
 			existing, err := client.Get(ctx, id)
 			if err != nil && !response.WasNotFound(existing.HttpResponse) {
@@ -225,11 +223,9 @@ func (r ManagerResource) Read() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("retrieving %s", *id)
 			resp, err := client.Get(ctx, *id)
 			if err != nil {
 				if response.WasNotFound(resp.HttpResponse) {
-					metadata.Logger.Infof("%s was not found - removing from state!", *id)
 					return metadata.MarkAsGone(id)
 				}
 				return fmt.Errorf("retrieving %s: %+v", *id, err)
@@ -278,7 +274,6 @@ func (r ManagerResource) Update() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("updating %s..", *id)
 			client := metadata.Client.Network.NetworkManagers
 			existing, err := client.Get(ctx, *id)
 			if err != nil {
@@ -330,7 +325,6 @@ func (r ManagerResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("deleting %s..", *id)
 			err = client.DeleteThenPoll(ctx, *id, networkmanagers.DeleteOperationOptions{
 				Force: pointer.To(true),
 			})

--- a/internal/services/network/private_endpoint_resource.go
+++ b/internal/services/network/private_endpoint_resource.go
@@ -612,7 +612,6 @@ func resourcePrivateEndpointUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 			if err := deletePrivateDnsZoneGroupForPrivateEndpoint(ctx, dnsClient, *id); err != nil {
 				return err
 			}
-			log.Printf("[DEBUG] Deleted the Existing Private DNS Zone Group associated with %s.", id)
 		}
 
 		if len(privateDnsZoneGroup) > 0 {
@@ -753,7 +752,6 @@ func resourcePrivateEndpointDelete(d *pluginsdk.ResourceData, meta interface{}) 
 	if err := deletePrivateDnsZoneGroupForPrivateEndpoint(ctx, dnsZoneGroupsClient, *id); err != nil {
 		return err
 	}
-	log.Printf("[DEBUG] Deleted the Private DNS Zone Group associated with %s.", id)
 
 	existing, err := client.Get(ctx, *id, privateendpoints.DefaultGetOperationOptions())
 	if err != nil {
@@ -785,8 +783,6 @@ func resourcePrivateEndpointDelete(d *pluginsdk.ResourceData, meta interface{}) 
 	if err = client.DeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %s: %+v", id, err)
 	}
-
-	log.Printf("[DEBUG] Deleted %s", id)
 
 	return nil
 }

--- a/internal/services/network/private_endpoint_resource.go
+++ b/internal/services/network/private_endpoint_resource.go
@@ -427,7 +427,6 @@ func resourcePrivateEndpointCreate(d *pluginsdk.ResourceData, meta interface{}) 
 		if err := createPrivateDnsZoneGroupForPrivateEndpoint(ctx, dnsClient, id, privateDnsZoneGroup); err != nil {
 			return err
 		}
-		log.Printf("[DEBUG] Created the Existing Private DNS Zone Group associated with %s", id)
 	}
 
 	return resourcePrivateEndpointRead(d, meta)
@@ -620,7 +619,6 @@ func resourcePrivateEndpointUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 			if err := createPrivateDnsZoneGroupForPrivateEndpoint(ctx, dnsClient, *id, privateDnsZoneGroup); err != nil {
 				return err
 			}
-			log.Printf("[DEBUG] Created the Existing Private DNS Zone Group associated with %s", id)
 		}
 	}
 

--- a/internal/services/network/private_endpoint_resource.go
+++ b/internal/services/network/private_endpoint_resource.go
@@ -424,7 +424,6 @@ func resourcePrivateEndpointCreate(d *pluginsdk.ResourceData, meta interface{}) 
 	// 1 Private Endpoint can have 1 Private DNS Zone Group
 	// since this is a new resource, there shouldn't be an existing one - so there's no need to delete it
 	if len(privateDnsZoneGroup) > 0 {
-		log.Printf("[DEBUG] Creating Private DNS Zone Group associated with %s..", id)
 		if err := createPrivateDnsZoneGroupForPrivateEndpoint(ctx, dnsClient, id, privateDnsZoneGroup); err != nil {
 			return err
 		}
@@ -611,7 +610,6 @@ func resourcePrivateEndpointUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 		}
 
 		if needToRemove || nameHasChanged || idHasBeenChanged {
-			log.Printf("[DEBUG] Deleting the Existing Private DNS Zone Group associated with %s..", id)
 			if err := deletePrivateDnsZoneGroupForPrivateEndpoint(ctx, dnsClient, *id); err != nil {
 				return err
 			}
@@ -619,7 +617,6 @@ func resourcePrivateEndpointUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 		}
 
 		if len(privateDnsZoneGroup) > 0 {
-			log.Printf("[DEBUG] Creating Private DNS Zone Group associated with %s..", id)
 			if err := createPrivateDnsZoneGroupForPrivateEndpoint(ctx, dnsClient, *id, privateDnsZoneGroup); err != nil {
 				return err
 			}
@@ -755,7 +752,6 @@ func resourcePrivateEndpointDelete(d *pluginsdk.ResourceData, meta interface{}) 
 		return err
 	}
 
-	log.Printf("[DEBUG] Deleting the Private DNS Zone Group associated with %s", id)
 	if err := deletePrivateDnsZoneGroupForPrivateEndpoint(ctx, dnsZoneGroupsClient, *id); err != nil {
 		return err
 	}
@@ -788,7 +784,6 @@ func resourcePrivateEndpointDelete(d *pluginsdk.ResourceData, meta interface{}) 
 		defer locks.UnlockByName(cosmosDbResId, "azurerm_private_endpoint")
 	}
 
-	log.Printf("[DEBUG] Deleting %s", id)
 	if err = client.DeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %s: %+v", id, err)
 	}
@@ -1025,7 +1020,6 @@ func deletePrivateDnsZoneGroupForPrivateEndpoint(ctx context.Context, client *pr
 	}
 
 	for _, privateDnsZoneId := range *privateDnsZoneIds {
-		log.Printf("[DEBUG] Deleting %s..", privateDnsZoneId)
 		if err := client.DeleteThenPoll(ctx, privateDnsZoneId); err != nil {
 			return fmt.Errorf("deleting %s: %+v", privateDnsZoneId, err)
 		}

--- a/internal/services/network/public_ip_prefix_resource.go
+++ b/internal/services/network/public_ip_prefix_resource.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
@@ -130,8 +129,6 @@ func resourcePublicIpPrefixCreate(d *pluginsdk.ResourceData, meta interface{}) e
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for AzureRM Public IP Prefix creation.")
 
 	id := publicipprefixes.NewPublicIPPrefixID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 

--- a/internal/services/network/public_ip_resource.go
+++ b/internal/services/network/public_ip_resource.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
@@ -211,8 +210,6 @@ func resourcePublicIpCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for AzureRM Public IP creation.")
-
 	id := commonids.NewPublicIPAddressID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
 	existing, err := client.Get(ctx, id, publicipaddresses.DefaultGetOperationOptions())
@@ -332,8 +329,6 @@ func resourcePublicIpUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.PublicIPAddresses
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for AzureRM Public IP update.")
 
 	id, err := commonids.ParsePublicIPAddressID(d.Id())
 	if err != nil {

--- a/internal/services/network/route_filter_resource.go
+++ b/internal/services/network/route_filter_resource.go
@@ -5,7 +5,6 @@ package network
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -110,8 +109,6 @@ func resourceRouteFilterCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Route Filter create.")
-
 	id := routefilters.NewRouteFilterID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 	location := location.Normalize(d.Get("location").(string))
 	t := d.Get("tags").(map[string]interface{})
@@ -152,8 +149,6 @@ func resourceRouteFilterUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 	client := meta.(*clients.Client).Network.RouteFilters
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for Route Filter update.")
 
 	id, err := routefilters.ParseRouteFilterID(d.Id())
 	if err != nil {

--- a/internal/services/network/subnet_resource.go
+++ b/internal/services/network/subnet_resource.go
@@ -6,7 +6,6 @@ package network
 import (
 	"context"
 	"fmt"
-	"log"
 	"regexp"
 	"strings"
 	"time"
@@ -301,8 +300,6 @@ func resourceSubnetCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for Azure ARM Subnet creation.")
 
 	id := commonids.NewSubnetID(subscriptionId, d.Get("resource_group_name").(string), d.Get("virtual_network_name").(string), d.Get("name").(string))
 	existing, err := client.Get(ctx, id, subnets.DefaultGetOperationOptions())

--- a/internal/services/network/subnet_route_table_association_resource.go
+++ b/internal/services/network/subnet_route_table_association_resource.go
@@ -61,8 +61,6 @@ func resourceSubnetRouteTableAssociationCreate(d *pluginsdk.ResourceData, meta i
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Subnet <-> Route Table Association creation.")
-
 	id, err := commonids.ParseSubnetID(d.Get("subnet_id").(string))
 	if err != nil {
 		return err

--- a/internal/services/network/virtual_network_gateway_connection_resource.go
+++ b/internal/services/network/virtual_network_gateway_connection_resource.go
@@ -6,7 +6,6 @@ package network
 import (
 	"context"
 	"fmt"
-	"log"
 	"math"
 	"time"
 
@@ -379,8 +378,6 @@ func resourceVirtualNetworkGatewayConnectionCreate(d *pluginsdk.ResourceData, me
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for AzureRM Virtual Network Gateway Connection creation.")
-
 	id := virtualnetworkgatewayconnections.NewConnectionID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
 	existing, err := client.Get(ctx, id)
@@ -587,8 +584,6 @@ func resourceVirtualNetworkGatewayConnectionUpdate(d *pluginsdk.ResourceData, me
 	vnetGatewayClient := meta.(*clients.Client).Network.VirtualNetworkGateways
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for AzureRM Virtual Network Gateway Connection update.")
 
 	id, err := virtualnetworkgatewayconnections.ParseConnectionID(d.Id())
 	if err != nil {

--- a/internal/services/network/virtual_network_gateway_resource.go
+++ b/internal/services/network/virtual_network_gateway_resource.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"log"
 	"math"
 	"time"
 
@@ -698,8 +697,6 @@ func resourceVirtualNetworkGatewayCreate(d *pluginsdk.ResourceData, meta interfa
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for AzureRM Virtual Network Gateway creation.")
-
 	id := virtualnetworkgateways.NewVirtualNetworkGatewayID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
 	existing, err := client.Get(ctx, id)
@@ -831,8 +828,6 @@ func resourceVirtualNetworkGatewayUpdate(d *pluginsdk.ResourceData, meta interfa
 	client := meta.(*clients.Client).Network.VirtualNetworkGateways
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for AzureRM Virtual Network Gateway update.")
 
 	id, err := virtualnetworkgateways.ParseVirtualNetworkGatewayID(d.Id())
 	if err != nil {

--- a/internal/services/orbital/orbital_contact_profile_resource.go
+++ b/internal/services/orbital/orbital_contact_profile_resource.go
@@ -229,8 +229,6 @@ func (r ContactProfileResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("deleting %s", *id)
-
 			if err := client.DeleteThenPoll(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}

--- a/internal/services/orbital/orbital_contact_resource.go
+++ b/internal/services/orbital/orbital_contact_resource.go
@@ -193,8 +193,6 @@ func (r ContactResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("deleting %s", *id)
-
 			if _, err := client.Delete(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}

--- a/internal/services/orbital/orbital_spacecraft_resource.go
+++ b/internal/services/orbital/orbital_spacecraft_resource.go
@@ -197,8 +197,6 @@ func (r SpacecraftResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("deleting %s", *id)
-
 			if err := client.DeleteThenPoll(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}

--- a/internal/services/policy/policy_definition_resource.go
+++ b/internal/services/policy/policy_definition_resource.go
@@ -215,7 +215,6 @@ func resourceArmPolicyDefinitionRead(d *pluginsdk.ResourceData, meta interface{}
 	resp, err := getPolicyDefinitionByName(ctx, client, id.Name, managementGroupName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			log.Printf("[INFO] Error reading Policy Definition %q - removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}

--- a/internal/services/postgres/postgresql_flexible_server_configuration_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_configuration_resource.go
@@ -68,8 +68,6 @@ func resourceFlexibleServerConfigurationUpdate(d *pluginsdk.ResourceData, meta i
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Azure Postgresql Flexible Server configuration creation.")
-
 	serverId, err := servers.ParseFlexibleServerID(d.Get("server_id").(string))
 	if err != nil {
 		return err

--- a/internal/services/postgres/postgresql_server_resource.go
+++ b/internal/services/postgres/postgresql_server_resource.go
@@ -387,8 +387,6 @@ func resourcePostgreSQLServerCreate(d *pluginsdk.ResourceData, meta interface{})
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for AzureRM PostgreSQL Server creation.")
-
 	id := servers.NewServerID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 	existing, err := client.Get(ctx, id)
 	if err != nil {

--- a/internal/services/postgres/postgresql_server_resource.go
+++ b/internal/services/postgres/postgresql_server_resource.go
@@ -547,7 +547,6 @@ func resourcePostgreSQLServerCreate(d *pluginsdk.ResourceData, meta interface{})
 
 	// Issue tracking the REST API update failure: https://github.com/Azure/azure-rest-api-specs/issues/14117
 	if mode == servers.CreateModeReplica {
-		log.Printf("[INFO] updating `public_network_access_enabled` and `identity` for %s", id)
 		properties := servers.ServerUpdateParameters{
 			Identity: expandedIdentity,
 			Properties: &servers.ServerUpdateParametersProperties{
@@ -561,7 +560,6 @@ func resourcePostgreSQLServerCreate(d *pluginsdk.ResourceData, meta interface{})
 	}
 
 	if mode == servers.CreateModePointInTimeRestore {
-		log.Printf("[INFO] updating `public_network_access_enabled` for %s", id)
 		properties := servers.ServerUpdateParameters{
 			Properties: &servers.ServerUpdateParametersProperties{
 				PublicNetworkAccess: &publicAccess,

--- a/internal/services/postgres/postgresql_virtual_network_rule_resource.go
+++ b/internal/services/postgres/postgresql_virtual_network_rule_resource.go
@@ -186,7 +186,6 @@ func postgreSQLVirtualNetworkStateStatusCodeRefreshFunc(ctx context.Context, cli
 		resp, err := client.Get(ctx, id)
 		if err != nil {
 			if response.WasNotFound(resp.HttpResponse) {
-				log.Printf("[DEBUG] Retrieving %s returned 404.", id)
 				return nil, "ResponseNotFound", nil
 			}
 
@@ -195,13 +194,11 @@ func postgreSQLVirtualNetworkStateStatusCodeRefreshFunc(ctx context.Context, cli
 
 		if model := resp.Model; model != nil {
 			if props := model.Properties; props != nil && props.State != nil {
-				log.Printf("[DEBUG] Retrieving %s returned Status %s", id, string(*props.State))
 				return resp, string(*props.State), nil
 			}
 		}
 
 		// Valid response was returned but VirtualNetworkRuleProperties was nil. Basically the rule exists, but with no properties for some reason. Assume Unknown instead of returning error.
-		log.Printf("[DEBUG] Retrieving %s returned empty `properties``", id)
 		return resp, "Unknown", nil
 	}
 }

--- a/internal/services/recoveryservices/backup_policy_file_share_resource.go
+++ b/internal/services/recoveryservices/backup_policy_file_share_resource.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"regexp"
 	"strings"
 	"time"
@@ -113,8 +112,6 @@ func resourceBackupProtectionPolicyFileShareCreateUpdate(d *pluginsdk.ResourceDa
 
 	id := protectionpolicies.NewBackupPolicyID(subscriptionId, d.Get("resource_group_name").(string), d.Get("recovery_vault_name").(string), d.Get("name").(string))
 
-	log.Printf("[DEBUG] Creating/updating %s", id)
-
 	// getting this ready now because its shared between *everything*, time is... complicated for this resource
 	// if it's using hourly backup schedule, it passes null in times
 	var times []string
@@ -192,8 +189,6 @@ func resourceBackupProtectionPolicyFileShareDelete(d *pluginsdk.ResourceData, me
 		return err
 	}
 
-	log.Printf("[DEBUG] Deleting %s", id)
-
 	if err = client.DeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %s: %+v", *id, err)
 	}
@@ -210,8 +205,6 @@ func resourceBackupProtectionPolicyFileShareRead(d *pluginsdk.ResourceData, meta
 	if err != nil {
 		return err
 	}
-
-	log.Printf("[DEBUG] Reading %s", id)
 
 	resp, err := client.Get(ctx, *id)
 	if err != nil {

--- a/internal/services/recoveryservices/backup_policy_vm_resource.go
+++ b/internal/services/recoveryservices/backup_policy_vm_resource.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"regexp"
 	"time"
 
@@ -118,8 +117,6 @@ func resourceBackupProtectionPolicyVMCreate(d *pluginsdk.ResourceData, meta inte
 
 	id := protectionpolicies.NewBackupPolicyID(subscriptionId, d.Get("resource_group_name").(string), d.Get("recovery_vault_name").(string), d.Get("name").(string))
 
-	log.Printf("[DEBUG] Creating %s", id)
-
 	// getting this ready now because its shared between *everything*, time is... complicated for this resource
 	timeOfDay := fmt.Sprintf("%s:00Z", d.Get("backup.0.time").(string))
 	times := append(make([]string, 0), timeOfDay)
@@ -196,8 +193,6 @@ func resourceBackupProtectionPolicyVMRead(d *pluginsdk.ResourceData, meta interf
 	if err != nil {
 		return err
 	}
-
-	log.Printf("[DEBUG] Reading %s", id)
 
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
@@ -291,8 +286,6 @@ func resourceBackupProtectionPolicyVMUpdate(d *pluginsdk.ResourceData, meta inte
 	if err != nil {
 		return err
 	}
-
-	log.Printf("[DEBUG] Updating %s", id)
 
 	// getting this ready now because its shared between *everything*, time is... complicated for this resource
 	timeOfDay := fmt.Sprintf("%s:00Z", d.Get("backup.0.time").(string))
@@ -433,8 +426,6 @@ func resourceBackupProtectionPolicyVMDelete(d *pluginsdk.ResourceData, meta inte
 	if err != nil {
 		return err
 	}
-
-	log.Printf("[DEBUG] Deleting %s", id)
 
 	if err = client.DeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %s: %+v", *id, err)

--- a/internal/services/recoveryservices/backup_protected_file_share_resource.go
+++ b/internal/services/recoveryservices/backup_protected_file_share_resource.go
@@ -259,8 +259,6 @@ func resourceBackupProtectedFileShareRead(d *pluginsdk.ResourceData, meta interf
 		return err
 	}
 
-	log.Printf("[DEBUG] Reading %s", *id)
-
 	resp, err := client.Get(ctx, *id, protecteditems.GetOperationOptions{})
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
@@ -302,8 +300,6 @@ func resourceBackupProtectedFileShareDelete(d *pluginsdk.ResourceData, meta inte
 	if err != nil {
 		return err
 	}
-
-	log.Printf("[DEBUG] Deleting %s", *id)
 
 	if err := client.DeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %s: %+v", id, err)

--- a/internal/services/recoveryservices/backup_protected_file_share_resource.go
+++ b/internal/services/recoveryservices/backup_protected_file_share_resource.go
@@ -6,7 +6,6 @@ package recoveryservices
 import (
 	"context"
 	"fmt"
-	"log"
 	"strconv"
 	"strings"
 	"time"
@@ -108,7 +107,6 @@ func resourceBackupProtectedFileShareCreateUpdate(d *pluginsdk.ResourceData, met
 	}
 
 	containerName := fmt.Sprintf("StorageContainer;storage;%s;%s", parsedStorageAccountID.ResourceGroupName, parsedStorageAccountID.StorageAccountName)
-	log.Printf("[DEBUG] creating/updating Recovery Service Protected File Share %q (Container Name %q)", fileShareName, containerName)
 
 	// the fileshare has a user defined name, but its system name (fileShareSystemName) is only known to Azure Backup
 	fileShareSystemName := ""

--- a/internal/services/recoveryservices/backup_protected_vm_resource.go
+++ b/internal/services/recoveryservices/backup_protected_vm_resource.go
@@ -90,8 +90,6 @@ func resourceRecoveryServicesBackupProtectedVMCreate(d *pluginsdk.ResourceData, 
 	protectedItemName := fmt.Sprintf("VM;iaasvmcontainerv2;%s;%s", parsedVmId.ResourceGroupName, parsedVmId.VirtualMachineName)
 	containerName := fmt.Sprintf("iaasvmcontainer;iaasvmcontainerv2;%s;%s", parsedVmId.ResourceGroupName, parsedVmId.VirtualMachineName)
 
-	log.Printf("[DEBUG] Creating Azure Backup Protected VM %s (resource group %q)", protectedItemName, resourceGroup)
-
 	id := protecteditems.NewProtectedItemID(subscriptionId, resourceGroup, vaultName, "Azure", containerName, protectedItemName)
 
 	existing, err := client.Get(ctx, id, protecteditems.GetOperationOptions{})
@@ -180,8 +178,6 @@ func resourceRecoveryServicesBackupProtectedVMRead(d *pluginsdk.ResourceData, me
 	if err != nil {
 		return err
 	}
-
-	log.Printf("[DEBUG] Reading %s", id)
 
 	resp, err := client.Get(ctx, *id, protecteditems.GetOperationOptions{})
 	if err != nil {
@@ -341,8 +337,6 @@ func resourceRecoveryServicesBackupProtectedVMDelete(d *pluginsdk.ResourceData, 
 			}
 		}
 	}
-
-	log.Printf("[DEBUG] Deleting %s", *id)
 
 	if err := client.DeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %s: %+v", *id, err)

--- a/internal/services/recoveryservices/recovery_services_vault_resource.go
+++ b/internal/services/recoveryservices/recovery_services_vault_resource.go
@@ -215,8 +215,6 @@ func resourceRecoveryServicesVaultCreate(d *pluginsdk.ResourceData, meta interfa
 	location := d.Get("location").(string)
 	t := d.Get("tags").(map[string]interface{})
 
-	log.Printf("[DEBUG] Creating Recovery Service %s", id.String())
-
 	existing, err := client.Get(ctx, id)
 	if err != nil {
 		if !response.WasNotFound(existing.HttpResponse) {

--- a/internal/services/redisenterprise/redis_enterprise_cluster_resource.go
+++ b/internal/services/redisenterprise/redis_enterprise_cluster_resource.go
@@ -229,7 +229,6 @@ func resourceRedisEnterpriseClusterUpdate(d *pluginsdk.ResourceData, meta interf
 	client := meta.(*clients.Client).RedisEnterprise.Client
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	log.Printf("[INFO] preparing arguments for Azure ARM Redis Cache update.")
 
 	id, err := redisenterprise.ParseRedisEnterpriseID(d.Id())
 	if err != nil {

--- a/internal/services/redisenterprise/redis_enterprise_database_resource.go
+++ b/internal/services/redisenterprise/redis_enterprise_database_resource.go
@@ -621,7 +621,6 @@ func forceUnlinkDatabase(d *pluginsdk.ResourceData, meta interface{}, unlinkedDb
 	client := meta.(*clients.Client).RedisEnterprise.DatabaseClient
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	log.Printf("[INFO]Preparing to unlink a linked database")
 
 	id, err := databases.ParseDatabaseID(d.Id())
 	if err != nil {

--- a/internal/services/relay/relay_hybrid_connection_authorization_rule_resource.go
+++ b/internal/services/relay/relay_hybrid_connection_authorization_rule_resource.go
@@ -5,7 +5,6 @@ package relay
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -69,8 +68,6 @@ func resourceRelayHybridConnectionAuthorizationRuleCreateUpdate(d *pluginsdk.Res
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for Relay HybridConnection Authorization Rule creation.")
 
 	resourceId := hybridconnections.NewHybridConnectionAuthorizationRuleID(subscriptionId, d.Get("resource_group_name").(string), d.Get("namespace_name").(string), d.Get("hybrid_connection_name").(string), d.Get("name").(string))
 	if d.IsNewResource() {

--- a/internal/services/relay/relay_hybrid_connection_resource.go
+++ b/internal/services/relay/relay_hybrid_connection_resource.go
@@ -75,8 +75,6 @@ func resourceArmRelayHybridConnectionCreateUpdate(d *pluginsdk.ResourceData, met
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Relay Hybrid Connection creation.")
-
 	id := hybridconnections.NewHybridConnectionID(subscriptionId, d.Get("resource_group_name").(string), d.Get("relay_namespace_name").(string), d.Get("name").(string))
 	if d.IsNewResource() {
 		existing, err := client.Get(ctx, id)

--- a/internal/services/relay/relay_namespace_authorization_rule_resource.go
+++ b/internal/services/relay/relay_namespace_authorization_rule_resource.go
@@ -5,7 +5,6 @@ package relay
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -63,8 +62,6 @@ func resourceRelayNamespaceAuthorizationRuleCreateUpdate(d *pluginsdk.ResourceDa
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for Relay Namespace Authorization Rule creation.")
 
 	resourceId := namespaces.NewAuthorizationRuleID(subscriptionId, d.Get("resource_group_name").(string), d.Get("namespace_name").(string), d.Get("name").(string))
 	if d.IsNewResource() {

--- a/internal/services/relay/relay_namespace_resource.go
+++ b/internal/services/relay/relay_namespace_resource.go
@@ -99,8 +99,6 @@ func resourceRelayNamespaceCreateUpdate(d *pluginsdk.ResourceData, meta interfac
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Relay Namespace create/update.")
-
 	id := namespaces.NewNamespaceID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 	if d.IsNewResource() {
 		existing, err := client.Get(ctx, id)

--- a/internal/services/resource/management_group_template_deployment_resource.go
+++ b/internal/services/resource/management_group_template_deployment_resource.go
@@ -196,7 +196,6 @@ func managementGroupTemplateDeploymentResourceUpdate(d *pluginsdk.ResourceData, 
 		return err
 	}
 
-	log.Printf("[DEBUG] Retrieving Management Group Template Deployment %q..", id.DeploymentName)
 	template, err := client.GetAtManagementGroupScope(ctx, id.ManagementGroupName, id.DeploymentName)
 	if err != nil {
 		return fmt.Errorf("retrieving Management Group Template Deployment %q: %+v", id.DeploymentName, err)

--- a/internal/services/resource/management_group_template_deployment_resource.go
+++ b/internal/services/resource/management_group_template_deployment_resource.go
@@ -364,7 +364,6 @@ func managementGroupTemplateDeploymentResourceDelete(d *pluginsdk.ResourceData, 
 	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
 		return fmt.Errorf("waiting for deletion of Management Group Template Deployment %q: %+v", id.DeploymentName, err)
 	}
-	log.Printf("[DEBUG] Deleted Management Group Template Deployment %q.", id.DeploymentName)
 
 	return nil
 }

--- a/internal/services/resource/management_group_template_deployment_resource.go
+++ b/internal/services/resource/management_group_template_deployment_resource.go
@@ -356,7 +356,6 @@ func managementGroupTemplateDeploymentResourceDelete(d *pluginsdk.ResourceData, 
 	// at this time unfortunately the Resources RP doesn't expose a means of deleting top-level objects
 	// so we're unable to delete these during deletion - this'll need to be detailed in the docs
 
-	log.Printf("[DEBUG] Deleting Management Group Template Deployment %q..", id.DeploymentName)
 	future, err := client.DeleteAtManagementGroupScope(ctx, id.ManagementGroupName, id.DeploymentName)
 	if err != nil {
 		return fmt.Errorf("deleting Management Group Template Deployment %q: %+v", id.DeploymentName, err)

--- a/internal/services/resource/resource_group_template_deployment_resource.go
+++ b/internal/services/resource/resource_group_template_deployment_resource.go
@@ -405,7 +405,6 @@ func resourceGroupTemplateDeploymentResourceDelete(d *pluginsdk.ResourceData, me
 	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
 		return fmt.Errorf("waiting for deletion of Template Deployment %q (Resource Group %q): %+v", id.DeploymentName, id.ResourceGroup, err)
 	}
-	log.Printf("[DEBUG] Deleted Template Deployment %q (Resource Group %q).", id.DeploymentName, id.ResourceGroup)
 
 	return nil
 }

--- a/internal/services/resource/resource_group_template_deployment_resource.go
+++ b/internal/services/resource/resource_group_template_deployment_resource.go
@@ -216,7 +216,6 @@ func resourceGroupTemplateDeploymentResourceUpdate(d *pluginsdk.ResourceData, me
 		return err
 	}
 
-	log.Printf("[DEBUG] Retrieving Template Deployment %q (Resource Group %q)..", id.DeploymentName, id.ResourceGroup)
 	template, err := client.Get(ctx, id.ResourceGroup, id.DeploymentName)
 	if err != nil {
 		return fmt.Errorf("retrieving Template Deployment %q (Resource Group %q): %+v", id.DeploymentName, id.ResourceGroup, err)
@@ -373,7 +372,6 @@ func resourceGroupTemplateDeploymentResourceDelete(d *pluginsdk.ResourceData, me
 		return err
 	}
 
-	log.Printf("[DEBUG] Retrieving Template Deployment %q (Resource Group %q)..", id.DeploymentName, id.ResourceGroup)
 	template, err := client.Get(ctx, id.ResourceGroup, id.DeploymentName)
 	if err != nil {
 		if utils.ResponseWasNotFound(template.Response) {

--- a/internal/services/resource/resource_group_template_deployment_resource.go
+++ b/internal/services/resource/resource_group_template_deployment_resource.go
@@ -398,7 +398,6 @@ func resourceGroupTemplateDeploymentResourceDelete(d *pluginsdk.ResourceData, me
 		log.Printf("[DEBUG] Skipping removing items provisioned by the Template Deployment %q (Resource Group %q) as the feature is disabled", id.DeploymentName, id.ResourceGroup)
 	}
 
-	log.Printf("[DEBUG] Deleting Template Deployment %q (Resource Group %q)..", id.DeploymentName, id.ResourceGroup)
 	future, err := client.Delete(ctx, id.ResourceGroup, id.DeploymentName)
 	if err != nil {
 		return fmt.Errorf("deleting Template Deployment %q (Resource Group %q): %+v", id.DeploymentName, id.ResourceGroup, err)

--- a/internal/services/resource/subscription_template_deployment_resource.go
+++ b/internal/services/resource/subscription_template_deployment_resource.go
@@ -339,7 +339,6 @@ func subscriptionTemplateDeploymentResourceDelete(d *pluginsdk.ResourceData, met
 	// at this time unfortunately the Resources RP doesn't expose a means of deleting top-level objects
 	// so we're unable to delete these during deletion - this'll need to be detailed in the docs
 
-	log.Printf("[DEBUG] Deleting Subscription Template Deployment %q..", id.DeploymentName)
 	future, err := client.DeleteAtSubscriptionScope(ctx, id.DeploymentName)
 	if err != nil {
 		return fmt.Errorf("deleting Subscription Template Deployment %q: %+v", id.DeploymentName, err)

--- a/internal/services/resource/subscription_template_deployment_resource.go
+++ b/internal/services/resource/subscription_template_deployment_resource.go
@@ -183,7 +183,6 @@ func subscriptionTemplateDeploymentResourceUpdate(d *pluginsdk.ResourceData, met
 		return err
 	}
 
-	log.Printf("[DEBUG] Retrieving Subscription Template Deployment %q..", id.DeploymentName)
 	template, err := client.GetAtSubscriptionScope(ctx, id.DeploymentName)
 	if err != nil {
 		return fmt.Errorf("retrieving Subscription Template Deployment %q: %+v", id.DeploymentName, err)

--- a/internal/services/resource/subscription_template_deployment_resource.go
+++ b/internal/services/resource/subscription_template_deployment_resource.go
@@ -347,7 +347,6 @@ func subscriptionTemplateDeploymentResourceDelete(d *pluginsdk.ResourceData, met
 	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
 		return fmt.Errorf("waiting for deletion of Subscription Template Deployment %q: %+v", id.DeploymentName, err)
 	}
-	log.Printf("[DEBUG] Deleted Subscription Template Deployment %q.", id.DeploymentName)
 
 	return nil
 }

--- a/internal/services/resource/tenant_template_deployment_resource.go
+++ b/internal/services/resource/tenant_template_deployment_resource.go
@@ -348,7 +348,6 @@ func tenantTemplateDeploymentResourceDelete(d *pluginsdk.ResourceData, meta inte
 	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
 		return fmt.Errorf("waiting for deletion of Tenant Template Deployment %q: %+v", id.DeploymentName, err)
 	}
-	log.Printf("[DEBUG] Deleted Tenant Template Deployment %q.", id.DeploymentName)
 
 	return nil
 }

--- a/internal/services/resource/tenant_template_deployment_resource.go
+++ b/internal/services/resource/tenant_template_deployment_resource.go
@@ -182,7 +182,6 @@ func tenantTemplateDeploymentResourceUpdate(d *pluginsdk.ResourceData, meta inte
 		return err
 	}
 
-	log.Printf("[DEBUG] Retrieving Tenant Template Deployment %q..", id.DeploymentName)
 	template, err := client.GetAtTenantScope(ctx, id.DeploymentName)
 	if err != nil {
 		return fmt.Errorf("retrieving Tenant Template Deployment %q: %+v", id.DeploymentName, err)

--- a/internal/services/resource/tenant_template_deployment_resource.go
+++ b/internal/services/resource/tenant_template_deployment_resource.go
@@ -340,7 +340,6 @@ func tenantTemplateDeploymentResourceDelete(d *pluginsdk.ResourceData, meta inte
 	// at this time unfortunately the Resources RP doesn't expose a means of deleting top-level objects
 	// so we're unable to delete these during deletion - this'll need to be detailed in the docs
 
-	log.Printf("[DEBUG] Deleting Tenant Template Deployment %q..", id.DeploymentName)
 	future, err := client.DeleteAtTenantScope(ctx, id.DeploymentName)
 	if err != nil {
 		return fmt.Errorf("deleting Tenant Template Deployment %q: %+v", id.DeploymentName, err)

--- a/internal/services/search/search_shared_private_link_service_resource.go
+++ b/internal/services/search/search_shared_private_link_service_resource.go
@@ -158,7 +158,6 @@ func (r SharedPrivateLinkServiceResource) Read() sdk.ResourceFunc {
 			resp, err := client.Get(ctx, *id, sharedprivatelinkresources.GetOperationOptions{})
 			if err != nil {
 				if response.WasNotFound(resp.HttpResponse) {
-					metadata.Logger.Infof("%q was not found - removing from state!", *id)
 					return metadata.MarkAsGone(id)
 				}
 

--- a/internal/services/servicebus/servicebus_namespace_resource.go
+++ b/internal/services/servicebus/servicebus_namespace_resource.go
@@ -749,7 +749,6 @@ func createNetworkRuleSetForNamespace(ctx context.Context, client *namespaces.Na
 	if _, err := client.CreateOrUpdateNetworkRuleSet(ctx, id, parameters); err != nil {
 		return fmt.Errorf("creating/updating %s: %+v", id, err)
 	}
-	log.Printf("[DEBUG] Created/updated the Network Rule Set associated with %s", id)
 
 	return nil
 }

--- a/internal/services/servicebus/servicebus_namespace_resource.go
+++ b/internal/services/servicebus/servicebus_namespace_resource.go
@@ -289,8 +289,6 @@ func resourceServiceBusNamespaceCreate(d *pluginsdk.ResourceData, meta interface
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for ServiceBus Namespace create")
-
 	location := location.Normalize(d.Get("location").(string))
 	sku := d.Get("sku").(string)
 	t := d.Get("tags").(map[string]interface{})
@@ -379,8 +377,6 @@ func resourceServiceBusNamespaceUpdate(d *pluginsdk.ResourceData, meta interface
 	client := meta.(*clients.Client).ServiceBus.NamespacesClient
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for ServiceBus Namespace update")
 
 	id, err := namespaces.ParseNamespaceID(d.Id())
 	if err != nil {

--- a/internal/services/servicebus/servicebus_namespace_resource.go
+++ b/internal/services/servicebus/servicebus_namespace_resource.go
@@ -474,7 +474,6 @@ func resourceServiceBusNamespaceUpdate(d *pluginsdk.ResourceData, meta interface
 			}
 			log.Printf("[DEBUG] Reset the Existing Network Rule Set associated with %s", id)
 		} else {
-			log.Printf("[DEBUG] Updating the Network Rule Set associated with %s..", id)
 			if err = createNetworkRuleSetForNamespace(ctx, client, *id, newNetworkRuleSet.([]interface{})); err != nil {
 				return err
 			}
@@ -725,8 +724,6 @@ func createNetworkRuleSetForNamespace(ctx context.Context, client *namespaces.Na
 	if len(input) < 1 || input[0] == nil {
 		return nil
 	}
-
-	log.Printf("[DEBUG] Creating/updating the Network Rule Set associated with %s..", id)
 
 	item := input[0].(map[string]interface{})
 

--- a/internal/services/servicebus/servicebus_namespace_resource.go
+++ b/internal/services/servicebus/servicebus_namespace_resource.go
@@ -468,12 +468,10 @@ func resourceServiceBusNamespaceUpdate(d *pluginsdk.ResourceData, meta interface
 			if err = resetNetworkRuleSetForNamespace(ctx, client, *id); err != nil {
 				return err
 			}
-			log.Printf("[DEBUG] Reset the Existing Network Rule Set associated with %s", id)
 		} else {
 			if err = createNetworkRuleSetForNamespace(ctx, client, *id, newNetworkRuleSet.([]interface{})); err != nil {
 				return err
 			}
-			log.Printf("[DEBUG] Updated the Network Rule Set associated with %s", id)
 		}
 	}
 

--- a/internal/services/servicebus/servicebus_subscription_resource.go
+++ b/internal/services/servicebus/servicebus_subscription_resource.go
@@ -5,7 +5,6 @@ package servicebus
 
 import (
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
@@ -174,7 +173,6 @@ func resourceServiceBusSubscriptionCreateUpdate(d *pluginsdk.ResourceData, meta 
 	client := meta.(*clients.Client).ServiceBus.SubscriptionsClient
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	log.Printf("[INFO] preparing arguments for ServiceBus Subscription creation.")
 
 	var id subscriptions.Subscriptions2Id
 	name := d.Get("name").(string)

--- a/internal/services/servicebus/servicebus_subscription_rule_resource.go
+++ b/internal/services/servicebus/servicebus_subscription_rule_resource.go
@@ -5,7 +5,6 @@ package servicebus
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -190,7 +189,6 @@ func resourceServiceBusSubscriptionRuleCreateUpdate(d *pluginsdk.ResourceData, m
 	subscriptionClient := meta.(*clients.Client).ServiceBus.SubscriptionsClient
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	log.Printf("[INFO] preparing arguments for Azure Service Bus Subscription Rule creation.")
 
 	filterType := d.Get("filter_type").(string)
 

--- a/internal/services/servicebus/servicebus_subscription_rule_resource.go
+++ b/internal/services/servicebus/servicebus_subscription_rule_resource.go
@@ -195,7 +195,8 @@ func resourceServiceBusSubscriptionRuleCreateUpdate(d *pluginsdk.ResourceData, m
 	var id subscriptions.RuleId
 	if subscriptionIdLit := d.Get("subscription_id").(string); subscriptionIdLit != "" {
 		subscriptionId, _ := rules.ParseSubscriptions2ID(subscriptionIdLit)
-		id = subscriptions.NewRuleID(subscriptionId.SubscriptionId,
+		id = subscriptions.NewRuleID(
+			subscriptionId.SubscriptionId,
 			subscriptionId.ResourceGroupName,
 			subscriptionId.NamespaceName,
 			subscriptionId.TopicName,

--- a/internal/services/servicebus/servicebus_topic_authorization_rule_resource.go
+++ b/internal/services/servicebus/servicebus_topic_authorization_rule_resource.go
@@ -68,7 +68,6 @@ func resourceServiceBusTopicAuthorizationRuleCreateUpdate(d *pluginsdk.ResourceD
 	client := meta.(*clients.Client).ServiceBus.TopicsAuthClient
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	log.Printf("[INFO] preparing arguments for AzureRM ServiceBus Topic Authorization Rule creation.")
 
 	var id topicsauthorizationrule.TopicAuthorizationRuleId
 	if topicIdLit := d.Get("topic_id").(string); topicIdLit != "" {

--- a/internal/services/servicebus/servicebus_topic_resource.go
+++ b/internal/services/servicebus/servicebus_topic_resource.go
@@ -5,7 +5,6 @@ package servicebus
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -141,7 +140,6 @@ func resourceServiceBusTopicCreateUpdate(d *pluginsdk.ResourceData, meta interfa
 	client := meta.(*clients.Client).ServiceBus.TopicsClient
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	log.Printf("[INFO] preparing arguments for Azure ServiceBus Topic creation.")
 
 	var id topics.TopicId
 	if namespaceIdLit := d.Get("namespace_id").(string); namespaceIdLit != "" {

--- a/internal/services/serviceconnector/app_service_connection_resource.go
+++ b/internal/services/serviceconnector/app_service_connection_resource.go
@@ -240,8 +240,6 @@ func (r AppServiceConnectorResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("deleting %s", *id)
-
 			if err := client.LinkerDeleteThenPoll(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}

--- a/internal/services/serviceconnector/function_app_connection_resource.go
+++ b/internal/services/serviceconnector/function_app_connection_resource.go
@@ -237,8 +237,6 @@ func (r FunctionAppConnectorResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("deleting %s", *id)
-
 			if err := client.LinkerDeleteThenPoll(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}

--- a/internal/services/serviceconnector/spring_cloud_connection_resource.go
+++ b/internal/services/serviceconnector/spring_cloud_connection_resource.go
@@ -239,8 +239,6 @@ func (r SpringCloudConnectorResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("deleting %s", *id)
-
 			if err := client.LinkerDeleteThenPoll(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}

--- a/internal/services/servicefabric/service_fabric_cluster_resource.go
+++ b/internal/services/servicefabric/service_fabric_cluster_resource.go
@@ -806,8 +806,6 @@ func resourceServiceFabricClusterDelete(d *pluginsdk.ResourceData, meta interfac
 		return err
 	}
 
-	log.Printf("[DEBUG] Deleting %s", id.ID())
-
 	resp, err := client.Delete(ctx, *id)
 	if err != nil {
 		if !response.WasNotFound(resp.HttpResponse) {

--- a/internal/services/springcloud/spring_cloud_service_resource.go
+++ b/internal/services/springcloud/spring_cloud_service_resource.go
@@ -504,14 +504,12 @@ func resourceSpringCloudServiceCreate(d *pluginsdk.ResourceData, meta interface{
 	}
 
 	if skuName != "E0" {
-		log.Printf("[DEBUG] Updating Config Server Settings for %s..", id)
 		if err := updateConfigServerSettings(ctx, configServersClient, id, gitProperty); err != nil {
 			return err
 		}
 		log.Printf("[DEBUG] Updated Config Server Settings for %s.", id)
 	}
 
-	log.Printf("[DEBUG] Updating Monitor Settings for %s..", id)
 	monitorSettings := appplatform.MonitoringSettingResource{
 		Properties: expandSpringCloudTrace(d.Get("trace").([]interface{})),
 	}
@@ -617,7 +615,6 @@ func resourceSpringCloudServiceUpdate(d *pluginsdk.ResourceData, meta interface{
 			return fmt.Errorf("`config_server_git_setting` is not supported for sku `E0`")
 		}
 		if skuName != "E0" {
-			log.Printf("[DEBUG] Updating Config Server Settings for %s..", *id)
 			if err := updateConfigServerSettings(ctx, configServersClient, *id, gitProperty); err != nil {
 				return err
 			}
@@ -626,7 +623,6 @@ func resourceSpringCloudServiceUpdate(d *pluginsdk.ResourceData, meta interface{
 	}
 
 	if d.HasChange("trace") {
-		log.Printf("[DEBUG] Updating Monitor Settings for %s..", id)
 		monitorSettings := appplatform.MonitoringSettingResource{
 			Properties: expandSpringCloudTrace(d.Get("trace").([]interface{})),
 		}
@@ -866,7 +862,6 @@ func resourceSpringCloudServiceDelete(d *pluginsdk.ResourceData, meta interface{
 }
 
 func updateConfigServerSettings(ctx context.Context, client *appplatform.ConfigServersClient, id parse.SpringCloudServiceId, gitProperty *appplatform.ConfigServerGitProperty) error {
-	log.Printf("[DEBUG] Updating Config Server Settings for %s..", id)
 	configServer := appplatform.ConfigServerResource{
 		Properties: &appplatform.ConfigServerProperties{
 			ConfigServer: &appplatform.ConfigServerSettings{

--- a/internal/services/springcloud/spring_cloud_service_resource.go
+++ b/internal/services/springcloud/spring_cloud_service_resource.go
@@ -507,7 +507,6 @@ func resourceSpringCloudServiceCreate(d *pluginsdk.ResourceData, meta interface{
 		if err := updateConfigServerSettings(ctx, configServersClient, id, gitProperty); err != nil {
 			return err
 		}
-		log.Printf("[DEBUG] Updated Config Server Settings for %s.", id)
 	}
 
 	monitorSettings := appplatform.MonitoringSettingResource{
@@ -520,7 +519,6 @@ func resourceSpringCloudServiceCreate(d *pluginsdk.ResourceData, meta interface{
 	if err = updateFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
 		return fmt.Errorf("waiting for update of monitor settings for %s: %+v", id, err)
 	}
-	log.Printf("[DEBUG] Updated Monitor Settings for %s.", id)
 
 	if d.Get("service_registry_enabled").(bool) {
 		future, err := serviceRegistryClient.CreateOrUpdate(ctx, id.ResourceGroup, id.SpringName, "default")
@@ -618,7 +616,6 @@ func resourceSpringCloudServiceUpdate(d *pluginsdk.ResourceData, meta interface{
 			if err := updateConfigServerSettings(ctx, configServersClient, *id, gitProperty); err != nil {
 				return err
 			}
-			log.Printf("[DEBUG] Updated Config Server Settings for %s.", *id)
 		}
 	}
 
@@ -633,7 +630,6 @@ func resourceSpringCloudServiceUpdate(d *pluginsdk.ResourceData, meta interface{
 		if err = updateFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
 			return fmt.Errorf("waiting for update of monitor settings for %s: %+v", id, err)
 		}
-		log.Printf("[DEBUG] Updated Monitor Settings for %s.", id)
 	}
 
 	if d.HasChange("service_registry_enabled") {
@@ -877,7 +873,6 @@ func updateConfigServerSettings(ctx context.Context, client *appplatform.ConfigS
 		return fmt.Errorf("waiting for update of config server for %s: %+v", id, err)
 	}
 
-	log.Printf("[DEBUG] Retrieving Config Server Settings for %s..", id)
 	resp, err := client.Get(ctx, id.ResourceGroup, id.SpringName)
 	if err != nil {
 		return fmt.Errorf("retrieving config server for %s: %+v", id, err)
@@ -887,7 +882,6 @@ func updateConfigServerSettings(ctx context.Context, client *appplatform.ConfigS
 			return fmt.Errorf("setting config server for %s: %+v", id, err)
 		}
 	}
-	log.Printf("[DEBUG] Updated Config Server Settings for %s.", id)
 	return nil
 }
 

--- a/internal/services/storage/storage_blob_resource.go
+++ b/internal/services/storage/storage_blob_resource.go
@@ -225,7 +225,6 @@ func resourceStorageBlobCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 		}
 	}
 
-	log.Printf("[DEBUG] Creating %s..", id)
 	metaDataRaw := d.Get("metadata").(map[string]interface{})
 	blobInput := BlobUpload{
 		AccountName:   accountName,
@@ -297,7 +296,6 @@ func resourceStorageBlobUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 	}
 
 	if d.HasChange("content_type") || d.HasChange("cache_control") {
-		log.Printf("[DEBUG] Updating Properties for %s...", id)
 		input := blobs.SetPropertiesInput{
 			ContentType:  pointer.To(d.Get("content_type").(string)),
 			CacheControl: pointer.To(d.Get("cache_control").(string)),
@@ -318,7 +316,6 @@ func resourceStorageBlobUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 	}
 
 	if d.HasChange("metadata") {
-		log.Printf("[DEBUG] Updating MetaData for %s...", id)
 		metaDataRaw := d.Get("metadata").(map[string]interface{})
 		input := blobs.SetMetaDataInput{
 			MetaData: ExpandMetaData(metaDataRaw),
@@ -335,7 +332,6 @@ func resourceStorageBlobUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 
 	if d.HasChange("access_tier") {
 		// this is only applicable for Gen2/BlobStorage accounts
-		log.Printf("[DEBUG] Updating Access Tier for %s...", id)
 		accessTier := blobs.AccessTier(d.Get("access_tier").(string))
 
 		if _, err := blobsClient.SetTier(ctx, id.ContainerName, id.BlobName, blobs.SetTierInput{Tier: accessTier}); err != nil {

--- a/internal/services/storage/storage_blob_resource.go
+++ b/internal/services/storage/storage_blob_resource.go
@@ -251,7 +251,6 @@ func resourceStorageBlobCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 	if err = blobInput.Create(ctx); err != nil {
 		return fmt.Errorf("creating %s: %v", id, err)
 	}
-	log.Printf("[DEBUG] Created %s.", id)
 
 	d.SetId(id.ID())
 
@@ -282,7 +281,6 @@ func resourceStorageBlobUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 		return fmt.Errorf("building Blobs Client: %v", err)
 	}
 
-	log.Printf("[INFO] Retrieving %s", id)
 	input := blobs.GetPropertiesInput{}
 	props, err := blobsClient.GetProperties(ctx, id.ContainerName, id.BlobName, input)
 	if err != nil {
@@ -312,7 +310,6 @@ func resourceStorageBlobUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 		if _, err = blobsClient.SetProperties(ctx, id.ContainerName, id.BlobName, input); err != nil {
 			return fmt.Errorf("updating Properties for %s: %v", id, err)
 		}
-		log.Printf("[DEBUG] Updated Properties for %s", id)
 	}
 
 	if d.HasChange("metadata") {
@@ -327,7 +324,6 @@ func resourceStorageBlobUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 		if _, err = blobsClient.SetMetaData(ctx, id.ContainerName, id.BlobName, input); err != nil {
 			return fmt.Errorf("updating MetaData for %s: %v", id, err)
 		}
-		log.Printf("[DEBUG] Updated MetaData for %s", id)
 	}
 
 	if d.HasChange("access_tier") {
@@ -338,7 +334,6 @@ func resourceStorageBlobUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 			return fmt.Errorf("updating Access Tier for %s: %v", id, err)
 		}
 
-		log.Printf("[DEBUG] Updated Access Tier for %s", id)
 	}
 
 	return resourceStorageBlobRead(d, meta)
@@ -370,7 +365,6 @@ func resourceStorageBlobRead(d *pluginsdk.ResourceData, meta interface{}) error 
 		return fmt.Errorf("building Blobs Client: %v", err)
 	}
 
-	log.Printf("[INFO] Retrieving %s", id)
 	input := blobs.GetPropertiesInput{}
 	props, err := blobsClient.GetProperties(ctx, id.ContainerName, id.BlobName, input)
 	if err != nil {

--- a/internal/services/storage/storage_blob_resource.go
+++ b/internal/services/storage/storage_blob_resource.go
@@ -333,7 +333,6 @@ func resourceStorageBlobUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 		if _, err := blobsClient.SetTier(ctx, id.ContainerName, id.BlobName, blobs.SetTierInput{Tier: accessTier}); err != nil {
 			return fmt.Errorf("updating Access Tier for %s: %v", id, err)
 		}
-
 	}
 
 	return resourceStorageBlobRead(d, meta)

--- a/internal/services/storage/storage_container_resource.go
+++ b/internal/services/storage/storage_container_resource.go
@@ -313,7 +313,6 @@ func resourceStorageContainerUpdate(d *pluginsdk.ResourceData, meta interface{})
 			return fmt.Errorf("locating Storage Account %q", id.AccountId.AccountName)
 		}
 		if d.HasChange("container_access_type") {
-
 			// Updating metadata does not work with AAD authentication, returns a cryptic 404
 			client, err := storageClient.ContainersDataPlaneClient(ctx, *account, storageClient.DataPlaneOperationSupportingOnlySharedKeyAuth())
 			if err != nil {
@@ -326,11 +325,9 @@ func resourceStorageContainerUpdate(d *pluginsdk.ResourceData, meta interface{})
 			if err = client.UpdateAccessLevel(ctx, id.ContainerName, accessLevel); err != nil {
 				return fmt.Errorf("updating Access Level for %s: %v", id, err)
 			}
-
 		}
 
 		if d.HasChange("metadata") {
-
 			client, err := storageClient.ContainersDataPlaneClient(ctx, *account, storageClient.DataPlaneOperationSupportingAnyAuthMethod())
 			if err != nil {
 				return fmt.Errorf("building Containers Client: %v", err)
@@ -342,7 +339,6 @@ func resourceStorageContainerUpdate(d *pluginsdk.ResourceData, meta interface{})
 			if err = client.UpdateMetaData(ctx, id.ContainerName, metaData); err != nil {
 				return fmt.Errorf("updating Metadata for %s: %v", id, err)
 			}
-
 		}
 
 		return resourceStorageContainerRead(d, meta)

--- a/internal/services/storage/storage_container_resource.go
+++ b/internal/services/storage/storage_container_resource.go
@@ -327,7 +327,6 @@ func resourceStorageContainerUpdate(d *pluginsdk.ResourceData, meta interface{})
 				return fmt.Errorf("updating Access Level for %s: %v", id, err)
 			}
 
-			log.Printf("[DEBUG] Updated Access Level for %s", id)
 		}
 
 		if d.HasChange("metadata") {
@@ -344,7 +343,6 @@ func resourceStorageContainerUpdate(d *pluginsdk.ResourceData, meta interface{})
 				return fmt.Errorf("updating Metadata for %s: %v", id, err)
 			}
 
-			log.Printf("[DEBUG] Updated Metadata for %s", id)
 		}
 
 		return resourceStorageContainerRead(d, meta)

--- a/internal/services/storage/storage_container_resource.go
+++ b/internal/services/storage/storage_container_resource.go
@@ -227,7 +227,6 @@ func resourceStorageContainerCreate(d *pluginsdk.ResourceData, meta interface{})
 				return tf.ImportAsExistsError("azurerm_storage_container", id.ID())
 			}
 
-			log.Printf("[INFO] Creating %s", id)
 			input := containers.CreateInput{
 				AccessLevel: accessLevel,
 				MetaData:    metaData,
@@ -314,7 +313,6 @@ func resourceStorageContainerUpdate(d *pluginsdk.ResourceData, meta interface{})
 			return fmt.Errorf("locating Storage Account %q", id.AccountId.AccountName)
 		}
 		if d.HasChange("container_access_type") {
-			log.Printf("[DEBUG] Updating Access Level for %s...", id)
 
 			// Updating metadata does not work with AAD authentication, returns a cryptic 404
 			client, err := storageClient.ContainersDataPlaneClient(ctx, *account, storageClient.DataPlaneOperationSupportingOnlySharedKeyAuth())
@@ -333,7 +331,6 @@ func resourceStorageContainerUpdate(d *pluginsdk.ResourceData, meta interface{})
 		}
 
 		if d.HasChange("metadata") {
-			log.Printf("[DEBUG] Updating Metadata for %s...", id)
 
 			client, err := storageClient.ContainersDataPlaneClient(ctx, *account, storageClient.DataPlaneOperationSupportingAnyAuthMethod())
 			if err != nil {

--- a/internal/services/storage/storage_data_lake_gen2_filesystem_resource.go
+++ b/internal/services/storage/storage_data_lake_gen2_filesystem_resource.go
@@ -452,15 +452,18 @@ func validateStorageDataLakeGen2FileSystemName(v interface{}, k string) (warning
 	if !regexp.MustCompile(`^\$root$|^[0-9a-z-]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
 			"only lowercase alphanumeric characters and hyphens allowed in %q: %q",
-			k, value))
+			k, value,
+		))
 	}
 	if len(value) < 3 || len(value) > 63 {
 		errors = append(errors, fmt.Errorf(
-			"%q must be between 3 and 63 characters: %q", k, value))
+			"%q must be between 3 and 63 characters: %q", k, value,
+		))
 	}
 	if regexp.MustCompile(`^-`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
-			"%q cannot begin with a hyphen: %q", k, value))
+			"%q cannot begin with a hyphen: %q", k, value,
+		))
 	}
 	return warnings, errors
 }

--- a/internal/services/storage/storage_data_lake_gen2_filesystem_resource.go
+++ b/internal/services/storage/storage_data_lake_gen2_filesystem_resource.go
@@ -213,7 +213,6 @@ func resourceStorageDataLakeGen2FileSystemCreate(d *pluginsdk.ResourceData, meta
 		return tf.ImportAsExistsError("azurerm_storage_data_lake_gen2_filesystem", id.ID())
 	}
 
-	log.Printf("[INFO] Creating %s...", id)
 	input := filesystems.CreateInput{
 		Properties: properties,
 	}
@@ -239,7 +238,6 @@ func resourceStorageDataLakeGen2FileSystemCreate(d *pluginsdk.ResourceData, meta
 	if acl != nil || owner != nil || group != nil {
 		var aclString *string
 		if acl != nil {
-			log.Printf("[INFO] Creating ACL %q for %s", acl, id)
 			v := acl.String()
 			aclString = &v
 		}
@@ -301,7 +299,6 @@ func resourceStorageDataLakeGen2FileSystemUpdate(d *pluginsdk.ResourceData, meta
 	propertiesRaw := d.Get("properties").(map[string]interface{})
 	properties := ExpandMetaData(propertiesRaw)
 
-	log.Printf("[INFO] Updating Properties for %s...", id)
 	input := filesystems.SetPropertiesInput{
 		Properties: properties,
 	}
@@ -323,7 +320,6 @@ func resourceStorageDataLakeGen2FileSystemUpdate(d *pluginsdk.ResourceData, meta
 	if acl != nil || owner != nil || group != nil {
 		var aclString *string
 		if acl != nil {
-			log.Printf("[INFO] Creating ACL %q for %s...", acl, id)
 			v := acl.String()
 			aclString = &v
 		}

--- a/internal/services/storage/storage_data_lake_gen2_path_resource.go
+++ b/internal/services/storage/storage_data_lake_gen2_path_resource.go
@@ -233,7 +233,6 @@ func resourceStorageDataLakeGen2PathCreate(d *pluginsdk.ResourceData, meta inter
 		group = &sv
 	}
 
-	log.Printf("[INFO] Creating %s...", id)
 	input := paths.CreateInput{
 		Resource: resource,
 	}

--- a/internal/services/storage/storage_share_file_resource.go
+++ b/internal/services/storage/storage_share_file_resource.go
@@ -324,7 +324,6 @@ func resourceStorageShareFileRead(d *pluginsdk.ResourceData, meta interface{}) e
 
 	props, err := client.GetProperties(ctx, id.ShareName, id.DirectoryPath, id.FileName)
 	if err != nil {
-		log.Printf("retrieving %s: %s", id, err)
 		d.SetId("")
 		return nil
 	}

--- a/internal/services/storage/storage_share_resource.go
+++ b/internal/services/storage/storage_share_resource.go
@@ -522,7 +522,6 @@ func resourceStorageShareUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 				return fmt.Errorf("updating Quota for %s: %v", id, err)
 			}
 
-			log.Printf("[DEBUG] Updated the Quota for %s", id)
 		}
 
 		if d.HasChange("metadata") {
@@ -534,7 +533,6 @@ func resourceStorageShareUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 				return fmt.Errorf("updating MetaData for %s: %v", id, err)
 			}
 
-			log.Printf("[DEBUG] Updated the MetaData for %s", id)
 		}
 
 		if d.HasChange("acl") {
@@ -546,7 +544,6 @@ func resourceStorageShareUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 				return fmt.Errorf("updating ACLs for %s: %v", id, err)
 			}
 
-			log.Printf("[DEBUG] Updated ACLs for %s", id)
 		}
 
 		if d.HasChange("access_tier") {
@@ -566,7 +563,6 @@ func resourceStorageShareUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 				return fmt.Errorf("updating access tier %s: %+v", id, err)
 			}
 
-			log.Printf("[DEBUG] Updated Access Tier for %s", id)
 		}
 
 		return resourceStorageShareRead(d, meta)

--- a/internal/services/storage/storage_share_resource.go
+++ b/internal/services/storage/storage_share_resource.go
@@ -152,7 +152,8 @@ func resourceStorageShare() *pluginsdk.Resource {
 						string(shares.HotAccessTier),
 						string(shares.CoolAccessTier),
 						string(shares.TransactionOptimizedAccessTier),
-					}, false),
+					}, false,
+				),
 			},
 
 			"rbac_scope_id": {

--- a/internal/services/storage/storage_share_resource.go
+++ b/internal/services/storage/storage_share_resource.go
@@ -275,7 +275,6 @@ func resourceStorageShareCreate(d *pluginsdk.ResourceData, meta interface{}) err
 				return tf.ImportAsExistsError("azurerm_storage_share", id.ID())
 			}
 
-			log.Printf("[INFO] Creating Share %q in Storage Account %q", shareName, accountName)
 			input := shares.CreateInput{
 				QuotaInGB:       quota,
 				MetaData:        metaData,
@@ -517,7 +516,6 @@ func resourceStorageShareUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 		}
 
 		if d.HasChange("quota") {
-			log.Printf("[DEBUG] Updating the Quota for %s", id)
 			quota := d.Get("quota").(int)
 
 			if err = client.UpdateQuota(ctx, id.ShareName, quota); err != nil {
@@ -528,7 +526,6 @@ func resourceStorageShareUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 		}
 
 		if d.HasChange("metadata") {
-			log.Printf("[DEBUG] Updating the MetaData for %s", id)
 
 			metaDataRaw := d.Get("metadata").(map[string]interface{})
 			metaData := ExpandMetaData(metaDataRaw)
@@ -541,7 +538,6 @@ func resourceStorageShareUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 		}
 
 		if d.HasChange("acl") {
-			log.Printf("[DEBUG] Updating the ACLs for %s", id)
 
 			aclsRaw := d.Get("acl").(*pluginsdk.Set).List()
 			acls := expandStorageShareACLsDeprecated(aclsRaw)

--- a/internal/services/storage/storage_share_resource.go
+++ b/internal/services/storage/storage_share_resource.go
@@ -522,29 +522,24 @@ func resourceStorageShareUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 			if err = client.UpdateQuota(ctx, id.ShareName, quota); err != nil {
 				return fmt.Errorf("updating Quota for %s: %v", id, err)
 			}
-
 		}
 
 		if d.HasChange("metadata") {
-
 			metaDataRaw := d.Get("metadata").(map[string]interface{})
 			metaData := ExpandMetaData(metaDataRaw)
 
 			if err = client.UpdateMetaData(ctx, id.ShareName, metaData); err != nil {
 				return fmt.Errorf("updating MetaData for %s: %v", id, err)
 			}
-
 		}
 
 		if d.HasChange("acl") {
-
 			aclsRaw := d.Get("acl").(*pluginsdk.Set).List()
 			acls := expandStorageShareACLsDeprecated(aclsRaw)
 
 			if err = client.UpdateACLs(ctx, id.ShareName, shares.SetAclInput{SignedIdentifiers: acls}); err != nil {
 				return fmt.Errorf("updating ACLs for %s: %v", id, err)
 			}
-
 		}
 
 		if d.HasChange("access_tier") {
@@ -563,7 +558,6 @@ func resourceStorageShareUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 			if err != nil {
 				return fmt.Errorf("updating access tier %s: %+v", id, err)
 			}
-
 		}
 
 		return resourceStorageShareRead(d, meta)

--- a/internal/services/storage/storage_table_resource.go
+++ b/internal/services/storage/storage_table_resource.go
@@ -286,7 +286,6 @@ func resourceStorageTableUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 	}
 
 	if d.HasChange("acl") {
-		log.Printf("[DEBUG] Updating ACLs for %s", id)
 
 		aclsRaw := d.Get("acl").(*pluginsdk.Set).List()
 		acls := expandStorageTableACLs(aclsRaw)

--- a/internal/services/storage/storage_table_resource.go
+++ b/internal/services/storage/storage_table_resource.go
@@ -300,7 +300,6 @@ func resourceStorageTableUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 			return fmt.Errorf("updating ACLs for %s: %v", id, err)
 		}
 
-		log.Printf("[DEBUG] Updated ACLs for %s", id)
 	}
 
 	return resourceStorageTableRead(d, meta)

--- a/internal/services/storage/storage_table_resource.go
+++ b/internal/services/storage/storage_table_resource.go
@@ -286,7 +286,6 @@ func resourceStorageTableUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 	}
 
 	if d.HasChange("acl") {
-
 		aclsRaw := d.Get("acl").(*pluginsdk.Set).List()
 		acls := expandStorageTableACLs(aclsRaw)
 
@@ -299,7 +298,6 @@ func resourceStorageTableUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 		if err = aclClient.UpdateACLs(ctx, id.TableName, acls); err != nil {
 			return fmt.Errorf("updating ACLs for %s: %v", id, err)
 		}
-
 	}
 
 	return resourceStorageTableRead(d, meta)

--- a/internal/services/storagecache/hpc_cache_blob_target_resource.go
+++ b/internal/services/storagecache/hpc_cache_blob_target_resource.go
@@ -88,7 +88,6 @@ func resourceHPCCacheBlobTargetCreateOrUpdate(d *pluginsdk.ResourceData, meta in
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Azure HPC Cache Blob Target creation.")
 	id := storagetargets.NewStorageTargetID(subscriptionId, d.Get("resource_group_name").(string), d.Get("cache_name").(string), d.Get("name").(string))
 
 	if d.IsNewResource() {

--- a/internal/services/storagecache/hpc_cache_nfs_target_resource.go
+++ b/internal/services/storagecache/hpc_cache_nfs_target_resource.go
@@ -139,7 +139,6 @@ func resourceHPCCacheNFSTargetCreateOrUpdate(d *pluginsdk.ResourceData, meta int
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Azure HPC Cache NFS Target creation.")
 	id := storagetargets.NewStorageTargetID(subscriptionId, d.Get("resource_group_name").(string), d.Get("cache_name").(string), d.Get("name").(string))
 
 	if d.IsNewResource() {

--- a/internal/services/storagecache/hpc_cache_resource.go
+++ b/internal/services/storagecache/hpc_cache_resource.go
@@ -60,7 +60,6 @@ func resourceHPCCacheCreateOrUpdate(d *pluginsdk.ResourceData, meta interface{})
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Azure HPC Cache creation.")
 	name := d.Get("name").(string)
 	resourceGroup := d.Get("resource_group_name").(string)
 

--- a/internal/services/streamanalytics/stream_analytics_cluster_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_cluster_resource.go
@@ -170,8 +170,6 @@ func (r ClusterResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("deleting %s", *id)
-
 			if err := client.DeleteThenPoll(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}

--- a/internal/services/streamanalytics/stream_analytics_job_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_job_resource.go
@@ -226,8 +226,6 @@ func resourceStreamAnalyticsJobCreate(d *pluginsdk.ResourceData, meta interface{
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Azure Stream Analytics Job creation.")
-
 	id := streamingjobs.NewStreamingJobID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
 	locks.ByID(id.ID())
@@ -427,8 +425,6 @@ func resourceStreamAnalyticsJobUpdate(d *pluginsdk.ResourceData, meta interface{
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for Azure Stream Analytics Job update.")
 
 	id, err := streamingjobs.ParseStreamingJobID(d.Id())
 	if err != nil {

--- a/internal/services/streamanalytics/stream_analytics_job_schedule_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_job_schedule_resource.go
@@ -260,8 +260,6 @@ func (r JobScheduleResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("deleting %s", *id)
-
 			streamingJobId := streamingjobs.NewStreamingJobID(id.SubscriptionId, id.ResourceGroup, id.StreamingJobName)
 			if err := client.StopThenPoll(ctx, streamingJobId); err != nil {
 				return fmt.Errorf("deleting %s: %+v", *id, err)

--- a/internal/services/streamanalytics/stream_analytics_managed_private_endpoint_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_managed_private_endpoint_resource.go
@@ -179,8 +179,6 @@ func (r ManagedPrivateEndpointResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("deleting %s", *id)
-
 			if err := client.DeleteThenPoll(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}

--- a/internal/services/streamanalytics/stream_analytics_output_cosmosdb_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_output_cosmosdb_resource.go
@@ -246,8 +246,6 @@ func (r OutputCosmosDBResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("deleting %s", *id)
-
 			if resp, err := client.Delete(ctx, *id); err != nil {
 				if !response.WasNotFound(resp.HttpResponse) {
 					return fmt.Errorf("deleting %s: %+v", *id, err)

--- a/internal/services/streamanalytics/stream_analytics_output_function_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_output_function_resource.go
@@ -253,8 +253,6 @@ func (r OutputFunctionResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("deleting %s", *id)
-
 			if _, err := client.Delete(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}

--- a/internal/services/streamanalytics/stream_analytics_output_powerbi_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_output_powerbi_resource.go
@@ -318,8 +318,6 @@ func (r OutputPowerBIResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("deleting %s", *id)
-
 			if resp, err := client.Delete(ctx, *id); err != nil {
 				if !response.WasNotFound(resp.HttpResponse) {
 					return fmt.Errorf("deleting %s: %+v", *id, err)

--- a/internal/services/streamanalytics/stream_analytics_output_servicebus_topic_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_output_servicebus_topic_resource.go
@@ -126,7 +126,6 @@ func resourceStreamAnalyticsOutputServiceBusTopicCreateUpdate(d *pluginsdk.Resou
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Azure Stream Analytics Output ServiceBus Topic creation.")
 	id := outputs.NewOutputID(subscriptionId, d.Get("resource_group_name").(string), d.Get("stream_analytics_job_name").(string), d.Get("name").(string))
 
 	if d.IsNewResource() {

--- a/internal/services/streamanalytics/stream_analytics_output_table_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_output_table_resource.go
@@ -315,8 +315,6 @@ func (r OutputTableResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("deleting %s", *id)
-
 			if resp, err := client.Delete(ctx, *id); err != nil {
 				if !response.WasNotFound(resp.HttpResponse) {
 					return fmt.Errorf("deleting %s: %+v", *id, err)

--- a/internal/services/streamanalytics/stream_analytics_reference_input_blob_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_reference_input_blob_resource.go
@@ -119,7 +119,6 @@ func resourceStreamAnalyticsReferenceInputBlobCreate(d *pluginsdk.ResourceData, 
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Azure Stream Analytics Reference Input Blob creation.")
 	id := inputs.NewInputID(subscriptionId, d.Get("resource_group_name").(string), d.Get("stream_analytics_job_name").(string), d.Get("name").(string))
 	if d.IsNewResource() {
 		existing, err := client.Get(ctx, id)
@@ -176,7 +175,6 @@ func resourceStreamAnalyticsReferenceInputBlobUpdate(d *pluginsdk.ResourceData, 
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Azure Stream Analytics Reference Input Blob update.")
 	id, err := inputs.ParseInputID(d.Id())
 	if err != nil {
 		return err

--- a/internal/services/streamanalytics/stream_analytics_reference_input_mssql_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_reference_input_mssql_resource.go
@@ -130,7 +130,6 @@ func resourceStreamAnalyticsReferenceInputMsSqlCreateUpdate(d *pluginsdk.Resourc
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Azure Stream Analytics Reference Input MsSql creation.")
 	id := inputs.NewInputID(subscriptionId, d.Get("resource_group_name").(string), d.Get("stream_analytics_job_name").(string), d.Get("name").(string))
 	if d.IsNewResource() {
 		existing, err := client.Get(ctx, id)

--- a/internal/services/streamanalytics/stream_analytics_stream_input_blob_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_stream_input_blob_resource.go
@@ -118,7 +118,6 @@ func resourceStreamAnalyticsStreamInputBlobCreateUpdate(d *pluginsdk.ResourceDat
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Azure Stream Analytics Stream Input Blob creation.")
 	id := inputs.NewInputID(subscriptionId, d.Get("resource_group_name").(string), d.Get("stream_analytics_job_name").(string), d.Get("name").(string))
 
 	if d.IsNewResource() {

--- a/internal/services/streamanalytics/stream_analytics_stream_input_eventhub_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_stream_input_eventhub_resource.go
@@ -119,7 +119,6 @@ func resourceStreamAnalyticsStreamInputEventHubCreateUpdate(d *pluginsdk.Resourc
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Azure Stream Analytics Stream Input EventHub creation.")
 	id := inputs.NewInputID(subscriptionId, d.Get("resource_group_name").(string), d.Get("stream_analytics_job_name").(string), d.Get("name").(string))
 	if d.IsNewResource() {
 		existing, err := client.Get(ctx, id)

--- a/internal/services/streamanalytics/stream_analytics_stream_input_eventhub_v2_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_stream_input_eventhub_v2_resource.go
@@ -345,8 +345,6 @@ func (r StreamInputEventHubV2Resource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("deleting %s", *id)
-
 			if resp, err := client.Delete(ctx, *id); err != nil {
 				if !response.WasNotFound(resp.HttpResponse) {
 					return fmt.Errorf("deleting %s: %+v", *id, err)

--- a/internal/services/streamanalytics/stream_analytics_stream_input_iothub_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_stream_input_iothub_resource.go
@@ -104,8 +104,6 @@ func resourceStreamAnalyticsStreamInputIoTHubCreateUpdate(d *pluginsdk.ResourceD
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for Azure Stream Analytics Stream Input IoTHub creation.")
-
 	id := inputs.NewInputID(subscriptionId, d.Get("resource_group_name").(string), d.Get("stream_analytics_job_name").(string), d.Get("name").(string))
 	if d.IsNewResource() {
 		existing, err := client.Get(ctx, id)

--- a/internal/services/trafficmanager/traffic_manager_profile_resource.go
+++ b/internal/services/trafficmanager/traffic_manager_profile_resource.go
@@ -6,7 +6,6 @@ package trafficmanager
 import (
 	"errors"
 	"fmt"
-	"log"
 	"math"
 	"strconv"
 	"strings"
@@ -208,8 +207,6 @@ func resourceArmTrafficManagerProfileCreate(d *pluginsdk.ResourceData, meta inte
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-
-	log.Printf("[INFO] preparing arguments for Traffic Manager Profile creation.")
 
 	id := profiles.NewTrafficManagerProfileID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 	existing, err := client.Get(ctx, id)

--- a/internal/services/videoindexer/video_indexer_account_resource.go
+++ b/internal/services/videoindexer/video_indexer_account_resource.go
@@ -247,7 +247,6 @@ func (r AccountResource) Delete() sdk.ResourceFunc {
 			client := metadata.Client.VideoIndexer.AccountClient
 
 			id, err := accounts.ParseAccountID(metadata.ResourceData.Id())
-			metadata.Logger.Infof("deleting %s", id)
 
 			if err != nil {
 				return err

--- a/internal/services/videoindexer/video_indexer_account_resource.go
+++ b/internal/services/videoindexer/video_indexer_account_resource.go
@@ -247,7 +247,6 @@ func (r AccountResource) Delete() sdk.ResourceFunc {
 			client := metadata.Client.VideoIndexer.AccountClient
 
 			id, err := accounts.ParseAccountID(metadata.ResourceData.Id())
-
 			if err != nil {
 				return err
 			}

--- a/internal/services/vmware/vmware_netapp_volume_attachment_resource.go
+++ b/internal/services/vmware/vmware_netapp_volume_attachment_resource.go
@@ -70,7 +70,6 @@ func (r NetappFileVolumeAttachmentResource) IDValidationFunc() pluginsdk.SchemaV
 func (r NetappFileVolumeAttachmentResource) Create() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
-			metadata.Logger.Infof("Decoding state...")
 			var state NetappFileVolumeAttachment
 			if err := metadata.Decode(&state); err != nil {
 				return err
@@ -85,7 +84,6 @@ func (r NetappFileVolumeAttachmentResource) Create() sdk.ResourceFunc {
 			}
 
 			id := datastores.NewDataStoreID(subscriptionId, vmWareClusterId.ResourceGroupName, vmWareClusterId.PrivateCloudName, vmWareClusterId.ClusterName, state.Name)
-			metadata.Logger.Infof("creating %s", id)
 
 			existing, err := client.Get(ctx, id)
 			if err != nil && !response.WasNotFound(existing.HttpResponse) {
@@ -125,11 +123,9 @@ func (r NetappFileVolumeAttachmentResource) Read() sdk.ResourceFunc {
 			}
 			clusterId := datastores.NewClusterID(id.SubscriptionId, id.ResourceGroupName, id.PrivateCloudName, id.ClusterName)
 
-			metadata.Logger.Infof("retrieving %s", *id)
 			resp, err := client.Get(ctx, *id)
 			if err != nil {
 				if response.WasNotFound(resp.HttpResponse) {
-					metadata.Logger.Infof("%s was not found - removing from state!", *id)
 					return metadata.MarkAsGone(id)
 				}
 				return fmt.Errorf("retrieving %s: %+v", *id, err)
@@ -162,7 +158,6 @@ func (r NetappFileVolumeAttachmentResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			metadata.Logger.Infof("deleting %s..", *id)
 			if err := client.DeleteThenPoll(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}

--- a/internal/services/web/app_service_plan_resource.go
+++ b/internal/services/web/app_service_plan_resource.go
@@ -320,8 +320,6 @@ func resourceAppServicePlanDelete(d *pluginsdk.ResourceData, meta interface{}) e
 		return err
 	}
 
-	log.Printf("[DEBUG] Deleting App Service Plan %q (Resource Group %q)", id.ServerFarmName, id.ResourceGroup)
-
 	resp, err := client.Delete(ctx, id.ResourceGroup, id.ServerFarmName)
 	if err != nil {
 		if !utils.ResponseWasNotFound(resp) {

--- a/internal/services/web/app_service_plan_resource.go
+++ b/internal/services/web/app_service_plan_resource.go
@@ -158,8 +158,6 @@ func resourceAppServicePlanCreateUpdate(d *pluginsdk.ResourceData, meta interfac
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for AzureRM App Service Plan creation.")
-
 	id := parse.NewAppServicePlanID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
 	if d.IsNewResource() {

--- a/internal/services/web/app_service_public_certificate_resource.go
+++ b/internal/services/web/app_service_public_certificate_resource.go
@@ -219,8 +219,6 @@ func resourceAppServicePublicCertificateDelete(d *pluginsdk.ResourceData, meta i
 		return err
 	}
 
-	log.Printf("[DEBUG] Deleting App Service Public Certificate %s", *id)
-
 	resp, err := client.DeletePublicCertificate(ctx, *id)
 	if err != nil {
 		if !response.WasNotFound(resp.HttpResponse) {

--- a/internal/services/web/app_service_resource.go
+++ b/internal/services/web/app_service_resource.go
@@ -234,7 +234,6 @@ func resourceAppServiceCreate(d *pluginsdk.ResourceData, meta interface{}) error
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for AzureRM App Service creation.")
 	id := parse.NewAppServiceID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
 	existing, err := client.Get(ctx, id.ResourceGroup, id.SiteName)

--- a/internal/services/web/app_service_resource.go
+++ b/internal/services/web/app_service_resource.go
@@ -804,8 +804,6 @@ func resourceAppServiceDelete(d *pluginsdk.ResourceData, meta interface{}) error
 		return err
 	}
 
-	log.Printf("[DEBUG] Deleting App Service %q (resource group %q)", id.SiteName, id.ResourceGroup)
-
 	deleteMetrics := true
 	deleteEmptyServerFarm := false
 	resp, err := client.Delete(ctx, id.ResourceGroup, id.SiteName, &deleteMetrics, &deleteEmptyServerFarm)

--- a/internal/services/web/app_service_slot_resource.go
+++ b/internal/services/web/app_service_slot_resource.go
@@ -558,8 +558,6 @@ func resourceAppServiceSlotDelete(d *pluginsdk.ResourceData, meta interface{}) e
 		return err
 	}
 
-	log.Printf("[DEBUG] Deleting Slot %q (App Service %q / Resource Group %q)", id.SlotName, id.SiteName, id.ResourceGroup)
-
 	deleteMetrics := true
 	deleteEmptyServerFarm := false
 	resp, err := client.DeleteSlot(ctx, id.ResourceGroup, id.SiteName, id.SlotName, &deleteMetrics, &deleteEmptyServerFarm)

--- a/internal/services/web/app_service_source_control_token_resource.go
+++ b/internal/services/web/app_service_source_control_token_resource.go
@@ -140,8 +140,6 @@ func resourceAppServiceSourceControlTokenDelete(d *pluginsdk.ResourceData, meta 
 	locks.ByName(scmType, appServiceSourceControlTokenResourceName)
 	defer locks.UnlockByName(scmType, appServiceSourceControlTokenResourceName)
 
-	log.Printf("[DEBUG] Deleting App Service Source Control Token (Type %q)", scmType)
-
 	properties := web.SourceControl{
 		SourceControlProperties: &web.SourceControlProperties{
 			Token:       pointer.To(token),

--- a/internal/services/web/app_service_source_control_token_resource.go
+++ b/internal/services/web/app_service_source_control_token_resource.go
@@ -75,8 +75,6 @@ func resourceAppServiceSourceControlTokenCreateUpdate(d *pluginsdk.ResourceData,
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for App Service Source Control Token creation.")
-
 	token := d.Get("token").(string)
 	tokenSecret := d.Get("token_secret").(string)
 	id := parse.NewAppServiceSourceControlTokenID(d.Get("type").(string))

--- a/internal/services/web/function_app_resource.go
+++ b/internal/services/web/function_app_resource.go
@@ -254,8 +254,6 @@ func resourceFunctionAppCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 		return fmt.Errorf("could not determine Storage domain suffix for environment %q", meta.(*clients.Client).Account.Environment.Name)
 	}
 
-	log.Printf("[INFO] preparing arguments for AzureRM Function App creation.")
-
 	id := parse.NewFunctionAppID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
 	existing, err := client.Get(ctx, id.ResourceGroup, id.SiteName)

--- a/internal/services/web/function_app_resource.go
+++ b/internal/services/web/function_app_resource.go
@@ -777,8 +777,6 @@ func resourceFunctionAppDelete(d *pluginsdk.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	log.Printf("[DEBUG] Deleting Function App %q (resource group %q)", id.SiteName, id.ResourceGroup)
-
 	deleteMetrics := true
 	deleteEmptyServerFarm := false
 	resp, err := client.Delete(ctx, id.ResourceGroup, id.SiteName, &deleteMetrics, &deleteEmptyServerFarm)

--- a/internal/services/web/function_app_slot_resource.go
+++ b/internal/services/web/function_app_slot_resource.go
@@ -231,8 +231,6 @@ func resourceFunctionAppSlotCreate(d *pluginsdk.ResourceData, meta interface{}) 
 		return fmt.Errorf("could not determine Storage domain suffix for environment %q", meta.(*clients.Client).Account.Environment.Name)
 	}
 
-	log.Printf("[INFO] preparing arguments for AzureRM Function App Slot creation.")
-
 	id := parse.NewFunctionAppSlotID(subscriptionId, d.Get("resource_group_name").(string), d.Get("function_app_name").(string), d.Get("name").(string))
 
 	if d.IsNewResource() {

--- a/internal/services/web/function_app_slot_resource.go
+++ b/internal/services/web/function_app_slot_resource.go
@@ -617,8 +617,6 @@ func resourceFunctionAppSlotDelete(d *pluginsdk.ResourceData, meta interface{}) 
 		return err
 	}
 
-	log.Printf("[DEBUG] Deleting Function App Slot %q (Function App %q / Resource Group %q)", id.SlotName, id.SiteName, id.ResourceGroup)
-
 	deleteMetrics := true
 	deleteEmptyServerFarm := false
 	resp, err := client.DeleteSlot(ctx, id.ResourceGroup, id.SiteName, id.SlotName, &deleteMetrics, &deleteEmptyServerFarm)

--- a/internal/services/web/function_app_slot_resource.go
+++ b/internal/services/web/function_app_slot_resource.go
@@ -690,8 +690,6 @@ func getFunctionAppSlotServiceTier(ctx context.Context, appServicePlanID string,
 		return "", fmt.Errorf("[ERROR] Unable to parse App Service Plan ID %q: %+v", appServicePlanID, err)
 	}
 
-	log.Printf("[DEBUG] Retrieving App Service Plan %q (Resource Group %q)", id.ServerFarmName, id.ResourceGroup)
-
 	appServicePlansClient := meta.(*clients.Client).Web.AppServicePlansClientV1
 	appServicePlan, err := appServicePlansClient.Get(ctx, id.ResourceGroup, id.ServerFarmName)
 	if err != nil {

--- a/internal/services/web/static_site_custom_domain_resource.go
+++ b/internal/services/web/static_site_custom_domain_resource.go
@@ -81,8 +81,6 @@ func resourceStaticSiteCustomDomainCreate(d *pluginsdk.ResourceData, meta interf
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for AzureRM Static Site custom domain creation.")
-
 	staticSiteId, err := parse.StaticSiteID(d.Get("static_site_id").(string))
 	if err != nil {
 		return err

--- a/internal/services/web/static_site_custom_domain_resource.go
+++ b/internal/services/web/static_site_custom_domain_resource.go
@@ -210,8 +210,6 @@ func resourceStaticSiteCustomDomainDelete(d *pluginsdk.ResourceData, meta interf
 		return err
 	}
 
-	log.Printf("[DEBUG] Deleting Static Site Custom Domain %q (resource group %q)", id.CustomDomainName, id.ResourceGroup)
-
 	future, err := client.DeleteStaticSiteCustomDomain(ctx, id.ResourceGroup, id.StaticSiteName, id.CustomDomainName)
 	if err != nil {
 		return fmt.Errorf("deleting %s: %+v", id, err)

--- a/internal/services/web/static_site_resource.go
+++ b/internal/services/web/static_site_resource.go
@@ -108,8 +108,6 @@ func resourceStaticSiteCreateOrUpdate(d *pluginsdk.ResourceData, meta interface{
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Printf("[INFO] preparing arguments for AzureRM Static Site creation.")
-
 	id := parse.NewStaticSiteID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
 	if d.IsNewResource() {

--- a/internal/services/web/static_site_resource.go
+++ b/internal/services/web/static_site_resource.go
@@ -258,8 +258,6 @@ func resourceStaticSiteDelete(d *pluginsdk.ResourceData, meta interface{}) error
 		return err
 	}
 
-	log.Printf("[DEBUG] Deleting Static Site %q (resource group %q)", id.Name, id.ResourceGroup)
-
 	future, err := client.DeleteStaticSite(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
 		if !response.WasNotFound(future.Response()) {


### PR DESCRIPTION
removing lifecycle logging as it was inconsistent and only a minority of resources implemented it.

If we want lifecycle logging it should likely go into the SDK.