### PR TITLE
azurerm_security_center_subscription_pricing - lock using subscription id so parallel changes do not fail

### DIFF
--- a/internal/services/securitycenter/security_center_subscription_pricing_resource.go
+++ b/internal/services/securitycenter/security_center_subscription_pricing_resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/preview/security/mgmt/v3.0/security" // nolint: staticcheck
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	pricings_v2023_01_01 "github.com/hashicorp/go-azure-sdk/resource-manager/security/2023-01-01/pricings"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -121,8 +122,8 @@ func resourceSecurityCenterSubscriptionPricingCreate(d *pluginsdk.ResourceData, 
 
 	// Lock on subscription ID to prevent concurrent pricing updates across different resource types,
 	// as the API only allows one pricing update per subscription at a time.
-	locks.ByName(subscriptionId, "azurerm_security_center_subscription_pricing")
-	defer locks.UnlockByName(subscriptionId, "azurerm_security_center_subscription_pricing")
+	locks.ByID(commonids.NewSubscriptionID(id.SubscriptionId).ID())
+	defer locks.UnlockByID(commonids.NewSubscriptionID(id.SubscriptionId).ID())
 
 	pricing := pricings_v2023_01_01.Pricing{
 		Properties: &pricings_v2023_01_01.PricingProperties{
@@ -207,8 +208,8 @@ func resourceSecurityCenterSubscriptionPricingUpdate(d *pluginsdk.ResourceData, 
 
 	// Lock on subscription ID to prevent concurrent pricing updates across different resource types,
 	// as the API only allows one pricing update per subscription at a time.
-	locks.ByName(id.SubscriptionId, "azurerm_security_center_subscription_pricing")
-	defer locks.UnlockByName(id.SubscriptionId, "azurerm_security_center_subscription_pricing")
+	locks.ByID(commonids.NewSubscriptionID(id.SubscriptionId).ID())
+	defer locks.UnlockByID(commonids.NewSubscriptionID(id.SubscriptionId).ID())
 
 	apiResponse, err := client.Get(ctx, *id)
 	if err != nil {
@@ -327,8 +328,8 @@ func resourceSecurityCenterSubscriptionPricingDelete(d *pluginsdk.ResourceData, 
 
 	// Lock on subscription ID to prevent concurrent pricing updates across different resource types,
 	// as the API only allows one pricing update per subscription at a time.
-	locks.ByName(id.SubscriptionId, "azurerm_security_center_subscription_pricing")
-	defer locks.UnlockByName(id.SubscriptionId, "azurerm_security_center_subscription_pricing")
+	locks.ByID(commonids.NewSubscriptionID(id.SubscriptionId).ID())
+	defer locks.UnlockByID(commonids.NewSubscriptionID(id.SubscriptionId).ID())
 
 	pricing := pricings_v2023_01_01.Pricing{
 		Properties: &pricings_v2023_01_01.PricingProperties{

--- a/internal/services/securitycenter/security_center_subscription_pricing_resource.go
+++ b/internal/services/securitycenter/security_center_subscription_pricing_resource.go
@@ -15,6 +15,7 @@ import (
 	pricings_v2023_01_01 "github.com/hashicorp/go-azure-sdk/resource-manager/security/2023-01-01/pricings"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/securitycenter/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/securitycenter/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -118,6 +119,11 @@ func resourceSecurityCenterSubscriptionPricingCreate(d *pluginsdk.ResourceData, 
 	defer cancel()
 	id := pricings_v2023_01_01.NewPricingID(subscriptionId, d.Get("resource_type").(string))
 
+	// Lock on subscription ID to prevent concurrent pricing updates across different resource types,
+	// as the API only allows one pricing update per subscription at a time.
+	locks.ByName(subscriptionId, "azurerm_security_center_subscription_pricing")
+	defer locks.UnlockByName(subscriptionId, "azurerm_security_center_subscription_pricing")
+
 	pricing := pricings_v2023_01_01.Pricing{
 		Properties: &pricings_v2023_01_01.PricingProperties{
 			PricingTier: pricings_v2023_01_01.PricingTier(d.Get("tier").(string)),
@@ -198,6 +204,11 @@ func resourceSecurityCenterSubscriptionPricingUpdate(d *pluginsdk.ResourceData, 
 	if err != nil {
 		return err
 	}
+
+	// Lock on subscription ID to prevent concurrent pricing updates across different resource types,
+	// as the API only allows one pricing update per subscription at a time.
+	locks.ByName(id.SubscriptionId, "azurerm_security_center_subscription_pricing")
+	defer locks.UnlockByName(id.SubscriptionId, "azurerm_security_center_subscription_pricing")
 
 	apiResponse, err := client.Get(ctx, *id)
 	if err != nil {
@@ -313,6 +324,11 @@ func resourceSecurityCenterSubscriptionPricingDelete(d *pluginsdk.ResourceData, 
 	if err != nil {
 		return fmt.Errorf("parsing %s: %+v", d.Id(), err)
 	}
+
+	// Lock on subscription ID to prevent concurrent pricing updates across different resource types,
+	// as the API only allows one pricing update per subscription at a time.
+	locks.ByName(id.SubscriptionId, "azurerm_security_center_subscription_pricing")
+	defer locks.UnlockByName(id.SubscriptionId, "azurerm_security_center_subscription_pricing")
 
 	pricing := pricings_v2023_01_01.Pricing{
 		Properties: &pricings_v2023_01_01.PricingProperties{

--- a/internal/services/securitycenter/security_center_subscription_pricing_resource_test.go
+++ b/internal/services/securitycenter/security_center_subscription_pricing_resource_test.go
@@ -82,6 +82,24 @@ func TestAccSecurityCenterSubscriptionPricing_update(t *testing.T) {
 	})
 }
 
+func TestAccSecurityCenterSubscriptionPricing_multiplePricingResources(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_security_center_subscription_pricing", "test_storage_accounts")
+	r := SecurityCenterSubscriptionPricingResource{}
+
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.multiplePricingResources(),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("tier").HasValue("Standard"),
+				check.That(data.ResourceName).Key("resource_type").HasValue("StorageAccounts"),
+				acceptance.TestCheckResourceAttr("azurerm_security_center_subscription_pricing.test_key_vaults", "tier", "Standard"),
+				acceptance.TestCheckResourceAttr("azurerm_security_center_subscription_pricing.test_key_vaults", "resource_type", "KeyVaults"),
+			),
+		},
+	})
+}
+
 func TestAccSecurityCenterSubscriptionPricing_cosmosDbs(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_security_center_subscription_pricing", "test")
 	r := SecurityCenterSubscriptionPricingResource{}
@@ -380,6 +398,55 @@ provider "azurerm" {
 resource "azurerm_security_center_subscription_pricing" "test" {
   tier          = "Free"
   resource_type = "CloudPosture"
+}
+`
+}
+
+func (SecurityCenterSubscriptionPricingResource) multiplePricingResources() string {
+	return `
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_security_center_subscription_pricing" "test" {
+  tier          = "Standard"
+  resource_type = "CloudPosture"
+
+  extension {
+    name = "SensitiveDataDiscovery"
+  }
+
+  extension {
+    name = "AgentlessVmScanning"
+    additional_extension_properties = {
+      ExclusionTags = "[]"
+    }
+  }
+}
+
+resource "azurerm_security_center_subscription_pricing" "test_storage_accounts" {
+  tier          = "Standard"
+  resource_type = "StorageAccounts"
+  subplan       = "DefenderForStorageV2"
+
+  extension {
+    additional_extension_properties = {
+      CapGBPerMonthPerStorageAccount = "5000"
+      AutomatedResponse              = "None"
+      BlobScanResultsOptions         = "BlobIndexTags"
+    }
+    name = "OnUploadMalwareScanning"
+  }
+
+  extension {
+    name = "SensitiveDataDiscovery"
+  }
+}
+
+resource "azurerm_security_center_subscription_pricing" "test_key_vaults" {
+  tier          = "Standard"
+  resource_type = "KeyVaults"
+  subplan       = "PerKeyVault"
 }
 `
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Lock pricing changes on subscription id so parallel changes do not fail.

│ Error: setting Pricing (Subscription: "xxxxxx"
│ Pricing Name: "CosmosDbs"): unexpected status 409 (409 Conflict) with error: Conflict: Another update operation is in progress. Please retry in a few minutes
│ 
│   with azurerm_security_center_subscription_pricing.this["CosmosDbs"],
│   on main.tf line 7, in resource "azurerm_security_center_subscription_pricing" "this":
│    7: resource "azurerm_security_center_subscription_pricing" "this" {
│ 
╵


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] ~I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.~
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] ~(For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.~


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_security_center_subscription_pricing` - prevent pricing to run in parallel on the same subscription


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change

Fixes #32451 

## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
