### PR TITLE
`Contributing Guides` - Clarify `None` value handling for data sources

### DIFF
--- a/contributing/topics/schema-design-considerations.md
+++ b/contributing/topics/schema-design-considerations.md
@@ -174,7 +174,7 @@ func (r resource) Read() sdk.ResourceFunc {
 }
 ```
 
-> **Note:** The above guidance applies to resources. For data sources, the `Read` function should return whatever value is retrieved from Azure, including `None`, rather than converting it to an empty value.
+> **Note:** The above guidance applies to any user-specifiable properties. For properties that are computed only, the `Read` function should return the value that is retrieved from Azure, including `None`, rather than converting it to an empty value.
 
 ## SKU fields
 

--- a/contributing/topics/schema-design-considerations.md
+++ b/contributing/topics/schema-design-considerations.md
@@ -174,6 +174,8 @@ func (r resource) Read() sdk.ResourceFunc {
 }
 ```
 
+> **Note:** The above guidance applies to resources. For data sources, the `Read` function should return whatever value is retrieved from Azure, including `None`, rather than converting it to an empty value.
+
 ## SKU fields
 
 Because the Azure API implementation for SKU fields tends to vary we can't easily standardise on a single approach, however, we should try to stick to one of the following two implementations:


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Clarifies that the `None` value guidance only applies to resources. Data sources should return the value from Azure as-is, including `None`.

Ref: https://github.com/hashicorp/terraform-provider-azurerm/pull/31216#discussion_r2746716142

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
