### PR TITLE
`azurerm_role_assignment` - use deterministic method to generate `name` property

### DIFF
--- a/internal/services/authorization/parse/role_assignment.go
+++ b/internal/services/authorization/parse/role_assignment.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/gofrs/uuid"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/authorization/2022-05-01-preview/roledefinitions"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 )
 
@@ -214,13 +215,17 @@ func RoleAssignmentID(input string) (*RoleAssignmentId, error) {
 	return &roleAssignmentId, nil
 }
 
-func RoleAssignmentName(scope string, principalId string, roleDefinitionId string) string {
+func RoleAssignmentName(scope string, principalId string, roleDefinitionId string) (string, error) {
 	namespace := uuid.Must(uuid.FromString("11fb06fb-712d-4ddd-98c7-e71bbd588830"))
 
 	normalizedScope := strings.TrimSuffix(strings.ToLower(scope), "/")
 	normalizedPrincipalId := strings.ToLower(principalId)
-	normalizedRoleDefinitionId := strings.ToLower(roleDefinitionId)
+	scopedRoleDefinitionId, err := roledefinitions.ParseScopedRoleDefinitionID(roleDefinitionId)
+	if err != nil {
+		return "", fmt.Errorf("parsing role definition ID %q: %+v", roleDefinitionId, err)
+	}
+	normalizedRoleDefinitionId := strings.ToLower(scopedRoleDefinitionId.RoleDefinitionId)
 	str := fmt.Sprintf("%s-%s-%s", normalizedScope, normalizedPrincipalId, normalizedRoleDefinitionId)
 
-	return uuid.NewV5(namespace, str).String()
+	return uuid.NewV5(namespace, str).String(), nil
 }

--- a/internal/services/authorization/parse/role_assignment.go
+++ b/internal/services/authorization/parse/role_assignment.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/gofrs/uuid"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 )
 
@@ -211,4 +212,15 @@ func RoleAssignmentID(input string) (*RoleAssignmentId, error) {
 	}
 
 	return &roleAssignmentId, nil
+}
+
+func RoleAssignmentName(scope string, principalId string, roleDefinitionId string) string {
+	namespace := uuid.Must(uuid.FromString("11fb06fb-712d-4ddd-98c7-e71bbd588830"))
+
+	normalizedScope := strings.TrimSuffix(strings.ToLower(scope), "/")
+	normalizedPrincipalId := strings.ToLower(principalId)
+	normalizedRoleDefinitionId := strings.ToLower(roleDefinitionId)
+	str := fmt.Sprintf("%s-%s-%s", normalizedScope, normalizedPrincipalId, normalizedRoleDefinitionId)
+
+	return uuid.NewV5(namespace, str).String()
 }

--- a/internal/services/authorization/parse/role_assignment.go
+++ b/internal/services/authorization/parse/role_assignment.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/gofrs/uuid"
-	"github.com/hashicorp/go-azure-sdk/resource-manager/authorization/2022-05-01-preview/roledefinitions"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 )
 
@@ -218,13 +217,21 @@ func RoleAssignmentID(input string) (*RoleAssignmentId, error) {
 func RoleAssignmentName(scope string, principalId string, roleDefinitionId string) (string, error) {
 	namespace := uuid.Must(uuid.FromString("11fb06fb-712d-4ddd-98c7-e71bbd588830"))
 
-	normalizedScope := strings.TrimSuffix(strings.ToLower(scope), "/")
+	normalizedScope := strings.ToLower(scope)
+	if normalizedScope != "/" {
+		normalizedScope = strings.TrimSuffix(normalizedScope, "/")
+	}
+
 	normalizedPrincipalId := strings.ToLower(principalId)
-	scopedRoleDefinitionId, err := roledefinitions.ParseScopedRoleDefinitionID(roleDefinitionId)
-	if err != nil {
+
+	// Get the UUID part of RoleDefinitionId
+	normalizedRoleDefinitionId := strings.Trim(strings.ToLower(roleDefinitionId), " /")
+	parts := strings.Split(normalizedRoleDefinitionId, "/")
+	normalizedRoleDefinitionId = parts[len(parts)-1]
+	if _, err := uuid.FromString(normalizedRoleDefinitionId); err != nil {
 		return "", fmt.Errorf("parsing role definition ID %q: %+v", roleDefinitionId, err)
 	}
-	normalizedRoleDefinitionId := strings.ToLower(scopedRoleDefinitionId.RoleDefinitionId)
+
 	str := fmt.Sprintf("%s-%s-%s", normalizedScope, normalizedPrincipalId, normalizedRoleDefinitionId)
 
 	return uuid.NewV5(namespace, str).String(), nil

--- a/internal/services/authorization/parse/role_assignment_test.go
+++ b/internal/services/authorization/parse/role_assignment_test.go
@@ -334,3 +334,83 @@ func TestRoleAssignmentID(t *testing.T) {
 		}
 	}
 }
+
+func TestRoleAssignmentName(t *testing.T) {
+	testData := []struct {
+		Scope            string
+		PrincipalId      string
+		RoleDefinitionId string
+		Expected         string
+		Error            bool
+	}{
+		{
+			Scope:            "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/myRg",
+			PrincipalId:      "22222222-2222-2222-2222-222222222222",
+			RoleDefinitionId: "/subscriptions/11111111-1111-1111-1111-111111111111/providers/Microsoft.Authorization/roleDefinitions/33333333-3333-3333-3333-333333333333",
+			Expected:         "eec47c62-a9a9-54dd-b8d8-f9e2839fab35",
+		},
+		{
+			Scope:            "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/myRg",
+			PrincipalId:      "22222222-2222-2222-2222-222222222222",
+			RoleDefinitionId: "/providers/Microsoft.Authorization/roleDefinitions/33333333-3333-3333-3333-333333333333",
+			Expected:         "eec47c62-a9a9-54dd-b8d8-f9e2839fab35",
+		},
+		{
+			Scope:            "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/myRg",
+			PrincipalId:      "22222222-2222-2222-2222-222222222222",
+			RoleDefinitionId: "/providers/Microsoft.Management/managementGroups/myMg/providers/Microsoft.Authorization/roleDefinitions/33333333-3333-3333-3333-333333333333",
+			Expected:         "eec47c62-a9a9-54dd-b8d8-f9e2839fab35",
+		},
+		{
+			Scope:            "/SUBSCRIPTIONS/11111111-1111-1111-1111-111111111111/RESOURCEGROUPS/MYRG",
+			PrincipalId:      "22222222-2222-2222-2222-222222222222",
+			RoleDefinitionId: "/SUBSCRIPTIONS/11111111-1111-1111-1111-111111111111/PROVIDERS/MICROSOFT.AUTHORIZATION/ROLEDEFINITIONS/33333333-3333-3333-3333-333333333333",
+			Expected:         "eec47c62-a9a9-54dd-b8d8-f9e2839fab35",
+		},
+		{
+			Scope:            "/",
+			PrincipalId:      "22222222-2222-2222-2222-222222222222",
+			RoleDefinitionId: "/subscriptions/11111111-1111-1111-1111-111111111111/providers/Microsoft.Authorization/roleDefinitions/33333333-3333-3333-3333-333333333333",
+			Expected:         "c095807d-5244-5404-8bce-e0e762e70618",
+		},
+		{
+			Scope:            "/providers/Microsoft.Management/managementGroups/myMg",
+			PrincipalId:      "22222222-2222-2222-2222-222222222222",
+			RoleDefinitionId: "/subscriptions/11111111-1111-1111-1111-111111111111/providers/Microsoft.Authorization/roleDefinitions/33333333-3333-3333-3333-333333333333",
+			Expected:         "6aab5ec9-d102-539e-8b65-b053c060e64f",
+		},
+		{
+			Scope:            "/subscriptions/11111111-1111-1111-1111-111111111111",
+			PrincipalId:      "99999999-9999-9999-9999-999999999999",
+			RoleDefinitionId: "/subscriptions/11111111-1111-1111-1111-111111111111/providers/Microsoft.Authorization/roleDefinitions/33333333-3333-3333-3333-333333333333",
+			Expected:         "54e40269-cc30-57bd-8031-5ca4efc75fd5",
+		},
+		{
+			Scope:            "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/myRg",
+			PrincipalId:      "22222222-2222-2222-2222-222222222222",
+			RoleDefinitionId: "/subscriptions/11111111-1111-1111-1111-111111111111/providers/Microsoft.Authorization/roleDefinitions/not-a-uuid",
+			Error:            true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing Scope=%q PrincipalId=%q RoleDefinitionId=%q", v.Scope, v.PrincipalId, v.RoleDefinitionId)
+
+		actual, err := RoleAssignmentName(v.Scope, v.PrincipalId, v.RoleDefinitionId)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("expected a value but got an error: %+v", err)
+		}
+
+		if v.Error {
+			t.Fatalf("expected an error but got none")
+		}
+
+		if actual != v.Expected {
+			t.Fatalf("expected %q, got %q", v.Expected, actual)
+		}
+	}
+}

--- a/internal/services/authorization/role_assignment_resource.go
+++ b/internal/services/authorization/role_assignment_resource.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gofrs/uuid"
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
@@ -86,6 +85,7 @@ func resourceArmRoleAssignment() *pluginsdk.Resource {
 				ForceNew:         true,
 				ExactlyOneOf:     []string{"role_definition_id", "role_definition_name"},
 				DiffSuppressFunc: suppress.CaseDifference,
+				ValidateFunc:     validation.StringMatch(regexp.MustCompile("(?i)^.*/providers/Microsoft.Authorization/roleDefinitions/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"), "should be in the format {scope}/providers/Microsoft.Authorization/roleDefinitions/00000000-0000-0000-0000-000000000000"),
 			},
 
 			"role_definition_name": {
@@ -196,21 +196,7 @@ func resourceArmRoleAssignmentCreate(d *pluginsdk.ResourceData, meta interface{}
 	principalId := d.Get("principal_id").(string)
 
 	if name == "" {
-		normalizedScope := strings.TrimSuffix(strings.ToLower(scopeId.Scope), "/")
-		normalizedPrincipalId := strings.ToLower(principalId)
-		parts := strings.Split(roleDefinitionId, "/")
-		normalizedRoleDefinitionId, err := uuid.FromString(parts[len(parts)-1])
-		if err != nil {
-			return fmt.Errorf("parsing role definition UUID from `role_definition_id` %q: %+v", roleDefinitionId, err)
-		}
-		str := fmt.Sprintf("%s-%s-%s", normalizedScope, normalizedPrincipalId, normalizedRoleDefinitionId)
-
-		namespace, err := uuid.FromString("11fb06fb-712d-4ddd-98c7-e71bbd588830")
-		if err != nil {
-			return fmt.Errorf("parsing namespace UUID for Role Assignment: %+v", err)
-		}
-
-		name = uuid.NewV5(namespace, str).String()
+		name = parse.RoleAssignmentName(scopeId.Scope, principalId, roleDefinitionId)
 	}
 
 	tenantId := ""

--- a/internal/services/authorization/role_assignment_resource.go
+++ b/internal/services/authorization/role_assignment_resource.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gofrs/uuid"
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
@@ -18,7 +19,6 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/authorization/2022-05-01-preview/roledefinitions"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2024-04-03/applicationgroup"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/resources/2022-12-01/subscriptions"
-	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -195,12 +195,15 @@ func resourceArmRoleAssignmentCreate(d *pluginsdk.ResourceData, meta interface{}
 	principalId := d.Get("principal_id").(string)
 
 	if name == "" {
-		generatedUUID, err := uuid.GenerateUUID()
+		normalizedScope := strings.ToLower(scopeId.Scope)
+		normalizedPrincipalId := strings.ToLower(principalId)
+		normalizedRoleDefinitionId := strings.ToLower(roleDefinitionId)
+		str := fmt.Sprintf("%s-%s-%s", normalizedScope, normalizedPrincipalId, normalizedRoleDefinitionId)
+		namespace, err := uuid.FromString("11fb06fb-712d-4ddd-98c7-e71bbd588830")
 		if err != nil {
-			return fmt.Errorf("generating UUID for Role Assignment: %+v", err)
+			return fmt.Errorf("parsing namespace UUID for Role Assignment: %+v", err)
 		}
-
-		name = generatedUUID
+		name = uuid.NewV5(namespace, str).String()
 	}
 
 	tenantId := ""

--- a/internal/services/authorization/role_assignment_resource.go
+++ b/internal/services/authorization/role_assignment_resource.go
@@ -99,9 +99,10 @@ func resourceArmRoleAssignment() *pluginsdk.Resource {
 			},
 
 			"principal_id": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IsUUID,
 			},
 
 			"principal_type": {
@@ -195,14 +196,20 @@ func resourceArmRoleAssignmentCreate(d *pluginsdk.ResourceData, meta interface{}
 	principalId := d.Get("principal_id").(string)
 
 	if name == "" {
-		normalizedScope := strings.ToLower(scopeId.Scope)
+		normalizedScope := strings.TrimSuffix(strings.ToLower(scopeId.Scope), "/")
 		normalizedPrincipalId := strings.ToLower(principalId)
-		normalizedRoleDefinitionId := strings.ToLower(roleDefinitionId)
+		parts := strings.Split(roleDefinitionId, "/")
+		normalizedRoleDefinitionId, err := uuid.FromString(parts[len(parts)-1])
+		if err != nil {
+			return fmt.Errorf("parsing role definition UUID from `role_definition_id` %q: %+v", roleDefinitionId, err)
+		}
 		str := fmt.Sprintf("%s-%s-%s", normalizedScope, normalizedPrincipalId, normalizedRoleDefinitionId)
+
 		namespace, err := uuid.FromString("11fb06fb-712d-4ddd-98c7-e71bbd588830")
 		if err != nil {
 			return fmt.Errorf("parsing namespace UUID for Role Assignment: %+v", err)
 		}
+
 		name = uuid.NewV5(namespace, str).String()
 	}
 

--- a/internal/services/authorization/role_assignment_resource.go
+++ b/internal/services/authorization/role_assignment_resource.go
@@ -196,7 +196,10 @@ func resourceArmRoleAssignmentCreate(d *pluginsdk.ResourceData, meta interface{}
 	principalId := d.Get("principal_id").(string)
 
 	if name == "" {
-		name = parse.RoleAssignmentName(scopeId.Scope, principalId, roleDefinitionId)
+		name, err = parse.RoleAssignmentName(scopeId.Scope, principalId, roleDefinitionId)
+		if err != nil {
+			return fmt.Errorf("generating role assignment name: %+v", err)
+		}
 	}
 
 	tenantId := ""

--- a/internal/services/authorization/role_assignment_resource.go
+++ b/internal/services/authorization/role_assignment_resource.go
@@ -85,7 +85,7 @@ func resourceArmRoleAssignment() *pluginsdk.Resource {
 				ForceNew:         true,
 				ExactlyOneOf:     []string{"role_definition_id", "role_definition_name"},
 				DiffSuppressFunc: suppress.CaseDifference,
-				ValidateFunc:     validation.StringMatch(regexp.MustCompile("(?i)^.*/providers/Microsoft.Authorization/roleDefinitions/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"), "should be in the format {scope}/providers/Microsoft.Authorization/roleDefinitions/00000000-0000-0000-0000-000000000000"),
+				ValidateFunc:     roledefinitions.ValidateScopedRoleDefinitionID,
 			},
 
 			"role_definition_name": {

--- a/internal/services/authorization/role_assignment_resource.go
+++ b/internal/services/authorization/role_assignment_resource.go
@@ -85,7 +85,6 @@ func resourceArmRoleAssignment() *pluginsdk.Resource {
 				ForceNew:         true,
 				ExactlyOneOf:     []string{"role_definition_id", "role_definition_name"},
 				DiffSuppressFunc: suppress.CaseDifference,
-				ValidateFunc:     roledefinitions.ValidateScopedRoleDefinitionID,
 			},
 
 			"role_definition_name": {

--- a/website/docs/r/role_assignment.html.markdown
+++ b/website/docs/r/role_assignment.html.markdown
@@ -175,7 +175,9 @@ EOT
 
 The following arguments are supported:
 
-* `name` - (Optional) A unique UUID/GUID for this Role Assignment - one will be generated if not specified. Changing this forces a new resource to be created.
+* `name` - (Optional) The UUID for this Role Assignment. If omitted, a UUID will be generated. Changing this forces a new resource to be created.
+
+-> **Note:** When `name` is omitted, a deterministic UUIDv5 is generated from the `scope`, `principal_id`, and `role_definition_id`, matching the naming behavior used by ARM templates, Bicep, and the Azure CLI.
 
 * `scope` - (Required) The scope at which the Role Assignment applies to, such as `/subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333`, `/subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup`, or `/subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup/providers/Microsoft.Compute/virtualMachines/myVM`, or `/providers/Microsoft.Management/managementGroups/myMG`. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR is to: 
1. Change role assignment id (`name` property) generation to a deterministic algorithm that will be used by ARM, Bicep, and the CLI. This ensures consistent IDs across tools, preventing duplicates and conflicts when managing the same assignment from different IaC tools or the portal.
2. Add validation for `principal_id` which complies with ARM api requirement and also meet the normalization requirement of the id calculation algorithm.
3. Fix incorrect test reference of `principal_id`
4.  Skip validation for `role_definition_id` as it will need to be discussed and addressed together with other resource  in separate PR. 

Internal document about the algorithm of the PR have been shared with HashiCorp via online meeting: 

> 
> Standard: UUID v5 (RFC 4122 name-based) 
> 
> Namespace: 11fb06fb-712d-4ddd-98c7-e71bbd588830 (the Azure namespace already used by ARM/Bicep) 
> 
> Input: the tuple of identifying properties (scope, role definition ID (**trailing GUID**), principal/directory object ID), joined with - as a delimiter 
> 
> Output: deterministic GUID, stable for a given tuple 
> 
> GUID = guid(scope, principalId, roleDefinitionId) 
> 


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

Run with the parameters `TEST_PREFIX = TestAccRoleAssignment`. The failed tests also failed in the main branch test. 

<img width="1117" height="699" alt="image" src="https://github.com/user-attachments/assets/373ebb82-3c9b-4f66-bb80-60e50abafc5c" />

With env.ARM_FIVEPOINTZERO_BETA = true

<img width="1120" height="688" alt="image" src="https://github.com/user-attachments/assets/47344c28-10f6-4b71-aca1-d16b918d5612" />


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
