### PR TITLE
`azurerm_api_management_logger` - support for `user_assigned_identity_client_id` in the `application_insights` block

### DIFF
--- a/internal/services/apimanagement/api_management_logger_resource.go
+++ b/internal/services/apimanagement/api_management_logger_resource.go
@@ -141,6 +141,15 @@ func resourceApiManagementLogger() *pluginsdk.Resource {
 								"application_insights.0.connection_string",
 							},
 						},
+
+						"user_assigned_identity_client_id": {
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.IsUUID,
+							RequiredWith: []string{
+								"application_insights.0.connection_string",
+							},
+						},
 					},
 				},
 			},
@@ -340,6 +349,9 @@ func expandApiManagementLoggerApplicationInsights(input []interface{}) *map[stri
 	}
 	if ai["connection_string"].(string) != "" {
 		credentials["connectionString"] = ai["connection_string"].(string)
+	}
+	if ai["user_assigned_identity_client_id"].(string) != "" {
+		credentials["identityClientId"] = ai["user_assigned_identity_client_id"].(string)
 	}
 	return &credentials
 }

--- a/internal/services/apimanagement/api_management_logger_resource_test.go
+++ b/internal/services/apimanagement/api_management_logger_resource_test.go
@@ -148,6 +148,30 @@ func TestAccApiManagementLogger_applicationInsightsConnectionString(t *testing.T
 	})
 }
 
+func TestAccApiManagementLogger_applicationInsightsUserAssignedIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_logger", "test")
+	r := ApiManagementLoggerResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.applicationInsightsUserAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("eventhub.#").HasValue("0"),
+				check.That(data.ResourceName).Key("application_insights.#").HasValue("1"),
+				check.That(data.ResourceName).Key("application_insights.0.connection_string").Exists(),
+				check.That(data.ResourceName).Key("application_insights.0.user_assigned_identity_client_id").Exists(),
+			),
+		},
+		{
+			ResourceName:            data.ResourceName,
+			ImportState:             true,
+			ImportStateVerify:       true,
+			ImportStateVerifyIgnore: []string{"application_insights.#", "application_insights.0.connection_string", "application_insights.0.instrumentation_key", "application_insights.0.user_assigned_identity_client_id", "application_insights.0.%"},
+		},
+	})
+}
+
 func TestAccApiManagementLogger_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_logger", "test")
 	r := ApiManagementLoggerResource{}
@@ -501,6 +525,65 @@ resource "azurerm_api_management_logger" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (ApiManagementLoggerResource) applicationInsightsUserAssignedIdentity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_application_insights" "test" {
+  name                = "acctestappinsights-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  application_type    = "other"
+}
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "uai-acctestapimnglogger-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_role_assignment" "test" {
+  scope                = azurerm_application_insights.test.id
+  role_definition_name = "Monitoring Metrics Publisher"
+  principal_id         = azurerm_user_assigned_identity.test.principal_id
+}
+
+resource "azurerm_api_management" "test" {
+  name                = "acctestAM-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  publisher_name      = "pub1"
+  publisher_email     = "pub1@email.com"
+
+  sku_name = "Consumption_0"
+  identity {
+    type = "UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id
+    ]
+  }
+}
+
+resource "azurerm_api_management_logger" "test" {
+  name                = "acctestapimnglogger-%[1]d"
+  api_management_name = azurerm_api_management.test.name
+  resource_group_name = azurerm_resource_group.test.name
+
+  application_insights {
+    connection_string                = azurerm_application_insights.test.connection_string
+    user_assigned_identity_client_id = azurerm_user_assigned_identity.test.client_id
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (ApiManagementLoggerResource) complete(data acceptance.TestData, description, buffered string) string {

--- a/website/docs/r/api_management_logger.html.markdown
+++ b/website/docs/r/api_management_logger.html.markdown
@@ -75,6 +75,8 @@ An `application_insights` block supports the following:
 
 * `instrumentation_key` - (Optional) The instrumentation key used to push data to Application Insights.
 
+* `user_assigned_identity_client_id` - (Optional) The Client Id of the User Assigned Identity with the `Monitoring Metrics Publisher` role on the target Application Insights resource, used to authenticate to Application Insights with a managed identity. Requires `connection_string` to be set.
+
 ~> **Note:** Either `connection_string` or `instrumentation_key` have to be specified.
 
 ---


### PR DESCRIPTION
## Community Note

* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

API Management can authenticate to Application Insights with a managed identity instead of an instrumentation key, which is the configuration Microsoft recommends for this logger. The `application_insights` block only accepted `connection_string` and `instrumentation_key`, so there was no way to configure managed-identity authentication through the provider.

This adds a `user_assigned_identity_client_id` argument to the `application_insights` block. When set, the client ID is written to the `identityClientId` credential alongside `connectionString`, which is the shape the Logger API expects for managed-identity auth. The implementation mirrors the existing `user_assigned_identity_client_id` field on the `eventhub` block, which already maps to the same credential key.

A few notes on the design:

* The logger's `credentials` are a free-form `map[string]string` in the SDK, so no API/SDK upgrade is required.
* The field is gated with `RequiredWith` on `connection_string`, since managed-identity auth uses the connection string (the connection string already conflicts with `instrumentation_key`).
* The `application_insights` block is `ForceNew` and is deliberately not read back from the API (the API does not return the credentials), so the new field follows the existing block's behaviour and is excluded from import verification, consistent with the sibling fields.
* This covers user-assigned identities (the client ID supplied by the user). System-assigned support would need a separate signal and is out of scope here.

## Testing

* `make test` and the provider schema validation pass.
* Added `TestAccApiManagementLogger_applicationInsightsUserAssignedIdentity`, which provisions a user-assigned identity with the `Monitoring Metrics Publisher` role on the Application Insights resource and configures the logger to use it. This requires a real subscription to run.

## Change Log

* `azurerm_api_management_logger` - support for the `user_assigned_identity_client_id` property in the `application_insights` block [GH-00000]

This is a (please select all that apply):

- [x] Enhancement

## Related Issue(s)

Fixes #32381

## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

AI was used for codebase research, drafting the implementation and test, and writing this description. The design and changes were reviewed and verified by the author.
