### PR TITLE
`azurerm_local_network_gateway` - change type of `address_space` to Set in 5.0

### DIFF
--- a/internal/services/network/custompollers/local_network_gateway_poller.go
+++ b/internal/services/network/custompollers/local_network_gateway_poller.go
@@ -1,0 +1,46 @@
+package custompollers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/localnetworkgateways"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+)
+
+var _ pollers.PollerType = &localNetworkGatewayPoller{}
+
+type localNetworkGatewayPoller struct {
+	client *localnetworkgateways.LocalNetworkGatewaysClient
+	id     localnetworkgateways.LocalNetworkGatewayId
+}
+
+func NewLocalNetworkGatewayPoller(client *localnetworkgateways.LocalNetworkGatewaysClient, id localnetworkgateways.LocalNetworkGatewayId) *localNetworkGatewayPoller {
+	return &localNetworkGatewayPoller{
+		client: client,
+		id:     id,
+	}
+}
+
+func (p localNetworkGatewayPoller) Poll(ctx context.Context) (*pollers.PollResult, error) {
+	resp, err := p.client.Get(ctx, p.id)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving %s: %+v", p.id, err)
+	}
+
+	pollingResult := pollers.PollResult{
+		Status:       pollers.PollingStatusInProgress,
+		PollInterval: 10 * time.Second,
+	}
+
+	if resp.Model != nil {
+		if pointer.From(resp.Model.Properties.ProvisioningState) == localnetworkgateways.ProvisioningStateSucceeded {
+			pollingResult.Status = pollers.PollingStatusSucceeded
+			return &pollingResult, nil
+		}
+	}
+
+	return &pollingResult, nil
+}

--- a/internal/services/network/local_network_gateway_data_source_test.go
+++ b/internal/services/network/local_network_gateway_data_source_test.go
@@ -22,8 +22,7 @@ func TestAccDataSourceLocalNetworkGateway_complete(t *testing.T) {
 			Config: r.complete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("gateway_address").HasValue("127.0.0.1"),
-				check.That(data.ResourceName).Key("address_space.0").HasValue("127.0.1.0/24"),
-				check.That(data.ResourceName).Key("address_space.1").HasValue("127.0.0.0/24"),
+				check.That(data.ResourceName).Key("address_space.#").HasValue("2"),
 				check.That(data.ResourceName).Key("bgp_settings.#").HasValue("1"),
 				check.That(data.ResourceName).Key("bgp_settings.0.asn").HasValue("2468"),
 				check.That(data.ResourceName).Key("bgp_settings.0.bgp_peering_address").HasValue("10.104.1.1"),

--- a/internal/services/network/local_network_gateway_resource.go
+++ b/internal/services/network/local_network_gateway_resource.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
-
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
@@ -18,6 +16,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
@@ -26,7 +26,7 @@ import (
 //go:generate go run ../../tools/generator-tests resourceidentity -resource-name local_network_gateway -service-package-name network -properties "name,resource_group_name" -known-values "subscription_id:data.Subscriptions.Primary"
 
 func resourceLocalNetworkGateway() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
+	r := &pluginsdk.Resource{
 		Create:   resourceLocalNetworkGatewayCreate,
 		Read:     resourceLocalNetworkGatewayRead,
 		Update:   resourceLocalNetworkGatewayUpdate,
@@ -68,7 +68,7 @@ func resourceLocalNetworkGateway() *pluginsdk.Resource {
 			},
 
 			"address_space": {
-				Type:     pluginsdk.TypeList,
+				Type:     pluginsdk.TypeSet,
 				Optional: true,
 				Elem: &pluginsdk.Schema{
 					Type:         pluginsdk.TypeString,
@@ -103,6 +103,12 @@ func resourceLocalNetworkGateway() *pluginsdk.Resource {
 			"tags": commonschema.Tags(),
 		},
 	}
+
+	if !features.FivePointOh() {
+		r.Schema["address_space"].Type = pluginsdk.TypeList
+	}
+
+	return r
 }
 
 func resourceLocalNetworkGatewayCreate(d *pluginsdk.ResourceData, meta interface{}) error {
@@ -130,21 +136,17 @@ func resourceLocalNetworkGatewayCreate(d *pluginsdk.ResourceData, meta interface
 		Name:     pointer.To(id.LocalNetworkGatewayName),
 		Location: pointer.To(location.Normalize(d.Get("location").(string))),
 		Properties: localnetworkgateways.LocalNetworkGatewayPropertiesFormat{
-			LocalNetworkAddressSpace: &localnetworkgateways.AddressSpace{},
+			LocalNetworkAddressSpace: expandLocalNetworkGatewayAddressSpaces(d),
 			BgpSettings:              expandLocalNetworkGatewayBGPSettings(d),
 		},
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
 
-	ipAddress := d.Get("gateway_address").(string)
-	fqdn := d.Get("gateway_fqdn").(string)
-	if ipAddress != "" {
+	if ipAddress := d.Get("gateway_address").(string); ipAddress != "" {
 		gateway.Properties.GatewayIPAddress = &ipAddress
 	} else {
-		gateway.Properties.Fqdn = &fqdn
+		gateway.Properties.Fqdn = pointer.To(d.Get("gateway_fqdn").(string))
 	}
-
-	gateway.Properties.LocalNetworkAddressSpace = expandLocalNetworkGatewayAddressSpaces(d)
 
 	if err := client.CreateOrUpdateCallbackThenPoll(ctx, id, gateway, sdk.SetIDAndIdentityCallback(meta, &id, d)); err != nil {
 		return fmt.Errorf("creating %s: %+v", id, err)
@@ -195,23 +197,25 @@ func resourceLocalNetworkGatewayUpdate(d *pluginsdk.ResourceData, meta interface
 		payload.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
 	}
 
-	// There is a bug in the provider where the address space ordering doesn't change as expected.
-	// In the UI we have to remove the current list of addresses in the address space and re-add them in the new order and we'll copy that here.
 	if d.HasChange("address_space") {
-		// since the local network gateway cannot have both empty address prefix and empty BGP setting(confirmed with service team, it is by design),
-		// replace the empty address prefix with the first address prefix in the "address_space" list to avoid error.
-		if v := d.Get("address_space").([]interface{}); len(v) > 0 {
-			payload.Properties.LocalNetworkAddressSpace = &localnetworkgateways.AddressSpace{
-				AddressPrefixes: &[]string{v[0].(string)},
+		if !features.FivePointOh() {
+			// There is a bug in the provider where the address space ordering doesn't change as expected.
+			// In the UI we have to remove the current list of addresses in the address space and re-add them in the new order and we'll copy that here.
+			// since the local network gateway cannot have both empty address prefix and empty BGP setting(confirmed with service team, it is by design),
+			// replace the empty address prefix with the first address prefix in the "address_space" list to avoid error.
+			if v := d.Get("address_space").([]interface{}); len(v) > 0 {
+				payload.Properties.LocalNetworkAddressSpace = &localnetworkgateways.AddressSpace{
+					AddressPrefixes: &[]string{v[0].(string)},
+				}
+			}
+
+			if err := client.CreateOrUpdateThenPoll(ctx, *id, *payload); err != nil {
+				return fmt.Errorf("removing %s: %+v", id, err)
 			}
 		}
 
-		if err := client.CreateOrUpdateThenPoll(ctx, *id, *payload); err != nil {
-			return fmt.Errorf("removing %s: %+v", id, err)
-		}
+		payload.Properties.LocalNetworkAddressSpace = expandLocalNetworkGatewayAddressSpaces(d)
 	}
-
-	payload.Properties.LocalNetworkAddressSpace = expandLocalNetworkGatewayAddressSpaces(d)
 
 	if err := client.CreateOrUpdateThenPoll(ctx, *id, *payload); err != nil {
 		return fmt.Errorf("updating %s: %+v", id, err)
@@ -313,8 +317,14 @@ func expandLocalNetworkGatewayBGPSettings(d *pluginsdk.ResourceData) *localnetwo
 func expandLocalNetworkGatewayAddressSpaces(d *pluginsdk.ResourceData) *localnetworkgateways.AddressSpace {
 	prefixes := make([]string, 0)
 
-	for _, pref := range d.Get("address_space").([]interface{}) {
-		prefixes = append(prefixes, pref.(string))
+	if !features.FivePointOh() {
+		for _, pref := range d.Get("address_space").([]interface{}) {
+			prefixes = append(prefixes, pref.(string))
+		}
+	} else {
+		for _, pref := range d.Get("address_space").(*pluginsdk.Set).List() {
+			prefixes = append(prefixes, pref.(string))
+		}
 	}
 
 	return &localnetworkgateways.AddressSpace{

--- a/internal/services/network/local_network_gateway_resource.go
+++ b/internal/services/network/local_network_gateway_resource.go
@@ -13,11 +13,13 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/localnetworkgateways"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/custompollers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
@@ -197,6 +199,9 @@ func resourceLocalNetworkGatewayUpdate(d *pluginsdk.ResourceData, meta interface
 		payload.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
 	}
 
+	pollerType := custompollers.NewLocalNetworkGatewayPoller(client, *id)
+	poller := pollers.NewPoller(pollerType, 10*time.Second, pollers.DefaultNumberOfDroppedConnectionsToAllow)
+
 	if d.HasChange("address_space") {
 		if !features.FivePointOh() {
 			// There is a bug in the provider where the address space ordering doesn't change as expected.
@@ -209,16 +214,25 @@ func resourceLocalNetworkGatewayUpdate(d *pluginsdk.ResourceData, meta interface
 				}
 			}
 
-			if err := client.CreateOrUpdateThenPoll(ctx, *id, *payload); err != nil {
+			if _, err := client.CreateOrUpdate(ctx, *id, *payload); err != nil {
 				return fmt.Errorf("removing %s: %+v", id, err)
+			}
+			if err := poller.PollUntilDone(ctx); err != nil {
+				return err
 			}
 		}
 
 		payload.Properties.LocalNetworkAddressSpace = expandLocalNetworkGatewayAddressSpaces(d)
 	}
 
-	if err := client.CreateOrUpdateThenPoll(ctx, *id, *payload); err != nil {
+	// This requires a custom poller because the API sometimes returns an async operation URL
+	// that only returns 404s, causing the provider to poll until timeout when using the `ThenPoll` method.
+	if _, err := client.CreateOrUpdate(ctx, *id, *payload); err != nil {
 		return fmt.Errorf("updating %s: %+v", id, err)
+	}
+
+	if err := poller.PollUntilDone(ctx); err != nil {
+		return err
 	}
 
 	return resourceLocalNetworkGatewayRead(d, meta)

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -517,6 +517,10 @@ Please follow the format in the example below for listing breaking changes in re
 
 * The `remote_debugging_version` property no longer accepts `VS2017` and `VS2019` as a value.
 
+### `azurerm_local_network_gateway`
+
+* The `address_space` property's type has been changed to a Set instead of a List, meaning that this is now unordered. Note that if you are referencing these nested items by index within your Terraform Configuration, this is no longer possible.
+
 ### `azurerm_log_analytics_linked_storage_account`
 
 * The deprecated `workspace_resource_id` property has been removed and superseded by the `workspace_id` property.


### PR DESCRIPTION


<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

The API respects the ordering sent in the initial create request, but not on updates. Previously this was worked around in the resource by removing all but the first CIDR range on updates, then sending an additional request to add the remaining ones.

As reported in #16327, this can cause connectivity to be broken on networks that according to `terraform plan` would be unchanged/unaffected.

To resolve, updated the type to a set, which resolves the ordering diff. This will apply once 5.0 releases.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #16327

Supersedes #32247

## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
