### PR TITLE
[azurerm_cdn_frontdoor:] Added `2025-12-01` CDN API for Front Door Rules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-azure-helpers v0.80.0
 	github.com/hashicorp/go-azure-sdk/data-plane v0.20260520.1174751
-	github.com/hashicorp/go-azure-sdk/resource-manager v0.20260520.1174751
+	github.com/hashicorp/go-azure-sdk/resource-manager v0.20260520.1174752-0.20260520174819-50f34b9d97b3
 	github.com/hashicorp/go-azure-sdk/sdk v0.20260520.1174751
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/go-hclog v1.6.3

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,8 @@ github.com/hashicorp/go-azure-helpers v0.80.0 h1:1k3CqMRdmxRBh66gkS2vXxEbvuP8pIe
 github.com/hashicorp/go-azure-helpers v0.80.0/go.mod h1:K+woaDnRuEg2qyg8pWMLeYhIcH7QAcUGLFlBHoF/WhA=
 github.com/hashicorp/go-azure-sdk/data-plane v0.20260520.1174751 h1:Z1WSesUpo9qbhdggEO8OsHo3Hglx4tw6NnK0HMUDGug=
 github.com/hashicorp/go-azure-sdk/data-plane v0.20260520.1174751/go.mod h1:6s/UkRqGmhgQ1u1Uo4USgp151hd1PZeuAqJYu1J0LTM=
-github.com/hashicorp/go-azure-sdk/resource-manager v0.20260520.1174751 h1:w3xUm9XI42lygQJ3MqWn4dDLJAyxvm2WMpWShrHvajk=
-github.com/hashicorp/go-azure-sdk/resource-manager v0.20260520.1174751/go.mod h1:/7HFLPYMPzOiOq8SNiRcTYGFImfWGrZJEyeRKMRDYFI=
+github.com/hashicorp/go-azure-sdk/resource-manager v0.20260520.1174752-0.20260520174819-50f34b9d97b3 h1:DL5rlvRQvmd0AZnBwsQTgqX0Lv5ogTMxo3BJDDd+I0M=
+github.com/hashicorp/go-azure-sdk/resource-manager v0.20260520.1174752-0.20260520174819-50f34b9d97b3/go.mod h1:/7HFLPYMPzOiOq8SNiRcTYGFImfWGrZJEyeRKMRDYFI=
 github.com/hashicorp/go-azure-sdk/sdk v0.20260520.1174751 h1:55TQwgmJIAKxn0Qtkoc6riZU2xBvDU3ikZhbVXvnzLc=
 github.com/hashicorp/go-azure-sdk/sdk v0.20260520.1174751/go.mod h1:f7jjJ/cl52ErcUVFr0XXmY+8Qajgi/AM3QbB6HVw5oc=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=

--- a/internal/services/cdn/client/client.go
+++ b/internal/services/cdn/client/client.go
@@ -14,26 +14,28 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2024-09-01/rules"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-04-15/afdcustomdomains"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-06-01/afdendpoints"
+	rules_v2025_12_01 "github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules"
 	waf "github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2025-03-01/webapplicationfirewallpolicies"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
 )
 
 type Client struct {
-	FrontDoorEndpointsClient        *cdnFrontDoorSdk.AFDEndpointsClient
-	FrontDoorOriginGroupsClient     *cdnFrontDoorSdk.AFDOriginGroupsClient
-	FrontDoorOriginsClient          *cdnFrontDoorSdk.AFDOriginsClient
-	FrontDoorCustomDomainsClient    *cdnFrontDoorSdk.AFDCustomDomainsClient
-	AFDCustomDomainsClient          *afdcustomdomains.AFDCustomDomainsClient
-	FrontDoorSecurityPoliciesClient *securitypolicies.SecurityPoliciesClient
-	FrontDoorRoutesClient           *cdnFrontDoorSdk.RoutesClient
-	FrontDoorRulesClient            *rules.RulesClient
-	FrontDoorProfilesClient         *profiles.ProfilesClient
-	FrontDoorSecretsClient          *cdnFrontDoorSdk.SecretsClient
-	FrontDoorRuleSetsClient         *rulesets.RuleSetsClient
-	FrontDoorFirewallPoliciesClient *waf.WebApplicationFirewallPoliciesClient
-	CustomDomainsClient             *cdnSdk.CustomDomainsClient
-	EndpointsClient                 *cdnSdk.EndpointsClient
-	ProfilesClient                  *cdnSdk.ProfilesClient
+	FrontDoorEndpointsClient         *cdnFrontDoorSdk.AFDEndpointsClient
+	FrontDoorOriginGroupsClient      *cdnFrontDoorSdk.AFDOriginGroupsClient
+	FrontDoorOriginsClient           *cdnFrontDoorSdk.AFDOriginsClient
+	FrontDoorCustomDomainsClient     *cdnFrontDoorSdk.AFDCustomDomainsClient
+	AFDCustomDomainsClient           *afdcustomdomains.AFDCustomDomainsClient
+	FrontDoorSecurityPoliciesClient  *securitypolicies.SecurityPoliciesClient
+	FrontDoorRoutesClient            *cdnFrontDoorSdk.RoutesClient
+	FrontDoorRulesClient             *rules.RulesClient
+	FrontDoorRulesClient_v2025_12_01 *rules_v2025_12_01.RulesClient
+	FrontDoorProfilesClient          *profiles.ProfilesClient
+	FrontDoorSecretsClient           *cdnFrontDoorSdk.SecretsClient
+	FrontDoorRuleSetsClient          *rulesets.RuleSetsClient
+	FrontDoorFirewallPoliciesClient  *waf.WebApplicationFirewallPoliciesClient
+	CustomDomainsClient              *cdnSdk.CustomDomainsClient
+	EndpointsClient                  *cdnSdk.EndpointsClient
+	ProfilesClient                   *cdnSdk.ProfilesClient
 
 	AFDEndpointsClient *afdendpoints.AFDEndpointsClient
 }
@@ -75,6 +77,12 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 	}
 	o.Configure(frontDoorRulesClient.Client, o.Authorizers.ResourceManager)
 
+	frontDoorRulesClient_v2025_12_01, err := rules_v2025_12_01.NewRulesClientWithBaseURI(o.Environment.ResourceManager)
+	if err != nil {
+		return nil, fmt.Errorf("building RulesClient v2025_12_01: %+v", err)
+	}
+	o.Configure(frontDoorRulesClient_v2025_12_01.Client, o.Authorizers.ResourceManager)
+
 	frontDoorProfilesClient, err := profiles.NewProfilesClientWithBaseURI(o.Environment.ResourceManager)
 	if err != nil {
 		return nil, fmt.Errorf("building ProfilesClient: %+v", err)
@@ -106,21 +114,22 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 	o.Configure(afdEndpointsClient.Client, o.Authorizers.ResourceManager)
 
 	client := Client{
-		FrontDoorEndpointsClient:        &frontDoorEndpointsClient,
-		FrontDoorOriginGroupsClient:     &frontDoorOriginGroupsClient,
-		FrontDoorOriginsClient:          &frontDoorOriginsClient,
-		FrontDoorCustomDomainsClient:    &frontDoorCustomDomainsClient,
-		AFDCustomDomainsClient:          afdCustomDomainsClient,
-		FrontDoorSecurityPoliciesClient: frontDoorSecurityPoliciesClient,
-		FrontDoorRoutesClient:           &frontDoorRoutesClient,
-		FrontDoorRulesClient:            frontDoorRulesClient,
-		FrontDoorProfilesClient:         frontDoorProfilesClient,
-		FrontDoorSecretsClient:          &frontDoorPolicySecretsClient,
-		FrontDoorRuleSetsClient:         frontDoorRuleSetsClient,
-		FrontDoorFirewallPoliciesClient: &frontDoorFirewallPoliciesClient,
-		CustomDomainsClient:             &customDomainsClient,
-		EndpointsClient:                 &endpointsClient,
-		ProfilesClient:                  &profilesClient,
+		FrontDoorEndpointsClient:         &frontDoorEndpointsClient,
+		FrontDoorOriginGroupsClient:      &frontDoorOriginGroupsClient,
+		FrontDoorOriginsClient:           &frontDoorOriginsClient,
+		FrontDoorCustomDomainsClient:     &frontDoorCustomDomainsClient,
+		AFDCustomDomainsClient:           afdCustomDomainsClient,
+		FrontDoorSecurityPoliciesClient:  frontDoorSecurityPoliciesClient,
+		FrontDoorRoutesClient:            &frontDoorRoutesClient,
+		FrontDoorRulesClient:             frontDoorRulesClient,
+		FrontDoorRulesClient_v2025_12_01: frontDoorRulesClient_v2025_12_01,
+		FrontDoorProfilesClient:          frontDoorProfilesClient,
+		FrontDoorSecretsClient:           &frontDoorPolicySecretsClient,
+		FrontDoorRuleSetsClient:          frontDoorRuleSetsClient,
+		FrontDoorFirewallPoliciesClient:  &frontDoorFirewallPoliciesClient,
+		CustomDomainsClient:              &customDomainsClient,
+		EndpointsClient:                  &endpointsClient,
+		ProfilesClient:                   &profilesClient,
 
 		AFDEndpointsClient: afdEndpointsClient,
 	}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/README.md
@@ -1,0 +1,99 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules` Documentation
+
+The `rules` SDK allows for interaction with Azure Resource Manager `cdn` (API Version `2025-12-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules"
+```
+
+
+### Client Initialization
+
+```go
+client := rules.NewRulesClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `RulesClient.Create`
+
+```go
+ctx := context.TODO()
+id := rules.NewRuleID("12345678-1234-9876-4563-123456789012", "example-resource-group", "profileName", "ruleSetName", "ruleName")
+
+payload := rules.Rule{
+	// ...
+}
+
+
+if err := client.CreateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `RulesClient.Delete`
+
+```go
+ctx := context.TODO()
+id := rules.NewRuleID("12345678-1234-9876-4563-123456789012", "example-resource-group", "profileName", "ruleSetName", "ruleName")
+
+if err := client.DeleteThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `RulesClient.Get`
+
+```go
+ctx := context.TODO()
+id := rules.NewRuleID("12345678-1234-9876-4563-123456789012", "example-resource-group", "profileName", "ruleSetName", "ruleName")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `RulesClient.ListByRuleSet`
+
+```go
+ctx := context.TODO()
+id := rules.NewRuleSetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "profileName", "ruleSetName")
+
+// alternatively `client.ListByRuleSet(ctx, id)` can be used to do batched pagination
+items, err := client.ListByRuleSetComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `RulesClient.Update`
+
+```go
+ctx := context.TODO()
+id := rules.NewRuleID("12345678-1234-9876-4563-123456789012", "example-resource-group", "profileName", "ruleSetName", "ruleName")
+
+payload := rules.RuleUpdateParameters{
+	// ...
+}
+
+
+if err := client.UpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/client.go
@@ -1,0 +1,26 @@
+package rules
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RulesClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewRulesClientWithBaseURI(sdkApi sdkEnv.Api) (*RulesClient, error) {
+	client, err := resourcemanager.NewClient(sdkApi, "rules", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating RulesClient: %+v", err)
+	}
+
+	return &RulesClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/constants.go
@@ -1,0 +1,2268 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AfdProvisioningState string
+
+const (
+	AfdProvisioningStateCreating  AfdProvisioningState = "Creating"
+	AfdProvisioningStateDeleting  AfdProvisioningState = "Deleting"
+	AfdProvisioningStateFailed    AfdProvisioningState = "Failed"
+	AfdProvisioningStateSucceeded AfdProvisioningState = "Succeeded"
+	AfdProvisioningStateUpdating  AfdProvisioningState = "Updating"
+)
+
+func PossibleValuesForAfdProvisioningState() []string {
+	return []string{
+		string(AfdProvisioningStateCreating),
+		string(AfdProvisioningStateDeleting),
+		string(AfdProvisioningStateFailed),
+		string(AfdProvisioningStateSucceeded),
+		string(AfdProvisioningStateUpdating),
+	}
+}
+
+func (s *AfdProvisioningState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseAfdProvisioningState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseAfdProvisioningState(input string) (*AfdProvisioningState, error) {
+	vals := map[string]AfdProvisioningState{
+		"creating":  AfdProvisioningStateCreating,
+		"deleting":  AfdProvisioningStateDeleting,
+		"failed":    AfdProvisioningStateFailed,
+		"succeeded": AfdProvisioningStateSucceeded,
+		"updating":  AfdProvisioningStateUpdating,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := AfdProvisioningState(input)
+	return &out, nil
+}
+
+type Algorithm string
+
+const (
+	AlgorithmSHATwoFiveSix Algorithm = "SHA256"
+)
+
+func PossibleValuesForAlgorithm() []string {
+	return []string{
+		string(AlgorithmSHATwoFiveSix),
+	}
+}
+
+func (s *Algorithm) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseAlgorithm(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseAlgorithm(input string) (*Algorithm, error) {
+	vals := map[string]Algorithm{
+		"sha256": AlgorithmSHATwoFiveSix,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := Algorithm(input)
+	return &out, nil
+}
+
+type CacheBehavior string
+
+const (
+	CacheBehaviorBypassCache  CacheBehavior = "BypassCache"
+	CacheBehaviorOverride     CacheBehavior = "Override"
+	CacheBehaviorSetIfMissing CacheBehavior = "SetIfMissing"
+)
+
+func PossibleValuesForCacheBehavior() []string {
+	return []string{
+		string(CacheBehaviorBypassCache),
+		string(CacheBehaviorOverride),
+		string(CacheBehaviorSetIfMissing),
+	}
+}
+
+func (s *CacheBehavior) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseCacheBehavior(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseCacheBehavior(input string) (*CacheBehavior, error) {
+	vals := map[string]CacheBehavior{
+		"bypasscache":  CacheBehaviorBypassCache,
+		"override":     CacheBehaviorOverride,
+		"setifmissing": CacheBehaviorSetIfMissing,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := CacheBehavior(input)
+	return &out, nil
+}
+
+type CacheType string
+
+const (
+	CacheTypeAll CacheType = "All"
+)
+
+func PossibleValuesForCacheType() []string {
+	return []string{
+		string(CacheTypeAll),
+	}
+}
+
+func (s *CacheType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseCacheType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseCacheType(input string) (*CacheType, error) {
+	vals := map[string]CacheType{
+		"all": CacheTypeAll,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := CacheType(input)
+	return &out, nil
+}
+
+type ClientPortOperator string
+
+const (
+	ClientPortOperatorAny                ClientPortOperator = "Any"
+	ClientPortOperatorBeginsWith         ClientPortOperator = "BeginsWith"
+	ClientPortOperatorContains           ClientPortOperator = "Contains"
+	ClientPortOperatorEndsWith           ClientPortOperator = "EndsWith"
+	ClientPortOperatorEqual              ClientPortOperator = "Equal"
+	ClientPortOperatorGreaterThan        ClientPortOperator = "GreaterThan"
+	ClientPortOperatorGreaterThanOrEqual ClientPortOperator = "GreaterThanOrEqual"
+	ClientPortOperatorLessThan           ClientPortOperator = "LessThan"
+	ClientPortOperatorLessThanOrEqual    ClientPortOperator = "LessThanOrEqual"
+	ClientPortOperatorRegEx              ClientPortOperator = "RegEx"
+)
+
+func PossibleValuesForClientPortOperator() []string {
+	return []string{
+		string(ClientPortOperatorAny),
+		string(ClientPortOperatorBeginsWith),
+		string(ClientPortOperatorContains),
+		string(ClientPortOperatorEndsWith),
+		string(ClientPortOperatorEqual),
+		string(ClientPortOperatorGreaterThan),
+		string(ClientPortOperatorGreaterThanOrEqual),
+		string(ClientPortOperatorLessThan),
+		string(ClientPortOperatorLessThanOrEqual),
+		string(ClientPortOperatorRegEx),
+	}
+}
+
+func (s *ClientPortOperator) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseClientPortOperator(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseClientPortOperator(input string) (*ClientPortOperator, error) {
+	vals := map[string]ClientPortOperator{
+		"any":                ClientPortOperatorAny,
+		"beginswith":         ClientPortOperatorBeginsWith,
+		"contains":           ClientPortOperatorContains,
+		"endswith":           ClientPortOperatorEndsWith,
+		"equal":              ClientPortOperatorEqual,
+		"greaterthan":        ClientPortOperatorGreaterThan,
+		"greaterthanorequal": ClientPortOperatorGreaterThanOrEqual,
+		"lessthan":           ClientPortOperatorLessThan,
+		"lessthanorequal":    ClientPortOperatorLessThanOrEqual,
+		"regex":              ClientPortOperatorRegEx,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ClientPortOperator(input)
+	return &out, nil
+}
+
+type CookiesOperator string
+
+const (
+	CookiesOperatorAny                CookiesOperator = "Any"
+	CookiesOperatorBeginsWith         CookiesOperator = "BeginsWith"
+	CookiesOperatorContains           CookiesOperator = "Contains"
+	CookiesOperatorEndsWith           CookiesOperator = "EndsWith"
+	CookiesOperatorEqual              CookiesOperator = "Equal"
+	CookiesOperatorGreaterThan        CookiesOperator = "GreaterThan"
+	CookiesOperatorGreaterThanOrEqual CookiesOperator = "GreaterThanOrEqual"
+	CookiesOperatorLessThan           CookiesOperator = "LessThan"
+	CookiesOperatorLessThanOrEqual    CookiesOperator = "LessThanOrEqual"
+	CookiesOperatorRegEx              CookiesOperator = "RegEx"
+)
+
+func PossibleValuesForCookiesOperator() []string {
+	return []string{
+		string(CookiesOperatorAny),
+		string(CookiesOperatorBeginsWith),
+		string(CookiesOperatorContains),
+		string(CookiesOperatorEndsWith),
+		string(CookiesOperatorEqual),
+		string(CookiesOperatorGreaterThan),
+		string(CookiesOperatorGreaterThanOrEqual),
+		string(CookiesOperatorLessThan),
+		string(CookiesOperatorLessThanOrEqual),
+		string(CookiesOperatorRegEx),
+	}
+}
+
+func (s *CookiesOperator) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseCookiesOperator(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseCookiesOperator(input string) (*CookiesOperator, error) {
+	vals := map[string]CookiesOperator{
+		"any":                CookiesOperatorAny,
+		"beginswith":         CookiesOperatorBeginsWith,
+		"contains":           CookiesOperatorContains,
+		"endswith":           CookiesOperatorEndsWith,
+		"equal":              CookiesOperatorEqual,
+		"greaterthan":        CookiesOperatorGreaterThan,
+		"greaterthanorequal": CookiesOperatorGreaterThanOrEqual,
+		"lessthan":           CookiesOperatorLessThan,
+		"lessthanorequal":    CookiesOperatorLessThanOrEqual,
+		"regex":              CookiesOperatorRegEx,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := CookiesOperator(input)
+	return &out, nil
+}
+
+type DeliveryRuleActionName string
+
+const (
+	DeliveryRuleActionNameCacheExpiration            DeliveryRuleActionName = "CacheExpiration"
+	DeliveryRuleActionNameCacheKeyQueryString        DeliveryRuleActionName = "CacheKeyQueryString"
+	DeliveryRuleActionNameModifyRequestHeader        DeliveryRuleActionName = "ModifyRequestHeader"
+	DeliveryRuleActionNameModifyResponseHeader       DeliveryRuleActionName = "ModifyResponseHeader"
+	DeliveryRuleActionNameOriginGroupOverride        DeliveryRuleActionName = "OriginGroupOverride"
+	DeliveryRuleActionNameRouteConfigurationOverride DeliveryRuleActionName = "RouteConfigurationOverride"
+	DeliveryRuleActionNameURLRedirect                DeliveryRuleActionName = "UrlRedirect"
+	DeliveryRuleActionNameURLRewrite                 DeliveryRuleActionName = "UrlRewrite"
+	DeliveryRuleActionNameURLSigning                 DeliveryRuleActionName = "UrlSigning"
+)
+
+func PossibleValuesForDeliveryRuleActionName() []string {
+	return []string{
+		string(DeliveryRuleActionNameCacheExpiration),
+		string(DeliveryRuleActionNameCacheKeyQueryString),
+		string(DeliveryRuleActionNameModifyRequestHeader),
+		string(DeliveryRuleActionNameModifyResponseHeader),
+		string(DeliveryRuleActionNameOriginGroupOverride),
+		string(DeliveryRuleActionNameRouteConfigurationOverride),
+		string(DeliveryRuleActionNameURLRedirect),
+		string(DeliveryRuleActionNameURLRewrite),
+		string(DeliveryRuleActionNameURLSigning),
+	}
+}
+
+func (s *DeliveryRuleActionName) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDeliveryRuleActionName(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDeliveryRuleActionName(input string) (*DeliveryRuleActionName, error) {
+	vals := map[string]DeliveryRuleActionName{
+		"cacheexpiration":            DeliveryRuleActionNameCacheExpiration,
+		"cachekeyquerystring":        DeliveryRuleActionNameCacheKeyQueryString,
+		"modifyrequestheader":        DeliveryRuleActionNameModifyRequestHeader,
+		"modifyresponseheader":       DeliveryRuleActionNameModifyResponseHeader,
+		"origingroupoverride":        DeliveryRuleActionNameOriginGroupOverride,
+		"routeconfigurationoverride": DeliveryRuleActionNameRouteConfigurationOverride,
+		"urlredirect":                DeliveryRuleActionNameURLRedirect,
+		"urlrewrite":                 DeliveryRuleActionNameURLRewrite,
+		"urlsigning":                 DeliveryRuleActionNameURLSigning,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DeliveryRuleActionName(input)
+	return &out, nil
+}
+
+type DeliveryRuleActionParametersType string
+
+const (
+	DeliveryRuleActionParametersTypeDeliveryRuleCacheExpirationActionParameters             DeliveryRuleActionParametersType = "DeliveryRuleCacheExpirationActionParameters"
+	DeliveryRuleActionParametersTypeDeliveryRuleCacheKeyQueryStringBehaviorActionParameters DeliveryRuleActionParametersType = "DeliveryRuleCacheKeyQueryStringBehaviorActionParameters"
+	DeliveryRuleActionParametersTypeDeliveryRuleHeaderActionParameters                      DeliveryRuleActionParametersType = "DeliveryRuleHeaderActionParameters"
+	DeliveryRuleActionParametersTypeDeliveryRuleOriginGroupOverrideActionParameters         DeliveryRuleActionParametersType = "DeliveryRuleOriginGroupOverrideActionParameters"
+	DeliveryRuleActionParametersTypeDeliveryRuleRouteConfigurationOverrideActionParameters  DeliveryRuleActionParametersType = "DeliveryRuleRouteConfigurationOverrideActionParameters"
+	DeliveryRuleActionParametersTypeDeliveryRuleURLRedirectActionParameters                 DeliveryRuleActionParametersType = "DeliveryRuleUrlRedirectActionParameters"
+	DeliveryRuleActionParametersTypeDeliveryRuleURLRewriteActionParameters                  DeliveryRuleActionParametersType = "DeliveryRuleUrlRewriteActionParameters"
+	DeliveryRuleActionParametersTypeDeliveryRuleURLSigningActionParameters                  DeliveryRuleActionParametersType = "DeliveryRuleUrlSigningActionParameters"
+)
+
+func PossibleValuesForDeliveryRuleActionParametersType() []string {
+	return []string{
+		string(DeliveryRuleActionParametersTypeDeliveryRuleCacheExpirationActionParameters),
+		string(DeliveryRuleActionParametersTypeDeliveryRuleCacheKeyQueryStringBehaviorActionParameters),
+		string(DeliveryRuleActionParametersTypeDeliveryRuleHeaderActionParameters),
+		string(DeliveryRuleActionParametersTypeDeliveryRuleOriginGroupOverrideActionParameters),
+		string(DeliveryRuleActionParametersTypeDeliveryRuleRouteConfigurationOverrideActionParameters),
+		string(DeliveryRuleActionParametersTypeDeliveryRuleURLRedirectActionParameters),
+		string(DeliveryRuleActionParametersTypeDeliveryRuleURLRewriteActionParameters),
+		string(DeliveryRuleActionParametersTypeDeliveryRuleURLSigningActionParameters),
+	}
+}
+
+func (s *DeliveryRuleActionParametersType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDeliveryRuleActionParametersType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDeliveryRuleActionParametersType(input string) (*DeliveryRuleActionParametersType, error) {
+	vals := map[string]DeliveryRuleActionParametersType{
+		"deliveryrulecacheexpirationactionparameters":             DeliveryRuleActionParametersTypeDeliveryRuleCacheExpirationActionParameters,
+		"deliveryrulecachekeyquerystringbehavioractionparameters": DeliveryRuleActionParametersTypeDeliveryRuleCacheKeyQueryStringBehaviorActionParameters,
+		"deliveryruleheaderactionparameters":                      DeliveryRuleActionParametersTypeDeliveryRuleHeaderActionParameters,
+		"deliveryruleorigingroupoverrideactionparameters":         DeliveryRuleActionParametersTypeDeliveryRuleOriginGroupOverrideActionParameters,
+		"deliveryrulerouteconfigurationoverrideactionparameters":  DeliveryRuleActionParametersTypeDeliveryRuleRouteConfigurationOverrideActionParameters,
+		"deliveryruleurlredirectactionparameters":                 DeliveryRuleActionParametersTypeDeliveryRuleURLRedirectActionParameters,
+		"deliveryruleurlrewriteactionparameters":                  DeliveryRuleActionParametersTypeDeliveryRuleURLRewriteActionParameters,
+		"deliveryruleurlsigningactionparameters":                  DeliveryRuleActionParametersTypeDeliveryRuleURLSigningActionParameters,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DeliveryRuleActionParametersType(input)
+	return &out, nil
+}
+
+type DeliveryRuleConditionParametersType string
+
+const (
+	DeliveryRuleConditionParametersTypeDeliveryRuleClientPortConditionParameters            DeliveryRuleConditionParametersType = "DeliveryRuleClientPortConditionParameters"
+	DeliveryRuleConditionParametersTypeDeliveryRuleCookiesConditionParameters               DeliveryRuleConditionParametersType = "DeliveryRuleCookiesConditionParameters"
+	DeliveryRuleConditionParametersTypeDeliveryRuleHTTPVersionConditionParameters           DeliveryRuleConditionParametersType = "DeliveryRuleHttpVersionConditionParameters"
+	DeliveryRuleConditionParametersTypeDeliveryRuleHostNameConditionParameters              DeliveryRuleConditionParametersType = "DeliveryRuleHostNameConditionParameters"
+	DeliveryRuleConditionParametersTypeDeliveryRuleIsDeviceConditionParameters              DeliveryRuleConditionParametersType = "DeliveryRuleIsDeviceConditionParameters"
+	DeliveryRuleConditionParametersTypeDeliveryRulePostArgsConditionParameters              DeliveryRuleConditionParametersType = "DeliveryRulePostArgsConditionParameters"
+	DeliveryRuleConditionParametersTypeDeliveryRuleQueryStringConditionParameters           DeliveryRuleConditionParametersType = "DeliveryRuleQueryStringConditionParameters"
+	DeliveryRuleConditionParametersTypeDeliveryRuleRemoteAddressConditionParameters         DeliveryRuleConditionParametersType = "DeliveryRuleRemoteAddressConditionParameters"
+	DeliveryRuleConditionParametersTypeDeliveryRuleRequestBodyConditionParameters           DeliveryRuleConditionParametersType = "DeliveryRuleRequestBodyConditionParameters"
+	DeliveryRuleConditionParametersTypeDeliveryRuleRequestHeaderConditionParameters         DeliveryRuleConditionParametersType = "DeliveryRuleRequestHeaderConditionParameters"
+	DeliveryRuleConditionParametersTypeDeliveryRuleRequestMethodConditionParameters         DeliveryRuleConditionParametersType = "DeliveryRuleRequestMethodConditionParameters"
+	DeliveryRuleConditionParametersTypeDeliveryRuleRequestSchemeConditionParameters         DeliveryRuleConditionParametersType = "DeliveryRuleRequestSchemeConditionParameters"
+	DeliveryRuleConditionParametersTypeDeliveryRuleRequestUriConditionParameters            DeliveryRuleConditionParametersType = "DeliveryRuleRequestUriConditionParameters"
+	DeliveryRuleConditionParametersTypeDeliveryRuleServerPortConditionParameters            DeliveryRuleConditionParametersType = "DeliveryRuleServerPortConditionParameters"
+	DeliveryRuleConditionParametersTypeDeliveryRuleSocketAddrConditionParameters            DeliveryRuleConditionParametersType = "DeliveryRuleSocketAddrConditionParameters"
+	DeliveryRuleConditionParametersTypeDeliveryRuleSslProtocolConditionParameters           DeliveryRuleConditionParametersType = "DeliveryRuleSslProtocolConditionParameters"
+	DeliveryRuleConditionParametersTypeDeliveryRuleURLFileExtensionMatchConditionParameters DeliveryRuleConditionParametersType = "DeliveryRuleUrlFileExtensionMatchConditionParameters"
+	DeliveryRuleConditionParametersTypeDeliveryRuleURLFilenameConditionParameters           DeliveryRuleConditionParametersType = "DeliveryRuleUrlFilenameConditionParameters"
+	DeliveryRuleConditionParametersTypeDeliveryRuleURLPathMatchConditionParameters          DeliveryRuleConditionParametersType = "DeliveryRuleUrlPathMatchConditionParameters"
+)
+
+func PossibleValuesForDeliveryRuleConditionParametersType() []string {
+	return []string{
+		string(DeliveryRuleConditionParametersTypeDeliveryRuleClientPortConditionParameters),
+		string(DeliveryRuleConditionParametersTypeDeliveryRuleCookiesConditionParameters),
+		string(DeliveryRuleConditionParametersTypeDeliveryRuleHTTPVersionConditionParameters),
+		string(DeliveryRuleConditionParametersTypeDeliveryRuleHostNameConditionParameters),
+		string(DeliveryRuleConditionParametersTypeDeliveryRuleIsDeviceConditionParameters),
+		string(DeliveryRuleConditionParametersTypeDeliveryRulePostArgsConditionParameters),
+		string(DeliveryRuleConditionParametersTypeDeliveryRuleQueryStringConditionParameters),
+		string(DeliveryRuleConditionParametersTypeDeliveryRuleRemoteAddressConditionParameters),
+		string(DeliveryRuleConditionParametersTypeDeliveryRuleRequestBodyConditionParameters),
+		string(DeliveryRuleConditionParametersTypeDeliveryRuleRequestHeaderConditionParameters),
+		string(DeliveryRuleConditionParametersTypeDeliveryRuleRequestMethodConditionParameters),
+		string(DeliveryRuleConditionParametersTypeDeliveryRuleRequestSchemeConditionParameters),
+		string(DeliveryRuleConditionParametersTypeDeliveryRuleRequestUriConditionParameters),
+		string(DeliveryRuleConditionParametersTypeDeliveryRuleServerPortConditionParameters),
+		string(DeliveryRuleConditionParametersTypeDeliveryRuleSocketAddrConditionParameters),
+		string(DeliveryRuleConditionParametersTypeDeliveryRuleSslProtocolConditionParameters),
+		string(DeliveryRuleConditionParametersTypeDeliveryRuleURLFileExtensionMatchConditionParameters),
+		string(DeliveryRuleConditionParametersTypeDeliveryRuleURLFilenameConditionParameters),
+		string(DeliveryRuleConditionParametersTypeDeliveryRuleURLPathMatchConditionParameters),
+	}
+}
+
+func (s *DeliveryRuleConditionParametersType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDeliveryRuleConditionParametersType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDeliveryRuleConditionParametersType(input string) (*DeliveryRuleConditionParametersType, error) {
+	vals := map[string]DeliveryRuleConditionParametersType{
+		"deliveryruleclientportconditionparameters":            DeliveryRuleConditionParametersTypeDeliveryRuleClientPortConditionParameters,
+		"deliveryrulecookiesconditionparameters":               DeliveryRuleConditionParametersTypeDeliveryRuleCookiesConditionParameters,
+		"deliveryrulehttpversionconditionparameters":           DeliveryRuleConditionParametersTypeDeliveryRuleHTTPVersionConditionParameters,
+		"deliveryrulehostnameconditionparameters":              DeliveryRuleConditionParametersTypeDeliveryRuleHostNameConditionParameters,
+		"deliveryruleisdeviceconditionparameters":              DeliveryRuleConditionParametersTypeDeliveryRuleIsDeviceConditionParameters,
+		"deliveryrulepostargsconditionparameters":              DeliveryRuleConditionParametersTypeDeliveryRulePostArgsConditionParameters,
+		"deliveryrulequerystringconditionparameters":           DeliveryRuleConditionParametersTypeDeliveryRuleQueryStringConditionParameters,
+		"deliveryruleremoteaddressconditionparameters":         DeliveryRuleConditionParametersTypeDeliveryRuleRemoteAddressConditionParameters,
+		"deliveryrulerequestbodyconditionparameters":           DeliveryRuleConditionParametersTypeDeliveryRuleRequestBodyConditionParameters,
+		"deliveryrulerequestheaderconditionparameters":         DeliveryRuleConditionParametersTypeDeliveryRuleRequestHeaderConditionParameters,
+		"deliveryrulerequestmethodconditionparameters":         DeliveryRuleConditionParametersTypeDeliveryRuleRequestMethodConditionParameters,
+		"deliveryrulerequestschemeconditionparameters":         DeliveryRuleConditionParametersTypeDeliveryRuleRequestSchemeConditionParameters,
+		"deliveryrulerequesturiconditionparameters":            DeliveryRuleConditionParametersTypeDeliveryRuleRequestUriConditionParameters,
+		"deliveryruleserverportconditionparameters":            DeliveryRuleConditionParametersTypeDeliveryRuleServerPortConditionParameters,
+		"deliveryrulesocketaddrconditionparameters":            DeliveryRuleConditionParametersTypeDeliveryRuleSocketAddrConditionParameters,
+		"deliveryrulesslprotocolconditionparameters":           DeliveryRuleConditionParametersTypeDeliveryRuleSslProtocolConditionParameters,
+		"deliveryruleurlfileextensionmatchconditionparameters": DeliveryRuleConditionParametersTypeDeliveryRuleURLFileExtensionMatchConditionParameters,
+		"deliveryruleurlfilenameconditionparameters":           DeliveryRuleConditionParametersTypeDeliveryRuleURLFilenameConditionParameters,
+		"deliveryruleurlpathmatchconditionparameters":          DeliveryRuleConditionParametersTypeDeliveryRuleURLPathMatchConditionParameters,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DeliveryRuleConditionParametersType(input)
+	return &out, nil
+}
+
+type DeploymentStatus string
+
+const (
+	DeploymentStatusFailed     DeploymentStatus = "Failed"
+	DeploymentStatusInProgress DeploymentStatus = "InProgress"
+	DeploymentStatusNotStarted DeploymentStatus = "NotStarted"
+	DeploymentStatusSucceeded  DeploymentStatus = "Succeeded"
+)
+
+func PossibleValuesForDeploymentStatus() []string {
+	return []string{
+		string(DeploymentStatusFailed),
+		string(DeploymentStatusInProgress),
+		string(DeploymentStatusNotStarted),
+		string(DeploymentStatusSucceeded),
+	}
+}
+
+func (s *DeploymentStatus) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDeploymentStatus(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDeploymentStatus(input string) (*DeploymentStatus, error) {
+	vals := map[string]DeploymentStatus{
+		"failed":     DeploymentStatusFailed,
+		"inprogress": DeploymentStatusInProgress,
+		"notstarted": DeploymentStatusNotStarted,
+		"succeeded":  DeploymentStatusSucceeded,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DeploymentStatus(input)
+	return &out, nil
+}
+
+type DestinationProtocol string
+
+const (
+	DestinationProtocolHTTP         DestinationProtocol = "Http"
+	DestinationProtocolHTTPS        DestinationProtocol = "Https"
+	DestinationProtocolMatchRequest DestinationProtocol = "MatchRequest"
+)
+
+func PossibleValuesForDestinationProtocol() []string {
+	return []string{
+		string(DestinationProtocolHTTP),
+		string(DestinationProtocolHTTPS),
+		string(DestinationProtocolMatchRequest),
+	}
+}
+
+func (s *DestinationProtocol) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDestinationProtocol(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDestinationProtocol(input string) (*DestinationProtocol, error) {
+	vals := map[string]DestinationProtocol{
+		"http":         DestinationProtocolHTTP,
+		"https":        DestinationProtocolHTTPS,
+		"matchrequest": DestinationProtocolMatchRequest,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DestinationProtocol(input)
+	return &out, nil
+}
+
+type ForwardingProtocol string
+
+const (
+	ForwardingProtocolHTTPOnly     ForwardingProtocol = "HttpOnly"
+	ForwardingProtocolHTTPSOnly    ForwardingProtocol = "HttpsOnly"
+	ForwardingProtocolMatchRequest ForwardingProtocol = "MatchRequest"
+)
+
+func PossibleValuesForForwardingProtocol() []string {
+	return []string{
+		string(ForwardingProtocolHTTPOnly),
+		string(ForwardingProtocolHTTPSOnly),
+		string(ForwardingProtocolMatchRequest),
+	}
+}
+
+func (s *ForwardingProtocol) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseForwardingProtocol(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseForwardingProtocol(input string) (*ForwardingProtocol, error) {
+	vals := map[string]ForwardingProtocol{
+		"httponly":     ForwardingProtocolHTTPOnly,
+		"httpsonly":    ForwardingProtocolHTTPSOnly,
+		"matchrequest": ForwardingProtocolMatchRequest,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ForwardingProtocol(input)
+	return &out, nil
+}
+
+type HTTPVersionOperator string
+
+const (
+	HTTPVersionOperatorEqual HTTPVersionOperator = "Equal"
+)
+
+func PossibleValuesForHTTPVersionOperator() []string {
+	return []string{
+		string(HTTPVersionOperatorEqual),
+	}
+}
+
+func (s *HTTPVersionOperator) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseHTTPVersionOperator(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseHTTPVersionOperator(input string) (*HTTPVersionOperator, error) {
+	vals := map[string]HTTPVersionOperator{
+		"equal": HTTPVersionOperatorEqual,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := HTTPVersionOperator(input)
+	return &out, nil
+}
+
+type HeaderAction string
+
+const (
+	HeaderActionAppend    HeaderAction = "Append"
+	HeaderActionDelete    HeaderAction = "Delete"
+	HeaderActionOverwrite HeaderAction = "Overwrite"
+)
+
+func PossibleValuesForHeaderAction() []string {
+	return []string{
+		string(HeaderActionAppend),
+		string(HeaderActionDelete),
+		string(HeaderActionOverwrite),
+	}
+}
+
+func (s *HeaderAction) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseHeaderAction(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseHeaderAction(input string) (*HeaderAction, error) {
+	vals := map[string]HeaderAction{
+		"append":    HeaderActionAppend,
+		"delete":    HeaderActionDelete,
+		"overwrite": HeaderActionOverwrite,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := HeaderAction(input)
+	return &out, nil
+}
+
+type HostNameOperator string
+
+const (
+	HostNameOperatorAny                HostNameOperator = "Any"
+	HostNameOperatorBeginsWith         HostNameOperator = "BeginsWith"
+	HostNameOperatorContains           HostNameOperator = "Contains"
+	HostNameOperatorEndsWith           HostNameOperator = "EndsWith"
+	HostNameOperatorEqual              HostNameOperator = "Equal"
+	HostNameOperatorGreaterThan        HostNameOperator = "GreaterThan"
+	HostNameOperatorGreaterThanOrEqual HostNameOperator = "GreaterThanOrEqual"
+	HostNameOperatorLessThan           HostNameOperator = "LessThan"
+	HostNameOperatorLessThanOrEqual    HostNameOperator = "LessThanOrEqual"
+	HostNameOperatorRegEx              HostNameOperator = "RegEx"
+)
+
+func PossibleValuesForHostNameOperator() []string {
+	return []string{
+		string(HostNameOperatorAny),
+		string(HostNameOperatorBeginsWith),
+		string(HostNameOperatorContains),
+		string(HostNameOperatorEndsWith),
+		string(HostNameOperatorEqual),
+		string(HostNameOperatorGreaterThan),
+		string(HostNameOperatorGreaterThanOrEqual),
+		string(HostNameOperatorLessThan),
+		string(HostNameOperatorLessThanOrEqual),
+		string(HostNameOperatorRegEx),
+	}
+}
+
+func (s *HostNameOperator) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseHostNameOperator(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseHostNameOperator(input string) (*HostNameOperator, error) {
+	vals := map[string]HostNameOperator{
+		"any":                HostNameOperatorAny,
+		"beginswith":         HostNameOperatorBeginsWith,
+		"contains":           HostNameOperatorContains,
+		"endswith":           HostNameOperatorEndsWith,
+		"equal":              HostNameOperatorEqual,
+		"greaterthan":        HostNameOperatorGreaterThan,
+		"greaterthanorequal": HostNameOperatorGreaterThanOrEqual,
+		"lessthan":           HostNameOperatorLessThan,
+		"lessthanorequal":    HostNameOperatorLessThanOrEqual,
+		"regex":              HostNameOperatorRegEx,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := HostNameOperator(input)
+	return &out, nil
+}
+
+type IsDeviceMatchValue string
+
+const (
+	IsDeviceMatchValueDesktop IsDeviceMatchValue = "Desktop"
+	IsDeviceMatchValueMobile  IsDeviceMatchValue = "Mobile"
+)
+
+func PossibleValuesForIsDeviceMatchValue() []string {
+	return []string{
+		string(IsDeviceMatchValueDesktop),
+		string(IsDeviceMatchValueMobile),
+	}
+}
+
+func (s *IsDeviceMatchValue) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseIsDeviceMatchValue(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseIsDeviceMatchValue(input string) (*IsDeviceMatchValue, error) {
+	vals := map[string]IsDeviceMatchValue{
+		"desktop": IsDeviceMatchValueDesktop,
+		"mobile":  IsDeviceMatchValueMobile,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := IsDeviceMatchValue(input)
+	return &out, nil
+}
+
+type IsDeviceOperator string
+
+const (
+	IsDeviceOperatorEqual IsDeviceOperator = "Equal"
+)
+
+func PossibleValuesForIsDeviceOperator() []string {
+	return []string{
+		string(IsDeviceOperatorEqual),
+	}
+}
+
+func (s *IsDeviceOperator) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseIsDeviceOperator(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseIsDeviceOperator(input string) (*IsDeviceOperator, error) {
+	vals := map[string]IsDeviceOperator{
+		"equal": IsDeviceOperatorEqual,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := IsDeviceOperator(input)
+	return &out, nil
+}
+
+type MatchProcessingBehavior string
+
+const (
+	MatchProcessingBehaviorContinue MatchProcessingBehavior = "Continue"
+	MatchProcessingBehaviorStop     MatchProcessingBehavior = "Stop"
+)
+
+func PossibleValuesForMatchProcessingBehavior() []string {
+	return []string{
+		string(MatchProcessingBehaviorContinue),
+		string(MatchProcessingBehaviorStop),
+	}
+}
+
+func (s *MatchProcessingBehavior) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseMatchProcessingBehavior(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseMatchProcessingBehavior(input string) (*MatchProcessingBehavior, error) {
+	vals := map[string]MatchProcessingBehavior{
+		"continue": MatchProcessingBehaviorContinue,
+		"stop":     MatchProcessingBehaviorStop,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := MatchProcessingBehavior(input)
+	return &out, nil
+}
+
+type MatchVariable string
+
+const (
+	MatchVariableClientPort       MatchVariable = "ClientPort"
+	MatchVariableCookies          MatchVariable = "Cookies"
+	MatchVariableHTTPVersion      MatchVariable = "HttpVersion"
+	MatchVariableHostName         MatchVariable = "HostName"
+	MatchVariableIsDevice         MatchVariable = "IsDevice"
+	MatchVariablePostArgs         MatchVariable = "PostArgs"
+	MatchVariableQueryString      MatchVariable = "QueryString"
+	MatchVariableRemoteAddress    MatchVariable = "RemoteAddress"
+	MatchVariableRequestBody      MatchVariable = "RequestBody"
+	MatchVariableRequestHeader    MatchVariable = "RequestHeader"
+	MatchVariableRequestMethod    MatchVariable = "RequestMethod"
+	MatchVariableRequestScheme    MatchVariable = "RequestScheme"
+	MatchVariableRequestUri       MatchVariable = "RequestUri"
+	MatchVariableServerPort       MatchVariable = "ServerPort"
+	MatchVariableSocketAddr       MatchVariable = "SocketAddr"
+	MatchVariableSslProtocol      MatchVariable = "SslProtocol"
+	MatchVariableURLFileExtension MatchVariable = "UrlFileExtension"
+	MatchVariableURLFileName      MatchVariable = "UrlFileName"
+	MatchVariableURLPath          MatchVariable = "UrlPath"
+)
+
+func PossibleValuesForMatchVariable() []string {
+	return []string{
+		string(MatchVariableClientPort),
+		string(MatchVariableCookies),
+		string(MatchVariableHTTPVersion),
+		string(MatchVariableHostName),
+		string(MatchVariableIsDevice),
+		string(MatchVariablePostArgs),
+		string(MatchVariableQueryString),
+		string(MatchVariableRemoteAddress),
+		string(MatchVariableRequestBody),
+		string(MatchVariableRequestHeader),
+		string(MatchVariableRequestMethod),
+		string(MatchVariableRequestScheme),
+		string(MatchVariableRequestUri),
+		string(MatchVariableServerPort),
+		string(MatchVariableSocketAddr),
+		string(MatchVariableSslProtocol),
+		string(MatchVariableURLFileExtension),
+		string(MatchVariableURLFileName),
+		string(MatchVariableURLPath),
+	}
+}
+
+func (s *MatchVariable) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseMatchVariable(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseMatchVariable(input string) (*MatchVariable, error) {
+	vals := map[string]MatchVariable{
+		"clientport":       MatchVariableClientPort,
+		"cookies":          MatchVariableCookies,
+		"httpversion":      MatchVariableHTTPVersion,
+		"hostname":         MatchVariableHostName,
+		"isdevice":         MatchVariableIsDevice,
+		"postargs":         MatchVariablePostArgs,
+		"querystring":      MatchVariableQueryString,
+		"remoteaddress":    MatchVariableRemoteAddress,
+		"requestbody":      MatchVariableRequestBody,
+		"requestheader":    MatchVariableRequestHeader,
+		"requestmethod":    MatchVariableRequestMethod,
+		"requestscheme":    MatchVariableRequestScheme,
+		"requesturi":       MatchVariableRequestUri,
+		"serverport":       MatchVariableServerPort,
+		"socketaddr":       MatchVariableSocketAddr,
+		"sslprotocol":      MatchVariableSslProtocol,
+		"urlfileextension": MatchVariableURLFileExtension,
+		"urlfilename":      MatchVariableURLFileName,
+		"urlpath":          MatchVariableURLPath,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := MatchVariable(input)
+	return &out, nil
+}
+
+type ParamIndicator string
+
+const (
+	ParamIndicatorExpires   ParamIndicator = "Expires"
+	ParamIndicatorKeyId     ParamIndicator = "KeyId"
+	ParamIndicatorSignature ParamIndicator = "Signature"
+)
+
+func PossibleValuesForParamIndicator() []string {
+	return []string{
+		string(ParamIndicatorExpires),
+		string(ParamIndicatorKeyId),
+		string(ParamIndicatorSignature),
+	}
+}
+
+func (s *ParamIndicator) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseParamIndicator(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseParamIndicator(input string) (*ParamIndicator, error) {
+	vals := map[string]ParamIndicator{
+		"expires":   ParamIndicatorExpires,
+		"keyid":     ParamIndicatorKeyId,
+		"signature": ParamIndicatorSignature,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ParamIndicator(input)
+	return &out, nil
+}
+
+type PostArgsOperator string
+
+const (
+	PostArgsOperatorAny                PostArgsOperator = "Any"
+	PostArgsOperatorBeginsWith         PostArgsOperator = "BeginsWith"
+	PostArgsOperatorContains           PostArgsOperator = "Contains"
+	PostArgsOperatorEndsWith           PostArgsOperator = "EndsWith"
+	PostArgsOperatorEqual              PostArgsOperator = "Equal"
+	PostArgsOperatorGreaterThan        PostArgsOperator = "GreaterThan"
+	PostArgsOperatorGreaterThanOrEqual PostArgsOperator = "GreaterThanOrEqual"
+	PostArgsOperatorLessThan           PostArgsOperator = "LessThan"
+	PostArgsOperatorLessThanOrEqual    PostArgsOperator = "LessThanOrEqual"
+	PostArgsOperatorRegEx              PostArgsOperator = "RegEx"
+)
+
+func PossibleValuesForPostArgsOperator() []string {
+	return []string{
+		string(PostArgsOperatorAny),
+		string(PostArgsOperatorBeginsWith),
+		string(PostArgsOperatorContains),
+		string(PostArgsOperatorEndsWith),
+		string(PostArgsOperatorEqual),
+		string(PostArgsOperatorGreaterThan),
+		string(PostArgsOperatorGreaterThanOrEqual),
+		string(PostArgsOperatorLessThan),
+		string(PostArgsOperatorLessThanOrEqual),
+		string(PostArgsOperatorRegEx),
+	}
+}
+
+func (s *PostArgsOperator) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parsePostArgsOperator(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parsePostArgsOperator(input string) (*PostArgsOperator, error) {
+	vals := map[string]PostArgsOperator{
+		"any":                PostArgsOperatorAny,
+		"beginswith":         PostArgsOperatorBeginsWith,
+		"contains":           PostArgsOperatorContains,
+		"endswith":           PostArgsOperatorEndsWith,
+		"equal":              PostArgsOperatorEqual,
+		"greaterthan":        PostArgsOperatorGreaterThan,
+		"greaterthanorequal": PostArgsOperatorGreaterThanOrEqual,
+		"lessthan":           PostArgsOperatorLessThan,
+		"lessthanorequal":    PostArgsOperatorLessThanOrEqual,
+		"regex":              PostArgsOperatorRegEx,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PostArgsOperator(input)
+	return &out, nil
+}
+
+type QueryStringBehavior string
+
+const (
+	QueryStringBehaviorExclude    QueryStringBehavior = "Exclude"
+	QueryStringBehaviorExcludeAll QueryStringBehavior = "ExcludeAll"
+	QueryStringBehaviorInclude    QueryStringBehavior = "Include"
+	QueryStringBehaviorIncludeAll QueryStringBehavior = "IncludeAll"
+)
+
+func PossibleValuesForQueryStringBehavior() []string {
+	return []string{
+		string(QueryStringBehaviorExclude),
+		string(QueryStringBehaviorExcludeAll),
+		string(QueryStringBehaviorInclude),
+		string(QueryStringBehaviorIncludeAll),
+	}
+}
+
+func (s *QueryStringBehavior) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseQueryStringBehavior(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseQueryStringBehavior(input string) (*QueryStringBehavior, error) {
+	vals := map[string]QueryStringBehavior{
+		"exclude":    QueryStringBehaviorExclude,
+		"excludeall": QueryStringBehaviorExcludeAll,
+		"include":    QueryStringBehaviorInclude,
+		"includeall": QueryStringBehaviorIncludeAll,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := QueryStringBehavior(input)
+	return &out, nil
+}
+
+type QueryStringOperator string
+
+const (
+	QueryStringOperatorAny                QueryStringOperator = "Any"
+	QueryStringOperatorBeginsWith         QueryStringOperator = "BeginsWith"
+	QueryStringOperatorContains           QueryStringOperator = "Contains"
+	QueryStringOperatorEndsWith           QueryStringOperator = "EndsWith"
+	QueryStringOperatorEqual              QueryStringOperator = "Equal"
+	QueryStringOperatorGreaterThan        QueryStringOperator = "GreaterThan"
+	QueryStringOperatorGreaterThanOrEqual QueryStringOperator = "GreaterThanOrEqual"
+	QueryStringOperatorLessThan           QueryStringOperator = "LessThan"
+	QueryStringOperatorLessThanOrEqual    QueryStringOperator = "LessThanOrEqual"
+	QueryStringOperatorRegEx              QueryStringOperator = "RegEx"
+)
+
+func PossibleValuesForQueryStringOperator() []string {
+	return []string{
+		string(QueryStringOperatorAny),
+		string(QueryStringOperatorBeginsWith),
+		string(QueryStringOperatorContains),
+		string(QueryStringOperatorEndsWith),
+		string(QueryStringOperatorEqual),
+		string(QueryStringOperatorGreaterThan),
+		string(QueryStringOperatorGreaterThanOrEqual),
+		string(QueryStringOperatorLessThan),
+		string(QueryStringOperatorLessThanOrEqual),
+		string(QueryStringOperatorRegEx),
+	}
+}
+
+func (s *QueryStringOperator) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseQueryStringOperator(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseQueryStringOperator(input string) (*QueryStringOperator, error) {
+	vals := map[string]QueryStringOperator{
+		"any":                QueryStringOperatorAny,
+		"beginswith":         QueryStringOperatorBeginsWith,
+		"contains":           QueryStringOperatorContains,
+		"endswith":           QueryStringOperatorEndsWith,
+		"equal":              QueryStringOperatorEqual,
+		"greaterthan":        QueryStringOperatorGreaterThan,
+		"greaterthanorequal": QueryStringOperatorGreaterThanOrEqual,
+		"lessthan":           QueryStringOperatorLessThan,
+		"lessthanorequal":    QueryStringOperatorLessThanOrEqual,
+		"regex":              QueryStringOperatorRegEx,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := QueryStringOperator(input)
+	return &out, nil
+}
+
+type RedirectType string
+
+const (
+	RedirectTypeFound             RedirectType = "Found"
+	RedirectTypeMoved             RedirectType = "Moved"
+	RedirectTypePermanentRedirect RedirectType = "PermanentRedirect"
+	RedirectTypeTemporaryRedirect RedirectType = "TemporaryRedirect"
+)
+
+func PossibleValuesForRedirectType() []string {
+	return []string{
+		string(RedirectTypeFound),
+		string(RedirectTypeMoved),
+		string(RedirectTypePermanentRedirect),
+		string(RedirectTypeTemporaryRedirect),
+	}
+}
+
+func (s *RedirectType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseRedirectType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseRedirectType(input string) (*RedirectType, error) {
+	vals := map[string]RedirectType{
+		"found":             RedirectTypeFound,
+		"moved":             RedirectTypeMoved,
+		"permanentredirect": RedirectTypePermanentRedirect,
+		"temporaryredirect": RedirectTypeTemporaryRedirect,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := RedirectType(input)
+	return &out, nil
+}
+
+type RemoteAddressOperator string
+
+const (
+	RemoteAddressOperatorAny      RemoteAddressOperator = "Any"
+	RemoteAddressOperatorGeoMatch RemoteAddressOperator = "GeoMatch"
+	RemoteAddressOperatorIPMatch  RemoteAddressOperator = "IPMatch"
+)
+
+func PossibleValuesForRemoteAddressOperator() []string {
+	return []string{
+		string(RemoteAddressOperatorAny),
+		string(RemoteAddressOperatorGeoMatch),
+		string(RemoteAddressOperatorIPMatch),
+	}
+}
+
+func (s *RemoteAddressOperator) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseRemoteAddressOperator(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseRemoteAddressOperator(input string) (*RemoteAddressOperator, error) {
+	vals := map[string]RemoteAddressOperator{
+		"any":      RemoteAddressOperatorAny,
+		"geomatch": RemoteAddressOperatorGeoMatch,
+		"ipmatch":  RemoteAddressOperatorIPMatch,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := RemoteAddressOperator(input)
+	return &out, nil
+}
+
+type RequestBodyOperator string
+
+const (
+	RequestBodyOperatorAny                RequestBodyOperator = "Any"
+	RequestBodyOperatorBeginsWith         RequestBodyOperator = "BeginsWith"
+	RequestBodyOperatorContains           RequestBodyOperator = "Contains"
+	RequestBodyOperatorEndsWith           RequestBodyOperator = "EndsWith"
+	RequestBodyOperatorEqual              RequestBodyOperator = "Equal"
+	RequestBodyOperatorGreaterThan        RequestBodyOperator = "GreaterThan"
+	RequestBodyOperatorGreaterThanOrEqual RequestBodyOperator = "GreaterThanOrEqual"
+	RequestBodyOperatorLessThan           RequestBodyOperator = "LessThan"
+	RequestBodyOperatorLessThanOrEqual    RequestBodyOperator = "LessThanOrEqual"
+	RequestBodyOperatorRegEx              RequestBodyOperator = "RegEx"
+)
+
+func PossibleValuesForRequestBodyOperator() []string {
+	return []string{
+		string(RequestBodyOperatorAny),
+		string(RequestBodyOperatorBeginsWith),
+		string(RequestBodyOperatorContains),
+		string(RequestBodyOperatorEndsWith),
+		string(RequestBodyOperatorEqual),
+		string(RequestBodyOperatorGreaterThan),
+		string(RequestBodyOperatorGreaterThanOrEqual),
+		string(RequestBodyOperatorLessThan),
+		string(RequestBodyOperatorLessThanOrEqual),
+		string(RequestBodyOperatorRegEx),
+	}
+}
+
+func (s *RequestBodyOperator) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseRequestBodyOperator(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseRequestBodyOperator(input string) (*RequestBodyOperator, error) {
+	vals := map[string]RequestBodyOperator{
+		"any":                RequestBodyOperatorAny,
+		"beginswith":         RequestBodyOperatorBeginsWith,
+		"contains":           RequestBodyOperatorContains,
+		"endswith":           RequestBodyOperatorEndsWith,
+		"equal":              RequestBodyOperatorEqual,
+		"greaterthan":        RequestBodyOperatorGreaterThan,
+		"greaterthanorequal": RequestBodyOperatorGreaterThanOrEqual,
+		"lessthan":           RequestBodyOperatorLessThan,
+		"lessthanorequal":    RequestBodyOperatorLessThanOrEqual,
+		"regex":              RequestBodyOperatorRegEx,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := RequestBodyOperator(input)
+	return &out, nil
+}
+
+type RequestHeaderOperator string
+
+const (
+	RequestHeaderOperatorAny                RequestHeaderOperator = "Any"
+	RequestHeaderOperatorBeginsWith         RequestHeaderOperator = "BeginsWith"
+	RequestHeaderOperatorContains           RequestHeaderOperator = "Contains"
+	RequestHeaderOperatorEndsWith           RequestHeaderOperator = "EndsWith"
+	RequestHeaderOperatorEqual              RequestHeaderOperator = "Equal"
+	RequestHeaderOperatorGreaterThan        RequestHeaderOperator = "GreaterThan"
+	RequestHeaderOperatorGreaterThanOrEqual RequestHeaderOperator = "GreaterThanOrEqual"
+	RequestHeaderOperatorLessThan           RequestHeaderOperator = "LessThan"
+	RequestHeaderOperatorLessThanOrEqual    RequestHeaderOperator = "LessThanOrEqual"
+	RequestHeaderOperatorRegEx              RequestHeaderOperator = "RegEx"
+)
+
+func PossibleValuesForRequestHeaderOperator() []string {
+	return []string{
+		string(RequestHeaderOperatorAny),
+		string(RequestHeaderOperatorBeginsWith),
+		string(RequestHeaderOperatorContains),
+		string(RequestHeaderOperatorEndsWith),
+		string(RequestHeaderOperatorEqual),
+		string(RequestHeaderOperatorGreaterThan),
+		string(RequestHeaderOperatorGreaterThanOrEqual),
+		string(RequestHeaderOperatorLessThan),
+		string(RequestHeaderOperatorLessThanOrEqual),
+		string(RequestHeaderOperatorRegEx),
+	}
+}
+
+func (s *RequestHeaderOperator) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseRequestHeaderOperator(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseRequestHeaderOperator(input string) (*RequestHeaderOperator, error) {
+	vals := map[string]RequestHeaderOperator{
+		"any":                RequestHeaderOperatorAny,
+		"beginswith":         RequestHeaderOperatorBeginsWith,
+		"contains":           RequestHeaderOperatorContains,
+		"endswith":           RequestHeaderOperatorEndsWith,
+		"equal":              RequestHeaderOperatorEqual,
+		"greaterthan":        RequestHeaderOperatorGreaterThan,
+		"greaterthanorequal": RequestHeaderOperatorGreaterThanOrEqual,
+		"lessthan":           RequestHeaderOperatorLessThan,
+		"lessthanorequal":    RequestHeaderOperatorLessThanOrEqual,
+		"regex":              RequestHeaderOperatorRegEx,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := RequestHeaderOperator(input)
+	return &out, nil
+}
+
+type RequestMethodMatchValue string
+
+const (
+	RequestMethodMatchValueDELETE  RequestMethodMatchValue = "DELETE"
+	RequestMethodMatchValueGET     RequestMethodMatchValue = "GET"
+	RequestMethodMatchValueHEAD    RequestMethodMatchValue = "HEAD"
+	RequestMethodMatchValueOPTIONS RequestMethodMatchValue = "OPTIONS"
+	RequestMethodMatchValuePOST    RequestMethodMatchValue = "POST"
+	RequestMethodMatchValuePUT     RequestMethodMatchValue = "PUT"
+	RequestMethodMatchValueTRACE   RequestMethodMatchValue = "TRACE"
+)
+
+func PossibleValuesForRequestMethodMatchValue() []string {
+	return []string{
+		string(RequestMethodMatchValueDELETE),
+		string(RequestMethodMatchValueGET),
+		string(RequestMethodMatchValueHEAD),
+		string(RequestMethodMatchValueOPTIONS),
+		string(RequestMethodMatchValuePOST),
+		string(RequestMethodMatchValuePUT),
+		string(RequestMethodMatchValueTRACE),
+	}
+}
+
+func (s *RequestMethodMatchValue) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseRequestMethodMatchValue(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseRequestMethodMatchValue(input string) (*RequestMethodMatchValue, error) {
+	vals := map[string]RequestMethodMatchValue{
+		"delete":  RequestMethodMatchValueDELETE,
+		"get":     RequestMethodMatchValueGET,
+		"head":    RequestMethodMatchValueHEAD,
+		"options": RequestMethodMatchValueOPTIONS,
+		"post":    RequestMethodMatchValuePOST,
+		"put":     RequestMethodMatchValuePUT,
+		"trace":   RequestMethodMatchValueTRACE,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := RequestMethodMatchValue(input)
+	return &out, nil
+}
+
+type RequestMethodOperator string
+
+const (
+	RequestMethodOperatorEqual RequestMethodOperator = "Equal"
+)
+
+func PossibleValuesForRequestMethodOperator() []string {
+	return []string{
+		string(RequestMethodOperatorEqual),
+	}
+}
+
+func (s *RequestMethodOperator) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseRequestMethodOperator(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseRequestMethodOperator(input string) (*RequestMethodOperator, error) {
+	vals := map[string]RequestMethodOperator{
+		"equal": RequestMethodOperatorEqual,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := RequestMethodOperator(input)
+	return &out, nil
+}
+
+type RequestSchemeMatchConditionParametersOperator string
+
+const (
+	RequestSchemeMatchConditionParametersOperatorEqual RequestSchemeMatchConditionParametersOperator = "Equal"
+)
+
+func PossibleValuesForRequestSchemeMatchConditionParametersOperator() []string {
+	return []string{
+		string(RequestSchemeMatchConditionParametersOperatorEqual),
+	}
+}
+
+func (s *RequestSchemeMatchConditionParametersOperator) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseRequestSchemeMatchConditionParametersOperator(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseRequestSchemeMatchConditionParametersOperator(input string) (*RequestSchemeMatchConditionParametersOperator, error) {
+	vals := map[string]RequestSchemeMatchConditionParametersOperator{
+		"equal": RequestSchemeMatchConditionParametersOperatorEqual,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := RequestSchemeMatchConditionParametersOperator(input)
+	return &out, nil
+}
+
+type RequestSchemeMatchValue string
+
+const (
+	RequestSchemeMatchValueHTTP  RequestSchemeMatchValue = "HTTP"
+	RequestSchemeMatchValueHTTPS RequestSchemeMatchValue = "HTTPS"
+)
+
+func PossibleValuesForRequestSchemeMatchValue() []string {
+	return []string{
+		string(RequestSchemeMatchValueHTTP),
+		string(RequestSchemeMatchValueHTTPS),
+	}
+}
+
+func (s *RequestSchemeMatchValue) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseRequestSchemeMatchValue(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseRequestSchemeMatchValue(input string) (*RequestSchemeMatchValue, error) {
+	vals := map[string]RequestSchemeMatchValue{
+		"http":  RequestSchemeMatchValueHTTP,
+		"https": RequestSchemeMatchValueHTTPS,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := RequestSchemeMatchValue(input)
+	return &out, nil
+}
+
+type RequestUriOperator string
+
+const (
+	RequestUriOperatorAny                RequestUriOperator = "Any"
+	RequestUriOperatorBeginsWith         RequestUriOperator = "BeginsWith"
+	RequestUriOperatorContains           RequestUriOperator = "Contains"
+	RequestUriOperatorEndsWith           RequestUriOperator = "EndsWith"
+	RequestUriOperatorEqual              RequestUriOperator = "Equal"
+	RequestUriOperatorGreaterThan        RequestUriOperator = "GreaterThan"
+	RequestUriOperatorGreaterThanOrEqual RequestUriOperator = "GreaterThanOrEqual"
+	RequestUriOperatorLessThan           RequestUriOperator = "LessThan"
+	RequestUriOperatorLessThanOrEqual    RequestUriOperator = "LessThanOrEqual"
+	RequestUriOperatorRegEx              RequestUriOperator = "RegEx"
+)
+
+func PossibleValuesForRequestUriOperator() []string {
+	return []string{
+		string(RequestUriOperatorAny),
+		string(RequestUriOperatorBeginsWith),
+		string(RequestUriOperatorContains),
+		string(RequestUriOperatorEndsWith),
+		string(RequestUriOperatorEqual),
+		string(RequestUriOperatorGreaterThan),
+		string(RequestUriOperatorGreaterThanOrEqual),
+		string(RequestUriOperatorLessThan),
+		string(RequestUriOperatorLessThanOrEqual),
+		string(RequestUriOperatorRegEx),
+	}
+}
+
+func (s *RequestUriOperator) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseRequestUriOperator(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseRequestUriOperator(input string) (*RequestUriOperator, error) {
+	vals := map[string]RequestUriOperator{
+		"any":                RequestUriOperatorAny,
+		"beginswith":         RequestUriOperatorBeginsWith,
+		"contains":           RequestUriOperatorContains,
+		"endswith":           RequestUriOperatorEndsWith,
+		"equal":              RequestUriOperatorEqual,
+		"greaterthan":        RequestUriOperatorGreaterThan,
+		"greaterthanorequal": RequestUriOperatorGreaterThanOrEqual,
+		"lessthan":           RequestUriOperatorLessThan,
+		"lessthanorequal":    RequestUriOperatorLessThanOrEqual,
+		"regex":              RequestUriOperatorRegEx,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := RequestUriOperator(input)
+	return &out, nil
+}
+
+type RuleCacheBehavior string
+
+const (
+	RuleCacheBehaviorHonorOrigin             RuleCacheBehavior = "HonorOrigin"
+	RuleCacheBehaviorOverrideAlways          RuleCacheBehavior = "OverrideAlways"
+	RuleCacheBehaviorOverrideIfOriginMissing RuleCacheBehavior = "OverrideIfOriginMissing"
+)
+
+func PossibleValuesForRuleCacheBehavior() []string {
+	return []string{
+		string(RuleCacheBehaviorHonorOrigin),
+		string(RuleCacheBehaviorOverrideAlways),
+		string(RuleCacheBehaviorOverrideIfOriginMissing),
+	}
+}
+
+func (s *RuleCacheBehavior) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseRuleCacheBehavior(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseRuleCacheBehavior(input string) (*RuleCacheBehavior, error) {
+	vals := map[string]RuleCacheBehavior{
+		"honororigin":             RuleCacheBehaviorHonorOrigin,
+		"overridealways":          RuleCacheBehaviorOverrideAlways,
+		"overrideiforiginmissing": RuleCacheBehaviorOverrideIfOriginMissing,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := RuleCacheBehavior(input)
+	return &out, nil
+}
+
+type RuleIsCompressionEnabled string
+
+const (
+	RuleIsCompressionEnabledDisabled RuleIsCompressionEnabled = "Disabled"
+	RuleIsCompressionEnabledEnabled  RuleIsCompressionEnabled = "Enabled"
+)
+
+func PossibleValuesForRuleIsCompressionEnabled() []string {
+	return []string{
+		string(RuleIsCompressionEnabledDisabled),
+		string(RuleIsCompressionEnabledEnabled),
+	}
+}
+
+func (s *RuleIsCompressionEnabled) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseRuleIsCompressionEnabled(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseRuleIsCompressionEnabled(input string) (*RuleIsCompressionEnabled, error) {
+	vals := map[string]RuleIsCompressionEnabled{
+		"disabled": RuleIsCompressionEnabledDisabled,
+		"enabled":  RuleIsCompressionEnabledEnabled,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := RuleIsCompressionEnabled(input)
+	return &out, nil
+}
+
+type RuleQueryStringCachingBehavior string
+
+const (
+	RuleQueryStringCachingBehaviorIgnoreQueryString            RuleQueryStringCachingBehavior = "IgnoreQueryString"
+	RuleQueryStringCachingBehaviorIgnoreSpecifiedQueryStrings  RuleQueryStringCachingBehavior = "IgnoreSpecifiedQueryStrings"
+	RuleQueryStringCachingBehaviorIncludeSpecifiedQueryStrings RuleQueryStringCachingBehavior = "IncludeSpecifiedQueryStrings"
+	RuleQueryStringCachingBehaviorUseQueryString               RuleQueryStringCachingBehavior = "UseQueryString"
+)
+
+func PossibleValuesForRuleQueryStringCachingBehavior() []string {
+	return []string{
+		string(RuleQueryStringCachingBehaviorIgnoreQueryString),
+		string(RuleQueryStringCachingBehaviorIgnoreSpecifiedQueryStrings),
+		string(RuleQueryStringCachingBehaviorIncludeSpecifiedQueryStrings),
+		string(RuleQueryStringCachingBehaviorUseQueryString),
+	}
+}
+
+func (s *RuleQueryStringCachingBehavior) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseRuleQueryStringCachingBehavior(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseRuleQueryStringCachingBehavior(input string) (*RuleQueryStringCachingBehavior, error) {
+	vals := map[string]RuleQueryStringCachingBehavior{
+		"ignorequerystring":            RuleQueryStringCachingBehaviorIgnoreQueryString,
+		"ignorespecifiedquerystrings":  RuleQueryStringCachingBehaviorIgnoreSpecifiedQueryStrings,
+		"includespecifiedquerystrings": RuleQueryStringCachingBehaviorIncludeSpecifiedQueryStrings,
+		"usequerystring":               RuleQueryStringCachingBehaviorUseQueryString,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := RuleQueryStringCachingBehavior(input)
+	return &out, nil
+}
+
+type ServerPortOperator string
+
+const (
+	ServerPortOperatorAny                ServerPortOperator = "Any"
+	ServerPortOperatorBeginsWith         ServerPortOperator = "BeginsWith"
+	ServerPortOperatorContains           ServerPortOperator = "Contains"
+	ServerPortOperatorEndsWith           ServerPortOperator = "EndsWith"
+	ServerPortOperatorEqual              ServerPortOperator = "Equal"
+	ServerPortOperatorGreaterThan        ServerPortOperator = "GreaterThan"
+	ServerPortOperatorGreaterThanOrEqual ServerPortOperator = "GreaterThanOrEqual"
+	ServerPortOperatorLessThan           ServerPortOperator = "LessThan"
+	ServerPortOperatorLessThanOrEqual    ServerPortOperator = "LessThanOrEqual"
+	ServerPortOperatorRegEx              ServerPortOperator = "RegEx"
+)
+
+func PossibleValuesForServerPortOperator() []string {
+	return []string{
+		string(ServerPortOperatorAny),
+		string(ServerPortOperatorBeginsWith),
+		string(ServerPortOperatorContains),
+		string(ServerPortOperatorEndsWith),
+		string(ServerPortOperatorEqual),
+		string(ServerPortOperatorGreaterThan),
+		string(ServerPortOperatorGreaterThanOrEqual),
+		string(ServerPortOperatorLessThan),
+		string(ServerPortOperatorLessThanOrEqual),
+		string(ServerPortOperatorRegEx),
+	}
+}
+
+func (s *ServerPortOperator) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseServerPortOperator(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseServerPortOperator(input string) (*ServerPortOperator, error) {
+	vals := map[string]ServerPortOperator{
+		"any":                ServerPortOperatorAny,
+		"beginswith":         ServerPortOperatorBeginsWith,
+		"contains":           ServerPortOperatorContains,
+		"endswith":           ServerPortOperatorEndsWith,
+		"equal":              ServerPortOperatorEqual,
+		"greaterthan":        ServerPortOperatorGreaterThan,
+		"greaterthanorequal": ServerPortOperatorGreaterThanOrEqual,
+		"lessthan":           ServerPortOperatorLessThan,
+		"lessthanorequal":    ServerPortOperatorLessThanOrEqual,
+		"regex":              ServerPortOperatorRegEx,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ServerPortOperator(input)
+	return &out, nil
+}
+
+type SocketAddrOperator string
+
+const (
+	SocketAddrOperatorAny     SocketAddrOperator = "Any"
+	SocketAddrOperatorIPMatch SocketAddrOperator = "IPMatch"
+)
+
+func PossibleValuesForSocketAddrOperator() []string {
+	return []string{
+		string(SocketAddrOperatorAny),
+		string(SocketAddrOperatorIPMatch),
+	}
+}
+
+func (s *SocketAddrOperator) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseSocketAddrOperator(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseSocketAddrOperator(input string) (*SocketAddrOperator, error) {
+	vals := map[string]SocketAddrOperator{
+		"any":     SocketAddrOperatorAny,
+		"ipmatch": SocketAddrOperatorIPMatch,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SocketAddrOperator(input)
+	return &out, nil
+}
+
+type SslProtocol string
+
+const (
+	SslProtocolTLSvOne         SslProtocol = "TLSv1"
+	SslProtocolTLSvOnePointOne SslProtocol = "TLSv1.1"
+	SslProtocolTLSvOnePointTwo SslProtocol = "TLSv1.2"
+)
+
+func PossibleValuesForSslProtocol() []string {
+	return []string{
+		string(SslProtocolTLSvOne),
+		string(SslProtocolTLSvOnePointOne),
+		string(SslProtocolTLSvOnePointTwo),
+	}
+}
+
+func (s *SslProtocol) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseSslProtocol(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseSslProtocol(input string) (*SslProtocol, error) {
+	vals := map[string]SslProtocol{
+		"tlsv1":   SslProtocolTLSvOne,
+		"tlsv1.1": SslProtocolTLSvOnePointOne,
+		"tlsv1.2": SslProtocolTLSvOnePointTwo,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SslProtocol(input)
+	return &out, nil
+}
+
+type SslProtocolOperator string
+
+const (
+	SslProtocolOperatorEqual SslProtocolOperator = "Equal"
+)
+
+func PossibleValuesForSslProtocolOperator() []string {
+	return []string{
+		string(SslProtocolOperatorEqual),
+	}
+}
+
+func (s *SslProtocolOperator) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseSslProtocolOperator(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseSslProtocolOperator(input string) (*SslProtocolOperator, error) {
+	vals := map[string]SslProtocolOperator{
+		"equal": SslProtocolOperatorEqual,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SslProtocolOperator(input)
+	return &out, nil
+}
+
+type Transform string
+
+const (
+	TransformLowercase   Transform = "Lowercase"
+	TransformRemoveNulls Transform = "RemoveNulls"
+	TransformTrim        Transform = "Trim"
+	TransformURLDecode   Transform = "UrlDecode"
+	TransformURLEncode   Transform = "UrlEncode"
+	TransformUppercase   Transform = "Uppercase"
+)
+
+func PossibleValuesForTransform() []string {
+	return []string{
+		string(TransformLowercase),
+		string(TransformRemoveNulls),
+		string(TransformTrim),
+		string(TransformURLDecode),
+		string(TransformURLEncode),
+		string(TransformUppercase),
+	}
+}
+
+func (s *Transform) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseTransform(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseTransform(input string) (*Transform, error) {
+	vals := map[string]Transform{
+		"lowercase":   TransformLowercase,
+		"removenulls": TransformRemoveNulls,
+		"trim":        TransformTrim,
+		"urldecode":   TransformURLDecode,
+		"urlencode":   TransformURLEncode,
+		"uppercase":   TransformUppercase,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := Transform(input)
+	return &out, nil
+}
+
+type URLFileExtensionOperator string
+
+const (
+	URLFileExtensionOperatorAny                URLFileExtensionOperator = "Any"
+	URLFileExtensionOperatorBeginsWith         URLFileExtensionOperator = "BeginsWith"
+	URLFileExtensionOperatorContains           URLFileExtensionOperator = "Contains"
+	URLFileExtensionOperatorEndsWith           URLFileExtensionOperator = "EndsWith"
+	URLFileExtensionOperatorEqual              URLFileExtensionOperator = "Equal"
+	URLFileExtensionOperatorGreaterThan        URLFileExtensionOperator = "GreaterThan"
+	URLFileExtensionOperatorGreaterThanOrEqual URLFileExtensionOperator = "GreaterThanOrEqual"
+	URLFileExtensionOperatorLessThan           URLFileExtensionOperator = "LessThan"
+	URLFileExtensionOperatorLessThanOrEqual    URLFileExtensionOperator = "LessThanOrEqual"
+	URLFileExtensionOperatorRegEx              URLFileExtensionOperator = "RegEx"
+)
+
+func PossibleValuesForURLFileExtensionOperator() []string {
+	return []string{
+		string(URLFileExtensionOperatorAny),
+		string(URLFileExtensionOperatorBeginsWith),
+		string(URLFileExtensionOperatorContains),
+		string(URLFileExtensionOperatorEndsWith),
+		string(URLFileExtensionOperatorEqual),
+		string(URLFileExtensionOperatorGreaterThan),
+		string(URLFileExtensionOperatorGreaterThanOrEqual),
+		string(URLFileExtensionOperatorLessThan),
+		string(URLFileExtensionOperatorLessThanOrEqual),
+		string(URLFileExtensionOperatorRegEx),
+	}
+}
+
+func (s *URLFileExtensionOperator) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseURLFileExtensionOperator(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseURLFileExtensionOperator(input string) (*URLFileExtensionOperator, error) {
+	vals := map[string]URLFileExtensionOperator{
+		"any":                URLFileExtensionOperatorAny,
+		"beginswith":         URLFileExtensionOperatorBeginsWith,
+		"contains":           URLFileExtensionOperatorContains,
+		"endswith":           URLFileExtensionOperatorEndsWith,
+		"equal":              URLFileExtensionOperatorEqual,
+		"greaterthan":        URLFileExtensionOperatorGreaterThan,
+		"greaterthanorequal": URLFileExtensionOperatorGreaterThanOrEqual,
+		"lessthan":           URLFileExtensionOperatorLessThan,
+		"lessthanorequal":    URLFileExtensionOperatorLessThanOrEqual,
+		"regex":              URLFileExtensionOperatorRegEx,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := URLFileExtensionOperator(input)
+	return &out, nil
+}
+
+type URLFileNameOperator string
+
+const (
+	URLFileNameOperatorAny                URLFileNameOperator = "Any"
+	URLFileNameOperatorBeginsWith         URLFileNameOperator = "BeginsWith"
+	URLFileNameOperatorContains           URLFileNameOperator = "Contains"
+	URLFileNameOperatorEndsWith           URLFileNameOperator = "EndsWith"
+	URLFileNameOperatorEqual              URLFileNameOperator = "Equal"
+	URLFileNameOperatorGreaterThan        URLFileNameOperator = "GreaterThan"
+	URLFileNameOperatorGreaterThanOrEqual URLFileNameOperator = "GreaterThanOrEqual"
+	URLFileNameOperatorLessThan           URLFileNameOperator = "LessThan"
+	URLFileNameOperatorLessThanOrEqual    URLFileNameOperator = "LessThanOrEqual"
+	URLFileNameOperatorRegEx              URLFileNameOperator = "RegEx"
+)
+
+func PossibleValuesForURLFileNameOperator() []string {
+	return []string{
+		string(URLFileNameOperatorAny),
+		string(URLFileNameOperatorBeginsWith),
+		string(URLFileNameOperatorContains),
+		string(URLFileNameOperatorEndsWith),
+		string(URLFileNameOperatorEqual),
+		string(URLFileNameOperatorGreaterThan),
+		string(URLFileNameOperatorGreaterThanOrEqual),
+		string(URLFileNameOperatorLessThan),
+		string(URLFileNameOperatorLessThanOrEqual),
+		string(URLFileNameOperatorRegEx),
+	}
+}
+
+func (s *URLFileNameOperator) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseURLFileNameOperator(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseURLFileNameOperator(input string) (*URLFileNameOperator, error) {
+	vals := map[string]URLFileNameOperator{
+		"any":                URLFileNameOperatorAny,
+		"beginswith":         URLFileNameOperatorBeginsWith,
+		"contains":           URLFileNameOperatorContains,
+		"endswith":           URLFileNameOperatorEndsWith,
+		"equal":              URLFileNameOperatorEqual,
+		"greaterthan":        URLFileNameOperatorGreaterThan,
+		"greaterthanorequal": URLFileNameOperatorGreaterThanOrEqual,
+		"lessthan":           URLFileNameOperatorLessThan,
+		"lessthanorequal":    URLFileNameOperatorLessThanOrEqual,
+		"regex":              URLFileNameOperatorRegEx,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := URLFileNameOperator(input)
+	return &out, nil
+}
+
+type URLPathOperator string
+
+const (
+	URLPathOperatorAny                URLPathOperator = "Any"
+	URLPathOperatorBeginsWith         URLPathOperator = "BeginsWith"
+	URLPathOperatorContains           URLPathOperator = "Contains"
+	URLPathOperatorEndsWith           URLPathOperator = "EndsWith"
+	URLPathOperatorEqual              URLPathOperator = "Equal"
+	URLPathOperatorGreaterThan        URLPathOperator = "GreaterThan"
+	URLPathOperatorGreaterThanOrEqual URLPathOperator = "GreaterThanOrEqual"
+	URLPathOperatorLessThan           URLPathOperator = "LessThan"
+	URLPathOperatorLessThanOrEqual    URLPathOperator = "LessThanOrEqual"
+	URLPathOperatorRegEx              URLPathOperator = "RegEx"
+	URLPathOperatorWildcard           URLPathOperator = "Wildcard"
+)
+
+func PossibleValuesForURLPathOperator() []string {
+	return []string{
+		string(URLPathOperatorAny),
+		string(URLPathOperatorBeginsWith),
+		string(URLPathOperatorContains),
+		string(URLPathOperatorEndsWith),
+		string(URLPathOperatorEqual),
+		string(URLPathOperatorGreaterThan),
+		string(URLPathOperatorGreaterThanOrEqual),
+		string(URLPathOperatorLessThan),
+		string(URLPathOperatorLessThanOrEqual),
+		string(URLPathOperatorRegEx),
+		string(URLPathOperatorWildcard),
+	}
+}
+
+func (s *URLPathOperator) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseURLPathOperator(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseURLPathOperator(input string) (*URLPathOperator, error) {
+	vals := map[string]URLPathOperator{
+		"any":                URLPathOperatorAny,
+		"beginswith":         URLPathOperatorBeginsWith,
+		"contains":           URLPathOperatorContains,
+		"endswith":           URLPathOperatorEndsWith,
+		"equal":              URLPathOperatorEqual,
+		"greaterthan":        URLPathOperatorGreaterThan,
+		"greaterthanorequal": URLPathOperatorGreaterThanOrEqual,
+		"lessthan":           URLPathOperatorLessThan,
+		"lessthanorequal":    URLPathOperatorLessThanOrEqual,
+		"regex":              URLPathOperatorRegEx,
+		"wildcard":           URLPathOperatorWildcard,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := URLPathOperator(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/id_rule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/id_rule.go
@@ -1,0 +1,148 @@
+package rules
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&RuleId{})
+}
+
+var _ resourceids.ResourceId = &RuleId{}
+
+// RuleId is a struct representing the Resource ID for a Rule
+type RuleId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	ProfileName       string
+	RuleSetName       string
+	RuleName          string
+}
+
+// NewRuleID returns a new RuleId struct
+func NewRuleID(subscriptionId string, resourceGroupName string, profileName string, ruleSetName string, ruleName string) RuleId {
+	return RuleId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		ProfileName:       profileName,
+		RuleSetName:       ruleSetName,
+		RuleName:          ruleName,
+	}
+}
+
+// ParseRuleID parses 'input' into a RuleId
+func ParseRuleID(input string) (*RuleId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&RuleId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := RuleId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseRuleIDInsensitively parses 'input' case-insensitively into a RuleId
+// note: this method should only be used for API response data and not user input
+func ParseRuleIDInsensitively(input string) (*RuleId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&RuleId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := RuleId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *RuleId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.ProfileName, ok = input.Parsed["profileName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "profileName", input)
+	}
+
+	if id.RuleSetName, ok = input.Parsed["ruleSetName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "ruleSetName", input)
+	}
+
+	if id.RuleName, ok = input.Parsed["ruleName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "ruleName", input)
+	}
+
+	return nil
+}
+
+// ValidateRuleID checks that 'input' can be parsed as a Rule ID
+func ValidateRuleID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseRuleID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Rule ID
+func (id RuleId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Cdn/profiles/%s/ruleSets/%s/rules/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.ProfileName, id.RuleSetName, id.RuleName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Rule ID
+func (id RuleId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftCdn", "Microsoft.Cdn", "Microsoft.Cdn"),
+		resourceids.StaticSegment("staticProfiles", "profiles", "profiles"),
+		resourceids.UserSpecifiedSegment("profileName", "profileName"),
+		resourceids.StaticSegment("staticRuleSets", "ruleSets", "ruleSets"),
+		resourceids.UserSpecifiedSegment("ruleSetName", "ruleSetName"),
+		resourceids.StaticSegment("staticRules", "rules", "rules"),
+		resourceids.UserSpecifiedSegment("ruleName", "ruleName"),
+	}
+}
+
+// String returns a human-readable description of this Rule ID
+func (id RuleId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Profile Name: %q", id.ProfileName),
+		fmt.Sprintf("Rule Set Name: %q", id.RuleSetName),
+		fmt.Sprintf("Rule Name: %q", id.RuleName),
+	}
+	return fmt.Sprintf("Rule (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/id_ruleset.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/id_ruleset.go
@@ -1,0 +1,139 @@
+package rules
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&RuleSetId{})
+}
+
+var _ resourceids.ResourceId = &RuleSetId{}
+
+// RuleSetId is a struct representing the Resource ID for a Rule Set
+type RuleSetId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	ProfileName       string
+	RuleSetName       string
+}
+
+// NewRuleSetID returns a new RuleSetId struct
+func NewRuleSetID(subscriptionId string, resourceGroupName string, profileName string, ruleSetName string) RuleSetId {
+	return RuleSetId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		ProfileName:       profileName,
+		RuleSetName:       ruleSetName,
+	}
+}
+
+// ParseRuleSetID parses 'input' into a RuleSetId
+func ParseRuleSetID(input string) (*RuleSetId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&RuleSetId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := RuleSetId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseRuleSetIDInsensitively parses 'input' case-insensitively into a RuleSetId
+// note: this method should only be used for API response data and not user input
+func ParseRuleSetIDInsensitively(input string) (*RuleSetId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&RuleSetId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := RuleSetId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *RuleSetId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.ProfileName, ok = input.Parsed["profileName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "profileName", input)
+	}
+
+	if id.RuleSetName, ok = input.Parsed["ruleSetName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "ruleSetName", input)
+	}
+
+	return nil
+}
+
+// ValidateRuleSetID checks that 'input' can be parsed as a Rule Set ID
+func ValidateRuleSetID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseRuleSetID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Rule Set ID
+func (id RuleSetId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Cdn/profiles/%s/ruleSets/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.ProfileName, id.RuleSetName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Rule Set ID
+func (id RuleSetId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftCdn", "Microsoft.Cdn", "Microsoft.Cdn"),
+		resourceids.StaticSegment("staticProfiles", "profiles", "profiles"),
+		resourceids.UserSpecifiedSegment("profileName", "profileName"),
+		resourceids.StaticSegment("staticRuleSets", "ruleSets", "ruleSets"),
+		resourceids.UserSpecifiedSegment("ruleSetName", "ruleSetName"),
+	}
+}
+
+// String returns a human-readable description of this Rule Set ID
+func (id RuleSetId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Profile Name: %q", id.ProfileName),
+		fmt.Sprintf("Rule Set Name: %q", id.RuleSetName),
+	}
+	return fmt.Sprintf("Rule Set (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/method_create.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/method_create.go
@@ -1,0 +1,87 @@
+package rules
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *Rule
+}
+
+// Create ...
+func (c RulesClient) Create(ctx context.Context, id RuleId, input Rule) (result CreateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusCreated,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// CreateThenPoll performs Create then polls until it's completed
+func (c RulesClient) CreateThenPoll(ctx context.Context, id RuleId, input Rule) error {
+	return c.CreateCallbackThenPoll(ctx, id, input, nil)
+}
+
+// CreateCallbackThenPoll performs Create, runs the optional callback function, then polls until it's completed
+func (c RulesClient) CreateCallbackThenPoll(ctx context.Context, id RuleId, input Rule, callback func() error) error {
+	result, err := c.Create(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Create: %+v", err)
+	}
+
+	if callback != nil {
+		if err := callback(); err != nil {
+			return fmt.Errorf("executing callback function: %+v", err)
+		}
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Create: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/method_delete.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/method_delete.go
@@ -1,0 +1,71 @@
+package rules
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// Delete ...
+func (c RulesClient) Delete(ctx context.Context, id RuleId) (result DeleteOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusNoContent,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodDelete,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// DeleteThenPoll performs Delete then polls until it's completed
+func (c RulesClient) DeleteThenPoll(ctx context.Context, id RuleId) error {
+	result, err := c.Delete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Delete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Delete: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/method_get.go
@@ -1,0 +1,53 @@
+package rules
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *Rule
+}
+
+// Get ...
+func (c RulesClient) Get(ctx context.Context, id RuleId) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model Rule
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/method_listbyruleset.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/method_listbyruleset.go
@@ -1,0 +1,105 @@
+package rules
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListByRuleSetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]Rule
+}
+
+type ListByRuleSetCompleteResult struct {
+	LatestHttpResponse *http.Response
+	Items              []Rule
+}
+
+type ListByRuleSetCustomPager struct {
+	NextLink *odata.Link `json:"nextLink"`
+}
+
+func (p *ListByRuleSetCustomPager) NextPageLink() *odata.Link {
+	defer func() {
+		p.NextLink = nil
+	}()
+
+	return p.NextLink
+}
+
+// ListByRuleSet ...
+func (c RulesClient) ListByRuleSet(ctx context.Context, id RuleSetId) (result ListByRuleSetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Pager:      &ListByRuleSetCustomPager{},
+		Path:       fmt.Sprintf("%s/rules", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]Rule `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListByRuleSetComplete retrieves all the results into a single object
+func (c RulesClient) ListByRuleSetComplete(ctx context.Context, id RuleSetId) (ListByRuleSetCompleteResult, error) {
+	return c.ListByRuleSetCompleteMatchingPredicate(ctx, id, RuleOperationPredicate{})
+}
+
+// ListByRuleSetCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c RulesClient) ListByRuleSetCompleteMatchingPredicate(ctx context.Context, id RuleSetId, predicate RuleOperationPredicate) (result ListByRuleSetCompleteResult, err error) {
+	items := make([]Rule, 0)
+
+	resp, err := c.ListByRuleSet(ctx, id)
+	if err != nil {
+		result.LatestHttpResponse = resp.HttpResponse
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListByRuleSetCompleteResult{
+		LatestHttpResponse: resp.HttpResponse,
+		Items:              items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/method_update.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/method_update.go
@@ -1,0 +1,86 @@
+package rules
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *Rule
+}
+
+// Update ...
+func (c RulesClient) Update(ctx context.Context, id RuleId, input RuleUpdateParameters) (result UpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPatch,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// UpdateThenPoll performs Update then polls until it's completed
+func (c RulesClient) UpdateThenPoll(ctx context.Context, id RuleId, input RuleUpdateParameters) error {
+	return c.UpdateCallbackThenPoll(ctx, id, input, nil)
+}
+
+// UpdateCallbackThenPoll performs Update, runs the optional callback function, then polls until it's completed
+func (c RulesClient) UpdateCallbackThenPoll(ctx context.Context, id RuleId, input RuleUpdateParameters, callback func() error) error {
+	result, err := c.Update(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Update: %+v", err)
+	}
+
+	if callback != nil {
+		if err := callback(); err != nil {
+			return fmt.Errorf("executing callback function: %+v", err)
+		}
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Update: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_cacheconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_cacheconfiguration.go
@@ -1,0 +1,12 @@
+package rules
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CacheConfiguration struct {
+	CacheBehavior              *RuleCacheBehavior              `json:"cacheBehavior,omitempty"`
+	CacheDuration              *string                         `json:"cacheDuration,omitempty"`
+	IsCompressionEnabled       *RuleIsCompressionEnabled       `json:"isCompressionEnabled,omitempty"`
+	QueryParameters            *string                         `json:"queryParameters,omitempty"`
+	QueryStringCachingBehavior *RuleQueryStringCachingBehavior `json:"queryStringCachingBehavior,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_cacheexpirationactionparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_cacheexpirationactionparameters.go
@@ -1,0 +1,52 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleActionParameters = CacheExpirationActionParameters{}
+
+type CacheExpirationActionParameters struct {
+	CacheBehavior CacheBehavior `json:"cacheBehavior"`
+	CacheDuration *string       `json:"cacheDuration,omitempty"`
+	CacheType     CacheType     `json:"cacheType"`
+
+	// Fields inherited from DeliveryRuleActionParameters
+
+	TypeName DeliveryRuleActionParametersType `json:"typeName"`
+}
+
+func (s CacheExpirationActionParameters) DeliveryRuleActionParameters() BaseDeliveryRuleActionParametersImpl {
+	return BaseDeliveryRuleActionParametersImpl{
+		TypeName: s.TypeName,
+	}
+}
+
+var _ json.Marshaler = CacheExpirationActionParameters{}
+
+func (s CacheExpirationActionParameters) MarshalJSON() ([]byte, error) {
+	type wrapper CacheExpirationActionParameters
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling CacheExpirationActionParameters: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling CacheExpirationActionParameters: %+v", err)
+	}
+
+	decoded["typeName"] = "DeliveryRuleCacheExpirationActionParameters"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling CacheExpirationActionParameters: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_cachekeyquerystringactionparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_cachekeyquerystringactionparameters.go
@@ -1,0 +1,51 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleActionParameters = CacheKeyQueryStringActionParameters{}
+
+type CacheKeyQueryStringActionParameters struct {
+	QueryParameters     *string             `json:"queryParameters,omitempty"`
+	QueryStringBehavior QueryStringBehavior `json:"queryStringBehavior"`
+
+	// Fields inherited from DeliveryRuleActionParameters
+
+	TypeName DeliveryRuleActionParametersType `json:"typeName"`
+}
+
+func (s CacheKeyQueryStringActionParameters) DeliveryRuleActionParameters() BaseDeliveryRuleActionParametersImpl {
+	return BaseDeliveryRuleActionParametersImpl{
+		TypeName: s.TypeName,
+	}
+}
+
+var _ json.Marshaler = CacheKeyQueryStringActionParameters{}
+
+func (s CacheKeyQueryStringActionParameters) MarshalJSON() ([]byte, error) {
+	type wrapper CacheKeyQueryStringActionParameters
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling CacheKeyQueryStringActionParameters: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling CacheKeyQueryStringActionParameters: %+v", err)
+	}
+
+	decoded["typeName"] = "DeliveryRuleCacheKeyQueryStringBehaviorActionParameters"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling CacheKeyQueryStringActionParameters: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_clientportmatchconditionparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_clientportmatchconditionparameters.go
@@ -1,0 +1,53 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleConditionParameters = ClientPortMatchConditionParameters{}
+
+type ClientPortMatchConditionParameters struct {
+	MatchValues     *[]string          `json:"matchValues,omitempty"`
+	NegateCondition *bool              `json:"negateCondition,omitempty"`
+	Operator        ClientPortOperator `json:"operator"`
+	Transforms      *[]Transform       `json:"transforms,omitempty"`
+
+	// Fields inherited from DeliveryRuleConditionParameters
+
+	TypeName DeliveryRuleConditionParametersType `json:"typeName"`
+}
+
+func (s ClientPortMatchConditionParameters) DeliveryRuleConditionParameters() BaseDeliveryRuleConditionParametersImpl {
+	return BaseDeliveryRuleConditionParametersImpl{
+		TypeName: s.TypeName,
+	}
+}
+
+var _ json.Marshaler = ClientPortMatchConditionParameters{}
+
+func (s ClientPortMatchConditionParameters) MarshalJSON() ([]byte, error) {
+	type wrapper ClientPortMatchConditionParameters
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling ClientPortMatchConditionParameters: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling ClientPortMatchConditionParameters: %+v", err)
+	}
+
+	decoded["typeName"] = "DeliveryRuleClientPortConditionParameters"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling ClientPortMatchConditionParameters: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_cookiesmatchconditionparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_cookiesmatchconditionparameters.go
@@ -1,0 +1,54 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleConditionParameters = CookiesMatchConditionParameters{}
+
+type CookiesMatchConditionParameters struct {
+	MatchValues     *[]string       `json:"matchValues,omitempty"`
+	NegateCondition *bool           `json:"negateCondition,omitempty"`
+	Operator        CookiesOperator `json:"operator"`
+	Selector        *string         `json:"selector,omitempty"`
+	Transforms      *[]Transform    `json:"transforms,omitempty"`
+
+	// Fields inherited from DeliveryRuleConditionParameters
+
+	TypeName DeliveryRuleConditionParametersType `json:"typeName"`
+}
+
+func (s CookiesMatchConditionParameters) DeliveryRuleConditionParameters() BaseDeliveryRuleConditionParametersImpl {
+	return BaseDeliveryRuleConditionParametersImpl{
+		TypeName: s.TypeName,
+	}
+}
+
+var _ json.Marshaler = CookiesMatchConditionParameters{}
+
+func (s CookiesMatchConditionParameters) MarshalJSON() ([]byte, error) {
+	type wrapper CookiesMatchConditionParameters
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling CookiesMatchConditionParameters: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling CookiesMatchConditionParameters: %+v", err)
+	}
+
+	decoded["typeName"] = "DeliveryRuleCookiesConditionParameters"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling CookiesMatchConditionParameters: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryruleaction.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryruleaction.go
@@ -1,0 +1,139 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeliveryRuleAction interface {
+	DeliveryRuleAction() BaseDeliveryRuleActionImpl
+}
+
+var _ DeliveryRuleAction = BaseDeliveryRuleActionImpl{}
+
+type BaseDeliveryRuleActionImpl struct {
+	Name DeliveryRuleActionName `json:"name"`
+}
+
+func (s BaseDeliveryRuleActionImpl) DeliveryRuleAction() BaseDeliveryRuleActionImpl {
+	return s
+}
+
+var _ DeliveryRuleAction = RawDeliveryRuleActionImpl{}
+
+// RawDeliveryRuleActionImpl is returned when the Discriminated Value doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawDeliveryRuleActionImpl struct {
+	deliveryRuleAction BaseDeliveryRuleActionImpl
+	Type               string
+	Values             map[string]interface{}
+}
+
+func (s RawDeliveryRuleActionImpl) DeliveryRuleAction() BaseDeliveryRuleActionImpl {
+	return s.deliveryRuleAction
+}
+
+func UnmarshalDeliveryRuleActionImplementation(input []byte) (DeliveryRuleAction, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling DeliveryRuleAction into map[string]interface: %+v", err)
+	}
+
+	var value string
+	if v, ok := temp["name"]; ok {
+		value = fmt.Sprintf("%v", v)
+	}
+
+	if strings.EqualFold(value, "CacheExpiration") {
+		var out DeliveryRuleCacheExpirationAction
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into DeliveryRuleCacheExpirationAction: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "CacheKeyQueryString") {
+		var out DeliveryRuleCacheKeyQueryStringAction
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into DeliveryRuleCacheKeyQueryStringAction: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "ModifyRequestHeader") {
+		var out DeliveryRuleRequestHeaderAction
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into DeliveryRuleRequestHeaderAction: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "ModifyResponseHeader") {
+		var out DeliveryRuleResponseHeaderAction
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into DeliveryRuleResponseHeaderAction: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "RouteConfigurationOverride") {
+		var out DeliveryRuleRouteConfigurationOverrideAction
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into DeliveryRuleRouteConfigurationOverrideAction: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "OriginGroupOverride") {
+		var out OriginGroupOverrideAction
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into OriginGroupOverrideAction: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "UrlRedirect") {
+		var out URLRedirectAction
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into URLRedirectAction: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "UrlRewrite") {
+		var out URLRewriteAction
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into URLRewriteAction: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "UrlSigning") {
+		var out URLSigningAction
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into URLSigningAction: %+v", err)
+		}
+		return out, nil
+	}
+
+	var parent BaseDeliveryRuleActionImpl
+	if err := json.Unmarshal(input, &parent); err != nil {
+		return nil, fmt.Errorf("unmarshaling into BaseDeliveryRuleActionImpl: %+v", err)
+	}
+
+	return RawDeliveryRuleActionImpl{
+		deliveryRuleAction: parent,
+		Type:               value,
+		Values:             temp,
+	}, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryruleactionparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryruleactionparameters.go
@@ -1,0 +1,131 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeliveryRuleActionParameters interface {
+	DeliveryRuleActionParameters() BaseDeliveryRuleActionParametersImpl
+}
+
+var _ DeliveryRuleActionParameters = BaseDeliveryRuleActionParametersImpl{}
+
+type BaseDeliveryRuleActionParametersImpl struct {
+	TypeName DeliveryRuleActionParametersType `json:"typeName"`
+}
+
+func (s BaseDeliveryRuleActionParametersImpl) DeliveryRuleActionParameters() BaseDeliveryRuleActionParametersImpl {
+	return s
+}
+
+var _ DeliveryRuleActionParameters = RawDeliveryRuleActionParametersImpl{}
+
+// RawDeliveryRuleActionParametersImpl is returned when the Discriminated Value doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawDeliveryRuleActionParametersImpl struct {
+	deliveryRuleActionParameters BaseDeliveryRuleActionParametersImpl
+	Type                         string
+	Values                       map[string]interface{}
+}
+
+func (s RawDeliveryRuleActionParametersImpl) DeliveryRuleActionParameters() BaseDeliveryRuleActionParametersImpl {
+	return s.deliveryRuleActionParameters
+}
+
+func UnmarshalDeliveryRuleActionParametersImplementation(input []byte) (DeliveryRuleActionParameters, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling DeliveryRuleActionParameters into map[string]interface: %+v", err)
+	}
+
+	var value string
+	if v, ok := temp["typeName"]; ok {
+		value = fmt.Sprintf("%v", v)
+	}
+
+	if strings.EqualFold(value, "DeliveryRuleCacheExpirationActionParameters") {
+		var out CacheExpirationActionParameters
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into CacheExpirationActionParameters: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "DeliveryRuleCacheKeyQueryStringBehaviorActionParameters") {
+		var out CacheKeyQueryStringActionParameters
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into CacheKeyQueryStringActionParameters: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "DeliveryRuleHeaderActionParameters") {
+		var out HeaderActionParameters
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into HeaderActionParameters: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "DeliveryRuleOriginGroupOverrideActionParameters") {
+		var out OriginGroupOverrideActionParameters
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into OriginGroupOverrideActionParameters: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "DeliveryRuleRouteConfigurationOverrideActionParameters") {
+		var out RouteConfigurationOverrideActionParameters
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into RouteConfigurationOverrideActionParameters: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "DeliveryRuleUrlRedirectActionParameters") {
+		var out URLRedirectActionParameters
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into URLRedirectActionParameters: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "DeliveryRuleUrlRewriteActionParameters") {
+		var out URLRewriteActionParameters
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into URLRewriteActionParameters: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "DeliveryRuleUrlSigningActionParameters") {
+		var out URLSigningActionParameters
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into URLSigningActionParameters: %+v", err)
+		}
+		return out, nil
+	}
+
+	var parent BaseDeliveryRuleActionParametersImpl
+	if err := json.Unmarshal(input, &parent); err != nil {
+		return nil, fmt.Errorf("unmarshaling into BaseDeliveryRuleActionParametersImpl: %+v", err)
+	}
+
+	return RawDeliveryRuleActionParametersImpl{
+		deliveryRuleActionParameters: parent,
+		Type:                         value,
+		Values:                       temp,
+	}, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryrulecacheexpirationaction.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryrulecacheexpirationaction.go
@@ -1,0 +1,50 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleAction = DeliveryRuleCacheExpirationAction{}
+
+type DeliveryRuleCacheExpirationAction struct {
+	Parameters CacheExpirationActionParameters `json:"parameters"`
+
+	// Fields inherited from DeliveryRuleAction
+
+	Name DeliveryRuleActionName `json:"name"`
+}
+
+func (s DeliveryRuleCacheExpirationAction) DeliveryRuleAction() BaseDeliveryRuleActionImpl {
+	return BaseDeliveryRuleActionImpl{
+		Name: s.Name,
+	}
+}
+
+var _ json.Marshaler = DeliveryRuleCacheExpirationAction{}
+
+func (s DeliveryRuleCacheExpirationAction) MarshalJSON() ([]byte, error) {
+	type wrapper DeliveryRuleCacheExpirationAction
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling DeliveryRuleCacheExpirationAction: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling DeliveryRuleCacheExpirationAction: %+v", err)
+	}
+
+	decoded["name"] = "CacheExpiration"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling DeliveryRuleCacheExpirationAction: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryrulecachekeyquerystringaction.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryrulecachekeyquerystringaction.go
@@ -1,0 +1,50 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleAction = DeliveryRuleCacheKeyQueryStringAction{}
+
+type DeliveryRuleCacheKeyQueryStringAction struct {
+	Parameters CacheKeyQueryStringActionParameters `json:"parameters"`
+
+	// Fields inherited from DeliveryRuleAction
+
+	Name DeliveryRuleActionName `json:"name"`
+}
+
+func (s DeliveryRuleCacheKeyQueryStringAction) DeliveryRuleAction() BaseDeliveryRuleActionImpl {
+	return BaseDeliveryRuleActionImpl{
+		Name: s.Name,
+	}
+}
+
+var _ json.Marshaler = DeliveryRuleCacheKeyQueryStringAction{}
+
+func (s DeliveryRuleCacheKeyQueryStringAction) MarshalJSON() ([]byte, error) {
+	type wrapper DeliveryRuleCacheKeyQueryStringAction
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling DeliveryRuleCacheKeyQueryStringAction: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling DeliveryRuleCacheKeyQueryStringAction: %+v", err)
+	}
+
+	decoded["name"] = "CacheKeyQueryString"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling DeliveryRuleCacheKeyQueryStringAction: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryruleclientportcondition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryruleclientportcondition.go
@@ -1,0 +1,50 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleCondition = DeliveryRuleClientPortCondition{}
+
+type DeliveryRuleClientPortCondition struct {
+	Parameters ClientPortMatchConditionParameters `json:"parameters"`
+
+	// Fields inherited from DeliveryRuleCondition
+
+	Name MatchVariable `json:"name"`
+}
+
+func (s DeliveryRuleClientPortCondition) DeliveryRuleCondition() BaseDeliveryRuleConditionImpl {
+	return BaseDeliveryRuleConditionImpl{
+		Name: s.Name,
+	}
+}
+
+var _ json.Marshaler = DeliveryRuleClientPortCondition{}
+
+func (s DeliveryRuleClientPortCondition) MarshalJSON() ([]byte, error) {
+	type wrapper DeliveryRuleClientPortCondition
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling DeliveryRuleClientPortCondition: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling DeliveryRuleClientPortCondition: %+v", err)
+	}
+
+	decoded["name"] = "ClientPort"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling DeliveryRuleClientPortCondition: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryrulecondition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryrulecondition.go
@@ -1,0 +1,219 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeliveryRuleCondition interface {
+	DeliveryRuleCondition() BaseDeliveryRuleConditionImpl
+}
+
+var _ DeliveryRuleCondition = BaseDeliveryRuleConditionImpl{}
+
+type BaseDeliveryRuleConditionImpl struct {
+	Name MatchVariable `json:"name"`
+}
+
+func (s BaseDeliveryRuleConditionImpl) DeliveryRuleCondition() BaseDeliveryRuleConditionImpl {
+	return s
+}
+
+var _ DeliveryRuleCondition = RawDeliveryRuleConditionImpl{}
+
+// RawDeliveryRuleConditionImpl is returned when the Discriminated Value doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawDeliveryRuleConditionImpl struct {
+	deliveryRuleCondition BaseDeliveryRuleConditionImpl
+	Type                  string
+	Values                map[string]interface{}
+}
+
+func (s RawDeliveryRuleConditionImpl) DeliveryRuleCondition() BaseDeliveryRuleConditionImpl {
+	return s.deliveryRuleCondition
+}
+
+func UnmarshalDeliveryRuleConditionImplementation(input []byte) (DeliveryRuleCondition, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling DeliveryRuleCondition into map[string]interface: %+v", err)
+	}
+
+	var value string
+	if v, ok := temp["name"]; ok {
+		value = fmt.Sprintf("%v", v)
+	}
+
+	if strings.EqualFold(value, "ClientPort") {
+		var out DeliveryRuleClientPortCondition
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into DeliveryRuleClientPortCondition: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "Cookies") {
+		var out DeliveryRuleCookiesCondition
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into DeliveryRuleCookiesCondition: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "HttpVersion") {
+		var out DeliveryRuleHTTPVersionCondition
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into DeliveryRuleHTTPVersionCondition: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "HostName") {
+		var out DeliveryRuleHostNameCondition
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into DeliveryRuleHostNameCondition: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "IsDevice") {
+		var out DeliveryRuleIsDeviceCondition
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into DeliveryRuleIsDeviceCondition: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "PostArgs") {
+		var out DeliveryRulePostArgsCondition
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into DeliveryRulePostArgsCondition: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "QueryString") {
+		var out DeliveryRuleQueryStringCondition
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into DeliveryRuleQueryStringCondition: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "RemoteAddress") {
+		var out DeliveryRuleRemoteAddressCondition
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into DeliveryRuleRemoteAddressCondition: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "RequestBody") {
+		var out DeliveryRuleRequestBodyCondition
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into DeliveryRuleRequestBodyCondition: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "RequestHeader") {
+		var out DeliveryRuleRequestHeaderCondition
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into DeliveryRuleRequestHeaderCondition: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "RequestMethod") {
+		var out DeliveryRuleRequestMethodCondition
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into DeliveryRuleRequestMethodCondition: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "RequestScheme") {
+		var out DeliveryRuleRequestSchemeCondition
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into DeliveryRuleRequestSchemeCondition: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "RequestUri") {
+		var out DeliveryRuleRequestUriCondition
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into DeliveryRuleRequestUriCondition: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "ServerPort") {
+		var out DeliveryRuleServerPortCondition
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into DeliveryRuleServerPortCondition: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "SocketAddr") {
+		var out DeliveryRuleSocketAddrCondition
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into DeliveryRuleSocketAddrCondition: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "SslProtocol") {
+		var out DeliveryRuleSslProtocolCondition
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into DeliveryRuleSslProtocolCondition: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "UrlFileExtension") {
+		var out DeliveryRuleURLFileExtensionCondition
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into DeliveryRuleURLFileExtensionCondition: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "UrlFileName") {
+		var out DeliveryRuleURLFileNameCondition
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into DeliveryRuleURLFileNameCondition: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "UrlPath") {
+		var out DeliveryRuleURLPathCondition
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into DeliveryRuleURLPathCondition: %+v", err)
+		}
+		return out, nil
+	}
+
+	var parent BaseDeliveryRuleConditionImpl
+	if err := json.Unmarshal(input, &parent); err != nil {
+		return nil, fmt.Errorf("unmarshaling into BaseDeliveryRuleConditionImpl: %+v", err)
+	}
+
+	return RawDeliveryRuleConditionImpl{
+		deliveryRuleCondition: parent,
+		Type:                  value,
+		Values:                temp,
+	}, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryruleconditionparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryruleconditionparameters.go
@@ -1,0 +1,219 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeliveryRuleConditionParameters interface {
+	DeliveryRuleConditionParameters() BaseDeliveryRuleConditionParametersImpl
+}
+
+var _ DeliveryRuleConditionParameters = BaseDeliveryRuleConditionParametersImpl{}
+
+type BaseDeliveryRuleConditionParametersImpl struct {
+	TypeName DeliveryRuleConditionParametersType `json:"typeName"`
+}
+
+func (s BaseDeliveryRuleConditionParametersImpl) DeliveryRuleConditionParameters() BaseDeliveryRuleConditionParametersImpl {
+	return s
+}
+
+var _ DeliveryRuleConditionParameters = RawDeliveryRuleConditionParametersImpl{}
+
+// RawDeliveryRuleConditionParametersImpl is returned when the Discriminated Value doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawDeliveryRuleConditionParametersImpl struct {
+	deliveryRuleConditionParameters BaseDeliveryRuleConditionParametersImpl
+	Type                            string
+	Values                          map[string]interface{}
+}
+
+func (s RawDeliveryRuleConditionParametersImpl) DeliveryRuleConditionParameters() BaseDeliveryRuleConditionParametersImpl {
+	return s.deliveryRuleConditionParameters
+}
+
+func UnmarshalDeliveryRuleConditionParametersImplementation(input []byte) (DeliveryRuleConditionParameters, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling DeliveryRuleConditionParameters into map[string]interface: %+v", err)
+	}
+
+	var value string
+	if v, ok := temp["typeName"]; ok {
+		value = fmt.Sprintf("%v", v)
+	}
+
+	if strings.EqualFold(value, "DeliveryRuleClientPortConditionParameters") {
+		var out ClientPortMatchConditionParameters
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into ClientPortMatchConditionParameters: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "DeliveryRuleCookiesConditionParameters") {
+		var out CookiesMatchConditionParameters
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into CookiesMatchConditionParameters: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "DeliveryRuleHttpVersionConditionParameters") {
+		var out HTTPVersionMatchConditionParameters
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into HTTPVersionMatchConditionParameters: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "DeliveryRuleHostNameConditionParameters") {
+		var out HostNameMatchConditionParameters
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into HostNameMatchConditionParameters: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "DeliveryRuleIsDeviceConditionParameters") {
+		var out IsDeviceMatchConditionParameters
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into IsDeviceMatchConditionParameters: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "DeliveryRulePostArgsConditionParameters") {
+		var out PostArgsMatchConditionParameters
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into PostArgsMatchConditionParameters: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "DeliveryRuleQueryStringConditionParameters") {
+		var out QueryStringMatchConditionParameters
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into QueryStringMatchConditionParameters: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "DeliveryRuleRemoteAddressConditionParameters") {
+		var out RemoteAddressMatchConditionParameters
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into RemoteAddressMatchConditionParameters: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "DeliveryRuleRequestBodyConditionParameters") {
+		var out RequestBodyMatchConditionParameters
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into RequestBodyMatchConditionParameters: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "DeliveryRuleRequestHeaderConditionParameters") {
+		var out RequestHeaderMatchConditionParameters
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into RequestHeaderMatchConditionParameters: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "DeliveryRuleRequestMethodConditionParameters") {
+		var out RequestMethodMatchConditionParameters
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into RequestMethodMatchConditionParameters: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "DeliveryRuleRequestSchemeConditionParameters") {
+		var out RequestSchemeMatchConditionParameters
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into RequestSchemeMatchConditionParameters: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "DeliveryRuleRequestUriConditionParameters") {
+		var out RequestUriMatchConditionParameters
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into RequestUriMatchConditionParameters: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "DeliveryRuleServerPortConditionParameters") {
+		var out ServerPortMatchConditionParameters
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into ServerPortMatchConditionParameters: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "DeliveryRuleSocketAddrConditionParameters") {
+		var out SocketAddrMatchConditionParameters
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into SocketAddrMatchConditionParameters: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "DeliveryRuleSslProtocolConditionParameters") {
+		var out SslProtocolMatchConditionParameters
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into SslProtocolMatchConditionParameters: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "DeliveryRuleUrlFileExtensionMatchConditionParameters") {
+		var out URLFileExtensionMatchConditionParameters
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into URLFileExtensionMatchConditionParameters: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "DeliveryRuleUrlFilenameConditionParameters") {
+		var out URLFileNameMatchConditionParameters
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into URLFileNameMatchConditionParameters: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "DeliveryRuleUrlPathMatchConditionParameters") {
+		var out URLPathMatchConditionParameters
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into URLPathMatchConditionParameters: %+v", err)
+		}
+		return out, nil
+	}
+
+	var parent BaseDeliveryRuleConditionParametersImpl
+	if err := json.Unmarshal(input, &parent); err != nil {
+		return nil, fmt.Errorf("unmarshaling into BaseDeliveryRuleConditionParametersImpl: %+v", err)
+	}
+
+	return RawDeliveryRuleConditionParametersImpl{
+		deliveryRuleConditionParameters: parent,
+		Type:                            value,
+		Values:                          temp,
+	}, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryrulecookiescondition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryrulecookiescondition.go
@@ -1,0 +1,50 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleCondition = DeliveryRuleCookiesCondition{}
+
+type DeliveryRuleCookiesCondition struct {
+	Parameters CookiesMatchConditionParameters `json:"parameters"`
+
+	// Fields inherited from DeliveryRuleCondition
+
+	Name MatchVariable `json:"name"`
+}
+
+func (s DeliveryRuleCookiesCondition) DeliveryRuleCondition() BaseDeliveryRuleConditionImpl {
+	return BaseDeliveryRuleConditionImpl{
+		Name: s.Name,
+	}
+}
+
+var _ json.Marshaler = DeliveryRuleCookiesCondition{}
+
+func (s DeliveryRuleCookiesCondition) MarshalJSON() ([]byte, error) {
+	type wrapper DeliveryRuleCookiesCondition
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling DeliveryRuleCookiesCondition: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling DeliveryRuleCookiesCondition: %+v", err)
+	}
+
+	decoded["name"] = "Cookies"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling DeliveryRuleCookiesCondition: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryrulehostnamecondition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryrulehostnamecondition.go
@@ -1,0 +1,50 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleCondition = DeliveryRuleHostNameCondition{}
+
+type DeliveryRuleHostNameCondition struct {
+	Parameters HostNameMatchConditionParameters `json:"parameters"`
+
+	// Fields inherited from DeliveryRuleCondition
+
+	Name MatchVariable `json:"name"`
+}
+
+func (s DeliveryRuleHostNameCondition) DeliveryRuleCondition() BaseDeliveryRuleConditionImpl {
+	return BaseDeliveryRuleConditionImpl{
+		Name: s.Name,
+	}
+}
+
+var _ json.Marshaler = DeliveryRuleHostNameCondition{}
+
+func (s DeliveryRuleHostNameCondition) MarshalJSON() ([]byte, error) {
+	type wrapper DeliveryRuleHostNameCondition
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling DeliveryRuleHostNameCondition: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling DeliveryRuleHostNameCondition: %+v", err)
+	}
+
+	decoded["name"] = "HostName"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling DeliveryRuleHostNameCondition: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryrulehttpversioncondition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryrulehttpversioncondition.go
@@ -1,0 +1,50 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleCondition = DeliveryRuleHTTPVersionCondition{}
+
+type DeliveryRuleHTTPVersionCondition struct {
+	Parameters HTTPVersionMatchConditionParameters `json:"parameters"`
+
+	// Fields inherited from DeliveryRuleCondition
+
+	Name MatchVariable `json:"name"`
+}
+
+func (s DeliveryRuleHTTPVersionCondition) DeliveryRuleCondition() BaseDeliveryRuleConditionImpl {
+	return BaseDeliveryRuleConditionImpl{
+		Name: s.Name,
+	}
+}
+
+var _ json.Marshaler = DeliveryRuleHTTPVersionCondition{}
+
+func (s DeliveryRuleHTTPVersionCondition) MarshalJSON() ([]byte, error) {
+	type wrapper DeliveryRuleHTTPVersionCondition
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling DeliveryRuleHTTPVersionCondition: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling DeliveryRuleHTTPVersionCondition: %+v", err)
+	}
+
+	decoded["name"] = "HttpVersion"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling DeliveryRuleHTTPVersionCondition: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryruleisdevicecondition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryruleisdevicecondition.go
@@ -1,0 +1,50 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleCondition = DeliveryRuleIsDeviceCondition{}
+
+type DeliveryRuleIsDeviceCondition struct {
+	Parameters IsDeviceMatchConditionParameters `json:"parameters"`
+
+	// Fields inherited from DeliveryRuleCondition
+
+	Name MatchVariable `json:"name"`
+}
+
+func (s DeliveryRuleIsDeviceCondition) DeliveryRuleCondition() BaseDeliveryRuleConditionImpl {
+	return BaseDeliveryRuleConditionImpl{
+		Name: s.Name,
+	}
+}
+
+var _ json.Marshaler = DeliveryRuleIsDeviceCondition{}
+
+func (s DeliveryRuleIsDeviceCondition) MarshalJSON() ([]byte, error) {
+	type wrapper DeliveryRuleIsDeviceCondition
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling DeliveryRuleIsDeviceCondition: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling DeliveryRuleIsDeviceCondition: %+v", err)
+	}
+
+	decoded["name"] = "IsDevice"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling DeliveryRuleIsDeviceCondition: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryrulepostargscondition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryrulepostargscondition.go
@@ -1,0 +1,50 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleCondition = DeliveryRulePostArgsCondition{}
+
+type DeliveryRulePostArgsCondition struct {
+	Parameters PostArgsMatchConditionParameters `json:"parameters"`
+
+	// Fields inherited from DeliveryRuleCondition
+
+	Name MatchVariable `json:"name"`
+}
+
+func (s DeliveryRulePostArgsCondition) DeliveryRuleCondition() BaseDeliveryRuleConditionImpl {
+	return BaseDeliveryRuleConditionImpl{
+		Name: s.Name,
+	}
+}
+
+var _ json.Marshaler = DeliveryRulePostArgsCondition{}
+
+func (s DeliveryRulePostArgsCondition) MarshalJSON() ([]byte, error) {
+	type wrapper DeliveryRulePostArgsCondition
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling DeliveryRulePostArgsCondition: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling DeliveryRulePostArgsCondition: %+v", err)
+	}
+
+	decoded["name"] = "PostArgs"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling DeliveryRulePostArgsCondition: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryrulequerystringcondition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryrulequerystringcondition.go
@@ -1,0 +1,50 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleCondition = DeliveryRuleQueryStringCondition{}
+
+type DeliveryRuleQueryStringCondition struct {
+	Parameters QueryStringMatchConditionParameters `json:"parameters"`
+
+	// Fields inherited from DeliveryRuleCondition
+
+	Name MatchVariable `json:"name"`
+}
+
+func (s DeliveryRuleQueryStringCondition) DeliveryRuleCondition() BaseDeliveryRuleConditionImpl {
+	return BaseDeliveryRuleConditionImpl{
+		Name: s.Name,
+	}
+}
+
+var _ json.Marshaler = DeliveryRuleQueryStringCondition{}
+
+func (s DeliveryRuleQueryStringCondition) MarshalJSON() ([]byte, error) {
+	type wrapper DeliveryRuleQueryStringCondition
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling DeliveryRuleQueryStringCondition: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling DeliveryRuleQueryStringCondition: %+v", err)
+	}
+
+	decoded["name"] = "QueryString"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling DeliveryRuleQueryStringCondition: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryruleremoteaddresscondition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryruleremoteaddresscondition.go
@@ -1,0 +1,50 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleCondition = DeliveryRuleRemoteAddressCondition{}
+
+type DeliveryRuleRemoteAddressCondition struct {
+	Parameters RemoteAddressMatchConditionParameters `json:"parameters"`
+
+	// Fields inherited from DeliveryRuleCondition
+
+	Name MatchVariable `json:"name"`
+}
+
+func (s DeliveryRuleRemoteAddressCondition) DeliveryRuleCondition() BaseDeliveryRuleConditionImpl {
+	return BaseDeliveryRuleConditionImpl{
+		Name: s.Name,
+	}
+}
+
+var _ json.Marshaler = DeliveryRuleRemoteAddressCondition{}
+
+func (s DeliveryRuleRemoteAddressCondition) MarshalJSON() ([]byte, error) {
+	type wrapper DeliveryRuleRemoteAddressCondition
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling DeliveryRuleRemoteAddressCondition: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling DeliveryRuleRemoteAddressCondition: %+v", err)
+	}
+
+	decoded["name"] = "RemoteAddress"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling DeliveryRuleRemoteAddressCondition: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryrulerequestbodycondition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryrulerequestbodycondition.go
@@ -1,0 +1,50 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleCondition = DeliveryRuleRequestBodyCondition{}
+
+type DeliveryRuleRequestBodyCondition struct {
+	Parameters RequestBodyMatchConditionParameters `json:"parameters"`
+
+	// Fields inherited from DeliveryRuleCondition
+
+	Name MatchVariable `json:"name"`
+}
+
+func (s DeliveryRuleRequestBodyCondition) DeliveryRuleCondition() BaseDeliveryRuleConditionImpl {
+	return BaseDeliveryRuleConditionImpl{
+		Name: s.Name,
+	}
+}
+
+var _ json.Marshaler = DeliveryRuleRequestBodyCondition{}
+
+func (s DeliveryRuleRequestBodyCondition) MarshalJSON() ([]byte, error) {
+	type wrapper DeliveryRuleRequestBodyCondition
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling DeliveryRuleRequestBodyCondition: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling DeliveryRuleRequestBodyCondition: %+v", err)
+	}
+
+	decoded["name"] = "RequestBody"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling DeliveryRuleRequestBodyCondition: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryrulerequestheaderaction.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryrulerequestheaderaction.go
@@ -1,0 +1,50 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleAction = DeliveryRuleRequestHeaderAction{}
+
+type DeliveryRuleRequestHeaderAction struct {
+	Parameters HeaderActionParameters `json:"parameters"`
+
+	// Fields inherited from DeliveryRuleAction
+
+	Name DeliveryRuleActionName `json:"name"`
+}
+
+func (s DeliveryRuleRequestHeaderAction) DeliveryRuleAction() BaseDeliveryRuleActionImpl {
+	return BaseDeliveryRuleActionImpl{
+		Name: s.Name,
+	}
+}
+
+var _ json.Marshaler = DeliveryRuleRequestHeaderAction{}
+
+func (s DeliveryRuleRequestHeaderAction) MarshalJSON() ([]byte, error) {
+	type wrapper DeliveryRuleRequestHeaderAction
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling DeliveryRuleRequestHeaderAction: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling DeliveryRuleRequestHeaderAction: %+v", err)
+	}
+
+	decoded["name"] = "ModifyRequestHeader"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling DeliveryRuleRequestHeaderAction: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryrulerequestheadercondition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryrulerequestheadercondition.go
@@ -1,0 +1,50 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleCondition = DeliveryRuleRequestHeaderCondition{}
+
+type DeliveryRuleRequestHeaderCondition struct {
+	Parameters RequestHeaderMatchConditionParameters `json:"parameters"`
+
+	// Fields inherited from DeliveryRuleCondition
+
+	Name MatchVariable `json:"name"`
+}
+
+func (s DeliveryRuleRequestHeaderCondition) DeliveryRuleCondition() BaseDeliveryRuleConditionImpl {
+	return BaseDeliveryRuleConditionImpl{
+		Name: s.Name,
+	}
+}
+
+var _ json.Marshaler = DeliveryRuleRequestHeaderCondition{}
+
+func (s DeliveryRuleRequestHeaderCondition) MarshalJSON() ([]byte, error) {
+	type wrapper DeliveryRuleRequestHeaderCondition
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling DeliveryRuleRequestHeaderCondition: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling DeliveryRuleRequestHeaderCondition: %+v", err)
+	}
+
+	decoded["name"] = "RequestHeader"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling DeliveryRuleRequestHeaderCondition: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryrulerequestmethodcondition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryrulerequestmethodcondition.go
@@ -1,0 +1,50 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleCondition = DeliveryRuleRequestMethodCondition{}
+
+type DeliveryRuleRequestMethodCondition struct {
+	Parameters RequestMethodMatchConditionParameters `json:"parameters"`
+
+	// Fields inherited from DeliveryRuleCondition
+
+	Name MatchVariable `json:"name"`
+}
+
+func (s DeliveryRuleRequestMethodCondition) DeliveryRuleCondition() BaseDeliveryRuleConditionImpl {
+	return BaseDeliveryRuleConditionImpl{
+		Name: s.Name,
+	}
+}
+
+var _ json.Marshaler = DeliveryRuleRequestMethodCondition{}
+
+func (s DeliveryRuleRequestMethodCondition) MarshalJSON() ([]byte, error) {
+	type wrapper DeliveryRuleRequestMethodCondition
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling DeliveryRuleRequestMethodCondition: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling DeliveryRuleRequestMethodCondition: %+v", err)
+	}
+
+	decoded["name"] = "RequestMethod"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling DeliveryRuleRequestMethodCondition: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryrulerequestschemecondition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryrulerequestschemecondition.go
@@ -1,0 +1,50 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleCondition = DeliveryRuleRequestSchemeCondition{}
+
+type DeliveryRuleRequestSchemeCondition struct {
+	Parameters RequestSchemeMatchConditionParameters `json:"parameters"`
+
+	// Fields inherited from DeliveryRuleCondition
+
+	Name MatchVariable `json:"name"`
+}
+
+func (s DeliveryRuleRequestSchemeCondition) DeliveryRuleCondition() BaseDeliveryRuleConditionImpl {
+	return BaseDeliveryRuleConditionImpl{
+		Name: s.Name,
+	}
+}
+
+var _ json.Marshaler = DeliveryRuleRequestSchemeCondition{}
+
+func (s DeliveryRuleRequestSchemeCondition) MarshalJSON() ([]byte, error) {
+	type wrapper DeliveryRuleRequestSchemeCondition
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling DeliveryRuleRequestSchemeCondition: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling DeliveryRuleRequestSchemeCondition: %+v", err)
+	}
+
+	decoded["name"] = "RequestScheme"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling DeliveryRuleRequestSchemeCondition: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryrulerequesturicondition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryrulerequesturicondition.go
@@ -1,0 +1,50 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleCondition = DeliveryRuleRequestUriCondition{}
+
+type DeliveryRuleRequestUriCondition struct {
+	Parameters RequestUriMatchConditionParameters `json:"parameters"`
+
+	// Fields inherited from DeliveryRuleCondition
+
+	Name MatchVariable `json:"name"`
+}
+
+func (s DeliveryRuleRequestUriCondition) DeliveryRuleCondition() BaseDeliveryRuleConditionImpl {
+	return BaseDeliveryRuleConditionImpl{
+		Name: s.Name,
+	}
+}
+
+var _ json.Marshaler = DeliveryRuleRequestUriCondition{}
+
+func (s DeliveryRuleRequestUriCondition) MarshalJSON() ([]byte, error) {
+	type wrapper DeliveryRuleRequestUriCondition
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling DeliveryRuleRequestUriCondition: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling DeliveryRuleRequestUriCondition: %+v", err)
+	}
+
+	decoded["name"] = "RequestUri"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling DeliveryRuleRequestUriCondition: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryruleresponseheaderaction.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryruleresponseheaderaction.go
@@ -1,0 +1,50 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleAction = DeliveryRuleResponseHeaderAction{}
+
+type DeliveryRuleResponseHeaderAction struct {
+	Parameters HeaderActionParameters `json:"parameters"`
+
+	// Fields inherited from DeliveryRuleAction
+
+	Name DeliveryRuleActionName `json:"name"`
+}
+
+func (s DeliveryRuleResponseHeaderAction) DeliveryRuleAction() BaseDeliveryRuleActionImpl {
+	return BaseDeliveryRuleActionImpl{
+		Name: s.Name,
+	}
+}
+
+var _ json.Marshaler = DeliveryRuleResponseHeaderAction{}
+
+func (s DeliveryRuleResponseHeaderAction) MarshalJSON() ([]byte, error) {
+	type wrapper DeliveryRuleResponseHeaderAction
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling DeliveryRuleResponseHeaderAction: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling DeliveryRuleResponseHeaderAction: %+v", err)
+	}
+
+	decoded["name"] = "ModifyResponseHeader"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling DeliveryRuleResponseHeaderAction: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryrulerouteconfigurationoverrideaction.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryrulerouteconfigurationoverrideaction.go
@@ -1,0 +1,50 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleAction = DeliveryRuleRouteConfigurationOverrideAction{}
+
+type DeliveryRuleRouteConfigurationOverrideAction struct {
+	Parameters RouteConfigurationOverrideActionParameters `json:"parameters"`
+
+	// Fields inherited from DeliveryRuleAction
+
+	Name DeliveryRuleActionName `json:"name"`
+}
+
+func (s DeliveryRuleRouteConfigurationOverrideAction) DeliveryRuleAction() BaseDeliveryRuleActionImpl {
+	return BaseDeliveryRuleActionImpl{
+		Name: s.Name,
+	}
+}
+
+var _ json.Marshaler = DeliveryRuleRouteConfigurationOverrideAction{}
+
+func (s DeliveryRuleRouteConfigurationOverrideAction) MarshalJSON() ([]byte, error) {
+	type wrapper DeliveryRuleRouteConfigurationOverrideAction
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling DeliveryRuleRouteConfigurationOverrideAction: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling DeliveryRuleRouteConfigurationOverrideAction: %+v", err)
+	}
+
+	decoded["name"] = "RouteConfigurationOverride"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling DeliveryRuleRouteConfigurationOverrideAction: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryruleserverportcondition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryruleserverportcondition.go
@@ -1,0 +1,50 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleCondition = DeliveryRuleServerPortCondition{}
+
+type DeliveryRuleServerPortCondition struct {
+	Parameters ServerPortMatchConditionParameters `json:"parameters"`
+
+	// Fields inherited from DeliveryRuleCondition
+
+	Name MatchVariable `json:"name"`
+}
+
+func (s DeliveryRuleServerPortCondition) DeliveryRuleCondition() BaseDeliveryRuleConditionImpl {
+	return BaseDeliveryRuleConditionImpl{
+		Name: s.Name,
+	}
+}
+
+var _ json.Marshaler = DeliveryRuleServerPortCondition{}
+
+func (s DeliveryRuleServerPortCondition) MarshalJSON() ([]byte, error) {
+	type wrapper DeliveryRuleServerPortCondition
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling DeliveryRuleServerPortCondition: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling DeliveryRuleServerPortCondition: %+v", err)
+	}
+
+	decoded["name"] = "ServerPort"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling DeliveryRuleServerPortCondition: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryrulesocketaddrcondition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryrulesocketaddrcondition.go
@@ -1,0 +1,50 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleCondition = DeliveryRuleSocketAddrCondition{}
+
+type DeliveryRuleSocketAddrCondition struct {
+	Parameters SocketAddrMatchConditionParameters `json:"parameters"`
+
+	// Fields inherited from DeliveryRuleCondition
+
+	Name MatchVariable `json:"name"`
+}
+
+func (s DeliveryRuleSocketAddrCondition) DeliveryRuleCondition() BaseDeliveryRuleConditionImpl {
+	return BaseDeliveryRuleConditionImpl{
+		Name: s.Name,
+	}
+}
+
+var _ json.Marshaler = DeliveryRuleSocketAddrCondition{}
+
+func (s DeliveryRuleSocketAddrCondition) MarshalJSON() ([]byte, error) {
+	type wrapper DeliveryRuleSocketAddrCondition
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling DeliveryRuleSocketAddrCondition: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling DeliveryRuleSocketAddrCondition: %+v", err)
+	}
+
+	decoded["name"] = "SocketAddr"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling DeliveryRuleSocketAddrCondition: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryrulesslprotocolcondition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryrulesslprotocolcondition.go
@@ -1,0 +1,50 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleCondition = DeliveryRuleSslProtocolCondition{}
+
+type DeliveryRuleSslProtocolCondition struct {
+	Parameters SslProtocolMatchConditionParameters `json:"parameters"`
+
+	// Fields inherited from DeliveryRuleCondition
+
+	Name MatchVariable `json:"name"`
+}
+
+func (s DeliveryRuleSslProtocolCondition) DeliveryRuleCondition() BaseDeliveryRuleConditionImpl {
+	return BaseDeliveryRuleConditionImpl{
+		Name: s.Name,
+	}
+}
+
+var _ json.Marshaler = DeliveryRuleSslProtocolCondition{}
+
+func (s DeliveryRuleSslProtocolCondition) MarshalJSON() ([]byte, error) {
+	type wrapper DeliveryRuleSslProtocolCondition
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling DeliveryRuleSslProtocolCondition: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling DeliveryRuleSslProtocolCondition: %+v", err)
+	}
+
+	decoded["name"] = "SslProtocol"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling DeliveryRuleSslProtocolCondition: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryruleurlfileextensioncondition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryruleurlfileextensioncondition.go
@@ -1,0 +1,50 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleCondition = DeliveryRuleURLFileExtensionCondition{}
+
+type DeliveryRuleURLFileExtensionCondition struct {
+	Parameters URLFileExtensionMatchConditionParameters `json:"parameters"`
+
+	// Fields inherited from DeliveryRuleCondition
+
+	Name MatchVariable `json:"name"`
+}
+
+func (s DeliveryRuleURLFileExtensionCondition) DeliveryRuleCondition() BaseDeliveryRuleConditionImpl {
+	return BaseDeliveryRuleConditionImpl{
+		Name: s.Name,
+	}
+}
+
+var _ json.Marshaler = DeliveryRuleURLFileExtensionCondition{}
+
+func (s DeliveryRuleURLFileExtensionCondition) MarshalJSON() ([]byte, error) {
+	type wrapper DeliveryRuleURLFileExtensionCondition
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling DeliveryRuleURLFileExtensionCondition: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling DeliveryRuleURLFileExtensionCondition: %+v", err)
+	}
+
+	decoded["name"] = "UrlFileExtension"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling DeliveryRuleURLFileExtensionCondition: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryruleurlfilenamecondition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryruleurlfilenamecondition.go
@@ -1,0 +1,50 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleCondition = DeliveryRuleURLFileNameCondition{}
+
+type DeliveryRuleURLFileNameCondition struct {
+	Parameters URLFileNameMatchConditionParameters `json:"parameters"`
+
+	// Fields inherited from DeliveryRuleCondition
+
+	Name MatchVariable `json:"name"`
+}
+
+func (s DeliveryRuleURLFileNameCondition) DeliveryRuleCondition() BaseDeliveryRuleConditionImpl {
+	return BaseDeliveryRuleConditionImpl{
+		Name: s.Name,
+	}
+}
+
+var _ json.Marshaler = DeliveryRuleURLFileNameCondition{}
+
+func (s DeliveryRuleURLFileNameCondition) MarshalJSON() ([]byte, error) {
+	type wrapper DeliveryRuleURLFileNameCondition
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling DeliveryRuleURLFileNameCondition: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling DeliveryRuleURLFileNameCondition: %+v", err)
+	}
+
+	decoded["name"] = "UrlFileName"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling DeliveryRuleURLFileNameCondition: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryruleurlpathcondition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_deliveryruleurlpathcondition.go
@@ -1,0 +1,50 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleCondition = DeliveryRuleURLPathCondition{}
+
+type DeliveryRuleURLPathCondition struct {
+	Parameters URLPathMatchConditionParameters `json:"parameters"`
+
+	// Fields inherited from DeliveryRuleCondition
+
+	Name MatchVariable `json:"name"`
+}
+
+func (s DeliveryRuleURLPathCondition) DeliveryRuleCondition() BaseDeliveryRuleConditionImpl {
+	return BaseDeliveryRuleConditionImpl{
+		Name: s.Name,
+	}
+}
+
+var _ json.Marshaler = DeliveryRuleURLPathCondition{}
+
+func (s DeliveryRuleURLPathCondition) MarshalJSON() ([]byte, error) {
+	type wrapper DeliveryRuleURLPathCondition
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling DeliveryRuleURLPathCondition: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling DeliveryRuleURLPathCondition: %+v", err)
+	}
+
+	decoded["name"] = "UrlPath"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling DeliveryRuleURLPathCondition: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_headeractionparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_headeractionparameters.go
@@ -1,0 +1,52 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleActionParameters = HeaderActionParameters{}
+
+type HeaderActionParameters struct {
+	HeaderAction HeaderAction `json:"headerAction"`
+	HeaderName   string       `json:"headerName"`
+	Value        *string      `json:"value,omitempty"`
+
+	// Fields inherited from DeliveryRuleActionParameters
+
+	TypeName DeliveryRuleActionParametersType `json:"typeName"`
+}
+
+func (s HeaderActionParameters) DeliveryRuleActionParameters() BaseDeliveryRuleActionParametersImpl {
+	return BaseDeliveryRuleActionParametersImpl{
+		TypeName: s.TypeName,
+	}
+}
+
+var _ json.Marshaler = HeaderActionParameters{}
+
+func (s HeaderActionParameters) MarshalJSON() ([]byte, error) {
+	type wrapper HeaderActionParameters
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling HeaderActionParameters: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling HeaderActionParameters: %+v", err)
+	}
+
+	decoded["typeName"] = "DeliveryRuleHeaderActionParameters"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling HeaderActionParameters: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_hostnamematchconditionparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_hostnamematchconditionparameters.go
@@ -1,0 +1,53 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleConditionParameters = HostNameMatchConditionParameters{}
+
+type HostNameMatchConditionParameters struct {
+	MatchValues     *[]string        `json:"matchValues,omitempty"`
+	NegateCondition *bool            `json:"negateCondition,omitempty"`
+	Operator        HostNameOperator `json:"operator"`
+	Transforms      *[]Transform     `json:"transforms,omitempty"`
+
+	// Fields inherited from DeliveryRuleConditionParameters
+
+	TypeName DeliveryRuleConditionParametersType `json:"typeName"`
+}
+
+func (s HostNameMatchConditionParameters) DeliveryRuleConditionParameters() BaseDeliveryRuleConditionParametersImpl {
+	return BaseDeliveryRuleConditionParametersImpl{
+		TypeName: s.TypeName,
+	}
+}
+
+var _ json.Marshaler = HostNameMatchConditionParameters{}
+
+func (s HostNameMatchConditionParameters) MarshalJSON() ([]byte, error) {
+	type wrapper HostNameMatchConditionParameters
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling HostNameMatchConditionParameters: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling HostNameMatchConditionParameters: %+v", err)
+	}
+
+	decoded["typeName"] = "DeliveryRuleHostNameConditionParameters"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling HostNameMatchConditionParameters: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_httpversionmatchconditionparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_httpversionmatchconditionparameters.go
@@ -1,0 +1,53 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleConditionParameters = HTTPVersionMatchConditionParameters{}
+
+type HTTPVersionMatchConditionParameters struct {
+	MatchValues     *[]string           `json:"matchValues,omitempty"`
+	NegateCondition *bool               `json:"negateCondition,omitempty"`
+	Operator        HTTPVersionOperator `json:"operator"`
+	Transforms      *[]Transform        `json:"transforms,omitempty"`
+
+	// Fields inherited from DeliveryRuleConditionParameters
+
+	TypeName DeliveryRuleConditionParametersType `json:"typeName"`
+}
+
+func (s HTTPVersionMatchConditionParameters) DeliveryRuleConditionParameters() BaseDeliveryRuleConditionParametersImpl {
+	return BaseDeliveryRuleConditionParametersImpl{
+		TypeName: s.TypeName,
+	}
+}
+
+var _ json.Marshaler = HTTPVersionMatchConditionParameters{}
+
+func (s HTTPVersionMatchConditionParameters) MarshalJSON() ([]byte, error) {
+	type wrapper HTTPVersionMatchConditionParameters
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling HTTPVersionMatchConditionParameters: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling HTTPVersionMatchConditionParameters: %+v", err)
+	}
+
+	decoded["typeName"] = "DeliveryRuleHttpVersionConditionParameters"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling HTTPVersionMatchConditionParameters: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_isdevicematchconditionparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_isdevicematchconditionparameters.go
@@ -1,0 +1,53 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleConditionParameters = IsDeviceMatchConditionParameters{}
+
+type IsDeviceMatchConditionParameters struct {
+	MatchValues     *[]IsDeviceMatchValue `json:"matchValues,omitempty"`
+	NegateCondition *bool                 `json:"negateCondition,omitempty"`
+	Operator        IsDeviceOperator      `json:"operator"`
+	Transforms      *[]Transform          `json:"transforms,omitempty"`
+
+	// Fields inherited from DeliveryRuleConditionParameters
+
+	TypeName DeliveryRuleConditionParametersType `json:"typeName"`
+}
+
+func (s IsDeviceMatchConditionParameters) DeliveryRuleConditionParameters() BaseDeliveryRuleConditionParametersImpl {
+	return BaseDeliveryRuleConditionParametersImpl{
+		TypeName: s.TypeName,
+	}
+}
+
+var _ json.Marshaler = IsDeviceMatchConditionParameters{}
+
+func (s IsDeviceMatchConditionParameters) MarshalJSON() ([]byte, error) {
+	type wrapper IsDeviceMatchConditionParameters
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling IsDeviceMatchConditionParameters: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling IsDeviceMatchConditionParameters: %+v", err)
+	}
+
+	decoded["typeName"] = "DeliveryRuleIsDeviceConditionParameters"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling IsDeviceMatchConditionParameters: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_origingroupoverride.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_origingroupoverride.go
@@ -1,0 +1,9 @@
+package rules
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OriginGroupOverride struct {
+	ForwardingProtocol *ForwardingProtocol `json:"forwardingProtocol,omitempty"`
+	OriginGroup        *ResourceReference  `json:"originGroup,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_origingroupoverrideaction.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_origingroupoverrideaction.go
@@ -1,0 +1,50 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleAction = OriginGroupOverrideAction{}
+
+type OriginGroupOverrideAction struct {
+	Parameters OriginGroupOverrideActionParameters `json:"parameters"`
+
+	// Fields inherited from DeliveryRuleAction
+
+	Name DeliveryRuleActionName `json:"name"`
+}
+
+func (s OriginGroupOverrideAction) DeliveryRuleAction() BaseDeliveryRuleActionImpl {
+	return BaseDeliveryRuleActionImpl{
+		Name: s.Name,
+	}
+}
+
+var _ json.Marshaler = OriginGroupOverrideAction{}
+
+func (s OriginGroupOverrideAction) MarshalJSON() ([]byte, error) {
+	type wrapper OriginGroupOverrideAction
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling OriginGroupOverrideAction: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling OriginGroupOverrideAction: %+v", err)
+	}
+
+	decoded["name"] = "OriginGroupOverride"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling OriginGroupOverrideAction: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_origingroupoverrideactionparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_origingroupoverrideactionparameters.go
@@ -1,0 +1,50 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleActionParameters = OriginGroupOverrideActionParameters{}
+
+type OriginGroupOverrideActionParameters struct {
+	OriginGroup ResourceReference `json:"originGroup"`
+
+	// Fields inherited from DeliveryRuleActionParameters
+
+	TypeName DeliveryRuleActionParametersType `json:"typeName"`
+}
+
+func (s OriginGroupOverrideActionParameters) DeliveryRuleActionParameters() BaseDeliveryRuleActionParametersImpl {
+	return BaseDeliveryRuleActionParametersImpl{
+		TypeName: s.TypeName,
+	}
+}
+
+var _ json.Marshaler = OriginGroupOverrideActionParameters{}
+
+func (s OriginGroupOverrideActionParameters) MarshalJSON() ([]byte, error) {
+	type wrapper OriginGroupOverrideActionParameters
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling OriginGroupOverrideActionParameters: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling OriginGroupOverrideActionParameters: %+v", err)
+	}
+
+	decoded["typeName"] = "DeliveryRuleOriginGroupOverrideActionParameters"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling OriginGroupOverrideActionParameters: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_postargsmatchconditionparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_postargsmatchconditionparameters.go
@@ -1,0 +1,54 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleConditionParameters = PostArgsMatchConditionParameters{}
+
+type PostArgsMatchConditionParameters struct {
+	MatchValues     *[]string        `json:"matchValues,omitempty"`
+	NegateCondition *bool            `json:"negateCondition,omitempty"`
+	Operator        PostArgsOperator `json:"operator"`
+	Selector        *string          `json:"selector,omitempty"`
+	Transforms      *[]Transform     `json:"transforms,omitempty"`
+
+	// Fields inherited from DeliveryRuleConditionParameters
+
+	TypeName DeliveryRuleConditionParametersType `json:"typeName"`
+}
+
+func (s PostArgsMatchConditionParameters) DeliveryRuleConditionParameters() BaseDeliveryRuleConditionParametersImpl {
+	return BaseDeliveryRuleConditionParametersImpl{
+		TypeName: s.TypeName,
+	}
+}
+
+var _ json.Marshaler = PostArgsMatchConditionParameters{}
+
+func (s PostArgsMatchConditionParameters) MarshalJSON() ([]byte, error) {
+	type wrapper PostArgsMatchConditionParameters
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling PostArgsMatchConditionParameters: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling PostArgsMatchConditionParameters: %+v", err)
+	}
+
+	decoded["typeName"] = "DeliveryRulePostArgsConditionParameters"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling PostArgsMatchConditionParameters: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_querystringmatchconditionparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_querystringmatchconditionparameters.go
@@ -1,0 +1,53 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleConditionParameters = QueryStringMatchConditionParameters{}
+
+type QueryStringMatchConditionParameters struct {
+	MatchValues     *[]string           `json:"matchValues,omitempty"`
+	NegateCondition *bool               `json:"negateCondition,omitempty"`
+	Operator        QueryStringOperator `json:"operator"`
+	Transforms      *[]Transform        `json:"transforms,omitempty"`
+
+	// Fields inherited from DeliveryRuleConditionParameters
+
+	TypeName DeliveryRuleConditionParametersType `json:"typeName"`
+}
+
+func (s QueryStringMatchConditionParameters) DeliveryRuleConditionParameters() BaseDeliveryRuleConditionParametersImpl {
+	return BaseDeliveryRuleConditionParametersImpl{
+		TypeName: s.TypeName,
+	}
+}
+
+var _ json.Marshaler = QueryStringMatchConditionParameters{}
+
+func (s QueryStringMatchConditionParameters) MarshalJSON() ([]byte, error) {
+	type wrapper QueryStringMatchConditionParameters
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling QueryStringMatchConditionParameters: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling QueryStringMatchConditionParameters: %+v", err)
+	}
+
+	decoded["typeName"] = "DeliveryRuleQueryStringConditionParameters"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling QueryStringMatchConditionParameters: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_remoteaddressmatchconditionparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_remoteaddressmatchconditionparameters.go
@@ -1,0 +1,53 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleConditionParameters = RemoteAddressMatchConditionParameters{}
+
+type RemoteAddressMatchConditionParameters struct {
+	MatchValues     *[]string             `json:"matchValues,omitempty"`
+	NegateCondition *bool                 `json:"negateCondition,omitempty"`
+	Operator        RemoteAddressOperator `json:"operator"`
+	Transforms      *[]Transform          `json:"transforms,omitempty"`
+
+	// Fields inherited from DeliveryRuleConditionParameters
+
+	TypeName DeliveryRuleConditionParametersType `json:"typeName"`
+}
+
+func (s RemoteAddressMatchConditionParameters) DeliveryRuleConditionParameters() BaseDeliveryRuleConditionParametersImpl {
+	return BaseDeliveryRuleConditionParametersImpl{
+		TypeName: s.TypeName,
+	}
+}
+
+var _ json.Marshaler = RemoteAddressMatchConditionParameters{}
+
+func (s RemoteAddressMatchConditionParameters) MarshalJSON() ([]byte, error) {
+	type wrapper RemoteAddressMatchConditionParameters
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling RemoteAddressMatchConditionParameters: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling RemoteAddressMatchConditionParameters: %+v", err)
+	}
+
+	decoded["typeName"] = "DeliveryRuleRemoteAddressConditionParameters"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling RemoteAddressMatchConditionParameters: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_requestbodymatchconditionparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_requestbodymatchconditionparameters.go
@@ -1,0 +1,53 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleConditionParameters = RequestBodyMatchConditionParameters{}
+
+type RequestBodyMatchConditionParameters struct {
+	MatchValues     *[]string           `json:"matchValues,omitempty"`
+	NegateCondition *bool               `json:"negateCondition,omitempty"`
+	Operator        RequestBodyOperator `json:"operator"`
+	Transforms      *[]Transform        `json:"transforms,omitempty"`
+
+	// Fields inherited from DeliveryRuleConditionParameters
+
+	TypeName DeliveryRuleConditionParametersType `json:"typeName"`
+}
+
+func (s RequestBodyMatchConditionParameters) DeliveryRuleConditionParameters() BaseDeliveryRuleConditionParametersImpl {
+	return BaseDeliveryRuleConditionParametersImpl{
+		TypeName: s.TypeName,
+	}
+}
+
+var _ json.Marshaler = RequestBodyMatchConditionParameters{}
+
+func (s RequestBodyMatchConditionParameters) MarshalJSON() ([]byte, error) {
+	type wrapper RequestBodyMatchConditionParameters
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling RequestBodyMatchConditionParameters: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling RequestBodyMatchConditionParameters: %+v", err)
+	}
+
+	decoded["typeName"] = "DeliveryRuleRequestBodyConditionParameters"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling RequestBodyMatchConditionParameters: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_requestheadermatchconditionparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_requestheadermatchconditionparameters.go
@@ -1,0 +1,54 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleConditionParameters = RequestHeaderMatchConditionParameters{}
+
+type RequestHeaderMatchConditionParameters struct {
+	MatchValues     *[]string             `json:"matchValues,omitempty"`
+	NegateCondition *bool                 `json:"negateCondition,omitempty"`
+	Operator        RequestHeaderOperator `json:"operator"`
+	Selector        *string               `json:"selector,omitempty"`
+	Transforms      *[]Transform          `json:"transforms,omitempty"`
+
+	// Fields inherited from DeliveryRuleConditionParameters
+
+	TypeName DeliveryRuleConditionParametersType `json:"typeName"`
+}
+
+func (s RequestHeaderMatchConditionParameters) DeliveryRuleConditionParameters() BaseDeliveryRuleConditionParametersImpl {
+	return BaseDeliveryRuleConditionParametersImpl{
+		TypeName: s.TypeName,
+	}
+}
+
+var _ json.Marshaler = RequestHeaderMatchConditionParameters{}
+
+func (s RequestHeaderMatchConditionParameters) MarshalJSON() ([]byte, error) {
+	type wrapper RequestHeaderMatchConditionParameters
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling RequestHeaderMatchConditionParameters: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling RequestHeaderMatchConditionParameters: %+v", err)
+	}
+
+	decoded["typeName"] = "DeliveryRuleRequestHeaderConditionParameters"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling RequestHeaderMatchConditionParameters: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_requestmethodmatchconditionparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_requestmethodmatchconditionparameters.go
@@ -1,0 +1,53 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleConditionParameters = RequestMethodMatchConditionParameters{}
+
+type RequestMethodMatchConditionParameters struct {
+	MatchValues     *[]RequestMethodMatchValue `json:"matchValues,omitempty"`
+	NegateCondition *bool                      `json:"negateCondition,omitempty"`
+	Operator        RequestMethodOperator      `json:"operator"`
+	Transforms      *[]Transform               `json:"transforms,omitempty"`
+
+	// Fields inherited from DeliveryRuleConditionParameters
+
+	TypeName DeliveryRuleConditionParametersType `json:"typeName"`
+}
+
+func (s RequestMethodMatchConditionParameters) DeliveryRuleConditionParameters() BaseDeliveryRuleConditionParametersImpl {
+	return BaseDeliveryRuleConditionParametersImpl{
+		TypeName: s.TypeName,
+	}
+}
+
+var _ json.Marshaler = RequestMethodMatchConditionParameters{}
+
+func (s RequestMethodMatchConditionParameters) MarshalJSON() ([]byte, error) {
+	type wrapper RequestMethodMatchConditionParameters
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling RequestMethodMatchConditionParameters: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling RequestMethodMatchConditionParameters: %+v", err)
+	}
+
+	decoded["typeName"] = "DeliveryRuleRequestMethodConditionParameters"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling RequestMethodMatchConditionParameters: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_requestschemematchconditionparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_requestschemematchconditionparameters.go
@@ -1,0 +1,53 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleConditionParameters = RequestSchemeMatchConditionParameters{}
+
+type RequestSchemeMatchConditionParameters struct {
+	MatchValues     *[]RequestSchemeMatchValue                    `json:"matchValues,omitempty"`
+	NegateCondition *bool                                         `json:"negateCondition,omitempty"`
+	Operator        RequestSchemeMatchConditionParametersOperator `json:"operator"`
+	Transforms      *[]Transform                                  `json:"transforms,omitempty"`
+
+	// Fields inherited from DeliveryRuleConditionParameters
+
+	TypeName DeliveryRuleConditionParametersType `json:"typeName"`
+}
+
+func (s RequestSchemeMatchConditionParameters) DeliveryRuleConditionParameters() BaseDeliveryRuleConditionParametersImpl {
+	return BaseDeliveryRuleConditionParametersImpl{
+		TypeName: s.TypeName,
+	}
+}
+
+var _ json.Marshaler = RequestSchemeMatchConditionParameters{}
+
+func (s RequestSchemeMatchConditionParameters) MarshalJSON() ([]byte, error) {
+	type wrapper RequestSchemeMatchConditionParameters
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling RequestSchemeMatchConditionParameters: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling RequestSchemeMatchConditionParameters: %+v", err)
+	}
+
+	decoded["typeName"] = "DeliveryRuleRequestSchemeConditionParameters"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling RequestSchemeMatchConditionParameters: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_requesturimatchconditionparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_requesturimatchconditionparameters.go
@@ -1,0 +1,53 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleConditionParameters = RequestUriMatchConditionParameters{}
+
+type RequestUriMatchConditionParameters struct {
+	MatchValues     *[]string          `json:"matchValues,omitempty"`
+	NegateCondition *bool              `json:"negateCondition,omitempty"`
+	Operator        RequestUriOperator `json:"operator"`
+	Transforms      *[]Transform       `json:"transforms,omitempty"`
+
+	// Fields inherited from DeliveryRuleConditionParameters
+
+	TypeName DeliveryRuleConditionParametersType `json:"typeName"`
+}
+
+func (s RequestUriMatchConditionParameters) DeliveryRuleConditionParameters() BaseDeliveryRuleConditionParametersImpl {
+	return BaseDeliveryRuleConditionParametersImpl{
+		TypeName: s.TypeName,
+	}
+}
+
+var _ json.Marshaler = RequestUriMatchConditionParameters{}
+
+func (s RequestUriMatchConditionParameters) MarshalJSON() ([]byte, error) {
+	type wrapper RequestUriMatchConditionParameters
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling RequestUriMatchConditionParameters: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling RequestUriMatchConditionParameters: %+v", err)
+	}
+
+	decoded["typeName"] = "DeliveryRuleRequestUriConditionParameters"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling RequestUriMatchConditionParameters: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_resourcereference.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_resourcereference.go
@@ -1,0 +1,8 @@
+package rules
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ResourceReference struct {
+	Id *string `json:"id,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_routeconfigurationoverrideactionparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_routeconfigurationoverrideactionparameters.go
@@ -1,0 +1,51 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleActionParameters = RouteConfigurationOverrideActionParameters{}
+
+type RouteConfigurationOverrideActionParameters struct {
+	CacheConfiguration  *CacheConfiguration  `json:"cacheConfiguration,omitempty"`
+	OriginGroupOverride *OriginGroupOverride `json:"originGroupOverride,omitempty"`
+
+	// Fields inherited from DeliveryRuleActionParameters
+
+	TypeName DeliveryRuleActionParametersType `json:"typeName"`
+}
+
+func (s RouteConfigurationOverrideActionParameters) DeliveryRuleActionParameters() BaseDeliveryRuleActionParametersImpl {
+	return BaseDeliveryRuleActionParametersImpl{
+		TypeName: s.TypeName,
+	}
+}
+
+var _ json.Marshaler = RouteConfigurationOverrideActionParameters{}
+
+func (s RouteConfigurationOverrideActionParameters) MarshalJSON() ([]byte, error) {
+	type wrapper RouteConfigurationOverrideActionParameters
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling RouteConfigurationOverrideActionParameters: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling RouteConfigurationOverrideActionParameters: %+v", err)
+	}
+
+	decoded["typeName"] = "DeliveryRuleRouteConfigurationOverrideActionParameters"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling RouteConfigurationOverrideActionParameters: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_rule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_rule.go
@@ -1,0 +1,16 @@
+package rules
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Rule struct {
+	Id         *string                `json:"id,omitempty"`
+	Name       *string                `json:"name,omitempty"`
+	Properties *RuleProperties        `json:"properties,omitempty"`
+	SystemData *systemdata.SystemData `json:"systemData,omitempty"`
+	Type       *string                `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_ruleproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_ruleproperties.go
@@ -1,0 +1,81 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RuleProperties struct {
+	Actions                 *[]DeliveryRuleAction    `json:"actions,omitempty"`
+	Conditions              *[]DeliveryRuleCondition `json:"conditions,omitempty"`
+	DeploymentStatus        *DeploymentStatus        `json:"deploymentStatus,omitempty"`
+	MatchProcessingBehavior *MatchProcessingBehavior `json:"matchProcessingBehavior,omitempty"`
+	Order                   *int64                   `json:"order,omitempty"`
+	ProvisioningState       *AfdProvisioningState    `json:"provisioningState,omitempty"`
+	RuleSetName             *string                  `json:"ruleSetName,omitempty"`
+}
+
+var _ json.Unmarshaler = &RuleProperties{}
+
+func (s *RuleProperties) UnmarshalJSON(bytes []byte) error {
+	var decoded struct {
+		DeploymentStatus        *DeploymentStatus        `json:"deploymentStatus,omitempty"`
+		MatchProcessingBehavior *MatchProcessingBehavior `json:"matchProcessingBehavior,omitempty"`
+		Order                   *int64                   `json:"order,omitempty"`
+		ProvisioningState       *AfdProvisioningState    `json:"provisioningState,omitempty"`
+		RuleSetName             *string                  `json:"ruleSetName,omitempty"`
+	}
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+
+	s.DeploymentStatus = decoded.DeploymentStatus
+	s.MatchProcessingBehavior = decoded.MatchProcessingBehavior
+	s.Order = decoded.Order
+	s.ProvisioningState = decoded.ProvisioningState
+	s.RuleSetName = decoded.RuleSetName
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling RuleProperties into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["actions"]; ok {
+		var listTemp []json.RawMessage
+		if err := json.Unmarshal(v, &listTemp); err != nil {
+			return fmt.Errorf("unmarshaling Actions into list []json.RawMessage: %+v", err)
+		}
+
+		output := make([]DeliveryRuleAction, 0)
+		for i, val := range listTemp {
+			impl, err := UnmarshalDeliveryRuleActionImplementation(val)
+			if err != nil {
+				return fmt.Errorf("unmarshaling index %d field 'Actions' for 'RuleProperties': %+v", i, err)
+			}
+			output = append(output, impl)
+		}
+		s.Actions = &output
+	}
+
+	if v, ok := temp["conditions"]; ok {
+		var listTemp []json.RawMessage
+		if err := json.Unmarshal(v, &listTemp); err != nil {
+			return fmt.Errorf("unmarshaling Conditions into list []json.RawMessage: %+v", err)
+		}
+
+		output := make([]DeliveryRuleCondition, 0)
+		for i, val := range listTemp {
+			impl, err := UnmarshalDeliveryRuleConditionImplementation(val)
+			if err != nil {
+				return fmt.Errorf("unmarshaling index %d field 'Conditions' for 'RuleProperties': %+v", i, err)
+			}
+			output = append(output, impl)
+		}
+		s.Conditions = &output
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_ruleupdateparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_ruleupdateparameters.go
@@ -1,0 +1,8 @@
+package rules
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RuleUpdateParameters struct {
+	Properties *RuleUpdatePropertiesParameters `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_ruleupdatepropertiesparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_ruleupdatepropertiesparameters.go
@@ -1,0 +1,75 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RuleUpdatePropertiesParameters struct {
+	Actions                 *[]DeliveryRuleAction    `json:"actions,omitempty"`
+	Conditions              *[]DeliveryRuleCondition `json:"conditions,omitempty"`
+	MatchProcessingBehavior *MatchProcessingBehavior `json:"matchProcessingBehavior,omitempty"`
+	Order                   *int64                   `json:"order,omitempty"`
+	RuleSetName             *string                  `json:"ruleSetName,omitempty"`
+}
+
+var _ json.Unmarshaler = &RuleUpdatePropertiesParameters{}
+
+func (s *RuleUpdatePropertiesParameters) UnmarshalJSON(bytes []byte) error {
+	var decoded struct {
+		MatchProcessingBehavior *MatchProcessingBehavior `json:"matchProcessingBehavior,omitempty"`
+		Order                   *int64                   `json:"order,omitempty"`
+		RuleSetName             *string                  `json:"ruleSetName,omitempty"`
+	}
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+
+	s.MatchProcessingBehavior = decoded.MatchProcessingBehavior
+	s.Order = decoded.Order
+	s.RuleSetName = decoded.RuleSetName
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling RuleUpdatePropertiesParameters into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["actions"]; ok {
+		var listTemp []json.RawMessage
+		if err := json.Unmarshal(v, &listTemp); err != nil {
+			return fmt.Errorf("unmarshaling Actions into list []json.RawMessage: %+v", err)
+		}
+
+		output := make([]DeliveryRuleAction, 0)
+		for i, val := range listTemp {
+			impl, err := UnmarshalDeliveryRuleActionImplementation(val)
+			if err != nil {
+				return fmt.Errorf("unmarshaling index %d field 'Actions' for 'RuleUpdatePropertiesParameters': %+v", i, err)
+			}
+			output = append(output, impl)
+		}
+		s.Actions = &output
+	}
+
+	if v, ok := temp["conditions"]; ok {
+		var listTemp []json.RawMessage
+		if err := json.Unmarshal(v, &listTemp); err != nil {
+			return fmt.Errorf("unmarshaling Conditions into list []json.RawMessage: %+v", err)
+		}
+
+		output := make([]DeliveryRuleCondition, 0)
+		for i, val := range listTemp {
+			impl, err := UnmarshalDeliveryRuleConditionImplementation(val)
+			if err != nil {
+				return fmt.Errorf("unmarshaling index %d field 'Conditions' for 'RuleUpdatePropertiesParameters': %+v", i, err)
+			}
+			output = append(output, impl)
+		}
+		s.Conditions = &output
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_serverportmatchconditionparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_serverportmatchconditionparameters.go
@@ -1,0 +1,53 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleConditionParameters = ServerPortMatchConditionParameters{}
+
+type ServerPortMatchConditionParameters struct {
+	MatchValues     *[]string          `json:"matchValues,omitempty"`
+	NegateCondition *bool              `json:"negateCondition,omitempty"`
+	Operator        ServerPortOperator `json:"operator"`
+	Transforms      *[]Transform       `json:"transforms,omitempty"`
+
+	// Fields inherited from DeliveryRuleConditionParameters
+
+	TypeName DeliveryRuleConditionParametersType `json:"typeName"`
+}
+
+func (s ServerPortMatchConditionParameters) DeliveryRuleConditionParameters() BaseDeliveryRuleConditionParametersImpl {
+	return BaseDeliveryRuleConditionParametersImpl{
+		TypeName: s.TypeName,
+	}
+}
+
+var _ json.Marshaler = ServerPortMatchConditionParameters{}
+
+func (s ServerPortMatchConditionParameters) MarshalJSON() ([]byte, error) {
+	type wrapper ServerPortMatchConditionParameters
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling ServerPortMatchConditionParameters: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling ServerPortMatchConditionParameters: %+v", err)
+	}
+
+	decoded["typeName"] = "DeliveryRuleServerPortConditionParameters"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling ServerPortMatchConditionParameters: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_socketaddrmatchconditionparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_socketaddrmatchconditionparameters.go
@@ -1,0 +1,53 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleConditionParameters = SocketAddrMatchConditionParameters{}
+
+type SocketAddrMatchConditionParameters struct {
+	MatchValues     *[]string          `json:"matchValues,omitempty"`
+	NegateCondition *bool              `json:"negateCondition,omitempty"`
+	Operator        SocketAddrOperator `json:"operator"`
+	Transforms      *[]Transform       `json:"transforms,omitempty"`
+
+	// Fields inherited from DeliveryRuleConditionParameters
+
+	TypeName DeliveryRuleConditionParametersType `json:"typeName"`
+}
+
+func (s SocketAddrMatchConditionParameters) DeliveryRuleConditionParameters() BaseDeliveryRuleConditionParametersImpl {
+	return BaseDeliveryRuleConditionParametersImpl{
+		TypeName: s.TypeName,
+	}
+}
+
+var _ json.Marshaler = SocketAddrMatchConditionParameters{}
+
+func (s SocketAddrMatchConditionParameters) MarshalJSON() ([]byte, error) {
+	type wrapper SocketAddrMatchConditionParameters
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling SocketAddrMatchConditionParameters: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling SocketAddrMatchConditionParameters: %+v", err)
+	}
+
+	decoded["typeName"] = "DeliveryRuleSocketAddrConditionParameters"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling SocketAddrMatchConditionParameters: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_sslprotocolmatchconditionparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_sslprotocolmatchconditionparameters.go
@@ -1,0 +1,53 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleConditionParameters = SslProtocolMatchConditionParameters{}
+
+type SslProtocolMatchConditionParameters struct {
+	MatchValues     *[]SslProtocol      `json:"matchValues,omitempty"`
+	NegateCondition *bool               `json:"negateCondition,omitempty"`
+	Operator        SslProtocolOperator `json:"operator"`
+	Transforms      *[]Transform        `json:"transforms,omitempty"`
+
+	// Fields inherited from DeliveryRuleConditionParameters
+
+	TypeName DeliveryRuleConditionParametersType `json:"typeName"`
+}
+
+func (s SslProtocolMatchConditionParameters) DeliveryRuleConditionParameters() BaseDeliveryRuleConditionParametersImpl {
+	return BaseDeliveryRuleConditionParametersImpl{
+		TypeName: s.TypeName,
+	}
+}
+
+var _ json.Marshaler = SslProtocolMatchConditionParameters{}
+
+func (s SslProtocolMatchConditionParameters) MarshalJSON() ([]byte, error) {
+	type wrapper SslProtocolMatchConditionParameters
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling SslProtocolMatchConditionParameters: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling SslProtocolMatchConditionParameters: %+v", err)
+	}
+
+	decoded["typeName"] = "DeliveryRuleSslProtocolConditionParameters"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling SslProtocolMatchConditionParameters: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_urlfileextensionmatchconditionparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_urlfileextensionmatchconditionparameters.go
@@ -1,0 +1,53 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleConditionParameters = URLFileExtensionMatchConditionParameters{}
+
+type URLFileExtensionMatchConditionParameters struct {
+	MatchValues     *[]string                `json:"matchValues,omitempty"`
+	NegateCondition *bool                    `json:"negateCondition,omitempty"`
+	Operator        URLFileExtensionOperator `json:"operator"`
+	Transforms      *[]Transform             `json:"transforms,omitempty"`
+
+	// Fields inherited from DeliveryRuleConditionParameters
+
+	TypeName DeliveryRuleConditionParametersType `json:"typeName"`
+}
+
+func (s URLFileExtensionMatchConditionParameters) DeliveryRuleConditionParameters() BaseDeliveryRuleConditionParametersImpl {
+	return BaseDeliveryRuleConditionParametersImpl{
+		TypeName: s.TypeName,
+	}
+}
+
+var _ json.Marshaler = URLFileExtensionMatchConditionParameters{}
+
+func (s URLFileExtensionMatchConditionParameters) MarshalJSON() ([]byte, error) {
+	type wrapper URLFileExtensionMatchConditionParameters
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling URLFileExtensionMatchConditionParameters: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling URLFileExtensionMatchConditionParameters: %+v", err)
+	}
+
+	decoded["typeName"] = "DeliveryRuleUrlFileExtensionMatchConditionParameters"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling URLFileExtensionMatchConditionParameters: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_urlfilenamematchconditionparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_urlfilenamematchconditionparameters.go
@@ -1,0 +1,53 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleConditionParameters = URLFileNameMatchConditionParameters{}
+
+type URLFileNameMatchConditionParameters struct {
+	MatchValues     *[]string           `json:"matchValues,omitempty"`
+	NegateCondition *bool               `json:"negateCondition,omitempty"`
+	Operator        URLFileNameOperator `json:"operator"`
+	Transforms      *[]Transform        `json:"transforms,omitempty"`
+
+	// Fields inherited from DeliveryRuleConditionParameters
+
+	TypeName DeliveryRuleConditionParametersType `json:"typeName"`
+}
+
+func (s URLFileNameMatchConditionParameters) DeliveryRuleConditionParameters() BaseDeliveryRuleConditionParametersImpl {
+	return BaseDeliveryRuleConditionParametersImpl{
+		TypeName: s.TypeName,
+	}
+}
+
+var _ json.Marshaler = URLFileNameMatchConditionParameters{}
+
+func (s URLFileNameMatchConditionParameters) MarshalJSON() ([]byte, error) {
+	type wrapper URLFileNameMatchConditionParameters
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling URLFileNameMatchConditionParameters: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling URLFileNameMatchConditionParameters: %+v", err)
+	}
+
+	decoded["typeName"] = "DeliveryRuleUrlFilenameConditionParameters"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling URLFileNameMatchConditionParameters: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_urlpathmatchconditionparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_urlpathmatchconditionparameters.go
@@ -1,0 +1,53 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleConditionParameters = URLPathMatchConditionParameters{}
+
+type URLPathMatchConditionParameters struct {
+	MatchValues     *[]string       `json:"matchValues,omitempty"`
+	NegateCondition *bool           `json:"negateCondition,omitempty"`
+	Operator        URLPathOperator `json:"operator"`
+	Transforms      *[]Transform    `json:"transforms,omitempty"`
+
+	// Fields inherited from DeliveryRuleConditionParameters
+
+	TypeName DeliveryRuleConditionParametersType `json:"typeName"`
+}
+
+func (s URLPathMatchConditionParameters) DeliveryRuleConditionParameters() BaseDeliveryRuleConditionParametersImpl {
+	return BaseDeliveryRuleConditionParametersImpl{
+		TypeName: s.TypeName,
+	}
+}
+
+var _ json.Marshaler = URLPathMatchConditionParameters{}
+
+func (s URLPathMatchConditionParameters) MarshalJSON() ([]byte, error) {
+	type wrapper URLPathMatchConditionParameters
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling URLPathMatchConditionParameters: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling URLPathMatchConditionParameters: %+v", err)
+	}
+
+	decoded["typeName"] = "DeliveryRuleUrlPathMatchConditionParameters"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling URLPathMatchConditionParameters: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_urlredirectaction.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_urlredirectaction.go
@@ -1,0 +1,50 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleAction = URLRedirectAction{}
+
+type URLRedirectAction struct {
+	Parameters URLRedirectActionParameters `json:"parameters"`
+
+	// Fields inherited from DeliveryRuleAction
+
+	Name DeliveryRuleActionName `json:"name"`
+}
+
+func (s URLRedirectAction) DeliveryRuleAction() BaseDeliveryRuleActionImpl {
+	return BaseDeliveryRuleActionImpl{
+		Name: s.Name,
+	}
+}
+
+var _ json.Marshaler = URLRedirectAction{}
+
+func (s URLRedirectAction) MarshalJSON() ([]byte, error) {
+	type wrapper URLRedirectAction
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling URLRedirectAction: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling URLRedirectAction: %+v", err)
+	}
+
+	decoded["name"] = "UrlRedirect"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling URLRedirectAction: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_urlredirectactionparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_urlredirectactionparameters.go
@@ -1,0 +1,55 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleActionParameters = URLRedirectActionParameters{}
+
+type URLRedirectActionParameters struct {
+	CustomFragment      *string              `json:"customFragment,omitempty"`
+	CustomHostname      *string              `json:"customHostname,omitempty"`
+	CustomPath          *string              `json:"customPath,omitempty"`
+	CustomQueryString   *string              `json:"customQueryString,omitempty"`
+	DestinationProtocol *DestinationProtocol `json:"destinationProtocol,omitempty"`
+	RedirectType        RedirectType         `json:"redirectType"`
+
+	// Fields inherited from DeliveryRuleActionParameters
+
+	TypeName DeliveryRuleActionParametersType `json:"typeName"`
+}
+
+func (s URLRedirectActionParameters) DeliveryRuleActionParameters() BaseDeliveryRuleActionParametersImpl {
+	return BaseDeliveryRuleActionParametersImpl{
+		TypeName: s.TypeName,
+	}
+}
+
+var _ json.Marshaler = URLRedirectActionParameters{}
+
+func (s URLRedirectActionParameters) MarshalJSON() ([]byte, error) {
+	type wrapper URLRedirectActionParameters
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling URLRedirectActionParameters: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling URLRedirectActionParameters: %+v", err)
+	}
+
+	decoded["typeName"] = "DeliveryRuleUrlRedirectActionParameters"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling URLRedirectActionParameters: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_urlrewriteaction.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_urlrewriteaction.go
@@ -1,0 +1,50 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleAction = URLRewriteAction{}
+
+type URLRewriteAction struct {
+	Parameters URLRewriteActionParameters `json:"parameters"`
+
+	// Fields inherited from DeliveryRuleAction
+
+	Name DeliveryRuleActionName `json:"name"`
+}
+
+func (s URLRewriteAction) DeliveryRuleAction() BaseDeliveryRuleActionImpl {
+	return BaseDeliveryRuleActionImpl{
+		Name: s.Name,
+	}
+}
+
+var _ json.Marshaler = URLRewriteAction{}
+
+func (s URLRewriteAction) MarshalJSON() ([]byte, error) {
+	type wrapper URLRewriteAction
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling URLRewriteAction: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling URLRewriteAction: %+v", err)
+	}
+
+	decoded["name"] = "UrlRewrite"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling URLRewriteAction: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_urlrewriteactionparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_urlrewriteactionparameters.go
@@ -1,0 +1,52 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleActionParameters = URLRewriteActionParameters{}
+
+type URLRewriteActionParameters struct {
+	Destination           string `json:"destination"`
+	PreserveUnmatchedPath *bool  `json:"preserveUnmatchedPath,omitempty"`
+	SourcePattern         string `json:"sourcePattern"`
+
+	// Fields inherited from DeliveryRuleActionParameters
+
+	TypeName DeliveryRuleActionParametersType `json:"typeName"`
+}
+
+func (s URLRewriteActionParameters) DeliveryRuleActionParameters() BaseDeliveryRuleActionParametersImpl {
+	return BaseDeliveryRuleActionParametersImpl{
+		TypeName: s.TypeName,
+	}
+}
+
+var _ json.Marshaler = URLRewriteActionParameters{}
+
+func (s URLRewriteActionParameters) MarshalJSON() ([]byte, error) {
+	type wrapper URLRewriteActionParameters
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling URLRewriteActionParameters: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling URLRewriteActionParameters: %+v", err)
+	}
+
+	decoded["typeName"] = "DeliveryRuleUrlRewriteActionParameters"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling URLRewriteActionParameters: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_urlsigningaction.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_urlsigningaction.go
@@ -1,0 +1,50 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleAction = URLSigningAction{}
+
+type URLSigningAction struct {
+	Parameters URLSigningActionParameters `json:"parameters"`
+
+	// Fields inherited from DeliveryRuleAction
+
+	Name DeliveryRuleActionName `json:"name"`
+}
+
+func (s URLSigningAction) DeliveryRuleAction() BaseDeliveryRuleActionImpl {
+	return BaseDeliveryRuleActionImpl{
+		Name: s.Name,
+	}
+}
+
+var _ json.Marshaler = URLSigningAction{}
+
+func (s URLSigningAction) MarshalJSON() ([]byte, error) {
+	type wrapper URLSigningAction
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling URLSigningAction: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling URLSigningAction: %+v", err)
+	}
+
+	decoded["name"] = "UrlSigning"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling URLSigningAction: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_urlsigningactionparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_urlsigningactionparameters.go
@@ -1,0 +1,51 @@
+package rules
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DeliveryRuleActionParameters = URLSigningActionParameters{}
+
+type URLSigningActionParameters struct {
+	Algorithm             *Algorithm                   `json:"algorithm,omitempty"`
+	ParameterNameOverride *[]URLSigningParamIdentifier `json:"parameterNameOverride,omitempty"`
+
+	// Fields inherited from DeliveryRuleActionParameters
+
+	TypeName DeliveryRuleActionParametersType `json:"typeName"`
+}
+
+func (s URLSigningActionParameters) DeliveryRuleActionParameters() BaseDeliveryRuleActionParametersImpl {
+	return BaseDeliveryRuleActionParametersImpl{
+		TypeName: s.TypeName,
+	}
+}
+
+var _ json.Marshaler = URLSigningActionParameters{}
+
+func (s URLSigningActionParameters) MarshalJSON() ([]byte, error) {
+	type wrapper URLSigningActionParameters
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling URLSigningActionParameters: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling URLSigningActionParameters: %+v", err)
+	}
+
+	decoded["typeName"] = "DeliveryRuleUrlSigningActionParameters"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling URLSigningActionParameters: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_urlsigningparamidentifier.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/model_urlsigningparamidentifier.go
@@ -1,0 +1,9 @@
+package rules
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type URLSigningParamIdentifier struct {
+	ParamIndicator ParamIndicator `json:"paramIndicator"`
+	ParamName      string         `json:"paramName"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/predicates.go
@@ -1,0 +1,27 @@
+package rules
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RuleOperationPredicate struct {
+	Id   *string
+	Name *string
+	Type *string
+}
+
+func (p RuleOperationPredicate) Matches(input Rule) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules/version.go
@@ -1,0 +1,14 @@
+package rules
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2025-12-01"
+
+func userAgent() string {
+	return "hashicorp/go-azure-sdk/rules/2025-12-01"
+}
+
+func AzureAPIVersion() string {
+	return defaultApiVersion
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -184,7 +184,7 @@ github.com/hashicorp/go-azure-sdk/data-plane/keyvault/7-4/secrets
 github.com/hashicorp/go-azure-sdk/data-plane/keyvault/7-4/settings
 github.com/hashicorp/go-azure-sdk/data-plane/keyvault/7-4/storage
 github.com/hashicorp/go-azure-sdk/data-plane/synapse/2021-06-01-preview/managedprivateendpoints
-# github.com/hashicorp/go-azure-sdk/resource-manager v0.20260520.1174751
+# github.com/hashicorp/go-azure-sdk/resource-manager v0.20260520.1174752-0.20260520174819-50f34b9d97b3
 ## explicit; go 1.25.5
 github.com/hashicorp/go-azure-sdk/resource-manager/aad/2021-05-01/domainservices
 github.com/hashicorp/go-azure-sdk/resource-manager/aadb2c/2021-04-01-preview
@@ -375,6 +375,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2024-02-01/securitypolici
 github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2024-09-01/rules
 github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-04-15/afdcustomdomains
 github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-06-01/afdendpoints
+github.com/hashicorp/go-azure-sdk/resource-manager/cdn/2025-12-01/rules
 github.com/hashicorp/go-azure-sdk/resource-manager/certificateregistration/2023-12-01/appservicecertificateorders
 github.com/hashicorp/go-azure-sdk/resource-manager/chaosstudio/2023-11-01
 github.com/hashicorp/go-azure-sdk/resource-manager/chaosstudio/2023-11-01/capabilities


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

This PR pulls the CDN `2025-12-01` API surface into the provider and wires a side-by-side Front Door rules client for follow-up resource work.

Specifically, this change:
- bumps `github.com/hashicorp/go-azure-sdk/resource-manager` to the pseudo-version that includes CDN `2025-12-01`
- updates vendored dependencies for that module change
- adds a new `FrontDoorRulesClient_v2025_12_01` to the CDN service client wiring

This does not change the existing Front Door rule resource implementation or behavior. The goal is to make the new API available now so a follow-up PR can add the atomic rules resource on top of this client wiring.

## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.

## Testing

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

Testing performed:
- `go test ./internal/services/cdn/client`

## Change Log

No changelog entry required; this is internal client and dependency wiring only.

This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change

## Related Issue(s)

N/A

## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No changes to security controls.
