### PR TITLE
`azurerm_container_app_environment` - prevent spurious diff caused by the implicit `Consumption` workload profile

### DIFF
--- a/internal/services/containerapps/container_app_environment_resource.go
+++ b/internal/services/containerapps/container_app_environment_resource.go
@@ -411,7 +411,7 @@ func (r ContainerAppEnvironmentResource) Read() sdk.ResourceFunc {
 					state.ZoneRedundant = pointer.From(props.ZoneRedundant)
 					state.StaticIP = pointer.From(props.StaticIP)
 					state.DefaultDomain = pointer.From(props.DefaultDomain)
-					state.WorkloadProfiles = helpers.FlattenWorkloadProfiles(props.WorkloadProfiles)
+					state.WorkloadProfiles = helpers.FlattenWorkloadProfiles(props.WorkloadProfiles, existingState.WorkloadProfiles)
 					state.InfrastructureResourceGroup = pointer.From(props.InfrastructureResourceGroup)
 
 					if props.CustomDomainConfiguration != nil {

--- a/internal/services/containerapps/container_app_environment_resource.go
+++ b/internal/services/containerapps/container_app_environment_resource.go
@@ -411,7 +411,36 @@ func (r ContainerAppEnvironmentResource) Read() sdk.ResourceFunc {
 					state.ZoneRedundant = pointer.From(props.ZoneRedundant)
 					state.StaticIP = pointer.From(props.StaticIP)
 					state.DefaultDomain = pointer.From(props.DefaultDomain)
-					state.WorkloadProfiles = helpers.FlattenWorkloadProfiles(props.WorkloadProfiles, existingState.WorkloadProfiles)
+					// Decide whether to keep the implicit `Consumption` profile the API adds.
+					// Prefer raw config (Create/Update); fall back to prior state when the SDK
+					// passes no config (refresh/import).
+					userDeclaredConsumption := false
+					if rawConfig := metadata.ResourceData.GetRawConfig(); !rawConfig.IsNull() {
+						if wp := rawConfig.AsValueMap()["workload_profile"]; !wp.IsNull() && wp.IsKnown() {
+							for it := wp.ElementIterator(); it.Next(); {
+								_, profile := it.Element()
+								if profile.IsNull() || !profile.IsKnown() {
+									continue
+								}
+								name, ok := profile.AsValueMap()["name"]
+								if !ok || name.IsNull() || !name.IsKnown() {
+									continue
+								}
+								if name.AsString() == string(helpers.WorkloadProfileSkuConsumption) {
+									userDeclaredConsumption = true
+									break
+								}
+							}
+						}
+					} else {
+						for _, p := range existingState.WorkloadProfiles {
+							if p.Name == string(helpers.WorkloadProfileSkuConsumption) {
+								userDeclaredConsumption = true
+								break
+							}
+						}
+					}
+					state.WorkloadProfiles = helpers.FlattenWorkloadProfiles(props.WorkloadProfiles, userDeclaredConsumption)
 					state.InfrastructureResourceGroup = pointer.From(props.InfrastructureResourceGroup)
 
 					if props.CustomDomainConfiguration != nil {

--- a/internal/services/containerapps/helpers/container_app_environment.go
+++ b/internal/services/containerapps/helpers/container_app_environment.go
@@ -123,25 +123,19 @@ func ExpandWorkloadProfiles(input []WorkloadProfileModel) *[]managedenvironments
 	return &result
 }
 
-func FlattenWorkloadProfiles(input *[]managedenvironments.WorkloadProfile, existing []WorkloadProfileModel) []WorkloadProfileModel {
+func FlattenWorkloadProfiles(input *[]managedenvironments.WorkloadProfile, userDeclaredConsumption bool) []WorkloadProfileModel {
 	if input == nil || len(*input) == 0 {
 		return []WorkloadProfileModel{}
-	}
-
-	userDeclaredConsumption := false
-	for _, p := range existing {
-		if p.Name == string(WorkloadProfileSkuConsumption) {
-			userDeclaredConsumption = true
-			break
-		}
 	}
 
 	apiProfiles := *input
 	result := make([]WorkloadProfileModel, 0, len(apiProfiles))
 
+	// When any dedicated profile exists, the API auto-appends an implicit
+	// `Consumption` profile to the response. If `userDeclaredConsumption` is
+	// false, that implicit profile is dropped to avoid a perpetual diff.
+	// `Consumption-GPU-*` SKUs have distinct names and are never filtered.
 	for _, v := range apiProfiles {
-		// Filter out the implicit `Consumption` profile that Azure auto-adds to any environment
-		// containing a dedicated profile, but only when the user has not declared one themselves.
 		if len(apiProfiles) > 1 && v.Name == string(WorkloadProfileSkuConsumption) && !userDeclaredConsumption {
 			continue
 		}

--- a/internal/services/containerapps/helpers/container_app_environment.go
+++ b/internal/services/containerapps/helpers/container_app_environment.go
@@ -123,13 +123,29 @@ func ExpandWorkloadProfiles(input []WorkloadProfileModel) *[]managedenvironments
 	return &result
 }
 
-func FlattenWorkloadProfiles(input *[]managedenvironments.WorkloadProfile) []WorkloadProfileModel {
+func FlattenWorkloadProfiles(input *[]managedenvironments.WorkloadProfile, existing []WorkloadProfileModel) []WorkloadProfileModel {
 	if input == nil || len(*input) == 0 {
 		return []WorkloadProfileModel{}
 	}
-	result := make([]WorkloadProfileModel, 0)
 
-	for _, v := range *input {
+	userDeclaredConsumption := false
+	for _, p := range existing {
+		if p.Name == string(WorkloadProfileSkuConsumption) {
+			userDeclaredConsumption = true
+			break
+		}
+	}
+
+	apiProfiles := *input
+	result := make([]WorkloadProfileModel, 0, len(apiProfiles))
+
+	for _, v := range apiProfiles {
+		// Filter out the implicit `Consumption` profile that Azure auto-adds to any environment
+		// containing a dedicated profile, but only when the user has not declared one themselves.
+		if len(apiProfiles) > 1 && v.Name == string(WorkloadProfileSkuConsumption) && !userDeclaredConsumption {
+			continue
+		}
+
 		result = append(result, WorkloadProfileModel{
 			Name:                v.Name,
 			MaximumCount:        pointer.From(v.MaximumCount),

--- a/internal/services/containerapps/helpers/container_app_environment_test.go
+++ b/internal/services/containerapps/helpers/container_app_environment_test.go
@@ -4,6 +4,7 @@
 package helpers
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -12,21 +13,19 @@ import (
 
 func TestFlattenWorkloadProfiles(t *testing.T) {
 	cases := []struct {
-		Name     string
-		Input    *[]managedenvironments.WorkloadProfile
-		Existing []WorkloadProfileModel
-		Expected []WorkloadProfileModel
+		Name                    string
+		Input                   *[]managedenvironments.WorkloadProfile
+		UserDeclaredConsumption bool
+		Expected                []WorkloadProfileModel
 	}{
 		{
 			Name:     "nil input returns empty",
 			Input:    nil,
-			Existing: nil,
 			Expected: []WorkloadProfileModel{},
 		},
 		{
 			Name:     "empty input returns empty",
 			Input:    &[]managedenvironments.WorkloadProfile{},
-			Existing: nil,
 			Expected: []WorkloadProfileModel{},
 		},
 		{
@@ -37,7 +36,7 @@ func TestFlattenWorkloadProfiles(t *testing.T) {
 					WorkloadProfileType: string(WorkloadProfileSkuConsumption),
 				},
 			},
-			Existing: nil,
+			UserDeclaredConsumption: true,
 			Expected: []WorkloadProfileModel{
 				{
 					Name:                string(WorkloadProfileSkuConsumption),
@@ -46,7 +45,7 @@ func TestFlattenWorkloadProfiles(t *testing.T) {
 			},
 		},
 		{
-			Name: "implicit Consumption is filtered when user declared only dedicated",
+			Name: "implicit Consumption is filtered when user did not declare it",
 			Input: &[]managedenvironments.WorkloadProfile{
 				{
 					Name:                "D4-01",
@@ -59,38 +58,7 @@ func TestFlattenWorkloadProfiles(t *testing.T) {
 					WorkloadProfileType: string(WorkloadProfileSkuConsumption),
 				},
 			},
-			Existing: []WorkloadProfileModel{
-				{
-					Name:                "D4-01",
-					WorkloadProfileType: string(WorkloadProfileSkuD4),
-					MinimumCount:        0,
-					MaximumCount:        3,
-				},
-			},
-			Expected: []WorkloadProfileModel{
-				{
-					Name:                "D4-01",
-					WorkloadProfileType: string(WorkloadProfileSkuD4),
-					MinimumCount:        0,
-					MaximumCount:        3,
-				},
-			},
-		},
-		{
-			Name: "implicit Consumption is filtered on import (existing empty) when API returned dedicated + Consumption",
-			Input: &[]managedenvironments.WorkloadProfile{
-				{
-					Name:                "D4-01",
-					WorkloadProfileType: string(WorkloadProfileSkuD4),
-					MinimumCount:        pointer.To(int64(0)),
-					MaximumCount:        pointer.To(int64(3)),
-				},
-				{
-					Name:                string(WorkloadProfileSkuConsumption),
-					WorkloadProfileType: string(WorkloadProfileSkuConsumption),
-				},
-			},
-			Existing: nil,
+			UserDeclaredConsumption: false,
 			Expected: []WorkloadProfileModel{
 				{
 					Name:                "D4-01",
@@ -114,18 +82,7 @@ func TestFlattenWorkloadProfiles(t *testing.T) {
 					WorkloadProfileType: string(WorkloadProfileSkuConsumption),
 				},
 			},
-			Existing: []WorkloadProfileModel{
-				{
-					Name:                "D4-01",
-					WorkloadProfileType: string(WorkloadProfileSkuD4),
-					MinimumCount:        0,
-					MaximumCount:        3,
-				},
-				{
-					Name:                string(WorkloadProfileSkuConsumption),
-					WorkloadProfileType: string(WorkloadProfileSkuConsumption),
-				},
-			},
+			UserDeclaredConsumption: true,
 			Expected: []WorkloadProfileModel{
 				{
 					Name:                "D4-01",
@@ -159,20 +116,7 @@ func TestFlattenWorkloadProfiles(t *testing.T) {
 					WorkloadProfileType: string(WorkloadProfileSkuConsumption),
 				},
 			},
-			Existing: []WorkloadProfileModel{
-				{
-					Name:                "D4-01",
-					WorkloadProfileType: string(WorkloadProfileSkuD4),
-					MinimumCount:        0,
-					MaximumCount:        3,
-				},
-				{
-					Name:                "E4-01",
-					WorkloadProfileType: string(WorkloadProfileSkuE4),
-					MinimumCount:        1,
-					MaximumCount:        2,
-				},
-			},
+			UserDeclaredConsumption: false,
 			Expected: []WorkloadProfileModel{
 				{
 					Name:                "D4-01",
@@ -202,18 +146,7 @@ func TestFlattenWorkloadProfiles(t *testing.T) {
 					WorkloadProfileType: string(WorkloadProfileSkuConsumptionGpuNc24A100),
 				},
 			},
-			Existing: []WorkloadProfileModel{
-				{
-					Name:                "D4-01",
-					WorkloadProfileType: string(WorkloadProfileSkuD4),
-					MinimumCount:        0,
-					MaximumCount:        3,
-				},
-				{
-					Name:                string(WorkloadProfileSkuConsumptionGpuNc24A100),
-					WorkloadProfileType: string(WorkloadProfileSkuConsumptionGpuNc24A100),
-				},
-			},
+			UserDeclaredConsumption: false,
 			Expected: []WorkloadProfileModel{
 				{
 					Name:                "D4-01",
@@ -227,26 +160,42 @@ func TestFlattenWorkloadProfiles(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "Consumption preserved when flag is true even alongside dedicated profiles",
+			Input: &[]managedenvironments.WorkloadProfile{
+				{
+					Name:                "D4-01",
+					WorkloadProfileType: string(WorkloadProfileSkuD4),
+					MinimumCount:        pointer.To(int64(0)),
+					MaximumCount:        pointer.To(int64(3)),
+				},
+				{
+					Name:                string(WorkloadProfileSkuConsumption),
+					WorkloadProfileType: string(WorkloadProfileSkuConsumption),
+				},
+			},
+			UserDeclaredConsumption: true,
+			Expected: []WorkloadProfileModel{
+				{
+					Name:                "D4-01",
+					WorkloadProfileType: string(WorkloadProfileSkuD4),
+					MinimumCount:        0,
+					MaximumCount:        3,
+				},
+				{
+					Name:                string(WorkloadProfileSkuConsumption),
+					WorkloadProfileType: string(WorkloadProfileSkuConsumption),
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			actual := FlattenWorkloadProfiles(tc.Input, tc.Existing)
-			if !workloadProfilesEqual(actual, tc.Expected) {
+			actual := FlattenWorkloadProfiles(tc.Input, tc.UserDeclaredConsumption)
+			if !reflect.DeepEqual(actual, tc.Expected) {
 				t.Fatalf("expected %#v, got %#v", tc.Expected, actual)
 			}
 		})
 	}
-}
-
-func workloadProfilesEqual(a, b []WorkloadProfileModel) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
 }

--- a/internal/services/containerapps/helpers/container_app_environment_test.go
+++ b/internal/services/containerapps/helpers/container_app_environment_test.go
@@ -1,0 +1,252 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package helpers
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/managedenvironments"
+)
+
+func TestFlattenWorkloadProfiles(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Input    *[]managedenvironments.WorkloadProfile
+		Existing []WorkloadProfileModel
+		Expected []WorkloadProfileModel
+	}{
+		{
+			Name:     "nil input returns empty",
+			Input:    nil,
+			Existing: nil,
+			Expected: []WorkloadProfileModel{},
+		},
+		{
+			Name:     "empty input returns empty",
+			Input:    &[]managedenvironments.WorkloadProfile{},
+			Existing: nil,
+			Expected: []WorkloadProfileModel{},
+		},
+		{
+			Name: "single Consumption profile is preserved (Consumption-only env)",
+			Input: &[]managedenvironments.WorkloadProfile{
+				{
+					Name:                string(WorkloadProfileSkuConsumption),
+					WorkloadProfileType: string(WorkloadProfileSkuConsumption),
+				},
+			},
+			Existing: nil,
+			Expected: []WorkloadProfileModel{
+				{
+					Name:                string(WorkloadProfileSkuConsumption),
+					WorkloadProfileType: string(WorkloadProfileSkuConsumption),
+				},
+			},
+		},
+		{
+			Name: "implicit Consumption is filtered when user declared only dedicated",
+			Input: &[]managedenvironments.WorkloadProfile{
+				{
+					Name:                "D4-01",
+					WorkloadProfileType: string(WorkloadProfileSkuD4),
+					MinimumCount:        pointer.To(int64(0)),
+					MaximumCount:        pointer.To(int64(3)),
+				},
+				{
+					Name:                string(WorkloadProfileSkuConsumption),
+					WorkloadProfileType: string(WorkloadProfileSkuConsumption),
+				},
+			},
+			Existing: []WorkloadProfileModel{
+				{
+					Name:                "D4-01",
+					WorkloadProfileType: string(WorkloadProfileSkuD4),
+					MinimumCount:        0,
+					MaximumCount:        3,
+				},
+			},
+			Expected: []WorkloadProfileModel{
+				{
+					Name:                "D4-01",
+					WorkloadProfileType: string(WorkloadProfileSkuD4),
+					MinimumCount:        0,
+					MaximumCount:        3,
+				},
+			},
+		},
+		{
+			Name: "implicit Consumption is filtered on import (existing empty) when API returned dedicated + Consumption",
+			Input: &[]managedenvironments.WorkloadProfile{
+				{
+					Name:                "D4-01",
+					WorkloadProfileType: string(WorkloadProfileSkuD4),
+					MinimumCount:        pointer.To(int64(0)),
+					MaximumCount:        pointer.To(int64(3)),
+				},
+				{
+					Name:                string(WorkloadProfileSkuConsumption),
+					WorkloadProfileType: string(WorkloadProfileSkuConsumption),
+				},
+			},
+			Existing: nil,
+			Expected: []WorkloadProfileModel{
+				{
+					Name:                "D4-01",
+					WorkloadProfileType: string(WorkloadProfileSkuD4),
+					MinimumCount:        0,
+					MaximumCount:        3,
+				},
+			},
+		},
+		{
+			Name: "Consumption is preserved when user explicitly declared it",
+			Input: &[]managedenvironments.WorkloadProfile{
+				{
+					Name:                "D4-01",
+					WorkloadProfileType: string(WorkloadProfileSkuD4),
+					MinimumCount:        pointer.To(int64(0)),
+					MaximumCount:        pointer.To(int64(3)),
+				},
+				{
+					Name:                string(WorkloadProfileSkuConsumption),
+					WorkloadProfileType: string(WorkloadProfileSkuConsumption),
+				},
+			},
+			Existing: []WorkloadProfileModel{
+				{
+					Name:                "D4-01",
+					WorkloadProfileType: string(WorkloadProfileSkuD4),
+					MinimumCount:        0,
+					MaximumCount:        3,
+				},
+				{
+					Name:                string(WorkloadProfileSkuConsumption),
+					WorkloadProfileType: string(WorkloadProfileSkuConsumption),
+				},
+			},
+			Expected: []WorkloadProfileModel{
+				{
+					Name:                "D4-01",
+					WorkloadProfileType: string(WorkloadProfileSkuD4),
+					MinimumCount:        0,
+					MaximumCount:        3,
+				},
+				{
+					Name:                string(WorkloadProfileSkuConsumption),
+					WorkloadProfileType: string(WorkloadProfileSkuConsumption),
+				},
+			},
+		},
+		{
+			Name: "multiple dedicated profiles + implicit Consumption: only Consumption filtered",
+			Input: &[]managedenvironments.WorkloadProfile{
+				{
+					Name:                "D4-01",
+					WorkloadProfileType: string(WorkloadProfileSkuD4),
+					MinimumCount:        pointer.To(int64(0)),
+					MaximumCount:        pointer.To(int64(3)),
+				},
+				{
+					Name:                "E4-01",
+					WorkloadProfileType: string(WorkloadProfileSkuE4),
+					MinimumCount:        pointer.To(int64(1)),
+					MaximumCount:        pointer.To(int64(2)),
+				},
+				{
+					Name:                string(WorkloadProfileSkuConsumption),
+					WorkloadProfileType: string(WorkloadProfileSkuConsumption),
+				},
+			},
+			Existing: []WorkloadProfileModel{
+				{
+					Name:                "D4-01",
+					WorkloadProfileType: string(WorkloadProfileSkuD4),
+					MinimumCount:        0,
+					MaximumCount:        3,
+				},
+				{
+					Name:                "E4-01",
+					WorkloadProfileType: string(WorkloadProfileSkuE4),
+					MinimumCount:        1,
+					MaximumCount:        2,
+				},
+			},
+			Expected: []WorkloadProfileModel{
+				{
+					Name:                "D4-01",
+					WorkloadProfileType: string(WorkloadProfileSkuD4),
+					MinimumCount:        0,
+					MaximumCount:        3,
+				},
+				{
+					Name:                "E4-01",
+					WorkloadProfileType: string(WorkloadProfileSkuE4),
+					MinimumCount:        1,
+					MaximumCount:        2,
+				},
+			},
+		},
+		{
+			Name: "Consumption-GPU profile is never filtered (different name from implicit Consumption)",
+			Input: &[]managedenvironments.WorkloadProfile{
+				{
+					Name:                "D4-01",
+					WorkloadProfileType: string(WorkloadProfileSkuD4),
+					MinimumCount:        pointer.To(int64(0)),
+					MaximumCount:        pointer.To(int64(3)),
+				},
+				{
+					Name:                string(WorkloadProfileSkuConsumptionGpuNc24A100),
+					WorkloadProfileType: string(WorkloadProfileSkuConsumptionGpuNc24A100),
+				},
+			},
+			Existing: []WorkloadProfileModel{
+				{
+					Name:                "D4-01",
+					WorkloadProfileType: string(WorkloadProfileSkuD4),
+					MinimumCount:        0,
+					MaximumCount:        3,
+				},
+				{
+					Name:                string(WorkloadProfileSkuConsumptionGpuNc24A100),
+					WorkloadProfileType: string(WorkloadProfileSkuConsumptionGpuNc24A100),
+				},
+			},
+			Expected: []WorkloadProfileModel{
+				{
+					Name:                "D4-01",
+					WorkloadProfileType: string(WorkloadProfileSkuD4),
+					MinimumCount:        0,
+					MaximumCount:        3,
+				},
+				{
+					Name:                string(WorkloadProfileSkuConsumptionGpuNc24A100),
+					WorkloadProfileType: string(WorkloadProfileSkuConsumptionGpuNc24A100),
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			actual := FlattenWorkloadProfiles(tc.Input, tc.Existing)
+			if !workloadProfilesEqual(actual, tc.Expected) {
+				t.Fatalf("expected %#v, got %#v", tc.Expected, actual)
+			}
+		})
+	}
+}
+
+func workloadProfilesEqual(a, b []WorkloadProfileModel) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
For any Container App Environment that contains a dedicated workload profile (e.g. `D4-01`), the Azure API auto-appends an implicit `Consumption` profile to the response. Before this PR that implicit profile was written into state verbatim, causing:
1. A perpetual diff `+ workload_profile { name = "Consumption" }` on every `terraform plan`.
2. Because `workload_profile` is a `TypeSet`, the hash reorder propagated into downstream resources, silently flipping `azurerm_container_app.workload_profile_name` from e.g. `"D4-01"` to `"Consumption"`.

<details>
<summary>click this for detail error log</summary>

```text
Note: Objects have changed outside of Terraform
        Terraform detected the following changes made outside of Terraform since the
        last "terraform apply" which may have affected this plan:
          # azurerm_container_app_environment.test has changed
          ~ resource "azurerm_container_app_environment" "test" {
                id                                          = "abcd"
                tags                                        = {
                    "Foo"    = "Bar"
                    "secret" = "sauce"
                }
                # (17 unchanged attributes hidden)
              + workload_profile {
                  + maximum_count         = 0
                  + minimum_count         = 0
                  + name                  = "Consumption"
                  + workload_profile_type = "Consumption"
                }
                # (1 unchanged block hidden)
            }
        Unless you have made equivalent changes to your configuration, or ignored the
        relevant attributes using ignore_changes, the following plan may include
        actions to undo or respond to these changes.
        ─────────────────────────────────────────────────────────────────────────────
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        Terraform will perform the following actions:
          # azurerm_container_app.test will be updated in-place
          ~ resource "azurerm_container_app" "test" {
                id                            = "abcd"
                name                          = "acctest-app"
                tags                          = {
                    "accTest" = "1"
                    "foo"     = "Bar"
                }
              ~ workload_profile_name         = "D4-01" -> "Consumption"
                # (9 unchanged attributes hidden)
                # (2 unchanged blocks hidden)
            }
        Plan: 0 to add, 1 to change, 0 to destroy.
```

</details>

The existing `DiffSuppressFunc` and `CustomizeDiff` could not resolve this issue:
1. `DiffSuppressFunc`: Only suppresses the env's own per-attribute diff, but does not prevent the additional "Consumption` profile been written into the state.
2. `CustomizeDiff`: Only prevents a spurious `ForceNew`, but does not prevent the additional "Consumption` profile been written into the state.

This PR adds a `userDeclaredConsumption` argument to `helpers.FlattenWorkloadProfiles`; when `false`, the implicit `Consumption` element is dropped before being persisted. `Read()` derives the flag from raw HCL when available, falling back to prior state when the SDK passes no config.

### Before this PR

| Terraform step | `env.workload_profile` in state | Diff & why |
|---|---|---|
| 1. `terraform apply` | `[D4-01]` | No diff. Create's internal `Read` flattens the API response to `[D4-01, Consumption]`, but the SDK's Apply post-processing (`normalizeNullValues` with `apply=true`) replaces the set with the plan value, silently dropping `Consumption`. |
| 2. `terraform refresh + plan` | `[D4-01]` → `[D4-01, Consumption]` | On refresh, the SDK applies `DiffSuppressFunc`. But the existing `OneAdditionalConsumptionProfileReturnedByAPI` expects the extra element on `oldV` (plan-time order); on refresh it appears on `newV`, so the check returns false and `Consumption` is written to state. Container env shows `+ workload_profile { Consumption }`; container app shows `~ workload_profile_name = "D4-01" -> "Consumption"` because `tolist(env.workload_profile).0` no longer points at `D4-01`.|

**Root cause:** 
1. The two state-writing paths behave inconsistently, and `DiffSuppressFunc` cannot be reached on refresh with the parameter order it was written for.
2. The visible test failure is the downstream symptom. Env's own plan-time diff is correctly suppressed because the `DiffSuppressFunc` is called with the argument order it was designed for `(old = polluted state, new = HCL)`. But the polluted state is read by `azurerm_container_app.workload_profile_name = local.workload_profiles.0.name`, which `DiffSuppressFunc` on env cannot reach, producing the actionable `~ "D4-01" -> "Consumption"` change.

### After this PR

| Terraform step | `env.workload_profile` in state | Diff & why |
|---|---|---|
| 1. `terraform apply` | `[D4-01]` | No diff. Raw config is available and contains no `Consumption`, so `FlattenWorkloadProfiles` drops the implicit profile before it enters state. |
| 2. `terraform refresh + plan` | `[D4-01]` | No diff. Raw config is null at refresh, so we fall back to prior state, which also has no `Consumption`, filter stays consistent. |
| 3. `terraform import` | `[D4-01]` | Both raw config and prior state are empty → default to filtering. If the user's HCL declares `Consumption`, a one-time `+ Consumption` diff appears; the following apply runs `Update`'s internal `Read` (raw config available) and self-heals. |
| 4. State polluted by a pre-PR run | `[D4-01, Consumption]` → `[D4-01]` (only after the next `apply` that touches env) | Refresh alone keeps `Consumption`: raw config is null, so the filter falls back to prior state and preserves it (to protect users who did declare Consumption). State heals only when `env.Update` runs — the wrapper's post-Update `Read` sees raw config, filters it out, and `container_app` then shows a one-time `~ "Consumption" -> "D4-01"`. |


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.



## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them.
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally.

## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)
```
TODO: tests output here
```

## Change Log

* `azurerm_container_app_environment` - prevent a non-empty plan caused by the implicit `Consumption` workload profile that Azure auto-adds to environments containing dedicated profiles [GH-32463]

This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

N/A

## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls
No.
