### PR TITLE
`azurerm_container_app` - fix rabbitmq scale rule metadata in acceptance test

### DIFF
--- a/internal/services/containerapps/container_app_resource_test.go
+++ b/internal/services/containerapps/container_app_resource_test.go
@@ -2760,7 +2760,9 @@ resource "azurerm_container_app" "test" {
       custom_rule_type = "rabbitmq"
 
       metadata = {
-        foo = "bar"
+        queueName = "myqueue"
+        mode      = "QueueLength"
+        value     = "10"
       }
 
       authentication {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

The acceptance test `TestAccContainerAppResource_scaleRulesUpdate` defines a `custom_scale_rule` with `custom_rule_type = "rabbitmq"` but supplies a placeholder metadata block of `foo = "bar"`. The KEDA RabbitMQ scaler requires specific keys (queueName, mode, value) and the Azure API rejects the request when they are missing, which causes the test to fail on apply.

The test failed with error below:
```
Container App Name: "acctest-capp-260602055417969317"): performing CreateOrUpdate: unexpected status 400 (400 Bad Request) with error: ScaleRuleMetadataMissing: The custom scale rule 'rabbitmq' doesn't include required metadata:'mode, value, queueName'.
```

This PR updates the test fixture to provide valid metadata for the RabbitMQ trigger so the test reflects a realistic configuration and passes consistently:

```
metadata = {
  queueName = "myqueue"
  mode      = "QueueLength"
  value     = "10"
}
```
There are no changes to provider source code, schema, or documentation — this is a test-only fix.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 

<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have successfully run tests with my changes locally

## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass.
```
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/containerapps -run=TestAccContainerAppResource_scaleRulesUpdate -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccContainerAppResource_scaleRulesUpdate
=== PAUSE TestAccContainerAppResource_scaleRulesUpdate
=== CONT  TestAccContainerAppResource_scaleRulesUpdate
--- PASS: TestAccContainerAppResource_scaleRulesUpdate (729.18s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/containerapps	729.215s
```

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

No changelog entry — this PR only updates an acceptance test fixture and does not change user-facing behavior.

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

N/A


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

No.