### PR TITLE
`costmanagement` - update `email_subject` validation and fix tests

### DIFF
--- a/internal/services/costmanagement/cost_anomaly_alert_resource_test.go
+++ b/internal/services/costmanagement/cost_anomaly_alert_resource_test.go
@@ -11,52 +11,75 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2023-08-01/scheduledactions"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
 type AnomalyAlertResource struct{}
 
-func TestAccResourceAnomalyAlert_update(t *testing.T) {
+func TestAccResourceAnomalyAlert_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cost_anomaly_alert", "test")
-	testResource := AnomalyAlertResource{}
-	data.ResourceTest(t, testResource, []acceptance.TestStep{
-		data.ApplyStep(testResource.basicConfig, testResource),
-		data.ImportStep(),
-		data.ApplyStep(testResource.updateConfig, testResource),
-		data.ImportStep(),
-		data.ApplyStep(testResource.basicConfig, testResource),
+	r := AnomalyAlertResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
 		data.ImportStep(),
 	})
 }
 
 func TestAccResourceAnomalyAlert_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cost_anomaly_alert", "test")
-	testResource := AnomalyAlertResource{}
-	data.ResourceTest(t, testResource, []acceptance.TestStep{
-		data.ApplyStep(testResource.completeConfig, testResource),
-		data.ImportStep(),
-		data.ApplyStep(testResource.updateConfig, testResource),
+	r := AnomalyAlertResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
 		data.ImportStep(),
 	})
 }
 
 func TestAccResourceAnomalyAlert_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cost_anomaly_alert", "test")
-	testResource := AnomalyAlertResource{}
-	data.ResourceTest(t, testResource, []acceptance.TestStep{
-		data.ApplyStep(testResource.basicConfig, testResource),
-		data.RequiresImportErrorStep(testResource.requiresImportConfig),
+	r := AnomalyAlertResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicForImport(),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		{
+			Config:      r.requiresImport(),
+			ExpectError: acceptance.RequiresImportError("azurerm_cost_anomaly_alert"),
+		},
 	})
 }
 
-func TestAccResourceAnomalyAlert_emailAddressSender(t *testing.T) {
+func TestAccResourceAnomalyAlert_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cost_anomaly_alert", "test")
-	testResource := AnomalyAlertResource{}
-	data.ResourceTest(t, testResource, []acceptance.TestStep{
-		data.ApplyStep(testResource.notificationEmailConfig, testResource),
+	r := AnomalyAlertResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.update(),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
 		data.ImportStep(),
-		data.ApplyStep(testResource.updateConfig, testResource),
+		{
+			Config: r.update2(),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
 		data.ImportStep(),
 	})
 }
@@ -75,23 +98,39 @@ func (AnomalyAlertResource) Exists(ctx context.Context, client *clients.Client, 
 	return pointer.To(resp.Model.Properties != nil), nil
 }
 
-func (AnomalyAlertResource) basicConfig(data acceptance.TestData) string {
+func (AnomalyAlertResource) basic() string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
 resource "azurerm_cost_anomaly_alert" "test" {
-  name            = "-acctest-%d"
-  display_name    = "acctest %d"
+  name            = "acctest-basic"
+  display_name    = "Finance budget"
   email_subject   = "Hi"
   email_addresses = ["test@test.com", "test@hashicorp.developer"]
   message         = "Oops, cost anomaly"
 }
-`, data.RandomInteger, data.RandomInteger)
+`)
 }
 
-func (AnomalyAlertResource) completeConfig(data acceptance.TestData) string {
+func (AnomalyAlertResource) basicForImport() string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_cost_anomaly_alert" "test" {
+  name            = "acctest-import"
+  display_name    = "Finance budget"
+  email_subject   = "Hi"
+  email_addresses = ["test@test.com", "test@hashicorp.developer"]
+  message         = "Oops, cost anomaly"
+}
+`)
+}
+
+func (AnomalyAlertResource) complete() string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -100,18 +139,18 @@ provider "azurerm" {
 data "azurerm_subscription" "test" {}
 
 resource "azurerm_cost_anomaly_alert" "test" {
-  name            = "-acctest-%d"
-  display_name    = "acctest %d"
-  subscription_id = data.azurerm_subscription.test.id
-  email_subject   = "Hi"
-  email_addresses = ["test@test.com", "test@hashicorp.developer"]
-  message         = "Cost anomaly complete test"
+  name               = "acctest-complete"
+  display_name       = "Finance budget"
+  subscription_id    = data.azurerm_subscription.test.id
+  email_subject      = "Hi"
+  email_addresses    = ["test@test.com", "test@hashicorp.developer"]
+  notification_email = "othertest@hashicorp.developer"
+  message            = "Cost anomaly complete test"
 }
-`, data.RandomInteger, data.RandomInteger)
+`)
 }
 
-func (r AnomalyAlertResource) requiresImportConfig(data acceptance.TestData) string {
-	template := r.basicConfig(data)
+func (r AnomalyAlertResource) requiresImport() string {
 	return fmt.Sprintf(`
 %s
 
@@ -122,38 +161,40 @@ resource "azurerm_cost_anomaly_alert" "import" {
   email_addresses = azurerm_cost_anomaly_alert.test.email_addresses
   message         = azurerm_cost_anomaly_alert.test.message
 }
-`, template)
+`, r.basicForImport())
 }
 
-func (AnomalyAlertResource) updateConfig(data acceptance.TestData) string {
+func (AnomalyAlertResource) update() string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
 resource "azurerm_cost_anomaly_alert" "test" {
-  name            = "-acctest-%d"
-  display_name    = "acctest name update %d"
+  name            = "acctest-update"
+  display_name    = "Budget"
   email_subject   = "Hi you!"
   email_addresses = ["tester@test.com", "test2@hashicorp.developer"]
-  message         = "An updated cost anomaly for you"
+  message         = "A cost anomaly for you"
 }
-`, data.RandomInteger, data.RandomInteger)
+`)
 }
 
-func (AnomalyAlertResource) notificationEmailConfig(data acceptance.TestData) string {
+func (AnomalyAlertResource) update2() string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
+data "azurerm_subscription" "test" {}
+
 resource "azurerm_cost_anomaly_alert" "test" {
-  name               = "-acctest-%d"
-  display_name       = "acctest %d"
-  email_subject      = "Hi"
-  email_addresses    = ["test@test.com", "test@hashicorp.developer"]
-  notification_email = "othertest@hashicorp.developer"
-  message            = "Custom sender email configured"
+  name            = "acctest-update"
+  display_name    = "Finance budget"
+  email_subject   = "Hello you!"
+  email_addresses = ["tester@test.com", "test2@hashicorp.developer", "test@test.com"]
+  message         = "An updated cost anomaly for you"
+  subscription_id = data.azurerm_subscription.test.id
 }
-`, data.RandomInteger, data.RandomInteger)
+`)
 }

--- a/internal/services/costmanagement/cost_anomaly_alert_resource_test.go
+++ b/internal/services/costmanagement/cost_anomaly_alert_resource_test.go
@@ -99,7 +99,7 @@ func (AnomalyAlertResource) Exists(ctx context.Context, client *clients.Client, 
 }
 
 func (AnomalyAlertResource) basic() string {
-	return fmt.Sprintf(`
+	return `
 provider "azurerm" {
   features {}
 }
@@ -111,11 +111,11 @@ resource "azurerm_cost_anomaly_alert" "test" {
   email_addresses = ["test@test.com", "test@hashicorp.developer"]
   message         = "Oops, cost anomaly"
 }
-`)
+`
 }
 
 func (AnomalyAlertResource) basicForImport() string {
-	return fmt.Sprintf(`
+	return `
 provider "azurerm" {
   features {}
 }
@@ -127,11 +127,11 @@ resource "azurerm_cost_anomaly_alert" "test" {
   email_addresses = ["test@test.com", "test@hashicorp.developer"]
   message         = "Oops, cost anomaly"
 }
-`)
+`
 }
 
 func (AnomalyAlertResource) complete() string {
-	return fmt.Sprintf(`
+	return `
 provider "azurerm" {
   features {}
 }
@@ -147,7 +147,7 @@ resource "azurerm_cost_anomaly_alert" "test" {
   notification_email = "othertest@hashicorp.developer"
   message            = "Cost anomaly complete test"
 }
-`)
+`
 }
 
 func (r AnomalyAlertResource) requiresImport() string {
@@ -165,7 +165,7 @@ resource "azurerm_cost_anomaly_alert" "import" {
 }
 
 func (AnomalyAlertResource) update() string {
-	return fmt.Sprintf(`
+	return `
 provider "azurerm" {
   features {}
 }
@@ -177,11 +177,11 @@ resource "azurerm_cost_anomaly_alert" "test" {
   email_addresses = ["tester@test.com", "test2@hashicorp.developer"]
   message         = "A cost anomaly for you"
 }
-`)
+`
 }
 
 func (AnomalyAlertResource) update2() string {
-	return fmt.Sprintf(`
+	return `
 provider "azurerm" {
   features {}
 }
@@ -196,5 +196,5 @@ resource "azurerm_cost_anomaly_alert" "test" {
   message         = "An updated cost anomaly for you"
   subscription_id = data.azurerm_subscription.test.id
 }
-`)
+`
 }

--- a/internal/services/costmanagement/cost_management_scheduled_action_resource.go
+++ b/internal/services/costmanagement/cost_management_scheduled_action_resource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2023-08-01/scheduledactions"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2023-08-01/views"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -24,7 +25,7 @@ type CostManagementScheduledActionResource struct{}
 var _ sdk.Resource = CostManagementScheduledActionResource{}
 
 func (r CostManagementScheduledActionResource) Arguments() map[string]*pluginsdk.Schema {
-	return map[string]*pluginsdk.Schema{
+	resource := map[string]*pluginsdk.Schema{
 		"name": {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
@@ -48,7 +49,7 @@ func (r CostManagementScheduledActionResource) Arguments() map[string]*pluginsdk
 		"email_subject": {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
-			ValidateFunc: validation.StringLenBetween(1, 70),
+			ValidateFunc: validation.StringLenBetween(1, 50),
 		},
 
 		"email_addresses": {
@@ -124,6 +125,12 @@ func (r CostManagementScheduledActionResource) Arguments() map[string]*pluginsdk
 			ValidateFunc: validation.IsRFC3339Time,
 		},
 	}
+
+	if !features.FivePointOh() {
+		resource["email_subject"].ValidateFunc = validation.StringLenBetween(1, 70)
+	}
+
+	return resource
 }
 
 func (r CostManagementScheduledActionResource) Attributes() map[string]*pluginsdk.Schema {

--- a/internal/services/costmanagement/cost_management_scheduled_action_resource_test.go
+++ b/internal/services/costmanagement/cost_management_scheduled_action_resource_test.go
@@ -141,7 +141,7 @@ resource "azurerm_cost_management_scheduled_action" "test" {
   view_id = "${data.azurerm_subscription.test.id}/providers/Microsoft.CostManagement/views/ms:CostByService"
 
   display_name         = "CostByServiceView%s"
-  email_subject        = substr("Cost Management Report for ${data.azurerm_subscription.test.display_name} Subscription", 0, 70)
+  email_subject        = substr("Cost Management Report for ${data.azurerm_subscription.test.display_name} Subscription", 0, 50)
   email_addresses      = ["test@test.com", "hashicorp@test.com"]
   email_address_sender = "test@test.com"
 
@@ -170,7 +170,7 @@ resource "azurerm_cost_management_scheduled_action" "test" {
 
   display_name         = "CostByServiceView%s"
   message              = "Hi"
-  email_subject        = substr("Cost Management Report for ${data.azurerm_subscription.test.display_name} Subscription", 0, 70)
+  email_subject        = substr("Cost Management Report for ${data.azurerm_subscription.test.display_name} Subscription", 0, 50)
   email_addresses      = ["test@test.com", "hashicorp@test.com"]
   email_address_sender = "test@test.com"
 
@@ -201,7 +201,7 @@ resource "azurerm_cost_management_scheduled_action" "test" {
 
   display_name         = "CostByServiceView%s"
   message              = "Hi"
-  email_subject        = substr("Cost Management Report for ${data.azurerm_subscription.test.display_name} Subscription", 0, 70)
+  email_subject        = substr("Cost Management Report for ${data.azurerm_subscription.test.display_name} Subscription", 0, 50)
   email_addresses      = ["test@test.com", "hashicorp@test.com"]
   email_address_sender = "test@test.com"
 
@@ -232,7 +232,7 @@ resource "azurerm_cost_management_scheduled_action" "test" {
 
   display_name         = "CostByServiceView%s"
   message              = "Hi"
-  email_subject        = substr("Cost Management Report for ${data.azurerm_subscription.test.display_name} Subscription", 0, 70)
+  email_subject        = substr("Cost Management Report for ${data.azurerm_subscription.test.display_name} Subscription", 0, 50)
   email_addresses      = ["test@test.com", "hashicorp@test.com"]
   email_address_sender = "test@test.com"
 
@@ -284,7 +284,7 @@ resource "azurerm_cost_management_scheduled_action" "test" {
   view_id = "${data.azurerm_subscription.test.id}/providers/Microsoft.CostManagement/views/ms:CostByService"
 
   display_name         = "CostByServiceView%s"
-  email_subject        = substr("Cost Management Report for ${data.azurerm_subscription.test.display_name} Subscription", 0, 70)
+  email_subject        = substr("Cost Management Report for ${data.azurerm_subscription.test.display_name} Subscription", 0, 50)
   email_addresses      = ["test@test.com", "hashicorp@test.com"]
   email_address_sender = "%s"
 

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -393,6 +393,10 @@ Please follow the format in the example below for listing breaking changes in re
 * The deprecated `managed_hsm_key_id` property has been removed in favour of the `key_vault_key_id` property.
 * The `minimal_tls_version` property no longer accepts `Tls` or `Tls11` as a value.
 
+### `azurerm_cost_management_scheduled_action`
+
+* Validation for `email_subject` has been changed to enforce a maximum length of 50 characters.
+
 ### `azurerm_container_app_environment`
 
 * The `logs_destination` property is no longer Computed and now must be set to `log-analytics` to be able to specify a value for `log_analytics_workspace_id`. It will now default to empty, meaning Streaming Only in the Azure Portal.

--- a/website/docs/r/cost_management_scheduled_action.html.markdown
+++ b/website/docs/r/cost_management_scheduled_action.html.markdown
@@ -40,7 +40,7 @@ The following arguments are supported:
 
 * `email_addresses` - (Required) Specifies a list of email addresses that will receive the Scheduled Action.
 
-* `email_subject` - (Required) Subject of the email. Length is limited to 70 characters.
+* `email_subject` - (Required) Subject of the email. Length is limited to 50 characters.
 
 * `end_date` - (Required) The end date and time of the Scheduled Action (UTC).
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This pr fixes the below errors and updates the validation to allow a maximum length of 50 characters for `email_subject` in 5.0. The numbers on the end of acctests must be removed because these are being rejected by the API.

```
InvalidScheduledActionEmailSubject: Email subject length exceeds the allowed limit of 50 characters. Please shorten the subject.

InvalidScheduledActionDisplayName: Potential phishing phrases found in the scheduled action display name. Please provide a valid display name.
```


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
