### PR TITLE
`azurerm_key_vault_key` - add support for the `release_policy` block

### DIFF
--- a/internal/services/keyvault/key_vault_key_resource.go
+++ b/internal/services/keyvault/key_vault_key_resource.go
@@ -15,6 +15,8 @@ import (
 	"fmt"
 	"log"
 	"math/big"
+	"reflect"
+	"slices"
 	"strings"
 	"time"
 
@@ -26,6 +28,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/keyvault"
 	"github.com/hashicorp/go-azure-sdk/data-plane/keyvault/7-4/deletedkeys"
 	"github.com/hashicorp/go-azure-sdk/data-plane/keyvault/7-4/keys"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -139,6 +142,29 @@ func resourceKeyVaultKey() *pluginsdk.Resource {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.IsRFC3339Time,
+			},
+
+			"release_policy": {
+				Type:     pluginsdk.TypeList,
+				Optional: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"json": {
+							Type:             pluginsdk.TypeString,
+							Required:         true,
+							ValidateFunc:     validation.StringIsJSON,
+							DiffSuppressFunc: pluginsdk.SuppressJsonDiff,
+						},
+
+						"immutable": {
+							Type:     pluginsdk.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+					},
+				},
 			},
 
 			"rotation_policy": {
@@ -272,6 +298,48 @@ func resourceKeyVaultKey() *pluginsdk.Resource {
 
 				return false
 			}),
+			func(_ context.Context, d *pluginsdk.ResourceDiff, _ interface{}) error {
+				if p := d.Get("release_policy").([]any); len(p) > 0 {
+					if t := d.Get("key_type").(string); !slices.Contains([]string{string(keys.JsonWebKeyTypeRSANegativeHSM), string(keys.JsonWebKeyTypeECNegativeHSM)}, t) {
+						return fmt.Errorf("when `release_policy` is set, `key_type` must be `RSA-HSM` or `EC-HSM`, got `%s`", t)
+					}
+
+					if d.Id() != "" {
+						if d.HasChange("release_policy.0.json") && (!d.HasChange("release_policy.0.immutable") && d.Get("release_policy.0.immutable").(bool)) {
+							// before triggering a resource recreation, confirm it's not just a whitespace difference
+							o, n := d.GetChange("release_policy.0.json")
+							if o != "" {
+								oldMap, err := structure.ExpandJsonFromString(o.(string))
+								if err != nil {
+									return fmt.Errorf("old: %+v", err)
+								}
+
+								newMap, err := structure.ExpandJsonFromString(n.(string))
+								if err != nil {
+									return fmt.Errorf("new: %+v", err)
+								}
+
+								if !reflect.DeepEqual(oldMap, newMap) {
+									if err := d.ForceNew("release_policy.0.json"); err != nil {
+										return err
+									}
+								}
+							}
+						}
+
+						if d.HasChange("release_policy.0.immutable") {
+							o, n := d.GetChange("release_policy.0.immutable")
+							if o.(bool) && !n.(bool) {
+								if err := d.ForceNew("release_policy.0.immutable"); err != nil {
+									return err
+								}
+							}
+						}
+					}
+				}
+
+				return nil
+			},
 		),
 	}
 }
@@ -281,7 +349,6 @@ func resourceKeyVaultKeyCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	log.Print("[INFO] preparing arguments for AzureRM KeyVault Key creation.")
 	name := d.Get("name").(string)
 	keyVaultId, err := commonids.ParseKeyVaultID(d.Get("key_vault_id").(string))
 	if err != nil {
@@ -309,26 +376,26 @@ func resourceKeyVaultKeyCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 		}
 	}
 
-	keyType := d.Get("key_type").(string)
-	keyOptions := expandKeyVaultKeyOptions(d)
-	t := d.Get("tags").(map[string]interface{})
-
 	// TODO: support Importing Keys once this is fixed:
 	// https://github.com/Azure/azure-rest-api-specs/issues/1747
 	parameters := keys.KeyCreateParameters{
-		Kty:    keys.JsonWebKeyType(keyType),
-		KeyOps: keyOptions,
+		Kty:    keys.JsonWebKeyType(d.Get("key_type").(string)),
+		KeyOps: expandKeyVaultKeyOptions(d),
 		Attributes: &keys.KeyAttributes{
 			Enabled: pointer.To(true),
 		},
+		Tags: pointer.To(tags.ToTypedObject(tags.Expand(d.Get("tags").(map[string]interface{})))),
+	}
 
-		Tags: pointer.To(tags.ToTypedObject(tags.Expand(t))),
+	if p := expandKeyVaultKeyReleasePolicy(d.Get("release_policy").([]any)); p != nil {
+		parameters.ReleasePolicy = p
+		// key must be exportable when `release_policy` is set
+		parameters.Attributes.Exportable = pointer.To(true)
 	}
 
 	switch parameters.Kty {
 	case keys.JsonWebKeyTypeEC, keys.JsonWebKeyTypeECNegativeHSM:
-		curveName := d.Get("curve").(string)
-		parameters.Crv = pointer.To(keys.JsonWebKeyCurveName(curveName))
+		parameters.Crv = pointer.ToEnum[keys.JsonWebKeyCurveName](d.Get("curve").(string))
 	case keys.JsonWebKeyTypeRSA, keys.JsonWebKeyTypeRSANegativeHSM:
 		keySize, ok := d.GetOk("key_size")
 		if !ok {
@@ -439,15 +506,13 @@ func resourceKeyVaultKeyUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 	client := meta.(*clients.Client).KeyVault.DataPlaneKeyVaultClient.Keys.Clone(id.KeyVaultBaseURL)
 	keyVersionId := keys.NewKeyversionID(id.KeyVaultBaseURL, id.Name, "")
 	keyId := keys.NewKeyID(id.KeyVaultBaseURL, id.Name)
-	keyOptions := expandKeyVaultKeyOptions(d)
-	t := d.Get("tags").(map[string]interface{})
 
 	parameters := keys.KeyUpdateParameters{
-		KeyOps: keyOptions,
+		KeyOps: expandKeyVaultKeyOptions(d),
 		Attributes: &keys.KeyAttributes{
 			Enabled: pointer.To(true),
 		},
-		Tags: pointer.To(tags.ToTypedObject(tags.Expand(t))),
+		Tags: pointer.To(tags.ToTypedObject(tags.Expand(d.Get("tags").(map[string]interface{})))),
 	}
 
 	if v, ok := d.GetOk("not_before_date"); ok {
@@ -458,6 +523,10 @@ func resourceKeyVaultKeyUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 	if v, ok := d.GetOk("expiration_date"); ok {
 		expirationDate, _ := time.Parse(time.RFC3339, v.(string)) // validated by schema
 		parameters.Attributes.Exp = pointer.To(expirationDate.Unix())
+	}
+
+	if d.HasChange("release_policy") {
+		parameters.ReleasePolicy = expandKeyVaultKeyReleasePolicy(d.Get("release_policy").([]interface{}))
 	}
 
 	if _, err = client.UpdateKey(ctx, keyVersionId, parameters); err != nil {
@@ -550,6 +619,12 @@ func resourceKeyVaultKeyRead(d *pluginsdk.ResourceData, meta interface{}) error 
 
 			d.Set("curve", string(pointer.From(key.Crv)))
 		}
+
+		data, err := flattenKeyVaultKeyReleasePolicy(resp.Model.ReleasePolicy)
+		if err != nil {
+			return fmt.Errorf("flattening `release_policy`: %+v", err)
+		}
+		d.Set("release_policy", data)
 
 		if attributes := resp.Model.Attributes; attributes != nil {
 			notBeforeDate := ""
@@ -852,6 +927,41 @@ func flattenKeyVaultKeyRotationPolicy(input keys.KeyRotationPolicy) []interface{
 	}
 
 	return []interface{}{policy}
+}
+
+func expandKeyVaultKeyReleasePolicy(input []any) *keys.KeyReleasePolicy {
+	if len(input) == 0 {
+		return nil
+	}
+
+	v := input[0].(map[string]interface{})
+
+	return &keys.KeyReleasePolicy{
+		Data:      pointer.To(base64.StdEncoding.EncodeToString([]byte(v["json"].(string)))),
+		Immutable: pointer.To(v["immutable"].(bool)),
+	}
+}
+
+func flattenKeyVaultKeyReleasePolicy(input *keys.KeyReleasePolicy) ([]any, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	data := ""
+	if input.Data != nil {
+		decoded, err := base64.RawURLEncoding.DecodeString(*input.Data)
+		if err != nil {
+			return nil, err
+		}
+		data = string(decoded)
+	}
+
+	return []any{
+		map[string]any{
+			"json":      data,
+			"immutable": pointer.From(input.Immutable),
+		},
+	}, nil
 }
 
 // Credit to Hashicorp modified from https://github.com/hashicorp/terraform-provider-tls/blob/v3.1.0/internal/provider/util.go#L79-L105

--- a/internal/services/keyvault/key_vault_key_resource.go
+++ b/internal/services/keyvault/key_vault_key_resource.go
@@ -311,12 +311,12 @@ func resourceKeyVaultKey() *pluginsdk.Resource {
 							if o != "" {
 								oldMap, err := structure.ExpandJsonFromString(o.(string))
 								if err != nil {
-									return fmt.Errorf("old: %+v", err)
+									return fmt.Errorf("expanding `release_policy.json`: %+v", err)
 								}
 
 								newMap, err := structure.ExpandJsonFromString(n.(string))
 								if err != nil {
-									return fmt.Errorf("new: %+v", err)
+									return fmt.Errorf("expanding updated `release_policy.json`: %+v", err)
 								}
 
 								if !reflect.DeepEqual(oldMap, newMap) {

--- a/internal/services/keyvault/key_vault_key_resource_test.go
+++ b/internal/services/keyvault/key_vault_key_resource_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/keyvault"
 	"github.com/hashicorp/go-azure-sdk/data-plane/keyvault/7-4/keys"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -435,6 +437,73 @@ func TestAccKeyVaultKey_RotationPolicyUnauthorized(t *testing.T) {
 			Config:      r.rotationPolicyUnauthorized(data),
 			ExpectError: regexp.MustCompile("current client lacks permissions to create Key Rotation Policy for Key"),
 		},
+	})
+}
+
+func TestAccKeyVaultKey_releasePolicy(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_key_vault_key", "test")
+	r := KeyVaultKeyResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.releasePolicy(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("key_size"),
+		{
+			Config: r.releasePolicyUpdated(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("key_size"),
+	})
+}
+
+func TestAccKeyVaultKey_releasePolicyCustomizeDiff(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_key_vault_key", "test")
+	r := KeyVaultKeyResource{}
+
+	data.ResourceTestIgnoreRecreate(t, r, []acceptance.TestStep{
+		{
+			Config:      r.releasePolicyInvalid(data),
+			PlanOnly:    true,
+			ExpectError: regexp.MustCompile("when `release_policy` is set, `key_type` must be `RSA-HSM` or `EC-HSM`"),
+		},
+		{
+			Config: r.releasePolicyUpdated(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("key_size"),
+		{
+			Config: r.releasePolicyUpdated(data, false),
+			ConfigPlanChecks: resource.ConfigPlanChecks{
+				PreApply: []plancheck.PlanCheck{
+					plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionReplace),
+				},
+			},
+		},
+		data.ImportStep("key_size"),
+		{
+			Config: r.releasePolicyUpdated(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("key_size"),
+		{
+			Config: r.releasePolicy(data, true),
+			ConfigPlanChecks: resource.ConfigPlanChecks{
+				PreApply: []plancheck.PlanCheck{
+					plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionReplace),
+				},
+			},
+		},
+		data.ImportStep("key_size"),
 	})
 }
 
@@ -1203,4 +1272,141 @@ resource "azurerm_key_vault_key" "test" {
   }
 }
 `, r.template(data, "standard"), data.RandomString)
+}
+
+func (r KeyVaultKeyResource) releasePolicy(data acceptance.TestData, immutable bool) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_key_vault_key" "test" {
+  name         = "key-%[2]d"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "EC-HSM"
+  key_size     = 2048
+
+  key_opts = [
+    "sign",
+    "verify",
+  ]
+
+  release_policy {
+    immutable = %t
+    json      = <<-EOT
+      {
+        "anyOf": [
+          {
+            "authority": "https://sharedcac.cac.attest.azure.net",
+            "allOf": [
+              {
+                "claim": "x-ms-compliance-status",
+                "equals": "azure-compliant-cvm"
+              }
+            ]
+          }
+        ],
+        "version": "0.2"
+      }
+EOT
+  }
+}
+`, r.templatePremium(data), data.RandomInteger, immutable)
+}
+
+func (r KeyVaultKeyResource) releasePolicyUpdated(data acceptance.TestData, immutable bool) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_key_vault_key" "test" {
+  name         = "key-%[2]d"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "EC-HSM"
+  key_size     = 2048
+
+  key_opts = [
+    "sign",
+    "verify",
+  ]
+
+  release_policy {
+    immutable = %t
+    json      = <<-EOT
+      {
+        "anyOf": [
+          {
+            "authority": "https://sharedcac.cac.attest.azure.net",
+            "allOf": [
+              {
+                "claim": "x-ms-compliance-status",
+                "equals": "azure-compliant-cvm"
+              },
+              {
+                "anyOf": [
+                  {
+                    "claim": "x-ms-attestation-type",
+                    "equals": "tdxvm"
+                  },
+                  {
+                    "claim": "x-ms-attestation-type",
+                    "equals": "sevsnpvm"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "version": "1.0.0"
+      }
+EOT
+  }
+}
+`, r.templatePremium(data), data.RandomInteger, immutable)
+}
+
+func (r KeyVaultKeyResource) releasePolicyInvalid(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_key_vault_key" "test" {
+  name         = "key-%[2]d"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "EC"
+  key_size     = 2048
+
+  key_opts = [
+    "sign",
+    "verify",
+  ]
+
+  release_policy {
+    json = <<-EOT
+      {
+        "anyOf": [
+          {
+            "authority": "https://sharedcac.cac.attest.azure.net",
+            "allOf": [
+              {
+                "claim": "x-ms-compliance-status",
+                "equals": "azure-compliant-cvm"
+              }
+            ]
+          }
+        ],
+        "version": "0.2"
+      }
+EOT
+  }
+}
+`, r.templatePremium(data), data.RandomInteger)
 }

--- a/website/docs/r/key_vault_key.html.markdown
+++ b/website/docs/r/key_vault_key.html.markdown
@@ -99,25 +99,39 @@ The following arguments are supported:
 
 * `key_vault_id` - (Required) The ID of the Key Vault where the Key should be created. Changing this forces a new resource to be created.
 
+* `key_opts` - (Required) A list of JSON web key operations. Possible values include: `decrypt`, `encrypt`, `sign`, `unwrapKey`, `verify` and `wrapKey`. Please note these values are case-sensitive.
+
 * `key_type` - (Required) Specifies the Key Type to use for this Key Vault Key. Possible values are `EC` (Elliptic Curve), `EC-HSM`, `RSA` and `RSA-HSM`. Changing this forces a new resource to be created.
 
-* `key_size` - (Optional) Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `key_type` is `RSA` or `RSA-HSM`. Changing this forces a new resource to be created.
+---
 
 * `curve` - (Optional) Specifies the curve to use when creating an `EC` key. Possible values are `P-256`, `P-256K`, `P-384`, and `P-521`. This field will be required in a future release if `key_type` is `EC` or `EC-HSM`. The API will default to `P-256` if nothing is specified. Changing this forces a new resource to be created.
-
-* `key_opts` - (Required) A list of JSON web key operations. Possible values include: `decrypt`, `encrypt`, `sign`, `unwrapKey`, `verify` and `wrapKey`. Please note these values are case sensitive.
-
-* `not_before_date` - (Optional) Key not usable before the provided UTC datetime (Y-m-d'T'H:M:S'Z').
-
-~> **Note:** Once `expiration_date` is set, it's not possible to unset the key even if it is deleted & recreated as underlying Azure API uses the restore of the purged key.
 
 * `expiration_date` - (Optional) Expiration UTC datetime (Y-m-d'T'H:M:S'Z').
 
 ~> **Note:** Removing this field from the config forces a new resource to be created.
 
-* `tags` - (Optional) A mapping of tags to assign to the resource.
+* `key_size` - (Optional) Specifies the Size of the RSA key to create in bytes. For example, 1024 or 2048. *Note*: This field is required if `key_type` is `RSA` or `RSA-HSM`. Changing this forces a new resource to be created.
+
+* `not_before_date` - (Optional) Key not usable before the provided UTC datetime (Y-m-d'T'H:M:S'Z').
+
+~> **Note:** Once `expiration_date` is set, it's not possible to unset the key even if it is deleted & recreated as underlying Azure API uses the restore of the purged key.
+
+* `release_policy` - (Optional) A `release_policy` block as defined below. Changing this forces a new resource to be created.
 
 * `rotation_policy` - (Optional) A `rotation_policy` block as defined below.
+
+* `tags` - (Optional) A mapping of tags to assign to the resource.
+
+---
+
+A `release_policy` block supports the following:
+
+* `json` - (Required) The policy contents in JSON format.
+
+* `immutable` - (Optional) Whether this policy is immutable. Defaults to `false`.
+
+~> **Note:** When `immutable` is set to `true`, changing either `immutable` or `json` will force a new resource to be created.
 
 ---
 

--- a/website/docs/r/key_vault_key.html.markdown
+++ b/website/docs/r/key_vault_key.html.markdown
@@ -119,6 +119,8 @@ The following arguments are supported:
 
 * `release_policy` - (Optional) A `release_policy` block as defined below. Changing this forces a new resource to be created.
 
+-> **Note:** When `release_policy` is set, the key is automatically set as exportable by the provider as this is an API requirement.
+
 * `rotation_policy` - (Optional) A `rotation_policy` block as defined below.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Adds support for the `release_policy` block


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #25054


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
