### PR TITLE
azurerm_function_app_flex_consumption - add support for go runtime

### DIFF
--- a/internal/services/appservice/function_app_flex_consumption_resource.go
+++ b/internal/services/appservice/function_app_flex_consumption_resource.go
@@ -165,6 +165,7 @@ func (r FunctionAppFlexConsumptionResource) Arguments() map[string]*pluginsdk.Sc
 			Required: true,
 			ValidateFunc: validation.StringInSlice([]string{
 				string(webapps.RuntimeNameDotnetNegativeisolated),
+				string(webapps.RuntimeNameGo),
 				string(webapps.RuntimeNameJava),
 				string(webapps.RuntimeNameNode),
 				string(webapps.RuntimeNamePowershell),

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/web/2023-12-01/webapps/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/web/2023-12-01/webapps/constants.go
@@ -1926,6 +1926,7 @@ type RuntimeName string
 const (
 	RuntimeNameCustom                 RuntimeName = "custom"
 	RuntimeNameDotnetNegativeisolated RuntimeName = "dotnet-isolated"
+	RuntimeNameGo                     RuntimeName = "go"
 	RuntimeNameJava                   RuntimeName = "java"
 	RuntimeNameNode                   RuntimeName = "node"
 	RuntimeNamePowershell             RuntimeName = "powershell"
@@ -1936,6 +1937,7 @@ func PossibleValuesForRuntimeName() []string {
 	return []string{
 		string(RuntimeNameCustom),
 		string(RuntimeNameDotnetNegativeisolated),
+		string(RuntimeNameGo),
 		string(RuntimeNameJava),
 		string(RuntimeNameNode),
 		string(RuntimeNamePowershell),
@@ -1960,6 +1962,7 @@ func parseRuntimeName(input string) (*RuntimeName, error) {
 	vals := map[string]RuntimeName{
 		"custom":          RuntimeNameCustom,
 		"dotnet-isolated": RuntimeNameDotnetNegativeisolated,
+		"go":              RuntimeNameGo,
 		"java":            RuntimeNameJava,
 		"node":            RuntimeNameNode,
 		"powershell":      RuntimeNamePowershell,

--- a/website/docs/r/function_app_flex_consumption.html.markdown
+++ b/website/docs/r/function_app_flex_consumption.html.markdown
@@ -83,7 +83,7 @@ The following arguments are supported:
 
 * `storage_authentication_type` - (Required) The authentication type which will be used to access the backend storage account for the Function App. Possible values are `StorageAccountConnectionString`, `SystemAssignedIdentity`, and `UserAssignedIdentity`.
 
-* `runtime_name` - (Required) The Runtime of the Linux Function App. Possible values are `node`, `dotnet-isolated`, `powershell`, `python`, `java` and `custom`.
+* `runtime_name` - (Required) The Runtime of the Linux Function App. Possible values are `node`, `dotnet-isolated`, `go`, `powershell`, `python`, `java` and `custom`.
 
 * `runtime_version` - (Required) The Runtime version of the Linux Function App. Accepted values varies with the value of `runtime_name`.
 


### PR DESCRIPTION
Community Note

<!-- Please leave the community note as is. -->
 - Please vote on this PR by adding a :thumbsup: reaction to the original PR to help the community and maintainers prioritize for review
 - Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

Description

This PR adds go as a supported runtime for the azurerm_function_app_flex_consumption resource. Azure Functions now supports the Go runtime on Flex Consumption plans, and this change makes the provider reflect that.

Changes made:

 - Added RuntimeNameGo constant ("go") to the vendored go-azure-sdk webapps constants, including the parser and possible-values helper.
 - Added "go" to the runtime_name validation list in function_app_flex_consumption_resource.go.
 - Updated the function_app_flex_consumption documentation to list go as a possible value for runtime_name.

PR Checklist

 - [X]  I have followed the guidelines in our Contributing Documentation.
 - [X]  I have checked to ensure there aren't other open Pull Requests for the same update/change.
 - [ ]  I have checked if my changes close any open issues. If so please include appropriate closing keywords below.
 - [X]  I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
 - [X]  I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
 For example: "azurerm_function_app_flex_consumption - add support for go runtime"

Changes to existing Resource / Data Source

 - [X]  I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
 - [ ]  I have written new tests for my resource or datasource changes & updated any relevant documentation.
 - [ ]  I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.

Testing

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. -->


Change Log

 - azurerm_function_app_flex_consumption - support for the go runtime in the runtime_name property

This is a (please select all that apply):

 - [ ]  Bug Fix
 - [ ]  New Feature (ie adding a service, resource, or data source)
 - [X]  Enhancement
 - [ ]  Breaking Change

Related Issue(s)

AI Assistance Disclosure

 - [ ]  AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

Changes to Security Controls

No changes to security controls.