### PR TITLE
`azurerm_netapp_account` - fixes removal of `active_directory` and drift detection

### DIFF
--- a/internal/services/netapp/netapp_account_resource.go
+++ b/internal/services/netapp/netapp_account_resource.go
@@ -168,11 +168,11 @@ func resourceNetAppAccount() *pluginsdk.Resource {
 
 func resourceNetAppAccountCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).NetApp.AccountClient
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id := netappaccounts.NewNetAppAccountID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
+	id := netappaccounts.NewNetAppAccountID(meta.(*clients.Client).Account.SubscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
 	locks.ByID(id.ID())
 	defer locks.UnlockByID(id.ID())
@@ -229,7 +229,8 @@ func resourceNetAppAccountCreate(d *pluginsdk.ResourceData, meta interface{}) er
 
 func resourceNetAppAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).NetApp.AccountClient
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	id, err := netappaccounts.ParseNetAppAccountID(d.Id())
@@ -240,19 +241,25 @@ func resourceNetAppAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) er
 	locks.ByID(id.ID())
 	defer locks.UnlockByID(id.ID())
 
-	update := netappaccounts.NetAppAccountPatch{
-		Properties: &netappaccounts.AccountProperties{},
+	existing, err := client.AccountsGet(ctx, *id)
+	if err != nil {
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	if existing.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", id)
+	}
+
+	if existing.Model.Properties == nil {
+		return fmt.Errorf("retrieving %s: `properties` was nil", id)
 	}
 
 	if d.HasChange("active_directory") {
-		activeDirectoriesRaw := d.Get("active_directory").([]interface{})
-		activeDirectories := expandNetAppActiveDirectories(activeDirectoriesRaw)
-		update.Properties.ActiveDirectories = activeDirectories
+		existing.Model.Properties.ActiveDirectories = expandNetAppActiveDirectories(d.Get("active_directory").([]interface{}))
 	}
 
 	if d.HasChange("tags") {
-		tagsRaw := d.Get("tags").(map[string]interface{})
-		update.Tags = tags.Expand(tagsRaw)
+		existing.Model.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
 	}
 
 	if d.HasChange("identity") {
@@ -260,11 +267,10 @@ func resourceNetAppAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) er
 		if err != nil {
 			return fmt.Errorf("expanding `identity`: %+v", err)
 		}
-
-		update.Identity = anfAccountIdentity
+		existing.Model.Identity = anfAccountIdentity
 	}
 
-	if err = client.AccountsUpdateThenPoll(ctx, *id, update); err != nil {
+	if err := client.AccountsCreateOrUpdateThenPoll(ctx, *id, *existing.Model); err != nil {
 		return fmt.Errorf("updating %s: %+v", id.ID(), err)
 	}
 
@@ -284,7 +290,7 @@ func resourceNetAppAccountRead(d *pluginsdk.ResourceData, meta interface{}) erro
 	resp, err := client.AccountsGet(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			log.Printf("[INFO] %s does not exist - removing from state", *id)
+			log.Printf("[DEBUG] %s was not found - removing from state", id)
 			d.SetId("")
 			return nil
 		}
@@ -297,28 +303,22 @@ func resourceNetAppAccountRead(d *pluginsdk.ResourceData, meta interface{}) erro
 	if model := resp.Model; model != nil {
 		d.Set("location", location.Normalize(model.Location))
 
-		if model.Identity != nil {
-			anfAccountIdentity, err := identity.FlattenLegacySystemAndUserAssignedMap(model.Identity)
-			if err != nil {
-				return fmt.Errorf("flattening `identity`: %+v", err)
-			}
-
-			if err := d.Set("identity", anfAccountIdentity); err != nil {
-				return fmt.Errorf("setting `identity`: %+v", err)
-			}
+		anfAccountIdentity, err := identity.FlattenLegacySystemAndUserAssignedMap(model.Identity)
+		if err != nil {
+			return fmt.Errorf("flattening `identity`: %+v", err)
 		}
 
-		if model.Properties.ActiveDirectories != nil {
-			adProps := *model.Properties.ActiveDirectories
-			// response returns an array, but only 1 NetApp AD connection is allowed per the Azure platform currently
-			if len(adProps) > 0 {
-				// the API returns opaque('***') values for password and server_root_ca_certificate, so we pass through current state values so change detection works
-				prevPassword := d.Get("active_directory.0.password").(string)
-				prevCaCert := d.Get("active_directory.0.server_root_ca_certificate").(string)
+		if err := d.Set("identity", anfAccountIdentity); err != nil {
+			return fmt.Errorf("setting `identity`: %+v", err)
+		}
 
-				if err = d.Set("active_directory", flattenNetAppActiveDirectories(&adProps[0], &prevPassword, &prevCaCert)); err != nil {
-					return fmt.Errorf("setting `active_directory`: %+v", err)
-				}
+		if model.Properties != nil {
+			// the API returns opaque('***') values for `active_directory.0.password` and `active_directory.0.server_root_ca_certificate`, so we pass through current state values so change detection works
+			prevPassword := d.Get("active_directory.0.password").(string)
+			prevCaCert := d.Get("active_directory.0.server_root_ca_certificate").(string)
+
+			if err = d.Set("active_directory", flattenNetAppActiveDirectories(model.Properties.ActiveDirectories, &prevPassword, &prevCaCert)); err != nil {
+				return fmt.Errorf("setting `active_directory`: %+v", err)
 			}
 		}
 
@@ -382,27 +382,29 @@ func expandNetAppActiveDirectories(input []interface{}) *[]netappaccounts.Active
 	return &results
 }
 
-func flattenNetAppActiveDirectories(input *netappaccounts.ActiveDirectory, prevPassword *string, prevCaCert *string) []interface{} {
-	if input == nil {
+func flattenNetAppActiveDirectories(input *[]netappaccounts.ActiveDirectory, prevPassword *string, prevCaCert *string) []interface{} {
+	if input == nil || len(*input) == 0 {
 		return []interface{}{}
 	}
 
+	v := (*input)[0]
+
 	return []interface{}{
 		map[string]interface{}{
-			"dns_servers":                       utils.FlattenStringSliceWithDelimiter(input.Dns, ","),
-			"domain":                            input.Domain,
-			"organizational_unit":               input.OrganizationalUnit,
+			"dns_servers":                       utils.FlattenStringSliceWithDelimiter(v.Dns, ","),
+			"domain":                            v.Domain,
+			"organizational_unit":               v.OrganizationalUnit,
 			"password":                          prevPassword,
-			"smb_server_name":                   input.SmbServerName,
-			"username":                          input.Username,
-			"site_name":                         input.Site,
-			"kerberos_ad_name":                  input.AdName,
-			"kerberos_kdc_ip":                   input.KdcIP,
-			"aes_encryption_enabled":            input.AesEncryption,
-			"local_nfs_users_with_ldap_allowed": input.AllowLocalNfsUsersWithLdap,
-			"ldap_over_tls_enabled":             input.LdapOverTLS,
+			"smb_server_name":                   v.SmbServerName,
+			"username":                          v.Username,
+			"site_name":                         v.Site,
+			"kerberos_ad_name":                  v.AdName,
+			"kerberos_kdc_ip":                   v.KdcIP,
+			"aes_encryption_enabled":            v.AesEncryption,
+			"local_nfs_users_with_ldap_allowed": v.AllowLocalNfsUsersWithLdap,
+			"ldap_over_tls_enabled":             v.LdapOverTLS,
 			"server_root_ca_certificate":        prevCaCert,
-			"ldap_signing_enabled":              input.LdapSigning,
+			"ldap_signing_enabled":              v.LdapSigning,
 		},
 	}
 }

--- a/internal/services/netapp/netapp_account_resource.go
+++ b/internal/services/netapp/netapp_account_resource.go
@@ -254,6 +254,15 @@ func resourceNetAppAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) er
 		return fmt.Errorf("retrieving %s: `properties` was nil", id)
 	}
 
+	if ad := existing.Model.Properties.ActiveDirectories; ad != nil && len(*ad) > 0 {
+		// The API doesn't return these, so we'll set these values based on config.
+		// If there are no changes to the `active_directory` block this ensures we don't unintentionally wipe these values
+		existingAD := (*ad)[0]
+		existingAD.ServerRootCACertificate = pointer.To(d.Get("active_directory.0.server_root_ca_certificate").(string))
+		existingAD.Password = pointer.To(d.Get("active_directory.0.password").(string))
+		existing.Model.Properties.ActiveDirectories = pointer.To([]netappaccounts.ActiveDirectory{existingAD})
+	}
+
 	if d.HasChange("active_directory") {
 		existing.Model.Properties.ActiveDirectories = expandNetAppActiveDirectories(d.Get("active_directory").([]interface{}))
 	}
@@ -313,7 +322,7 @@ func resourceNetAppAccountRead(d *pluginsdk.ResourceData, meta interface{}) erro
 		}
 
 		if model.Properties != nil {
-			// the API returns opaque('***') values for `active_directory.0.password` and `active_directory.0.server_root_ca_certificate`, so we pass through current state values so change detection works
+			// the API doesn't return values for `active_directory.0.password` and `active_directory.0.server_root_ca_certificate`, so we pass through current state values so change detection works
 			prevPassword := d.Get("active_directory.0.password").(string)
 			prevCaCert := d.Get("active_directory.0.server_root_ca_certificate").(string)
 

--- a/internal/services/netapp/netapp_account_resource_test.go
+++ b/internal/services/netapp/netapp_account_resource_test.go
@@ -128,6 +128,14 @@ func testAccNetAppAccount_update(t *testing.T) {
 		},
 		data.ImportStep("active_directory.0.password", "active_directory.0.server_root_ca_certificate"),
 		{
+			Config: r.completePartialUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("active_directory.#").HasValue("1"),
+			),
+		},
+		data.ImportStep("active_directory.0.password", "active_directory.0.server_root_ca_certificate"),
+		{
 			Config: r.basicConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
@@ -270,6 +278,51 @@ resource "azurerm_netapp_account" "test" {
   tags = {
     "CreatedOnDate" = "2022-07-08T23-50-21Z",
     "FoO"           = "BaR"
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r NetAppAccountResource) completePartialUpdate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "user-assigned-identity-%[2]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_netapp_account" "test" {
+  name                = "acctest-NetAppAccount-%[2]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  active_directory {
+    username                          = "aduser"
+    password                          = "aduserpwd"
+    smb_server_name                   = "SMB-SERVER"
+    dns_servers                       = ["1.2.3.4", "1.2.3.5"]
+    domain                            = "westcentralus.com"
+    organizational_unit               = "OU=FirstLevel"
+    site_name                         = "My-Site-Name"
+    kerberos_ad_name                  = "My-AD-Server"
+    kerberos_kdc_ip                   = "192.168.1.1"
+    aes_encryption_enabled            = true
+    local_nfs_users_with_ldap_allowed = true
+    ldap_over_tls_enabled             = true
+    server_root_ca_certificate        = "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNZekNDQWN5Z0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRVUZBREF1TVFzd0NRWURWUVFHRXdKVlV6RU0gCk1Bb0dBMVVFQ2hNRFNVSk5NUkV3RHdZRFZRUUxFd2hNYjJOaGJDQkRRVEFlRncwNU9URXlNakl3TlRBd01EQmEgCkZ3MHdNREV5TWpNd05EVTVOVGxhTUM0eEN6QUpCZ05WQkFZVEFsVlRNUXd3Q2dZRFZRUUtFd05KUWsweEVUQVAgCkJnTlZCQXNUQ0V4dlkyRnNJRU5CTUlHZk1BMEdDU3FHU0liM0RRRUJBUVVBQTRHTkFEQ0JpUUtCZ1FEMmJaRW8gCjd4R2FYMi8wR0hrck5GWnZseEJvdTl2MUptdC9QRGlUTVB2ZThyOUZlSkFRMFFkdkZTVC8wSlBRWUQyMHJIMGIgCmltZERMZ05kTnlubXlSb1MyUy9JSW5mcG1mNjlpeWMyRzBUUHlSdm1ISWlPWmJkQ2QrWUJIUWkxYWRrajE3TkQgCmNXajZTMTR0VnVyRlg3M3p4MHNOb01TNzlxM3R1WEtyRHN4ZXV3SURBUUFCbzRHUU1JR05NRXNHQ1ZVZER3R0cgCitFSUJEUVErRXp4SFpXNWxjbUYwWldRZ1lua2dkR2hsSUZObFkzVnlaVmRoZVNCVFpXTjFjbWwwZVNCVFpYSjIgClpYSWdabTl5SUU5VEx6TTVNQ0FvVWtGRFJpa3dEZ1lEVlIwUEFRSC9CQVFEQWdBR01BOEdBMVVkRXdFQi93UUYgCk1BTUJBZjh3SFFZRFZSME9CQllFRkozK29jUnlDVEp3MDY3ZExTd3IvbmFseDZZTU1BMEdDU3FHU0liM0RRRUIgCkJRVUFBNEdCQU1hUXp0K3phajFHVTc3eXpscjhpaU1CWGdkUXJ3c1paV0pvNWV4bkF1Y0pBRVlRWm1PZnlMaU0gCkQ2b1lxK1puZnZNMG44Ry9ZNzlxOG5od3Z1eHBZT25SU0FYRnA2eFNrcklPZVp0Sk1ZMWgwMExLcC9KWDNOZzEgCnN2WjJhZ0UxMjZKSHNRMGJoek41VEtzWWZid2ZUd2ZqZFdBR3k2VmYxbllpL3JPK3J5TU8KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLSA="
+    ldap_signing_enabled              = true
+  }
+
+  tags = {
+    "CreatedOnDate" = "2022-07-08T23-50-21Z",
+    "FoO"           = "BaR"
+    Hello           = "World"
   }
 }
 `, r.template(data), data.RandomInteger)

--- a/internal/services/netapp/netapp_account_resource_test.go
+++ b/internal/services/netapp/netapp_account_resource_test.go
@@ -116,20 +116,24 @@ func testAccNetAppAccount_update(t *testing.T) {
 			Config: r.basicConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("active_directory.#").HasValue("0"),
-				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
 			),
 		},
+		data.ImportStep(),
 		{
 			Config: r.completeConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("active_directory.#").HasValue("1"),
-				check.That(data.ResourceName).Key("tags.%").HasValue("2"),
-				check.That(data.ResourceName).Key("tags.FoO").HasValue("BaR"),
 			),
 		},
-		data.ImportStep("active_directory"),
+		data.ImportStep("active_directory.0.password", "active_directory.0.server_root_ca_certificate"),
+		{
+			Config: r.basicConfig(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
 	})
 }
 
@@ -186,7 +190,7 @@ func TestAccNetAppAccount_updateManagedIdentity(t *testing.T) {
 	})
 }
 
-func (t NetAppAccountResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (r NetAppAccountResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := netappaccounts.ParseNetAppAccountID(state.ID)
 	if err != nil {
 		return nil, err
@@ -208,10 +212,6 @@ resource "azurerm_netapp_account" "test" {
   name                = "acctest-NetAppAccount-%[2]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-
-  tags = {
-    "CreatedOnDate" = "2022-07-08T23-50-21Z",
-  }
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -224,10 +224,6 @@ resource "azurerm_netapp_account" "import" {
   name                = azurerm_netapp_account.test.name
   location            = azurerm_netapp_account.test.location
   resource_group_name = azurerm_netapp_account.test.resource_group_name
-
-  tags = {
-    "CreatedOnDate" = "2022-07-08T23-50-21Z",
-  }
 }
 `, r.basicConfig(data))
 }
@@ -236,10 +232,23 @@ func (r NetAppAccountResource) completeConfig(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %[1]s
 
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "user-assigned-identity-%[2]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
 resource "azurerm_netapp_account" "test" {
   name                = "acctest-NetAppAccount-%[2]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
+
+  identity {
+    type = "UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id
+    ]
+  }
 
   active_directory {
     username                          = "aduser"
@@ -344,7 +353,5 @@ resource "azurerm_resource_group" "test" {
     "SkipNRMSNSG"   = "true"
   }
 }
-
-
 `, data.RandomInteger, data.Locations.Primary)
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Fixes:
- removal of `active_directory` block, previously this led to a persistent diff as the PATCH operation appears to ignore empty arrays or `null` input for removal
- read function now calls `d.Set()` even if `ActiveDirectories` is nil to ensure the provider can detect if `active_directory` was removed from the resource in Azure. Previously this drift was undetected because of the conditional that skips `d.Set` if it was nil in the response.

Adds:
- additional test step to remove both the `active_directory` and `identity` blocks

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

<img width="435" height="207" alt="image" src="https://github.com/user-attachments/assets/4899899f-f242-4f42-8a37-d5eef78acddb" />


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change



## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
