### PR TITLE
`GHA` - Optimisations part deux

### DIFF
--- a/.github/workflows/add-waiting-response-on-fail.yaml
+++ b/.github/workflows/add-waiting-response-on-fail.yaml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Get Artifact
         id: get_artifact
-        uses: dawidd6/action-download-artifact@07ab29fd4a977ae4d2b275087cf67563dfdf0295 # v9
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
         with:
           github_token: ${{secrets.GITHUB_TOKEN}}
           run_id: ${{ github.event.workflow_run.id }}
@@ -28,7 +28,7 @@ jobs:
           echo "ghowner=$(cat artifact/ghowner.txt)" >>${GITHUB_OUTPUT}
           echo "prnumber=$(cat artifact/prnumber.txt)" >>${GITHUB_OUTPUT}
       - name: Add waiting-response on fail
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9
         with:
           script: |
             github.rest.issues.addLabels({

--- a/.github/workflows/auto-assign-reviewers-to-pr.yaml
+++ b/.github/workflows/auto-assign-reviewers-to-pr.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Get Artifact
         id: get_artifact
         continue-on-error: true
-        uses: dawidd6/action-download-artifact@07ab29fd4a977ae4d2b275087cf67563dfdf0295 # v9
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
         with:
           github_token: ${{secrets.GITHUB_TOKEN}}
           workflow: pull-request-reviewed.yaml
@@ -32,7 +32,7 @@ jobs:
           echo "prNumber=$(cat artifact/prnumber.txt)" >>${GITHUB_OUTPUT}
 
       - name: Assign the reviewer as assignee when changes are requested
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/automation-open-pull-request-go-sdk.yaml
+++ b/.github/workflows/automation-open-pull-request-go-sdk.yaml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: "open a pull request"
         id: open-pr

--- a/.github/workflows/automation-open-pull-request-pandora.yaml
+++ b/.github/workflows/automation-open-pull-request-pandora.yaml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: "open a pull request"
         id: open-pr

--- a/.github/workflows/breaking-change-detection.yaml
+++ b/.github/workflows/breaking-change-detection.yaml
@@ -22,8 +22,8 @@ jobs:
   detect:
     runs-on: custom-linux-small
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: ./.go-version
       - run: bash ./scripts/run-breaking-change-detection.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,8 +36,8 @@ jobs:
     outputs:
       go-version: ${{ steps.get-go-version.outputs.go-version }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: 'go.mod'
       - name: Detect Go version
@@ -60,10 +60,10 @@ jobs:
       product-prerelease-version: ${{ steps.set-product-version.outputs.prerelease-product-version }}
       product-minor-version: ${{ steps.set-product-version.outputs.minor-product-version }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Set variables
         id: set-product-version
-        uses: hashicorp/actions-set-product-version@v2
+        uses: hashicorp/actions-set-product-version@d9be602dfa87e201c79a3937c038f19391c9a430 # v2
 
   # Creates metadata.json file containing build metadata for consumption by CRT workflows.
   #
@@ -75,15 +75,15 @@ jobs:
       filepath: ${{ steps.generate-metadata-file.outputs.filepath }}
     steps:
       - name: "Checkout directory"
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Generate metadata file
         id: generate-metadata-file
-        uses: hashicorp/actions-generate-metadata@v1
+        uses: hashicorp/actions-generate-metadata@a43468dfb100445f2c2aa52cdc3d57b2c982a0f3 # v1
         with:
           version: ${{ needs.set-product-version.outputs.product-version }}
           product: ${{ env.PKG_NAME }}
           repositoryOwner: "hashicorp"
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: metadata.json
           path: ${{ steps.generate-metadata-file.outputs.filepath }}
@@ -98,7 +98,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout directory"
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           path: ${{ env.PKG_NAME }}
       - name: "Copy manifest from checkout directory to a file with the desired name"
@@ -112,7 +112,7 @@ jobs:
 
           cp "$source" "$destination"
           echo "filename=$destination" >> "$GITHUB_OUTPUT"
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: terraform-registry-manifest.json
           path: ${{ steps.terraform-registry-manifest.outputs.filename }}
@@ -151,8 +151,8 @@ jobs:
 
     name: Go ${{ needs.get-go-version.outputs.go-version }} ${{ matrix.goos }} ${{ matrix.goarch }} build
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: hashicorp/actions-go-build@v1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: hashicorp/actions-go-build@dd7ca5a30c402c933e1fe61e0ff7165e5c4ee9e4 # v1
         env:
           CGO_ENABLED: 0
           BASE_VERSION: ${{ needs.set-product-version.outputs.product-base-version }}
@@ -202,7 +202,7 @@ jobs:
       issues: write
     steps:
       - name: Create Failure Issue
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9
         with:
           script: |
             const issueTitle = `🚨 Main Build Broken (Run #${context.runNumber})`;

--- a/.github/workflows/changelog_entry.yml
+++ b/.github/workflows/changelog_entry.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         continue-on-error: true
       - name: get merge commit message 
         id: pull
@@ -27,7 +27,7 @@ jobs:
             CHANGELOG_ENTRY: ${{ steps.pull.outputs.message }}
         run: |
             echo "$CHANGELOG_ENTRY" > changelog_entry.txt
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
             name: changelog_entry
             path: changelog_entry.txt

--- a/.github/workflows/close-failing-ci-prs.yaml
+++ b/.github/workflows/close-failing-ci-prs.yaml
@@ -14,6 +14,6 @@ jobs:
   close-failing-ci-prs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Process PRs with failing CI
         run: ./scripts/close-failing-ci-prs.sh -o "${{ github.repository_owner }}" -r "${{ github.event.repository.name }}" -t "${{ secrets.GITHUB_TOKEN }}" -l

--- a/.github/workflows/close-inactive-draft-prs.yaml
+++ b/.github/workflows/close-inactive-draft-prs.yaml
@@ -12,7 +12,7 @@ jobs:
   stale-draft-prs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Process stale draft PRs
         run: ./scripts/close-inactive-draft-prs.sh -o "${{ github.repository_owner }}" -r "${{ github.event.repository.name }}" -t "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/comment-ci-failure-outdated.yaml
+++ b/.github/workflows/comment-ci-failure-outdated.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Strike through fixed failure and clean up
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9
         with:
           result-encoding: string
           retries: 3

--- a/.github/workflows/comment-ci-failure.yaml
+++ b/.github/workflows/comment-ci-failure.yaml
@@ -21,7 +21,7 @@ jobs:
         run: |
           echo "gha_url=https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}" >> $GITHUB_ENV
       - name: Add failure to unified build comment
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9
         with:
           result-encoding: string
           retries: 3

--- a/.github/workflows/comment-stale-prs.yaml
+++ b/.github/workflows/comment-stale-prs.yaml
@@ -11,7 +11,7 @@ jobs:
   comment-stale-prs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10
         with:
           stale-pr-message: |
             This PR is being labeled as "stale" because it has not been updated for 30 or more days.

--- a/.github/workflows/enforce-list-resources.yaml
+++ b/.github/workflows/enforce-list-resources.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'allow-without-list') && !contains(github.event.pull_request.labels.*.name, 'list-not-supported') }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
       - run: bash scripts/enforce-list-for-new-resources.sh

--- a/.github/workflows/gradually-deprecated.yaml
+++ b/.github/workflows/gradually-deprecated.yaml
@@ -17,10 +17,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: ./.go-version
       - run: bash ./scripts/run-gradually-deprecated.sh

--- a/.github/workflows/increment-milestone.yaml
+++ b/.github/workflows/increment-milestone.yaml
@@ -14,7 +14,7 @@ jobs:
   increment-milestone:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
       - name: "Increment Milestone"

--- a/.github/workflows/issue-comment-created.yaml
+++ b/.github/workflows/issue-comment-created.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.issue.pull_request && endsWith(github.event.comment.body, '/wr')
     steps:
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      - uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9
         with:
           script: |
             github.rest.issues.addLabels({

--- a/.github/workflows/issue-opened.yaml
+++ b/.github/workflows/issue-opened.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-    - uses: github/issue-labeler@99b4c5dda477c65f4ef08486b73c5787e1e33601 # v2
+    - uses: github/issue-labeler@c1b0f9f52a63158c4adc09425e858e87b32e9685 # v3.4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         configuration-path: .github/labeler-issue-triage.yml

--- a/.github/workflows/issue-opened.yaml
+++ b/.github/workflows/issue-opened.yaml
@@ -12,8 +12,8 @@ jobs:
   issue_triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - uses: github/issue-labeler@c1b0f9f52a63158c4adc09425e858e87b32e9685 # v3.4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    - uses: github/issue-labeler@99b4c5dda477c65f4ef08486b73c5787e1e33601 # v2
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         configuration-path: .github/labeler-issue-triage.yml

--- a/.github/workflows/label-ci-status.yaml
+++ b/.github/workflows/label-ci-status.yaml
@@ -13,7 +13,7 @@ jobs:
     if: github.event.check_suite.pull_requests[0] != null
     steps:
       - name: Add or remove ci-failed label
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9
         with:
           script: |
             const pullRequests = context.payload.check_suite.pull_requests;

--- a/.github/workflows/link-milestone.yaml
+++ b/.github/workflows/link-milestone.yaml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           # we cannot use go-version-file here because no repositories are checked out so there is no file to reference
           go-version: '1.26'

--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -12,7 +12,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771 # v5.0.1
+      - uses: dessant/lock-threads@b2726a6ae6f1e1b06eb0ff28f7e4fb5e4246bbca # v6
         with:
           github-token: ${{ github.token }}
           issue-comment: >

--- a/.github/workflows/milestone-closed.yaml
+++ b/.github/workflows/milestone-closed.yaml
@@ -13,7 +13,7 @@ jobs:
   Comment:
     runs-on: ubuntu-latest
     steps:
-      - uses: bflad/action-milestone-comment@ae6c9fdf5778064d4e09b4632604a16b7289096c # v1.0.2
+      - uses: bflad/action-milestone-comment@4618cbf8bf938d31af1c576beeaaa77f486f5af3 # v2
         with:
           body: |
             This functionality has been released in [${{ github.event.milestone.title }} of the Terraform Provider](https://github.com/${{ github.repository }}/blob/${{ github.event.milestone.title }}/CHANGELOG.md).  Please see the [Terraform documentation on provider versioning](https://www.terraform.io/docs/configuration/providers.html#provider-versions) or reach out if you need any assistance upgrading.

--- a/.github/workflows/mkdocs.yaml
+++ b/.github/workflows/mkdocs.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Publish
         uses: mhausenblas/mkdocs-deploy-gh-pages@d77dd03172e96abbcdb081d8c948224762033653 # 1.26

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -15,15 +15,67 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+
+  # ==========================================
+  # PATH FILTERING LOGIC
+  # ==========================================
+  # We use dorny/paths-filter to only run heavy checks when relevant files change.
+  # 
+  # How to add a new Phase 1 job:
+  # 1. Add a new filter to the `paths-filter` job below.
+  # 2. In your job, add `needs: paths-filter` and `if: needs.paths-filter.outputs.<your-filter> == 'true'`.
+  # 
+  # How to add a new Phase 2/3 job:
+  # 1. It must depend on paths-filter and ALL Phase 1 jobs it needs.
+  # 2. Because GitHub Actions skips downstream jobs if any `needs` dependency is skipped,
+  #    you MUST use the following boilerplate `if` condition to ensure it runs correctly:
+  #    if: |
+  #      always() && 
+  #      needs.paths-filter.outputs.<your-filter> == 'true' &&
+  #      (needs.depscheck.result == 'success' || needs.depscheck.result == 'skipped') && ...
+  # ==========================================
+
+  paths-filter:
+    runs-on: ubuntu-latest
+    outputs:
+      website: ${{ steps.filter.outputs.website }}
+      go: ${{ steps.filter.outputs.go }}
+      scripts: ${{ steps.filter.outputs.scripts }}
+      examples: ${{ steps.filter.outputs.examples }}
+      vendor: ${{ steps.filter.outputs.vendor }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            website:
+              - 'website/**'
+            go:
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
+            scripts:
+              - 'scripts/**'
+              - '**/*.sh'
+            examples:
+              - 'examples/**'
+            vendor:
+              - 'vendor/**'
+              - 'go.mod'
+              - 'go.sum'
+
   # ==========================================
   # Phase 1: Fail-Fast
   # ==========================================
 
   depscheck:
+    needs: paths-filter
+    if: needs.paths-filter.outputs.vendor == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: ./.go-version
       - run: bash scripts/gogetcookie.sh
@@ -51,7 +103,7 @@ jobs:
 
   depscheck-on-success:
     needs: depscheck
-    if: success()
+    if: success() && needs.depscheck.result == 'success'
     uses: ./.github/workflows/comment-ci-failure-outdated.yaml
     with:
       check_name: "Vendor Dependencies Check"
@@ -59,10 +111,12 @@ jobs:
   # ------------------------------------------
 
   fmtcheck:
+    needs: paths-filter
+    if: needs.paths-filter.outputs.go == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: ./.go-version
       - run: make fmtcheck
@@ -88,7 +142,7 @@ jobs:
 
   fmtcheck-on-success:
     needs: fmtcheck
-    if: success()
+    if: success() && needs.fmtcheck.result == 'success'
     uses: ./.github/workflows/comment-ci-failure-outdated.yaml
     with:
       check_name: "GoLang Formatting Check"
@@ -96,9 +150,11 @@ jobs:
   # ------------------------------------------
 
   shellcheck:
+    needs: paths-filter
+    if: needs.paths-filter.outputs.scripts == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Run ShellCheck
         run: make shellcheck
       - name: Guidance on failure
@@ -124,7 +180,7 @@ jobs:
 
   shellcheck-on-success:
     needs: shellcheck
-    if: success()
+    if: success() && needs.shellcheck.result == 'success'
     uses: ./.github/workflows/comment-ci-failure-outdated.yaml
     with:
       check_name: "ShellCheck Scripts"
@@ -132,10 +188,12 @@ jobs:
   # ------------------------------------------
 
   website-lint:
+    needs: paths-filter
+    if: needs.paths-filter.outputs.website == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: ./.go-version
       - run: bash scripts/gogetcookie.sh
@@ -165,7 +223,7 @@ jobs:
 
   website-lint-on-success:
     needs: website-lint
-    if: success()
+    if: success() && needs.website-lint.result == 'success'
     uses: ./.github/workflows/comment-ci-failure-outdated.yaml
     with:
       check_name: "Website Linting"
@@ -213,11 +271,18 @@ jobs:
   # ==========================================
 
   build:
-    needs: [depscheck, fmtcheck, shellcheck, website-lint, document-validate]
+    needs: [paths-filter, depscheck, fmtcheck, shellcheck, website-lint, document-validate]
+    if: |
+      always() && 
+      needs.paths-filter.outputs.go == 'true' &&
+      (needs.depscheck.result == 'success' || needs.depscheck.result == 'skipped') && 
+      (needs.fmtcheck.result == 'success' || needs.fmtcheck.result == 'skipped') && 
+      (needs.shellcheck.result == 'success' || needs.shellcheck.result == 'skipped') && 
+      (needs.website-lint.result == 'success' || needs.website-lint.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: ./.go-version
       - run: bash scripts/gogetcookie.sh
@@ -244,7 +309,7 @@ jobs:
 
   build-on-success:
     needs: build
-    if: success()
+    if: success() && needs.build.result == 'success'
     uses: ./.github/workflows/comment-ci-failure-outdated.yaml
     with:
       check_name: "GoLang Compilation"
@@ -252,14 +317,21 @@ jobs:
   # ------------------------------------------
 
   golangci-lint:
-    needs: [depscheck, fmtcheck, shellcheck, website-lint, document-validate]
+    needs: [paths-filter, depscheck, fmtcheck, shellcheck, website-lint, document-validate]
+    if: |
+      always() && 
+      needs.paths-filter.outputs.go == 'true' &&
+      (needs.depscheck.result == 'success' || needs.depscheck.result == 'skipped') && 
+      (needs.fmtcheck.result == 'success' || needs.fmtcheck.result == 'skipped') && 
+      (needs.shellcheck.result == 'success' || needs.shellcheck.result == 'skipped') && 
+      (needs.website-lint.result == 'success' || needs.website-lint.result == 'skipped')
     runs-on: custom-linux-large
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: ./.go-version
-      - uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7.0.1
+      - uses: golangci/golangci-lint-action@db582008a42febd596419635a5abc9d9815daa9c # v9
         with:
           version: 'v2.4.0'
           install-mode: 'goinstall'
@@ -289,7 +361,7 @@ jobs:
 
   golangci-lint-on-success:
     needs: golangci-lint
-    if: success()
+    if: success() && needs.golangci-lint.result == 'success'
     uses: ./.github/workflows/comment-ci-failure-outdated.yaml
     with:
       check_name: "GoLang Linting"
@@ -297,11 +369,18 @@ jobs:
   # ------------------------------------------
 
   tflint:
-    needs: [depscheck, fmtcheck, shellcheck, website-lint, document-validate]
+    needs: [paths-filter, depscheck, fmtcheck, shellcheck, website-lint, document-validate]
+    if: |
+      always() && 
+      needs.paths-filter.outputs.go == 'true' &&
+      (needs.depscheck.result == 'success' || needs.depscheck.result == 'skipped') && 
+      (needs.fmtcheck.result == 'success' || needs.fmtcheck.result == 'skipped') && 
+      (needs.shellcheck.result == 'success' || needs.shellcheck.result == 'skipped') && 
+      (needs.website-lint.result == 'success' || needs.website-lint.result == 'skipped')
     runs-on: custom-linux-medium
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: ./.go-version
       - run: bash scripts/gogetcookie.sh
@@ -331,7 +410,7 @@ jobs:
 
   tflint-on-success:
     needs: tflint
-    if: success()
+    if: success() && needs.tflint.result == 'success'
     uses: ./.github/workflows/comment-ci-failure-outdated.yaml
     with:
       check_name: "Terraform Schema Linting"
@@ -339,11 +418,18 @@ jobs:
   # ------------------------------------------
 
   gencheck:
-    needs: [depscheck, fmtcheck, shellcheck, website-lint, document-validate]
+    needs: [paths-filter, depscheck, fmtcheck, shellcheck, website-lint, document-validate]
+    if: |
+      always() && 
+      needs.paths-filter.outputs.go == 'true' &&
+      (needs.depscheck.result == 'success' || needs.depscheck.result == 'skipped') && 
+      (needs.fmtcheck.result == 'success' || needs.fmtcheck.result == 'skipped') && 
+      (needs.shellcheck.result == 'success' || needs.shellcheck.result == 'skipped') && 
+      (needs.website-lint.result == 'success' || needs.website-lint.result == 'skipped')
     runs-on: custom-linux-large
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: ./.go-version
       - run: bash scripts/gogetcookie.sh
@@ -370,7 +456,7 @@ jobs:
 
   gencheck-on-success:
     needs: gencheck
-    if: success()
+    if: success() && needs.gencheck.result == 'success'
     uses: ./.github/workflows/comment-ci-failure-outdated.yaml
     with:
       check_name: "Generation Check"
@@ -378,12 +464,19 @@ jobs:
   # ------------------------------------------
 
   unit-tests:
-    needs: [depscheck, fmtcheck, shellcheck, website-lint, document-validate]
+    needs: [paths-filter, depscheck, fmtcheck, shellcheck, website-lint, document-validate]
+    if: |
+      always() && 
+      needs.paths-filter.outputs.go == 'true' &&
+      (needs.depscheck.result == 'success' || needs.depscheck.result == 'skipped') && 
+      (needs.fmtcheck.result == 'success' || needs.fmtcheck.result == 'skipped') && 
+      (needs.shellcheck.result == 'success' || needs.shellcheck.result == 'skipped') && 
+      (needs.website-lint.result == 'success' || needs.website-lint.result == 'skipped')
     runs-on: custom-linux-xl
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           cache-dependency-path: go.mod
           go-version-file: ./.go-version
@@ -425,7 +518,7 @@ jobs:
 
   unit-tests-on-success:
     needs: unit-tests
-    if: success()
+    if: success() && needs.unit-tests.result == 'success'
     uses: ./.github/workflows/comment-ci-failure-outdated.yaml
     with:
       check_name: "Unit Tests"
@@ -433,11 +526,18 @@ jobs:
   # ------------------------------------------
 
   validate-examples:
-    needs: [depscheck, fmtcheck, shellcheck, website-lint, document-validate]
+    needs: [paths-filter, depscheck, fmtcheck, shellcheck, website-lint, document-validate]
+    if: |
+      always() && 
+      needs.paths-filter.outputs.examples == 'true' &&
+      (needs.depscheck.result == 'success' || needs.depscheck.result == 'skipped') && 
+      (needs.fmtcheck.result == 'success' || needs.fmtcheck.result == 'skipped') && 
+      (needs.shellcheck.result == 'success' || needs.shellcheck.result == 'skipped') && 
+      (needs.website-lint.result == 'success' || needs.website-lint.result == 'skipped')
     runs-on: custom-linux-small
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: ./.go-version
       - run: bash scripts/gogetcookie.sh
@@ -466,7 +566,7 @@ jobs:
 
   validate-examples-on-success:
     needs: validate-examples
-    if: success()
+    if: success() && needs.validate-examples.result == 'success'
     uses: ./.github/workflows/comment-ci-failure-outdated.yaml
     with:
       check_name: "Validate Examples"

--- a/.github/workflows/preview-api-version-linter.yaml
+++ b/.github/workflows/preview-api-version-linter.yaml
@@ -17,8 +17,8 @@ jobs:
   preview-api-version-linter:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: ./.go-version
       - run: go run internal/tools/preview-api-version-linter/main.go

--- a/.github/workflows/provider-release.yml
+++ b/.github/workflows/provider-release.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "bob - setup"
-        uses: hashicorp/action-setup-bob@v2
+        uses: hashicorp/action-setup-bob@01076d9cc869139ac97693d0869f0e80a666cb3b # v2
         with:
           github-token:
             ${{ secrets.BOB_GITHUB_TOKEN }}

--- a/.github/workflows/provider-test.yaml
+++ b/.github/workflows/provider-test.yaml
@@ -36,15 +36,15 @@ jobs:
     if: needs.secrets-check.outputs.available == 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: ./.go-version
 
       - name: Azure CLI login (using OIDC)
-        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
+        uses: azure/login@93381592711f247e165c389ebb30b596c84cdc48 # v3
         with:
           client-id: ${{ secrets.ARM_CLIENT_ID }}
           tenant-id: ${{ secrets.ARM_TENANT_ID }}

--- a/.github/workflows/pull-request-reviewed-workflow.yaml
+++ b/.github/workflows/pull-request-reviewed-workflow.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Get Artifact
         id: get_artifact
         continue-on-error: true
-        uses: dawidd6/action-download-artifact@07ab29fd4a977ae4d2b275087cf67563dfdf0295 # v9
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
         with:
           github_token: ${{secrets.GITHUB_TOKEN}}
           workflow: pull-request-reviewed.yaml

--- a/.github/workflows/pull-request-reviewed.yaml
+++ b/.github/workflows/pull-request-reviewed.yaml
@@ -33,7 +33,7 @@ jobs:
         run: |
           mkdir -p wr_actions
           echo "remove-waiting-response" > wr_actions/action.txt                
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: artifact
           path: wr_actions

--- a/.github/workflows/pull-request-type.yaml
+++ b/.github/workflows/pull-request-type.yaml
@@ -12,7 +12,7 @@ jobs:
   pr_triage_label_type:
     runs-on: ubuntu-latest
     steps:
-    - uses: github/issue-labeler@c1b0f9f52a63158c4adc09425e858e87b32e9685 # v3.4
+    - uses: github/issue-labeler@99b4c5dda477c65f4ef08486b73c5787e1e33601 # v2
       continue-on-error: true
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -11,11 +11,11 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
+    - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6
       with:
         configuration-path: .github/labeler-pull-request-triage.yml
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
-    - uses: CodelyTV/pr-size-labeler@095a41fca88b8764fd9e008ad269bcdb82bb38b9 # 1.10.4
+    - uses: CodelyTV/pr-size-labeler@095a41fca88b8764fd9e008ad269bcdb82bb38b9 # v1
       with:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         xs_label: 'size/XS'

--- a/.github/workflows/remove-issue-label.yml
+++ b/.github/workflows/remove-issue-label.yml
@@ -13,7 +13,7 @@ jobs:
   remove-label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      - uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9
         env:
           REMOVE_LABEL: ${{ inputs.label-name }}
         with:

--- a/.github/workflows/run-team-city-tests-on-comment.yaml
+++ b/.github/workflows/run-team-city-tests-on-comment.yaml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Check team membership
         id: check-membership
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9
         with:
           github-token: ${{ secrets.GH_MEMEBERSHIP_CHECK_TOKEN }}
           script: |
@@ -69,7 +69,7 @@ jobs:
       TCTEST_REPO: terraform-providers/terraform-provider-azurerm
     steps:
       - name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.2.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: '1.26'
 
@@ -82,7 +82,7 @@ jobs:
 
       - name: Cache tctest binary
         id: cache-tctest
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/go/bin/tctest
           key: tctest-${{ runner.os }}-${{ steps.tctest-version.outputs.version }}
@@ -94,7 +94,7 @@ jobs:
 
       - name: Get PR commit SHA
         id: get-pr-sha
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -160,7 +160,7 @@ jobs:
 
       - name: Comment on success
         if: success()
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -173,7 +173,7 @@ jobs:
 
       - name: Comment on failure
         if: failure()
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -190,7 +190,7 @@ jobs:
     if: needs.check-team-membership.outputs.is-team-member == 'false'
     steps:
       - name: Comment unauthorized
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/save-artifacts.yaml
+++ b/.github/workflows/save-artifacts.yaml
@@ -14,7 +14,7 @@ jobs:
           echo ${{ github.repository_owner }} > wr_actions/ghowner.txt
           echo ${{ github.event.repository.name }} > wr_actions/ghrepo.txt
           echo ${{ github.event.pull_request.number }} > wr_actions/prnumber.txt
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: artifact
           path: wr_actions

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -21,8 +21,8 @@ jobs:
   detect:
     runs-on: custom-linux-small
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: ./.go-version
       - run: bash ./scripts/run-static-analysis.sh

--- a/.github/workflows/teamcity-test.yaml
+++ b/.github/workflows/teamcity-test.yaml
@@ -21,13 +21,13 @@ jobs:
   teamcity-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: zulu
           java-version: 17
           java-package: jdk
-      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/update_changelog.yml
+++ b/.github/workflows/update_changelog.yml
@@ -28,7 +28,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Download artifact from "Get Changelog Entry" workflow
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # 4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: changelog_entry # Match name used in changelog_entry.yml upload artifact step
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -72,7 +72,7 @@ jobs:
           if [[  $prs -gt 0  ]]; then
               echo "existing=true" >> "$GITHUB_OUTPUT"
           fi
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: check for branch
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -135,7 +135,7 @@ jobs:
           --add-label "changelog"
           
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: '1.22'
 


### PR DESCRIPTION
- Update `pr-validation.yaml` to use path filtering to skip checks if their targets are not touched.

- Update everywhere possible to try and get away from the [deprecated](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) `Node.js v20` (EOL April 2026, planned sunset in Actions Q3 2026) 
