### PR TITLE
`azurerm_express_route_connection` - fix issue causing unintentional changes to `internet_security_enabled`

### DIFF
--- a/internal/services/network/express_route_connection_resource.go
+++ b/internal/services/network/express_route_connection_resource.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
-
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
@@ -18,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -160,7 +159,7 @@ func resourceExpressRouteConnection() *pluginsdk.Resource {
 		resource.Schema["private_link_fast_path_enabled"] = &pluginsdk.Schema{
 			Type:       pluginsdk.TypeBool,
 			Optional:   true,
-			Deprecated: "'private_link_fast_path_enabled' has been deprecated as it is no longer supported by the resource and will be removed in v5.0 of the AzureRM Provider",
+			Deprecated: "`private_link_fast_path_enabled` has been deprecated as it is no longer supported by the resource and will be removed in v5.0 of the AzureRM Provider",
 		}
 
 		resource.Schema["internet_security_enabled"] = &pluginsdk.Schema{
@@ -307,36 +306,51 @@ func resourceExpressRouteConnectionUpdate(d *pluginsdk.ResourceData, meta interf
 		return err
 	}
 
-	enableInternetSecurity := false
+	existing, err := client.Get(ctx, *id)
+	if err != nil {
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	if existing.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", id)
+	}
+
+	if existing.Model.Properties == nil {
+		return fmt.Errorf("retrieving %s: `properties` was nil", id)
+	}
+	props := existing.Model.Properties
+
+	if d.HasChange("authorization_key") {
+		props.AuthorizationKey = nil
+		if authKey := d.Get("authorization_key").(string); authKey != "" {
+			props.AuthorizationKey = pointer.To(authKey)
+		}
+	}
+
 	if !features.FivePointOh() && d.HasChanges("enable_internet_security", "internet_security_enabled") {
 		if d.HasChange("enable_internet_security") && !d.GetRawConfig().AsValueMap()["enable_internet_security"].IsNull() {
-			enableInternetSecurity = d.Get("enable_internet_security").(bool)
+			props.EnableInternetSecurity = pointer.To(d.Get("enable_internet_security").(bool))
 		}
 		if d.HasChange("internet_security_enabled") && !d.GetRawConfig().AsValueMap()["internet_security_enabled"].IsNull() {
-			enableInternetSecurity = d.Get("internet_security_enabled").(bool)
+			props.EnableInternetSecurity = pointer.To(d.Get("internet_security_enabled").(bool))
 		}
 	} else if d.HasChange("internet_security_enabled") {
-		enableInternetSecurity = d.Get("internet_security_enabled").(bool)
+		props.EnableInternetSecurity = pointer.To(d.Get("internet_security_enabled").(bool))
 	}
 
-	parameters := expressrouteconnections.ExpressRouteConnection{
-		Name: id.ExpressRouteConnectionName,
-		Properties: &expressrouteconnections.ExpressRouteConnectionProperties{
-			ExpressRouteCircuitPeering: expressrouteconnections.ExpressRouteCircuitPeeringId{
-				Id: pointer.To(d.Get("express_route_circuit_peering_id").(string)),
-			},
-			EnableInternetSecurity:    pointer.To(enableInternetSecurity),
-			RoutingConfiguration:      expandExpressRouteConnectionRouting(d.Get("routing").([]interface{})),
-			RoutingWeight:             pointer.To(int64(d.Get("routing_weight").(int))),
-			ExpressRouteGatewayBypass: pointer.To(d.Get("express_route_gateway_bypass_enabled").(bool)),
-		},
+	if d.HasChange("express_route_gateway_bypass_enabled") {
+		props.ExpressRouteGatewayBypass = pointer.To(d.Get("express_route_gateway_bypass_enabled").(bool))
 	}
 
-	if v, ok := d.GetOk("authorization_key"); ok {
-		parameters.Properties.AuthorizationKey = pointer.To(v.(string))
+	if d.HasChange("routing") {
+		props.RoutingConfiguration = expandExpressRouteConnectionRouting(d.Get("routing").([]interface{}))
 	}
 
-	if err := client.CreateOrUpdateThenPoll(ctx, *id, parameters); err != nil {
+	if d.HasChange("routing_weight") {
+		props.RoutingWeight = pointer.To(int64(d.Get("routing_weight").(int)))
+	}
+
+	if err := client.CreateOrUpdateThenPoll(ctx, *id, *existing.Model); err != nil {
 		return fmt.Errorf("updating %s: %+v", id, err)
 	}
 

--- a/internal/services/network/express_route_connection_resource_test.go
+++ b/internal/services/network/express_route_connection_resource_test.go
@@ -115,7 +115,18 @@ func testAccExpressRouteConnection_update(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.update(data),
+			Config: r.update(data, 2),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That("azurerm_express_route_connection.test").Key("internet_security_enabled").HasValue("true"),
+			),
+		},
+		data.ImportStep(),
+		{
+			// regression test step for https://github.com/hashicorp/terraform-provider-azurerm/issues/32486
+			// updating only routing_weight to confirm `internet_security_enabled` doesn't unintentionally change
+			// can be removed post 5.0 (features.FivePointOh)
+			Config: r.update(data, 4),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That("azurerm_express_route_connection.test").Key("internet_security_enabled").HasValue("true"),
@@ -210,7 +221,7 @@ resource "azurerm_express_route_connection" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r ExpressRouteConnectionResource) update(data acceptance.TestData) string {
+func (r ExpressRouteConnectionResource) update(data acceptance.TestData, routingWeight int) string {
 	return fmt.Sprintf(`
 %s
 
@@ -264,7 +275,7 @@ resource "azurerm_express_route_connection" "test" {
   name                                 = "acctest-ExpressRouteConnection-%d"
   express_route_gateway_id             = azurerm_express_route_gateway.test.id
   express_route_circuit_peering_id     = azurerm_express_route_circuit_peering.test.id
-  routing_weight                       = 2
+  routing_weight                       = %[3]d
   authorization_key                    = "90f8db47-e25b-4b65-a68b-7743ced2a16b"
   internet_security_enabled            = true
   express_route_gateway_bypass_enabled = true
@@ -280,9 +291,8 @@ resource "azurerm_express_route_connection" "test" {
     inbound_route_map_id  = azurerm_route_map.routemap1.id
     outbound_route_map_id = azurerm_route_map.routemap2.id
   }
-  depends_on = [azurerm_route_map.routemap1, azurerm_route_map.routemap2]
 }
-`, r.template(data), data.RandomInteger)
+`, r.template(data), data.RandomInteger, routingWeight)
 }
 
 func (r ExpressRouteConnectionResource) template(data acceptance.TestData) string {


### PR DESCRIPTION


<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Due to the update function building an entirely new payload rather than retrieving + modifying one, the `internet_security_enabled` property was getting set to `false` if there were no changes made to it, even if this property was set to `true` in config.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #32486


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
