### PR TITLE
`azurerm_container_app_environment` - fix auto append `Consumption` profile error in acc test

### DIFF
--- a/internal/services/containerapps/container_app_job_resource_test.go
+++ b/internal/services/containerapps/container_app_job_resource_test.go
@@ -1486,16 +1486,12 @@ func (r ContainerAppJobResource) withWorkloadProfile(data acceptance.TestData) s
 
 %s
 
-locals {
-  workload_profiles = tolist(azurerm_container_app_environment.test.workload_profile)
-}
-
 resource "azurerm_container_app_job" "test" {
   name                         = "acctest-cajob%[2]d"
   resource_group_name          = azurerm_resource_group.test.name
   location                     = azurerm_resource_group.test.location
   container_app_environment_id = azurerm_container_app_environment.test.id
-  workload_profile_name        = local.workload_profiles.0.name
+  workload_profile_name        = "D4-01"
 
   replica_timeout_in_seconds = 10
   replica_retry_limit        = 10

--- a/internal/services/containerapps/container_app_resource_test.go
+++ b/internal/services/containerapps/container_app_resource_test.go
@@ -1461,17 +1461,13 @@ func (r ContainerAppResource) withWorkloadProfile(data acceptance.TestData) stri
 	return fmt.Sprintf(`
 %s
 
-locals {
-  workload_profiles = tolist(azurerm_container_app_environment.test.workload_profile)
-}
-
 resource "azurerm_container_app" "test" {
   name                         = "acctest-capp-%[2]d"
   resource_group_name          = azurerm_resource_group.test.name
   container_app_environment_id = azurerm_container_app_environment.test.id
   revision_mode                = "Single"
 
-  workload_profile_name = local.workload_profiles.0.name
+  workload_profile_name = "D4-01"
 
   template {
     container {
@@ -1502,12 +1498,9 @@ resource "azurerm_container_app" "test" {
 }
 
 func (r ContainerAppResource) withMultipleWorkloadProfiles(data acceptance.TestData, workloadProfileIndex int) string {
+	workloadProfileNames := []string{"D4-01", "D4-02"}
 	return fmt.Sprintf(`
 %s
-
-locals {
-  workload_profiles = tolist(azurerm_container_app_environment.test.workload_profile)
-}
 
 resource "azurerm_container_app" "test" {
   name                         = "acctest-capp-%[2]d"
@@ -1515,7 +1508,7 @@ resource "azurerm_container_app" "test" {
   container_app_environment_id = azurerm_container_app_environment.test.id
   revision_mode                = "Single"
 
-  workload_profile_name = local.workload_profiles.%[3]d.name
+  workload_profile_name = "%[3]s"
 
   template {
     container {
@@ -1542,16 +1535,12 @@ resource "azurerm_container_app" "test" {
     accTest = "1"
   }
 }
-`, r.templateMultipleWorkloadProfiles(data), data.RandomInteger, workloadProfileIndex)
+`, r.templateMultipleWorkloadProfiles(data), data.RandomInteger, workloadProfileNames[workloadProfileIndex])
 }
 
 func (r ContainerAppResource) withSmallerGranularityCPUMemoryCombinations(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
-
-locals {
-  workload_profiles = tolist(azurerm_container_app_environment.test.workload_profile)
-}
 
 resource "azurerm_container_app" "test" {
   name                         = "acctest-capp-%[2]d"
@@ -1559,7 +1548,7 @@ resource "azurerm_container_app" "test" {
   container_app_environment_id = azurerm_container_app_environment.test.id
   revision_mode                = "Single"
 
-  workload_profile_name = local.workload_profiles.0.name
+  workload_profile_name = "D4-01"
 
   template {
     container {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
For any Container App Environment that contains a dedicated workload profile (e.g. `D4-01`), the Azure API auto-appends an implicit Consumption profile to the response. The Container App use `tolist` and the order of the profiles in the list is not fixed, which caused the tests to failed.

Impacted tests: 
1. TestAccContainerAppResource_workloadProfile
2. TestAccContainerAppResource_workloadProfileUpdate
3. TestAccContainerAppResource_smallerGranularityCPUMemoryCombination
4. TestAccContainerAppJob_withWorkloadProfile

<details>
<summary>click this for detail error log</summary>

```text
Note: Objects have changed outside of Terraform
        Terraform detected the following changes made outside of Terraform since the
        last "terraform apply" which may have affected this plan:
          # azurerm_container_app_environment.test has changed
          ~ resource "azurerm_container_app_environment" "test" {
                id                                          = "abcd"
                tags                                        = {
                    "Foo"    = "Bar"
                    "secret" = "sauce"
                }
                # (17 unchanged attributes hidden)
              + workload_profile {
                  + maximum_count         = 0
                  + minimum_count         = 0
                  + name                  = "Consumption"
                  + workload_profile_type = "Consumption"
                }
                # (1 unchanged block hidden)
            }
        Unless you have made equivalent changes to your configuration, or ignored the
        relevant attributes using ignore_changes, the following plan may include
        actions to undo or respond to these changes.
        ─────────────────────────────────────────────────────────────────────────────
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        Terraform will perform the following actions:
          # azurerm_container_app.test will be updated in-place
          ~ resource "azurerm_container_app" "test" {
                id                            = "abcd"
                name                          = "acctest-app"
                tags                          = {
                    "accTest" = "1"
                    "foo"     = "Bar"
                }
              ~ workload_profile_name         = "D4-01" -> "Consumption"
                # (9 unchanged attributes hidden)
                # (2 unchanged blocks hidden)
            }
        Plan: 0 to add, 1 to change, 0 to destroy.
```

</details>

This PR use specific profile name in the tests to avoid error above.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. 
```
TF_ACC=1 go test -v ./internal/services/containerapps -run=TestAccContainerAppResource_smallerGranularityCPUMemoryCombinations -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccContainerAppResource_smallerGranularityCPUMemoryCombinations
=== PAUSE TestAccContainerAppResource_smallerGranularityCPUMemoryCombinations
=== CONT  TestAccContainerAppResource_smallerGranularityCPUMemoryCombinations
--- PASS: TestAccContainerAppResource_smallerGranularityCPUMemoryCombinations (1784.42s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/containerapps	1784.472s

TF_ACC=1 go test -v ./internal/services/containerapps -run=TestAccContainerAppJob_withWorkloadProfile -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccContainerAppJob_withWorkloadProfile
=== PAUSE TestAccContainerAppJob_withWorkloadProfile
=== CONT  TestAccContainerAppJob_withWorkloadProfile
--- PASS: TestAccContainerAppJob_withWorkloadProfile (1706.71s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/containerapps	1706.748s

TF_ACC=1 go test -v ./internal/services/containerapps -run=TestAccContainerAppResource_workloadProfile -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccContainerAppResource_workloadProfile
=== PAUSE TestAccContainerAppResource_workloadProfile
=== CONT  TestAccContainerAppResource_workloadProfile
--- PASS: TestAccContainerAppResource_workloadProfile (1794.76s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/containerapps	1794.827s

TestAccContainerAppResource_workloadProfileUpdate
18:06:14     === RUN   TestAccContainerAppResource_workloadProfileUpdate
    === PAUSE TestAccContainerAppResource_workloadProfileUpdate
    === CONT  TestAccContainerAppResource_workloadProfileUpdate
    --- PASS: TestAccContainerAppResource_workloadProfileUpdate (1764.94s)
    PASS
```
Build `Container Apps Acceptant Test` from team city shows above tests all passed: `Build #1076`

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

No changelog entry — this PR only updates an acceptance test fixture and does not change user-facing behavior.

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

N/A


## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

No.
