### PR TITLE
add go support to azurerm_linux_function_app 

### DIFF
--- a/internal/services/appservice/helpers/function_app_schema.go
+++ b/internal/services/appservice/helpers/function_app_schema.go
@@ -1324,6 +1324,7 @@ type ApplicationStackLinuxFunctionApp struct {
 	// Note - Function Apps differ to Web Apps here. They do not use the named properties in the SiteConfig block and exclusively use the app_settings map
 	DotNetVersion         string                   `tfschema:"dotnet_version"`              // Supported values `3.1`, `6.0`, `7.0`, `8.0`, `9.0` and `10.0`
 	DotNetIsolated        bool                     `tfschema:"use_dotnet_isolated_runtime"` // Supported values `true` for `dotnet-isolated`, `false` otherwise
+	GoVersion             string                   `tfschema:"go_version"`                  // Supported values `1.22`, `1.23`
 	NodeVersion           string                   `tfschema:"node_version"`                // Supported values `12LTS`, `14LTS`, `16LTS`, `18LTS, `20LTS`, `22LTS`
 	PythonVersion         string                   `tfschema:"python_version"`              // Supported values `3.14`, `3.13`, `3.12`, `3.11`, `3.10`, `3.9`, `3.8`, `3.7`
 	PowerShellCoreVersion string                   `tfschema:"powershell_core_version"`     // Supported values are `7.0`, `7.2`
@@ -1374,6 +1375,7 @@ func linuxFunctionAppStackSchema() *pluginsdk.Schema {
 						"site_config.0.application_stack.0.node_version",
 						"site_config.0.application_stack.0.powershell_core_version",
 						"site_config.0.application_stack.0.docker",
+						"site_config.0.application_stack.0.go_version",
 						"site_config.0.application_stack.0.use_custom_runtime",
 					},
 					Description: "The version of .Net. Possible values are `3.1`, `6.0`, `7.0`, `8.0` and `9.0`",
@@ -1389,9 +1391,30 @@ func linuxFunctionAppStackSchema() *pluginsdk.Schema {
 						"site_config.0.application_stack.0.node_version",
 						"site_config.0.application_stack.0.powershell_core_version",
 						"site_config.0.application_stack.0.docker",
+						"site_config.0.application_stack.0.go_version",
 						"site_config.0.application_stack.0.use_custom_runtime",
 					},
 					Description: "Should the DotNet process use an isolated runtime. Defaults to `false`.",
+				},
+
+				"go_version": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						"1.22",
+						"1.23",
+					}, false),
+					ExactlyOneOf: []string{
+						"site_config.0.application_stack.0.dotnet_version",
+						"site_config.0.application_stack.0.go_version",
+						"site_config.0.application_stack.0.python_version",
+						"site_config.0.application_stack.0.java_version",
+						"site_config.0.application_stack.0.node_version",
+						"site_config.0.application_stack.0.powershell_core_version",
+						"site_config.0.application_stack.0.docker",
+						"site_config.0.application_stack.0.use_custom_runtime",
+					},
+					Description: "The version of Go to use. Possible values are `1.22` and `1.23`.",
 				},
 
 				"python_version": {
@@ -1414,6 +1437,7 @@ func linuxFunctionAppStackSchema() *pluginsdk.Schema {
 						"site_config.0.application_stack.0.node_version",
 						"site_config.0.application_stack.0.powershell_core_version",
 						"site_config.0.application_stack.0.docker",
+						"site_config.0.application_stack.0.go_version",
 						"site_config.0.application_stack.0.use_custom_runtime",
 					},
 					Description: "The version of Python to use. Possible values include `3.14`, `3.13`, `3.12`, `3.11`, `3.10`, `3.9`, `3.8`, and `3.7`.",
@@ -1438,6 +1462,7 @@ func linuxFunctionAppStackSchema() *pluginsdk.Schema {
 						"site_config.0.application_stack.0.node_version",
 						"site_config.0.application_stack.0.powershell_core_version",
 						"site_config.0.application_stack.0.docker",
+						"site_config.0.application_stack.0.go_version",
 						"site_config.0.application_stack.0.use_custom_runtime",
 					},
 					Description: "The version of Node to use. Possible values include `12`, `14`, `16`, `18`, `20`, `22` and `24`",
@@ -1458,6 +1483,7 @@ func linuxFunctionAppStackSchema() *pluginsdk.Schema {
 						"site_config.0.application_stack.0.node_version",
 						"site_config.0.application_stack.0.powershell_core_version",
 						"site_config.0.application_stack.0.docker",
+						"site_config.0.application_stack.0.go_version",
 						"site_config.0.application_stack.0.use_custom_runtime",
 					},
 					Description: "The version of PowerShell Core to use. Possibles values are `7`, `7.2`, and `7.4`",
@@ -1480,6 +1506,7 @@ func linuxFunctionAppStackSchema() *pluginsdk.Schema {
 						"site_config.0.application_stack.0.node_version",
 						"site_config.0.application_stack.0.powershell_core_version",
 						"site_config.0.application_stack.0.docker",
+						"site_config.0.application_stack.0.go_version",
 						"site_config.0.application_stack.0.use_custom_runtime",
 					},
 					Description: "The version of Java to use. Possible values are `8`, `11`, `17`, `21` and `25`",
@@ -1534,6 +1561,7 @@ func linuxFunctionAppStackSchema() *pluginsdk.Schema {
 						"site_config.0.application_stack.0.node_version",
 						"site_config.0.application_stack.0.powershell_core_version",
 						"site_config.0.application_stack.0.docker",
+						"site_config.0.application_stack.0.go_version",
 						"site_config.0.application_stack.0.use_custom_runtime",
 					},
 					Description: "A docker block",
@@ -1549,6 +1577,7 @@ func linuxFunctionAppStackSchema() *pluginsdk.Schema {
 						"site_config.0.application_stack.0.node_version",
 						"site_config.0.application_stack.0.powershell_core_version",
 						"site_config.0.application_stack.0.docker",
+						"site_config.0.application_stack.0.go_version",
 						"site_config.0.application_stack.0.use_custom_runtime",
 					},
 				},
@@ -1570,6 +1599,11 @@ func linuxFunctionAppStackSchemaComputed() *pluginsdk.Schema {
 
 				"use_dotnet_isolated_runtime": {
 					Type:     pluginsdk.TypeBool,
+					Computed: true,
+				},
+
+				"go_version": {
+					Type:     pluginsdk.TypeString,
 					Computed: true,
 				},
 
@@ -1661,6 +1695,7 @@ func windowsFunctionAppStackSchema() *pluginsdk.Schema {
 						"site_config.0.application_stack.0.java_version",
 						"site_config.0.application_stack.0.node_version",
 						"site_config.0.application_stack.0.powershell_core_version",
+						"site_config.0.application_stack.0.go_version",
 						"site_config.0.application_stack.0.use_custom_runtime",
 					},
 					Description: "The version of .Net. Possible values are `v3.0`, `v4.0`, `v6.0`, `v7.0`, `v8.0`, `v9.0` and `v10.0`",
@@ -1674,6 +1709,7 @@ func windowsFunctionAppStackSchema() *pluginsdk.Schema {
 						"site_config.0.application_stack.0.java_version",
 						"site_config.0.application_stack.0.node_version",
 						"site_config.0.application_stack.0.powershell_core_version",
+						"site_config.0.application_stack.0.go_version",
 						"site_config.0.application_stack.0.use_custom_runtime",
 					},
 					Description: "Should the DotNet process use an isolated runtime. Defaults to `false`.",
@@ -1696,6 +1732,7 @@ func windowsFunctionAppStackSchema() *pluginsdk.Schema {
 						"site_config.0.application_stack.0.java_version",
 						"site_config.0.application_stack.0.node_version",
 						"site_config.0.application_stack.0.powershell_core_version",
+						"site_config.0.application_stack.0.go_version",
 						"site_config.0.application_stack.0.use_custom_runtime",
 					},
 					Description: "The version of Node to use. Possible values include `~12`, `~14`, `~16`, `~18`, `~20` and `~22`",
@@ -1716,6 +1753,7 @@ func windowsFunctionAppStackSchema() *pluginsdk.Schema {
 						"site_config.0.application_stack.0.java_version",
 						"site_config.0.application_stack.0.node_version",
 						"site_config.0.application_stack.0.powershell_core_version",
+						"site_config.0.application_stack.0.go_version",
 						"site_config.0.application_stack.0.use_custom_runtime",
 					},
 					Description: "The version of Java to use. Possible values are `1.8`, `11`, `17`, `21` and `25`",
@@ -1735,6 +1773,7 @@ func windowsFunctionAppStackSchema() *pluginsdk.Schema {
 						"site_config.0.application_stack.0.java_version",
 						"site_config.0.application_stack.0.node_version",
 						"site_config.0.application_stack.0.powershell_core_version",
+						"site_config.0.application_stack.0.go_version",
 						"site_config.0.application_stack.0.use_custom_runtime",
 					},
 					Description: "The PowerShell Core version to use. Possible values are `7`, `7.2`, `7.4`, and `7.6`",
@@ -1749,6 +1788,7 @@ func windowsFunctionAppStackSchema() *pluginsdk.Schema {
 						"site_config.0.application_stack.0.java_version",
 						"site_config.0.application_stack.0.node_version",
 						"site_config.0.application_stack.0.powershell_core_version",
+						"site_config.0.application_stack.0.go_version",
 						"site_config.0.application_stack.0.use_custom_runtime",
 					},
 					Description: "Does the Function App use a custom Application Stack?",
@@ -1932,6 +1972,11 @@ func ExpandSiteConfigLinuxFunctionApp(siteConfig []SiteConfigLinuxFunctionApp, e
 			appSettings = updateOrAppendAppSettings(appSettings, "FUNCTIONS_WORKER_RUNTIME", "node", false)
 			appSettings = updateOrAppendAppSettings(appSettings, "WEBSITE_NODE_DEFAULT_VERSION", linuxAppStack.NodeVersion, false)
 			expanded.LinuxFxVersion = pointer.To(fmt.Sprintf("NODE|%s", linuxAppStack.NodeVersion))
+		}
+
+		if linuxAppStack.GoVersion != "" {
+			appSettings = updateOrAppendAppSettings(appSettings, "FUNCTIONS_WORKER_RUNTIME", "golang", false)
+			expanded.LinuxFxVersion = pointer.To(fmt.Sprintf("GO|%s", linuxAppStack.GoVersion))
 		}
 
 		if linuxAppStack.PythonVersion != "" {

--- a/internal/services/appservice/helpers/function_app_slot_schema.go
+++ b/internal/services/appservice/helpers/function_app_slot_schema.go
@@ -1089,6 +1089,14 @@ func ExpandSiteConfigLinuxFunctionAppSlot(siteConfig []SiteConfigLinuxFunctionAp
 			expanded.LinuxFxVersion = pointer.To(fmt.Sprintf("NODE|%s", linuxAppStack.NodeVersion))
 		}
 
+		if linuxAppStack.GoVersion != "" {
+			appSettings = append(appSettings, webapps.NameValuePair{
+				Name:  pointer.To("FUNCTIONS_WORKER_RUNTIME"),
+				Value: pointer.To("golang"),
+			})
+			expanded.LinuxFxVersion = pointer.To(fmt.Sprintf("GO|%s", linuxAppStack.GoVersion))
+		}
+
 		if linuxAppStack.PythonVersion != "" {
 			appSettings = append(appSettings, webapps.NameValuePair{
 				Name:  pointer.To("FUNCTIONS_WORKER_RUNTIME"),

--- a/internal/services/appservice/helpers/fx_strings.go
+++ b/internal/services/appservice/helpers/fx_strings.go
@@ -127,6 +127,10 @@ func EncodeFunctionAppLinuxFxVersion(input []ApplicationStackLinuxFunctionApp) *
 		appType = string(FxStringPrefixPython)
 		appString = appStack.PythonVersion
 
+	case appStack.GoVersion != "":
+		appType = string(FxStringPrefixGo)
+		appString = appStack.GoVersion
+
 	case appStack.JavaVersion != "":
 		appType = string(FxStringPrefixJava)
 		appString = appStack.JavaVersion
@@ -177,6 +181,10 @@ func DecodeFunctionAppLinuxFxVersion(input string) ([]ApplicationStackLinuxFunct
 
 	case FxStringPrefixNode:
 		appStack := ApplicationStackLinuxFunctionApp{NodeVersion: parts[1]}
+		result = append(result, appStack)
+
+	case FxStringPrefixGo:
+		appStack := ApplicationStackLinuxFunctionApp{GoVersion: parts[1]}
 		result = append(result, appStack)
 
 	case FxStringPrefixPython:


### PR DESCRIPTION
## Description

Azure Functions [announced Go support (preview)](https://techcommunity.microsoft.com/blog/appsonazureblog/announcing-go-support-in-azure-functions-preview/4523801) on the Flex Consumption plan (June 2026). This PR adds `go_version` to the `application_stack` block for `azurerm_linux_function_app` and `azurerm_linux_function_app_slot` resources.

## Changes

- Add `GoVersion` field to `ApplicationStackLinuxFunctionApp` struct
- Add `go_version` schema attribute with validation (`1.22`, `1.23`)
- Add `go_version` to all `ExactlyOneOf` constraint lists
- Set `FUNCTIONS_WORKER_RUNTIME=golang` and `LinuxFxVersion=GO|<version>` in expand logic
- Add Go case to `EncodeFunctionAppLinuxFxVersion` and `DecodeFunctionAppLinuxFxVersion`
- Add `go_version` to computed schema (data sources)
- Support in slot resources

## Usage

```hcl
resource "azurerm_linux_function_app" "example" {
  # ...

  site_config {
    application_stack {
      go_version = "1.23"
    }
  }
}
```

## Notes

- Go support is currently Linux-only (Flex Consumption plan)
- The `FxStringPrefixGo` constant already existed in `fx_strings.go` (used by web apps) — this extends it to function apps
- Runtime value is `golang` (not `go`) per the Azure Functions SDK naming

## Testing

- `go build ./internal/services/appservice/...` passes
- Acceptance tests to be added (need Go-supported region/plan for CI)