### PR TITLE
`azurerm_(linux|windows|orchestrated)_virtual_machine_scale_set` - allow batch updates for instasnces when using manual upgrade mode

### DIFF
--- a/internal/services/compute/linux_virtual_machine_scale_set_resource_other_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource_other_test.go
@@ -3264,7 +3264,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   sku                 = "%s"
-  instances           = 1
+  instances           = 20
   admin_username      = "adminuser"
   admin_password      = "P@ssword1234!"
   upgrade_mode        = "Manual"

--- a/internal/services/compute/virtual_machine_scale_set_update.go
+++ b/internal/services/compute/virtual_machine_scale_set_update.go
@@ -140,28 +140,25 @@ func (metadata virtualMachineScaleSetUpdateMetaData) upgradeInstancesForManualUp
 		}
 	}
 
-	// TODO: there's a performance enhancement to do batches here, but this is fine for a first pass
-	for _, instanceId := range instanceIdsToRoll {
-		instanceIds := []string{instanceId}
-
-		log.Printf("[DEBUG] Updating Instance %q to the Latest Configuration..", instanceId)
+	if len(instanceIdsToRoll) > 0 {
+		log.Printf("[DEBUG] Updating Instances to the Latest Configuration...")
 		ids := virtualmachinescalesets.VirtualMachineScaleSetVMInstanceRequiredIDs{
-			InstanceIds: instanceIds,
+			InstanceIds: instanceIdsToRoll,
 		}
 		if err := client.UpdateInstancesThenPoll(ctx, *id, ids); err != nil {
-			return fmt.Errorf("updating Instance %q (%s %s) to the Latest Configuration: %+v", instanceId, metadata.OSType, id, err)
+			return fmt.Errorf("updating Instances for %s %s to the Latest Configuration: %+v", metadata.OSType, id, err)
 		}
-		log.Printf("[DEBUG] Updated Instance %q to the Latest Configuration.", instanceId)
+		log.Printf("[DEBUG] Updated Instances to the Latest Configuration.")
 
 		if metadata.CanReimageOnManualUpgrade {
-			log.Printf("[DEBUG] Reimaging Instance %q..", instanceId)
+			log.Printf("[DEBUG] Reimaging Instances...")
 			reImageInput := virtualmachinescalesets.VirtualMachineScaleSetReimageParameters{
-				InstanceIds: &instanceIds,
+				InstanceIds: &instanceIdsToRoll,
 			}
 			if err := client.ReimageThenPoll(ctx, *id, reImageInput); err != nil {
-				return fmt.Errorf("reimaging Instance %q (%s %s): %+v", instanceId, metadata.OSType, id, err)
+				return fmt.Errorf("reimaging Instances for %s %s: %+v", metadata.OSType, id, err)
 			}
-			log.Printf("[DEBUG] Reimaged Instance %q..", instanceId)
+			log.Printf("[DEBUG] Reimaged Instances...")
 		}
 	}
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Allow for updating instance in batch when updating the virtual machine scale set setting with manual update mode to allow faster update. 

There is no clear limitation on how large the batch of instances can be from service side documentation or api and I cannot find any existing pattern for batching the size in codebase. So, follow the same pattern as [AzureCli](https://github.com/Azure/azure-cli/blob/65f5c5c3b1d7f9337db3045c46bd597a642c250f/src/azure-cli/azure/cli/command_modules/vm/custom.py#L4645) to use the whole instance lists as input.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

Test with customize `TEST_PREFIX = TestAcc(Linux|Windows|Orchestrated)VirtualMachineScaleSet` Failed test also failed on main with same reason

<img width="1008" height="900" alt="image" src="https://github.com/user-attachments/assets/ea752b81-022a-40a5-9311-de7ad3e1f349" />

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #32412


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
