### PR TITLE
`azurerm_network_manager_deployment` - add custom poller

### DIFF
--- a/internal/services/network/custompollers/network_manager_deployment_poller.go
+++ b/internal/services/network/custompollers/network_manager_deployment_poller.go
@@ -1,0 +1,62 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package custompollers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/networkmanagers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
+)
+
+var _ pollers.PollerType = &networkManagerDeploymentPoller{}
+
+type networkManagerDeploymentPoller struct {
+	client *networkmanagers.NetworkManagersClient
+	id     parse.ManagerDeploymentId
+}
+
+func NewNetworkManagerDeploymentPoller(client *networkmanagers.NetworkManagersClient, id parse.ManagerDeploymentId) pollers.PollerType {
+	return &networkManagerDeploymentPoller{
+		client: client,
+		id:     id,
+	}
+}
+
+func (p networkManagerDeploymentPoller) Poll(ctx context.Context) (*pollers.PollResult, error) {
+	result := &pollers.PollResult{
+		PollInterval: 10 * time.Second,
+		Status:       pollers.PollingStatusInProgress,
+	}
+
+	payload := networkmanagers.NetworkManagerDeploymentStatusParameter{
+		Regions:         &[]string{location.Normalize(p.id.Location)},
+		DeploymentTypes: &[]networkmanagers.ConfigurationType{networkmanagers.ConfigurationType(p.id.ScopeAccess)},
+	}
+
+	networkManagerId := networkmanagers.NewNetworkManagerID(p.id.SubscriptionId, p.id.ResourceGroup, p.id.NetworkManagerName)
+	resp, err := p.client.NetworkManagerDeploymentStatusList(ctx, networkManagerId, payload)
+	if err != nil {
+		result.Status = pollers.PollingStatusFailed
+		return result, pollers.PollingFailedError{
+			Message: fmt.Errorf("listing deployments for %s", networkManagerId).Error(),
+		}
+	}
+
+	// List request may initially return no results
+	if resp.Model == nil || resp.Model.Value == nil || len(*resp.Model.Value) == 0 {
+		return result, nil
+	}
+
+	if *(*resp.Model.Value)[0].DeploymentStatus == networkmanagers.DeploymentStatusDeployed {
+		result.Status = pollers.PollingStatusSucceeded
+		return result, nil
+	}
+
+	return result, nil
+}

--- a/internal/services/network/custompollers/network_manager_deployment_poller.go
+++ b/internal/services/network/custompollers/network_manager_deployment_poller.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/networkmanagers"
 	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
@@ -53,7 +54,7 @@ func (p networkManagerDeploymentPoller) Poll(ctx context.Context) (*pollers.Poll
 		return result, nil
 	}
 
-	if *(*resp.Model.Value)[0].DeploymentStatus == networkmanagers.DeploymentStatusDeployed {
+	if pointer.From((*resp.Model.Value)[0].DeploymentStatus) == networkmanagers.DeploymentStatusDeployed {
 		result.Status = pollers.PollingStatusSucceeded
 		return result, nil
 	}

--- a/internal/services/network/network_manager_deployment_resource.go
+++ b/internal/services/network/network_manager_deployment_resource.go
@@ -13,9 +13,11 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/networkmanagers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/custompollers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -138,8 +140,17 @@ func (r ManagerDeploymentResource) Create() sdk.ResourceFunc {
 				CommitType:       networkmanagers.ConfigurationType(state.ScopeAccess),
 			}
 
-			// TODO: implement callback, requires migrating to an ID implementing `resourceids.ResourceId`
-			if err := client.NetworkManagerCommitsPostThenPoll(ctx, *networkManagerId, input); err != nil {
+			// The API has an issue where it may return an async operation URL that is invalid, breaking the default LRO poller
+			if _, err := client.NetworkManagerCommitsPost(ctx, *networkManagerId, input); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			if metadata.Client.Features.PersistIDOnCreateBeforePollingForCompletion {
+				metadata.SetID(id)
+			}
+
+			poller := pollers.NewPoller(custompollers.NewNetworkManagerDeploymentPoller(client, *id), time.Second*10, pollers.DefaultNumberOfDroppedConnectionsToAllow)
+			if err := poller.PollUntilDone(ctx); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Adds custom poller to the `azurerm_network_manager_deployment` resource


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

```
=== RUN   TestAccNetworkManager
=== RUN   TestAccNetworkManager/Deployment
--- PASS: TestAccNetworkManager/Deployment/requiresImport (173.10s)
--- PASS: TestAccNetworkManager/Deployment/basic (166.00s)
--- PASS: TestAccNetworkManager/Deployment/basicAdmin (1664.95s)
--- PASS: TestAccNetworkManager/Deployment/complete (163.12s)
--- PASS: TestAccNetworkManager/Deployment/update (215.15s)
--- PASS: TestAccNetworkManager/Deployment/withTriggers (185.65s)
--- PASS: TestAccNetworkManager/Deployment (2567.97s)
--- PASS: TestAccNetworkManager (2567.97s)
PASS
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #32527


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
