### PR TITLE
Added Oracle Grid Infrastructure Minor Versions data source

### DIFF
--- a/internal/services/oracle/oracle_gi_versions_data_source.go
+++ b/internal/services/oracle/oracle_gi_versions_data_source.go
@@ -64,6 +64,10 @@ func (d GiVersionsDataSource) ResourceType() string {
 	return "azurerm_oracle_gi_versions"
 }
 
+func (d GiVersionsDataSource) DeprecatedInFavourOfDataSource() string {
+	return "azurerm_oracle_grid_infrastructure_versions"
+}
+
 func (d GiVersionsDataSource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
 	return giversions.ValidateGiVersionID
 }

--- a/internal/services/oracle/oracle_grid_infrastructure_minor_versions_data_source.go
+++ b/internal/services/oracle/oracle_grid_infrastructure_minor_versions_data_source.go
@@ -1,0 +1,163 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package oracle
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-09-01/giminorversions"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type GridInfrastructureMinorVersionsDataSource struct{}
+
+type GridInfrastructureMinorVersionsModel struct {
+	Location                        string                                `tfschema:"location"`
+	GridInfrastructureVersion       string                                `tfschema:"grid_infrastructure_version"`
+	ShapeFamily                     string                                `tfschema:"shape_family"`
+	Zone                            string                                `tfschema:"zone"`
+	GridInfrastructureMinorVersions []GridInfrastructureMinorVersionModel `tfschema:"versions"`
+}
+
+type GridInfrastructureMinorVersionModel struct {
+	Id            string `tfschema:"id"`
+	Name          string `tfschema:"name"`
+	Version       string `tfschema:"version"`
+	GridImageOcid string `tfschema:"grid_image_ocid"`
+}
+
+func (d GridInfrastructureMinorVersionsDataSource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"location": commonschema.Location(),
+
+		"grid_infrastructure_version": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+			Description:  "The GI (Grid Infrastructure) version to list minor versions for.",
+		},
+
+		"shape_family": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringInSlice(giminorversions.PossibleValuesForShapeFamily(), false),
+			Description:  "Filter the minor versions by shape family. Possible values are 'EXADATA' and 'EXADB_XS'.",
+		},
+
+		"zone": {
+			Type:        pluginsdk.TypeString,
+			Optional:    true,
+			Description: "Filter the minor versions by zone.",
+		},
+	}
+}
+
+func (d GridInfrastructureMinorVersionsDataSource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"versions": {
+			Type:        pluginsdk.TypeList,
+			Computed:    true,
+			Description: "A list of available Oracle Grid Infrastructure minor versions and their properties.",
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"id": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+
+					"name": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+
+					"version": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+
+					"grid_image_ocid": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d GridInfrastructureMinorVersionsDataSource) ModelObject() interface{} {
+	return &GridInfrastructureMinorVersionsModel{}
+}
+
+func (d GridInfrastructureMinorVersionsDataSource) ResourceType() string {
+	return "azurerm_oracle_grid_infrastructure_minor_versions"
+}
+
+func (d GridInfrastructureMinorVersionsDataSource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return giminorversions.ValidateGiVersionID
+}
+
+func (d GridInfrastructureMinorVersionsDataSource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Oracle.OracleClient.GiMinorVersions
+			subscriptionId := metadata.Client.Account.SubscriptionId
+
+			state := GridInfrastructureMinorVersionsModel{
+				GridInfrastructureMinorVersions: make([]GridInfrastructureMinorVersionModel, 0),
+			}
+			if err := metadata.Decode(&state); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			id := giminorversions.NewGiVersionID(subscriptionId, state.Location, state.GridInfrastructureVersion)
+
+			options := giminorversions.DefaultListByParentOperationOptions()
+			if state.ShapeFamily != "" {
+				options.ShapeFamily = pointer.ToEnum[giminorversions.ShapeFamily](state.ShapeFamily)
+			}
+			if state.Zone != "" {
+				options.Zone = &state.Zone
+			}
+
+			if state.ShapeFamily == "" || state.Zone == "" {
+				log.Printf("[WARN] GI Minor Versions data source: ShapeFamily or Zone parameter is empty. This may result in unfiltered results from the API. Consider specifying both ShapeFamily and Zone for more precise version filtering.")
+			}
+
+			resp, err := client.ListByParent(ctx, id, options)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return fmt.Errorf("%s was not found", id)
+				}
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+
+			if model := resp.Model; model != nil {
+				for _, element := range *model {
+					if props := element.Properties; props != nil {
+						state.GridInfrastructureMinorVersions = append(state.GridInfrastructureMinorVersions, GridInfrastructureMinorVersionModel{
+							Id:            pointer.From(element.Id),
+							Name:          pointer.From(element.Name),
+							Version:       props.Version,
+							GridImageOcid: pointer.From(props.GridImageOcid),
+						})
+					}
+				}
+			}
+
+			metadata.SetID(id)
+
+			return metadata.Encode(&state)
+		},
+	}
+}

--- a/internal/services/oracle/oracle_grid_infrastructure_minor_versions_data_source_test.go
+++ b/internal/services/oracle/oracle_grid_infrastructure_minor_versions_data_source_test.go
@@ -1,0 +1,107 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package oracle_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+type GridInfrastructureMinorVersionsDataSource struct{}
+
+func TestAccGridInfrastructureMinorVersionsDataSource_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_oracle_grid_infrastructure_minor_versions", "test")
+	r := GridInfrastructureMinorVersionsDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("versions.#").IsNotEmpty(),
+				check.That(data.ResourceName).Key("versions.0.id").Exists(),
+				check.That(data.ResourceName).Key("versions.0.name").Exists(),
+				check.That(data.ResourceName).Key("versions.0.version").Exists(),
+				check.That(data.ResourceName).Key("versions.0.grid_image_ocid").Exists(),
+			),
+		},
+	})
+}
+
+func TestAccGridInfrastructureMinorVersionsDataSource_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_oracle_grid_infrastructure_minor_versions", "test")
+	r := GridInfrastructureMinorVersionsDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("versions.#").IsNotEmpty(),
+				check.That(data.ResourceName).Key("versions.0.id").Exists(),
+				check.That(data.ResourceName).Key("versions.0.name").Exists(),
+				check.That(data.ResourceName).Key("versions.0.version").Exists(),
+				check.That(data.ResourceName).Key("versions.0.grid_image_ocid").Exists(),
+			),
+		},
+	})
+}
+
+func (d GridInfrastructureMinorVersionsDataSource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_oracle_grid_infrastructure_versions" "test" {
+  location = local.location
+  shape    = "ExaDbXS"
+  zone     = local.zone
+}
+
+data "azurerm_oracle_grid_infrastructure_minor_versions" "test" {
+  location                    = local.location
+  grid_infrastructure_version = one([for item in data.azurerm_oracle_grid_infrastructure_versions.test.versions : item.name if item.version == local.grid_infrastructure_version])
+  shape_family                = "EXADB_XS"
+  zone                        = local.zone
+}
+`, d.template(data))
+}
+
+func (d GridInfrastructureMinorVersionsDataSource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_oracle_grid_infrastructure_versions" "test" {
+  location = local.location
+  shape    = "ExaDbXS"
+  zone     = local.zone
+}
+
+data "azurerm_oracle_grid_infrastructure_minor_versions" "test" {
+  location                    = local.location
+  grid_infrastructure_version = data.azurerm_oracle_grid_infrastructure_versions.test.versions[0].name
+  shape_family                = "EXADB_XS"
+  zone                        = local.zone
+}
+`, d.template(data))
+}
+
+func (a GridInfrastructureMinorVersionsDataSource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+locals {
+  zone       = "1"
+  location   = "%[1]s"
+  grid_infrastructure_version = "26.0.0.0"
+}
+
+`, data.Locations.Primary)
+}

--- a/internal/services/oracle/oracle_grid_infrastructure_versions_data_source.go
+++ b/internal/services/oracle/oracle_grid_infrastructure_versions_data_source.go
@@ -1,0 +1,147 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package oracle
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/oracledatabase/2025-09-01/giversions"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type GridInfrastructureVersionsDataSource struct{}
+
+type GridInfrastructureVersionsModel struct {
+	GridInfrastructureVersions []GridInfrastructureVersionModel `tfschema:"versions"`
+	Location                   string                           `tfschema:"location"`
+	Shape                      string                           `tfschema:"shape"`
+	Zone                       string                           `tfschema:"zone"`
+}
+
+type GridInfrastructureVersionModel struct {
+	Id      string `tfschema:"id"`
+	Name    string `tfschema:"name"`
+	Version string `tfschema:"version"`
+}
+
+func (d GridInfrastructureVersionsDataSource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"location": commonschema.Location(),
+		"shape": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringInSlice(giversions.PossibleValuesForSystemShapes(), false),
+			Description:  "Filter the versions by system shape. Possible values are 'ExaDbXS', 'Exadata.X9M', and 'Exadata.X11M'.",
+		},
+		"zone": {
+			Type:        pluginsdk.TypeString,
+			Optional:    true,
+			Description: "Filter the versions by zone",
+		},
+	}
+}
+
+func (d GridInfrastructureVersionsDataSource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"versions": {
+			Type:        pluginsdk.TypeList,
+			Computed:    true,
+			Description: "A list of available Oracle Grid Infrastructure versions and their properties.",
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"id": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+
+					"name": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+
+					"version": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d GridInfrastructureVersionsDataSource) ModelObject() interface{} {
+	return &GridInfrastructureVersionsModel{}
+}
+
+func (d GridInfrastructureVersionsDataSource) ResourceType() string {
+	return "azurerm_oracle_grid_infrastructure_versions"
+}
+
+func (d GridInfrastructureVersionsDataSource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return giversions.ValidateGiVersionID
+}
+
+func (d GridInfrastructureVersionsDataSource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Oracle.OracleClient.GiVersions
+			subscriptionId := metadata.Client.Account.SubscriptionId
+
+			state := GridInfrastructureVersionsModel{
+				GridInfrastructureVersions: make([]GridInfrastructureVersionModel, 0),
+			}
+			if err := metadata.Decode(&state); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			id := giversions.NewLocationID(subscriptionId,
+				state.Location)
+
+			options := giversions.ListByLocationOperationOptions{}
+			if state.Shape != "" {
+				options.Shape = pointer.To(giversions.SystemShapes(state.Shape))
+			}
+			if state.Zone != "" {
+				options.Zone = &state.Zone
+			}
+
+			if state.Shape == "" || state.Zone == "" {
+				log.Printf("[WARN] GI Versions data source: Shape or Zone parameter is empty. This may result in unfiltered results from the API. Consider specifying both Shape and Zone for more precise version filtering.")
+			}
+
+			resp, err := client.ListByLocation(ctx, id, options)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return fmt.Errorf("%s was not found", id)
+				}
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+
+			if model := resp.Model; model != nil {
+				for _, element := range *model {
+					if props := element.Properties; props != nil {
+						state.GridInfrastructureVersions = append(state.GridInfrastructureVersions, GridInfrastructureVersionModel{
+							Id:      pointer.From(element.Id),
+							Name:    pointer.From(element.Name),
+							Version: props.Version,
+						})
+					}
+				}
+			}
+
+			metadata.SetID(id)
+
+			return metadata.Encode(&state)
+		},
+	}
+}

--- a/internal/services/oracle/oracle_grid_infrastructure_versions_data_source_test.go
+++ b/internal/services/oracle/oracle_grid_infrastructure_versions_data_source_test.go
@@ -1,0 +1,73 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package oracle_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+type GridInfrastructureVersionsDataSource struct{}
+
+func TestAccGridInfrastructureVersionsDataSource_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_oracle_grid_infrastructure_versions", "test")
+	r := GridInfrastructureVersionsDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("versions.#").IsNotEmpty(),
+				check.That(data.ResourceName).Key("versions.0.id").Exists(),
+				check.That(data.ResourceName).Key("versions.0.name").Exists(),
+				check.That(data.ResourceName).Key("versions.0.version").Exists(),
+			),
+		},
+	})
+}
+
+func TestAccGridInfrastructureVersionsDataSource_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_oracle_grid_infrastructure_versions", "test")
+	r := GridInfrastructureVersionsDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.complete(),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("versions.#").IsNotEmpty(),
+				check.That(data.ResourceName).Key("versions.0.id").Exists(),
+				check.That(data.ResourceName).Key("versions.0.name").Exists(),
+				check.That(data.ResourceName).Key("versions.0.version").Exists(),
+			),
+		},
+	})
+}
+
+func (d GridInfrastructureVersionsDataSource) basic() string {
+	return `
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_oracle_grid_infrastructure_versions" "test" {
+  location = "eastus"
+}
+`
+}
+
+func (d GridInfrastructureVersionsDataSource) complete() string {
+	return `
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_oracle_grid_infrastructure_versions" "test" {
+  location = "eastus"
+  shape    = "Exadata.X9M"
+  zone     = "2"
+}
+`
+}

--- a/internal/services/oracle/registration.go
+++ b/internal/services/oracle/registration.go
@@ -37,6 +37,8 @@ func (r Registration) DataSources() []sdk.DataSource {
 		ExadataInfraDataSource{},
 		ExascaleDatabaseStorageVaultDataSource{},
 		GiVersionsDataSource{},
+		GridInfrastructureMinorVersionsDataSource{},
+		GridInfrastructureVersionsDataSource{},
 		ResourceAnchorDataSource{},
 	}
 }

--- a/website/docs/d/oracle_gi_versions.html.markdown
+++ b/website/docs/d/oracle_gi_versions.html.markdown
@@ -8,6 +8,8 @@ description: |-
 
 # Data Source: azurerm_oracle_gi_versions
 
+!> **Note:** The `azurerm_oracle_gi_versions` data source has been deprecated in favour of the `azurerm_oracle_grid_infrastructure_versions` data source. Please use `azurerm_oracle_grid_infrastructure_versions` instead.
+
 This data source provides the list of GI Versions in Oracle Cloud Infrastructure Database service.
 
 Gets a list of supported GI versions.

--- a/website/docs/d/oracle_grid_infrastructure_minor_versions.html.markdown
+++ b/website/docs/d/oracle_grid_infrastructure_minor_versions.html.markdown
@@ -1,0 +1,78 @@
+---
+subcategory: "Oracle"
+layout: "azurerm"
+page_title: "Azure Resource Manager: Data Source: azurerm_oracle_grid_infrastructure_minor_versions"
+description: |-
+  Gets the list of Oracle Grid Infrastructure minor versions.
+---
+
+# Data Source: azurerm_oracle_grid_infrastructure_minor_versions
+
+Use this data source to access the Oracle Grid Infrastructure minor versions available for a Grid Infrastructure version.
+
+## Example Usage
+
+```hcl
+data "azurerm_oracle_grid_infrastructure_versions" "example" {
+  location = "uksouth"
+  shape    = "ExaDbXS"
+  zone     = "1"
+}
+
+data "azurerm_oracle_grid_infrastructure_minor_versions" "example" {
+  location                    = "uksouth"
+  grid_infrastructure_version = data.azurerm_oracle_grid_infrastructure_versions.example.versions[0].name
+  shape_family                = "EXADB_XS"
+  zone                        = "1"
+}
+
+output "versions" {
+  value = data.azurerm_oracle_grid_infrastructure_minor_versions.example.versions
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `grid_infrastructure_version` - (Required) The name of the Oracle Grid Infrastructure version to query for minor versions.
+
+* `location` - (Required) The Azure Region to query for Oracle Grid Infrastructure minor versions.
+
+---
+
+* `shape_family` - (Optional) The shape family used to filter the available Oracle Grid Infrastructure minor versions. Possible values are `EXADATA` and `EXADB_XS`.
+
+* `zone` - (Optional) The Azure availability zone used to filter the available Oracle Grid Infrastructure minor versions.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Oracle Grid Infrastructure minor versions data source.
+
+* `versions` - A `versions` block as defined below.
+
+---
+
+A `versions` block exports the following:
+
+* `id` - The ID of the Oracle Grid Infrastructure minor version.
+
+* `grid_image_ocid` - The Oracle Cloud Identifier (OCID) of the Grid Infrastructure image.
+
+* `name` - The name of the Oracle Grid Infrastructure minor version.
+
+* `version` - The Oracle Grid Infrastructure minor version.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/configure#define-operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Oracle Grid Infrastructure minor versions.
+
+## API Providers
+<!-- This section is generated, changes will be overwritten -->
+This data source uses the following Azure API Providers:
+
+* `Oracle.Database` - 2025-09-01

--- a/website/docs/d/oracle_grid_infrastructure_versions.html.markdown
+++ b/website/docs/d/oracle_grid_infrastructure_versions.html.markdown
@@ -1,0 +1,67 @@
+---
+subcategory: "Oracle"
+layout: "azurerm"
+page_title: "Azure Resource Manager: Data Source: azurerm_oracle_grid_infrastructure_versions"
+description: |-
+  Gets the list of Oracle Grid Infrastructure versions.
+---
+
+# Data Source: azurerm_oracle_grid_infrastructure_versions
+
+Use this data source to access the Oracle Grid Infrastructure versions available in a location.
+
+## Example Usage
+
+```hcl
+data "azurerm_oracle_grid_infrastructure_versions" "example" {
+  location = "West Europe"
+  shape    = "Exadata.X9M"
+  zone     = "2"
+}
+
+output "versions" {
+  value = data.azurerm_oracle_grid_infrastructure_versions.example.versions
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `location` - (Required) The Azure Region to query for Oracle Grid Infrastructure versions.
+
+---
+
+* `shape` - (Optional) The system shape used to filter the available Oracle Grid Infrastructure versions. Possible values are `ExaDbXS`, `Exadata.X9M`, and `Exadata.X11M`.
+
+* `zone` - (Optional) The Azure availability zone used to filter the available Oracle Grid Infrastructure versions.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Oracle Grid Infrastructure versions data source.
+
+* `versions` - A `versions` block as defined below.
+
+---
+
+A `versions` block exports the following:
+
+* `id` - The ID of the Oracle Grid Infrastructure version.
+
+* `name` - The name of the Oracle Grid Infrastructure version.
+
+* `version` - The Oracle Grid Infrastructure version.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/configure#define-operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Oracle Grid Infrastructure versions.
+
+## API Providers
+<!-- This section is generated, changes will be overwritten -->
+This data source uses the following Azure API Providers:
+
+* `Oracle.Database` - 2025-09-01


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

The following changes have been made to the Oracle provider to support the existing Oracle Grid Infrastructure Minor Versions feature:

New data sources added:

* oracle_grid_infrastructure_minor_versions_data_source
* oracle_grid_infrastructure_versions_data_source

Deprecated data source:

* oracle_gi_versions_data_source

Users should migrate from oracle_gi_versions_data_source to oracle_grid_infrastructure_versions_data_source, as the former is deprecated and may be removed in a future release.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

<img width="690" height="313" alt="20260607-180127-screenshot" src="https://github.com/user-attachments/assets/47459da5-0482-4ee4-a54c-dff92fcc4f56" />

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `oracle_grid_infrastructure_versions_data_source` - added a new data source for Oracle Grid Infrastructure Versions.
* `oracle_grid_infrastructure_minor_versions_data_source` - added a new data source for Oracle Grid Infrastructure Minor Versions.
* `oracle_gi_versions_data_source` - added deprecation notice; use oracle_grid_infrastructure_versions_data_source instead.

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #32531


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
