### PR TITLE
**New Resource** - `azurerm_key_vault_managed_hardware_security_module_security_domain`

### DIFF
--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_key_resource_test.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_key_resource_test.go
@@ -323,13 +323,16 @@ resource "azurerm_key_vault_managed_hardware_security_module" "test" {
   tenant_id                = data.azurerm_client_config.current.tenant_id
   admin_object_ids         = [data.azurerm_client_config.current.object_id]
   purge_protection_enabled = false
+}
 
+resource "azurerm_key_vault_managed_hardware_security_module_security_domain" "test" {
+  managed_hsm_id                            = azurerm_key_vault_managed_hardware_security_module.test.id
   security_domain_key_vault_certificate_ids = [for cert in azurerm_key_vault_certificate.cert : cert.id]
   security_domain_quorum                    = 3
 }
 
 resource "azurerm_key_vault_managed_hardware_security_module_role_assignment" "test" {
-  managed_hsm_id     = azurerm_key_vault_managed_hardware_security_module.test.id
+  managed_hsm_id     = azurerm_key_vault_managed_hardware_security_module_security_domain.test.id // Note: 1:1 relationship with the MHSM resource and uses the same ID.
   name               = "1e243909-064c-6ac3-84e9-1c8bf8d6ad22"
   scope              = "/keys"
   role_definition_id = "/Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/21dbd100-6940-42c2-9190-5d6cb909625b"
@@ -337,7 +340,7 @@ resource "azurerm_key_vault_managed_hardware_security_module_role_assignment" "t
 }
 
 resource "azurerm_key_vault_managed_hardware_security_module_role_assignment" "test1" {
-  managed_hsm_id     = azurerm_key_vault_managed_hardware_security_module.test.id
+  managed_hsm_id     = azurerm_key_vault_managed_hardware_security_module_security_domain.test.id // Note: 1:1 relationship with the MHSM resource and uses the same ID.
   name               = "1e243909-064c-6ac3-84e9-1c8bf8d6ad23"
   scope              = "/keys"
   role_definition_id = "/Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/515eb02d-2335-4d2d-92f2-b1cbdf9c3778"

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_key_rotation_policy_resource_test.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_key_rotation_policy_resource_test.go
@@ -197,13 +197,16 @@ resource "azurerm_key_vault_managed_hardware_security_module" "test" {
   tenant_id                = data.azurerm_client_config.current.tenant_id
   admin_object_ids         = [data.azurerm_client_config.current.object_id]
   purge_protection_enabled = false
+}
 
+resource "azurerm_key_vault_managed_hardware_security_module_security_domain" "test" {
+  managed_hsm_id                            = azurerm_key_vault_managed_hardware_security_module.test.id
   security_domain_key_vault_certificate_ids = [for cert in azurerm_key_vault_certificate.cert : cert.id]
   security_domain_quorum                    = 3
 }
 
 resource "azurerm_key_vault_managed_hardware_security_module_role_assignment" "test" {
-  managed_hsm_id     = azurerm_key_vault_managed_hardware_security_module.test.id
+  managed_hsm_id     = azurerm_key_vault_managed_hardware_security_module_security_domain.test.id // Note: 1:1 relationship with the MHSM resource and uses the same ID.
   name               = "1e243909-064c-6ac3-84e9-1c8bf8d6ad22"
   scope              = "/keys"
   role_definition_id = "/Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/21dbd100-6940-42c2-9190-5d6cb909625b"
@@ -211,7 +214,7 @@ resource "azurerm_key_vault_managed_hardware_security_module_role_assignment" "t
 }
 
 resource "azurerm_key_vault_managed_hardware_security_module_role_assignment" "test1" {
-  managed_hsm_id     = azurerm_key_vault_managed_hardware_security_module.test.id
+  managed_hsm_id     = azurerm_key_vault_managed_hardware_security_module_security_domain.test.id // Note: 1:1 relationship with the MHSM resource and uses the same ID.
   name               = "1e243909-064c-6ac3-84e9-1c8bf8d6ad23"
   scope              = "/keys"
   role_definition_id = "/Microsoft.KeyVault/providers/Microsoft.Authorization/roleDefinitions/515eb02d-2335-4d2d-92f2-b1cbdf9c3778"

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_resource.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_resource.go
@@ -53,8 +53,6 @@ func resourceKeyVaultManagedHardwareSecurityModule() *pluginsdk.Resource {
 			Delete: pluginsdk.DefaultTimeout(60 * time.Minute),
 		},
 
-		CustomizeDiff: pluginsdk.CustomizeDiffShim(keyVaultHSMCustomizeDiff),
-
 		Schema: map[string]*pluginsdk.Schema{
 			"name": {
 				Type:         pluginsdk.TypeString,
@@ -145,38 +143,41 @@ func resourceKeyVaultManagedHardwareSecurityModule() *pluginsdk.Resource {
 				},
 			},
 
-			"security_domain_key_vault_certificate_ids": {
-				Type:         pluginsdk.TypeList,
-				MinItems:     3,
-				MaxItems:     10,
-				Optional:     true,
-				RequiredWith: []string{"security_domain_quorum"},
-				Elem: &pluginsdk.Schema{
-					Type:         pluginsdk.TypeString,
-					ValidateFunc: keyvault.ValidateNestedItemID(keyvault.VersionTypeVersioned, keyvault.NestedItemTypeCertificate),
-				},
-			},
-
-			"security_domain_quorum": {
-				Type:         pluginsdk.TypeInt,
-				Optional:     true,
-				RequiredWith: []string{"security_domain_key_vault_certificate_ids"},
-				ValidateFunc: validation.IntBetween(2, 10),
-			},
-
-			"security_domain_encrypted_data": {
-				Type:      pluginsdk.TypeString,
-				Computed:  true,
-				Sensitive: true,
-			},
-
 			// https://github.com/Azure/azure-rest-api-specs/issues/13365
 			"tags": commonschema.Tags(),
 		},
 	}
 
 	if !features.FivePointOh() {
-		r.Schema["security_domain_key_vault_certificate_ids"].Elem.(*pluginsdk.Schema).ValidateFunc = keyvault.ValidateNestedItemID(keyvault.VersionTypeVersioned, keyvault.NestedItemTypeAny)
+		r.CustomizeDiff = pluginsdk.CustomizeDiffShim(keyVaultHSMCustomizeDiff)
+
+		r.Schema["security_domain_key_vault_certificate_ids"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeList,
+			MinItems:     3,
+			MaxItems:     10,
+			Optional:     true,
+			RequiredWith: []string{"security_domain_quorum"},
+			Elem: &pluginsdk.Schema{
+				Type:         pluginsdk.TypeString,
+				ValidateFunc: keyvault.ValidateNestedItemID(keyvault.VersionTypeVersioned, keyvault.NestedItemTypeAny),
+			},
+			Deprecated: "the `security_domain_key_vault_certificate_ids` property has been deprecated in favour of the `azurerm_key_vault_managed_hardware_security_module_security_domain` resource and will be removed in version 5.0 of the AzureRM Provider.",
+		}
+
+		r.Schema["security_domain_quorum"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeInt,
+			Optional:     true,
+			RequiredWith: []string{"security_domain_key_vault_certificate_ids"},
+			ValidateFunc: validation.IntBetween(2, 10),
+			Deprecated:   "the `security_domain_quorum` property has been deprecated in favour of the `azurerm_key_vault_managed_hardware_security_module_security_domain` resource and will be removed in version 5.0 of the AzureRM Provider.",
+		}
+
+		r.Schema["security_domain_encrypted_data"] = &pluginsdk.Schema{
+			Type:       pluginsdk.TypeString,
+			Computed:   true,
+			Sensitive:  true,
+			Deprecated: "the `security_domain_encrypted_data` property has been deprecated in favour of the `azurerm_key_vault_managed_hardware_security_module_security_domain` resource and will be removed in version 5.0 of the AzureRM Provider.",
+		}
 	}
 
 	return r
@@ -245,20 +246,22 @@ func resourceArmKeyVaultManagedHardwareSecurityModuleCreate(d *pluginsdk.Resourc
 	}
 	client.AddToCache(id, dataPlaneUri)
 
-	// security domain download to activate this module
-	if ok := d.HasChange("security_domain_key_vault_certificate_ids"); ok {
-		// get hsm uri
-		resp, err := client.ManagedHsmClient.Get(ctx, id)
-		if err != nil || resp.Model == nil || resp.Model.Properties == nil || resp.Model.Properties.HsmUri == nil {
-			return fmt.Errorf("got nil HSMUri for %s: %+v", id, err)
-		}
+	if !features.FivePointOh() {
+		// security domain download to activate this module
+		if ok := d.HasChange("security_domain_key_vault_certificate_ids"); ok {
+			// get hsm uri
+			resp, err := client.ManagedHsmClient.Get(ctx, id)
+			if err != nil || resp.Model == nil || resp.Model.Properties == nil || resp.Model.Properties.HsmUri == nil {
+				return fmt.Errorf("got nil HSMUri for %s: %+v", id, err)
+			}
 
-		keyVaultClient := meta.(*clients.Client).KeyVault.ManagementClient
-		encData, err := securityDomainDownload(ctx, client.DataPlaneSecurityDomainsClient, *keyVaultClient, *resp.Model.Properties.HsmUri, d.Get("security_domain_key_vault_certificate_ids").([]interface{}), d.Get("security_domain_quorum").(int))
-		if err != nil {
-			return fmt.Errorf("downloading security domain for %q: %+v", id, err)
+			keyVaultClient := meta.(*clients.Client).KeyVault.ManagementClient
+			encData, err := securityDomainDownload(ctx, client.DataPlaneSecurityDomainsClient, *keyVaultClient, *resp.Model.Properties.HsmUri, d.Get("security_domain_key_vault_certificate_ids").([]interface{}), d.Get("security_domain_quorum").(int))
+			if err != nil {
+				return fmt.Errorf("downloading security domain for %q: %+v", id, err)
+			}
+			d.Set("security_domain_encrypted_data", encData)
 		}
-		d.Set("security_domain_encrypted_data", encData)
 	}
 
 	return resourceArmKeyVaultManagedHardwareSecurityModuleRead(d, meta)
@@ -305,20 +308,22 @@ func resourceArmKeyVaultManagedHardwareSecurityModuleUpdate(d *pluginsdk.Resourc
 		}
 	}
 
-	// security domain download to activate this module
-	if ok := d.HasChange("security_domain_key_vault_certificate_ids"); ok {
-		// get hsm uri
-		resp, err := hsmClient.Get(ctx, *id)
-		if err != nil || resp.Model == nil || resp.Model.Properties == nil || resp.Model.Properties.HsmUri == nil {
-			return fmt.Errorf("got nil HSMUri for %s: %+v", id, err)
-		}
+	if !features.FivePointOh() {
+		// security domain download to activate this module
+		if ok := d.HasChange("security_domain_key_vault_certificate_ids"); ok {
+			// get hsm uri
+			resp, err := hsmClient.Get(ctx, *id)
+			if err != nil || resp.Model == nil || resp.Model.Properties == nil || resp.Model.Properties.HsmUri == nil {
+				return fmt.Errorf("got nil HSMUri for %s: %+v", id, err)
+			}
 
-		keyVaultClient := meta.(*clients.Client).KeyVault.ManagementClient
-		encData, err := securityDomainDownload(ctx, kvClient.DataPlaneSecurityDomainsClient, *keyVaultClient, *resp.Model.Properties.HsmUri, d.Get("security_domain_key_vault_certificate_ids").([]interface{}), d.Get("security_domain_quorum").(int))
-		if err != nil {
-			return fmt.Errorf("downloading security domain for %q: %+v", id, err)
+			keyVaultClient := meta.(*clients.Client).KeyVault.ManagementClient
+			encData, err := securityDomainDownload(ctx, kvClient.DataPlaneSecurityDomainsClient, *keyVaultClient, *resp.Model.Properties.HsmUri, d.Get("security_domain_key_vault_certificate_ids").([]interface{}), d.Get("security_domain_quorum").(int))
+			if err != nil {
+				return fmt.Errorf("downloading security domain for %q: %+v", id, err)
+			}
+			d.Set("security_domain_encrypted_data", encData)
 		}
-		d.Set("security_domain_encrypted_data", encData)
 	}
 
 	return nil

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_resource.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_resource.go
@@ -5,11 +5,7 @@ package managedhsm
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/base64"
-	"encoding/json"
 	"fmt"
-	"io"
 	"log"
 	"time"
 
@@ -31,7 +27,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	kv74 "github.com/jackofallops/kermit/sdk/keyvault/7.4/keyvault"
 )
 
 func resourceKeyVaultManagedHardwareSecurityModule() *pluginsdk.Resource {
@@ -479,83 +474,6 @@ func flattenMHSMNetworkAcls(acl *managedhsms.MHSMNetworkRuleSet) []interface{} {
 			"default_action": defaultAction,
 		},
 	}
-}
-
-func securityDomainDownload(ctx context.Context, sdClient *kv74.HSMSecurityDomainClient, keyClient kv74.BaseClient, vaultBaseUrl string, certIds []interface{}, quorum int) (encDataStr string, err error) {
-	var param kv74.CertificateInfoObject
-
-	param.Required = pointer.To(int32(quorum))
-	certs := make([]kv74.SecurityDomainJSONWebKey, 0, len(certIds))
-	for _, certID := range certIds {
-		certIDStr, ok := certID.(string)
-		if !ok {
-			continue
-		}
-
-		nestedItemType := keyvault.NestedItemTypeCertificate
-		if !features.FivePointOh() {
-			nestedItemType = keyvault.NestedItemTypeAny
-		}
-
-		keyID, err := keyvault.ParseNestedItemID(certIDStr, keyvault.VersionTypeVersioned, nestedItemType)
-		if err != nil {
-			return "", fmt.Errorf("parsing %q: %+v", certIDStr, err)
-		}
-		certRes, err := keyClient.GetCertificate(ctx, keyID.KeyVaultBaseURL, keyID.Name, keyID.Version)
-		if err != nil {
-			return "", fmt.Errorf("retrieving key %s: %v", certID, err)
-		}
-		if certRes.Cer == nil {
-			return "", fmt.Errorf("got nil key for %s", certID)
-		}
-		cert := kv74.SecurityDomainJSONWebKey{
-			Kty:    pointer.To("RSA"),
-			KeyOps: &[]string{""},
-			Alg:    pointer.To("RSA-OAEP-256"),
-		}
-		if certRes.Policy != nil && certRes.Policy.KeyProperties != nil {
-			cert.Kty = pointer.To(string(certRes.Policy.KeyProperties.KeyType))
-		}
-		x5c := ""
-		if contents := certRes.Cer; contents != nil {
-			x5c = base64.StdEncoding.EncodeToString(*contents)
-		}
-		cert.X5c = &[]string{x5c}
-
-		sum256 := sha256.Sum256([]byte(x5c))
-		s256Dst := make([]byte, base64.StdEncoding.EncodedLen(len(sum256)))
-		base64.URLEncoding.Encode(s256Dst, sum256[:])
-		cert.X5tS256 = pointer.To(string(s256Dst))
-		certs = append(certs, cert)
-	}
-	param.Certificates = &certs
-
-	future, err := sdClient.Download(ctx, vaultBaseUrl, param)
-	if err != nil {
-		return "", fmt.Errorf("downloading for %s: %v", vaultBaseUrl, err)
-	}
-
-	originResponse := future.Response()
-	data, err := io.ReadAll(originResponse.Body)
-	if err != nil {
-		return "", err
-	}
-	var encData struct {
-		Value string `json:"value"`
-	}
-
-	err = json.Unmarshal(data, &encData)
-	if err != nil {
-		return "", fmt.Errorf("unmarshal EncData: %v", err)
-	}
-
-	pollerType := custompollers.NewHSMDownloadPoller(sdClient, vaultBaseUrl)
-	poller := pollers.NewPoller(pollerType, 10*time.Second, pollers.DefaultNumberOfDroppedConnectionsToAllow)
-	if err := poller.PollUntilDone(ctx); err != nil {
-		return "", fmt.Errorf("waiting for security domain to download: %+v", err)
-	}
-
-	return encData.Value, err
 }
 
 func keyVaultHSMCustomizeDiff(_ context.Context, d *pluginsdk.ResourceDiff, _ interface{}) error {

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_resource_test.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_resource_test.go
@@ -51,6 +51,9 @@ func TestAccKeyVaultManagedHardwareSecurityModule(t *testing.T) {
 			"rotationPolicy":     testAccMHSMKeyRotationPolicy_all,
 			"data_source":        testAccKeyVaultMHSMKeyDataSource_basic,
 		},
+		"securityDomain": {
+			"combined": testAccKeyVaultManagedHardwareSecurityModuleSecurityDomain_basic,
+		},
 	})
 }
 

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_resource_test.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_resource_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
@@ -69,6 +70,10 @@ func testAccKeyVaultManagedHardwareSecurityModule_basic(t *testing.T) {
 }
 
 func testAccKeyVaultManagedHardwareSecurityModule_download(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("The inline security domain properties are deprecated and removed in 5.0. See TestAccKeyVaultManagedHardwareSecurityModuleSecurityDomain_basic instead.")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_key_vault_managed_hardware_security_module", "test")
 	r := KeyVaultManagedHardwareSecurityModuleResource{}
 

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_role_assignment_resource_test.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_role_assignment_resource_test.go
@@ -87,7 +87,7 @@ resource "azurerm_key_vault_managed_hardware_security_module_role_assignment" "t
   role_definition_id = data.azurerm_key_vault_managed_hardware_security_module_role_definition.officer.resource_manager_id
   principal_id       = data.azurerm_client_config.current.object_id
 }
-`, KeyVaultManagedHardwareSecurityModuleResource{}.download(data, 3))
+`, KeyVaultManagedHardwareSecurityModuleSecurityDomainResource{}.template(data, 3, 2))
 }
 
 func (r KeyVaultManagedHSMRoleAssignmentResource) customRole(data acceptance.TestData) string {

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_role_definition_resource_test.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_role_definition_resource_test.go
@@ -117,5 +117,5 @@ resource "azurerm_key_vault_managed_hardware_security_module_role_definition" "t
 }
 
 func (r KeyVaultMHSMRoleDefinitionResource) template(data acceptance.TestData) string {
-	return KeyVaultManagedHardwareSecurityModuleResource{}.download(data, 3)
+	return KeyVaultManagedHardwareSecurityModuleSecurityDomainResource{}.template(data, 3, 2)
 }

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_security_domain_resource.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_security_domain_resource.go
@@ -33,7 +33,7 @@ func (r KeyVaultMHSMSecurityDomainResource) ModelObject() interface{} {
 type KeyVaultMHSMSecurityDomainResourceSchema struct {
 	ManagedHSMID   string   `tfschema:"managed_hsm_id"`
 	CertificateIds []string `tfschema:"security_domain_key_vault_certificate_ids"`
-	Quorum         int      `tfschema:"security_domain_quorum"`
+	Quorum         int64    `tfschema:"security_domain_quorum"`
 	EncryptedData  string   `tfschema:"security_domain_encrypted_data"`
 }
 
@@ -111,7 +111,7 @@ func (r KeyVaultMHSMSecurityDomainResource) Create() sdk.ResourceFunc {
 				certs[i] = v
 			}
 
-			encData, err := securityDomainDownload(ctx, kvClient.DataPlaneSecurityDomainsClient, *keyVaultClient, *resp.Model.Properties.HsmUri, certs, config.Quorum)
+			encData, err := securityDomainDownload(ctx, kvClient.DataPlaneSecurityDomainsClient, *keyVaultClient, *resp.Model.Properties.HsmUri, certs, int(config.Quorum))
 			if err != nil {
 				return fmt.Errorf("downloading security domain for %q: %+v", managedHsmId, err)
 			}
@@ -178,7 +178,7 @@ func (r KeyVaultMHSMSecurityDomainResource) Update() sdk.ResourceFunc {
 				certs[i] = v
 			}
 
-			encData, err := securityDomainDownload(ctx, kvClient.DataPlaneSecurityDomainsClient, *keyVaultClient, *resp.Model.Properties.HsmUri, certs, config.Quorum)
+			encData, err := securityDomainDownload(ctx, kvClient.DataPlaneSecurityDomainsClient, *keyVaultClient, *resp.Model.Properties.HsmUri, certs, int(config.Quorum)) // Note: Casting here is safe due to max value of `10`
 			if err != nil {
 				return fmt.Errorf("downloading security domain for %q: %+v", managedHsmId, err)
 			}

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_security_domain_resource.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_security_domain_resource.go
@@ -2,15 +2,24 @@ package managedhsm
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"io"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/keyvault"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/managedhsms"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/managedhsm/custompollers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+	keyvault2 "github.com/jackofallops/kermit/sdk/keyvault/7.4/keyvault"
 )
 
 type KeyVaultMHSMSecurityDomainResource struct{}
@@ -139,8 +148,8 @@ func (r KeyVaultMHSMSecurityDomainResource) Read() sdk.ResourceFunc {
 	}
 }
 
-// Update doesn't make any changes to the resource, it's only used for re-downloading the security domain.
-// e.g. Compromised keys, key rotation, etc.
+// Update doesn't make any changes to the resource, it's only used for re-downloading the security domain with updated
+// encryption conditions. e.g. Compromised keys, key rotation, etc.
 func (r KeyVaultMHSMSecurityDomainResource) Update() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Timeout: 30 * time.Minute,
@@ -189,4 +198,81 @@ func (r KeyVaultMHSMSecurityDomainResource) Delete() sdk.ResourceFunc {
 			return nil
 		},
 	}
+}
+
+func securityDomainDownload(ctx context.Context, sdClient *keyvault2.HSMSecurityDomainClient, keyClient keyvault2.BaseClient, vaultBaseUrl string, certIds []interface{}, quorum int) (encDataStr string, err error) {
+	var param keyvault2.CertificateInfoObject
+
+	param.Required = pointer.To(int32(quorum))
+	certs := make([]keyvault2.SecurityDomainJSONWebKey, 0, len(certIds))
+	for _, certID := range certIds {
+		certIDStr, ok := certID.(string)
+		if !ok {
+			continue
+		}
+
+		nestedItemType := keyvault.NestedItemTypeCertificate
+		if !features.FivePointOh() {
+			nestedItemType = keyvault.NestedItemTypeAny
+		}
+
+		keyID, err := keyvault.ParseNestedItemID(certIDStr, keyvault.VersionTypeVersioned, nestedItemType)
+		if err != nil {
+			return "", fmt.Errorf("parsing %q: %+v", certIDStr, err)
+		}
+		certRes, err := keyClient.GetCertificate(ctx, keyID.KeyVaultBaseURL, keyID.Name, keyID.Version)
+		if err != nil {
+			return "", fmt.Errorf("retrieving key %s: %v", certID, err)
+		}
+		if certRes.Cer == nil {
+			return "", fmt.Errorf("got nil key for %s", certID)
+		}
+		cert := keyvault2.SecurityDomainJSONWebKey{
+			Kty:    pointer.To("RSA"),
+			KeyOps: &[]string{""},
+			Alg:    pointer.To("RSA-OAEP-256"),
+		}
+		if certRes.Policy != nil && certRes.Policy.KeyProperties != nil {
+			cert.Kty = pointer.To(string(certRes.Policy.KeyProperties.KeyType))
+		}
+		x5c := ""
+		if contents := certRes.Cer; contents != nil {
+			x5c = base64.StdEncoding.EncodeToString(*contents)
+		}
+		cert.X5c = &[]string{x5c}
+
+		sum256 := sha256.Sum256([]byte(x5c))
+		s256Dst := make([]byte, base64.StdEncoding.EncodedLen(len(sum256)))
+		base64.URLEncoding.Encode(s256Dst, sum256[:])
+		cert.X5tS256 = pointer.To(string(s256Dst))
+		certs = append(certs, cert)
+	}
+	param.Certificates = &certs
+
+	future, err := sdClient.Download(ctx, vaultBaseUrl, param)
+	if err != nil {
+		return "", fmt.Errorf("downloading for %s: %v", vaultBaseUrl, err)
+	}
+
+	originResponse := future.Response()
+	data, err := io.ReadAll(originResponse.Body)
+	if err != nil {
+		return "", err
+	}
+	var encData struct {
+		Value string `json:"value"`
+	}
+
+	err = json.Unmarshal(data, &encData)
+	if err != nil {
+		return "", fmt.Errorf("unmarshal EncData: %v", err)
+	}
+
+	pollerType := custompollers.NewHSMDownloadPoller(sdClient, vaultBaseUrl)
+	poller := pollers.NewPoller(pollerType, 10*time.Second, pollers.DefaultNumberOfDroppedConnectionsToAllow)
+	if err := poller.PollUntilDone(ctx); err != nil {
+		return "", fmt.Errorf("waiting for security domain to download: %+v", err)
+	}
+
+	return encData.Value, err
 }

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_security_domain_resource.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_security_domain_resource.go
@@ -96,14 +96,14 @@ func (r KeyVaultMHSMSecurityDomainResource) Create() sdk.ResourceFunc {
 				return fmt.Errorf("decoding: %+v", err)
 			}
 
-			managedHsmId, err := managedhsms.ParseManagedHSMID(config.ManagedHSMID)
+			id, err := managedhsms.ParseManagedHSMID(config.ManagedHSMID)
 			if err != nil {
 				return err
 			}
 
-			resp, err := hsmClient.Get(ctx, *managedHsmId)
+			resp, err := hsmClient.Get(ctx, *id)
 			if err != nil || resp.Model == nil || resp.Model.Properties == nil || resp.Model.Properties.HsmUri == nil {
-				return fmt.Errorf("got nil HSMUri for %s: %+v", managedHsmId, err)
+				return fmt.Errorf("got nil HSMUri for %s: %+v", id, err)
 			}
 
 			certs := make([]interface{}, len(config.CertificateIds))
@@ -113,12 +113,12 @@ func (r KeyVaultMHSMSecurityDomainResource) Create() sdk.ResourceFunc {
 
 			encData, err := securityDomainDownload(ctx, kvClient.DataPlaneSecurityDomainsClient, *keyVaultClient, *resp.Model.Properties.HsmUri, certs, int(config.Quorum))
 			if err != nil {
-				return fmt.Errorf("downloading security domain for %q: %+v", managedHsmId, err)
+				return fmt.Errorf("downloading security domain for %q: %+v", id, err)
 			}
 
 			config.EncryptedData = encData
 
-			metadata.SetID(managedHsmId)
+			metadata.SetID(id)
 			return metadata.Encode(&config)
 		},
 	}
@@ -130,17 +130,17 @@ func (r KeyVaultMHSMSecurityDomainResource) Read() sdk.ResourceFunc {
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
 			hsmClient := metadata.Client.ManagedHSMs.ManagedHsmClient
 
-			managedHsmId, err := managedhsms.ParseManagedHSMID(metadata.ResourceData.Id())
+			id, err := managedhsms.ParseManagedHSMID(metadata.ResourceData.Id())
 			if err != nil {
 				return err
 			}
 
-			resp, err := hsmClient.Get(ctx, *managedHsmId)
+			resp, err := hsmClient.Get(ctx, *id)
 			if err != nil {
 				if response.WasNotFound(resp.HttpResponse) {
-					return metadata.MarkAsGone(*managedHsmId)
+					return metadata.MarkAsGone(*id)
 				}
-				return fmt.Errorf("retrieving %s: %+v", managedHsmId, err)
+				return fmt.Errorf("retrieving %s: %+v", id, err)
 			}
 
 			return nil
@@ -163,14 +163,14 @@ func (r KeyVaultMHSMSecurityDomainResource) Update() sdk.ResourceFunc {
 				return fmt.Errorf("decoding: %+v", err)
 			}
 
-			managedHsmId, err := managedhsms.ParseManagedHSMID(config.ManagedHSMID)
+			id, err := managedhsms.ParseManagedHSMID(config.ManagedHSMID)
 			if err != nil {
 				return err
 			}
 
-			resp, err := hsmClient.Get(ctx, *managedHsmId)
+			resp, err := hsmClient.Get(ctx, *id)
 			if err != nil || resp.Model == nil || resp.Model.Properties == nil || resp.Model.Properties.HsmUri == nil {
-				return fmt.Errorf("got nil HSMUri for %s: %+v", managedHsmId, err)
+				return fmt.Errorf("got nil HSMUri for %s: %+v", id, err)
 			}
 
 			certs := make([]interface{}, len(config.CertificateIds))
@@ -180,7 +180,7 @@ func (r KeyVaultMHSMSecurityDomainResource) Update() sdk.ResourceFunc {
 
 			encData, err := securityDomainDownload(ctx, kvClient.DataPlaneSecurityDomainsClient, *keyVaultClient, *resp.Model.Properties.HsmUri, certs, int(config.Quorum)) // Note: Casting here is safe due to max value of `10`
 			if err != nil {
-				return fmt.Errorf("downloading security domain for %q: %+v", managedHsmId, err)
+				return fmt.Errorf("downloading security domain for %q: %+v", id, err)
 			}
 
 			config.EncryptedData = encData

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_security_domain_resource.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_security_domain_resource.go
@@ -1,0 +1,192 @@
+package managedhsm
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/keyvault"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/managedhsms"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type KeyVaultMHSMSecurityDomainResource struct{}
+
+var _ sdk.ResourceWithUpdate = KeyVaultMHSMSecurityDomainResource{}
+
+func (r KeyVaultMHSMSecurityDomainResource) ModelObject() interface{} {
+	return &KeyVaultMHSMSecurityDomainResourceSchema{}
+}
+
+type KeyVaultMHSMSecurityDomainResourceSchema struct {
+	ManagedHSMID   string   `tfschema:"managed_hsm_id"`
+	CertificateIds []string `tfschema:"security_domain_key_vault_certificate_ids"`
+	Quorum         int      `tfschema:"security_domain_quorum"`
+	EncryptedData  string   `tfschema:"security_domain_encrypted_data"`
+}
+
+func (r KeyVaultMHSMSecurityDomainResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return managedhsms.ValidateManagedHSMID
+}
+
+func (r KeyVaultMHSMSecurityDomainResource) ResourceType() string {
+	return "azurerm_key_vault_managed_hardware_security_module_security_domain"
+}
+
+func (r KeyVaultMHSMSecurityDomainResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"managed_hsm_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: managedhsms.ValidateManagedHSMID,
+		},
+
+		"security_domain_key_vault_certificate_ids": {
+			Type:     pluginsdk.TypeList,
+			Required: true,
+			MinItems: 3,
+			MaxItems: 10,
+			Elem: &pluginsdk.Schema{
+				Type:         pluginsdk.TypeString,
+				ValidateFunc: keyvault.ValidateNestedItemID(keyvault.VersionTypeVersioned, keyvault.NestedItemTypeCertificate),
+			},
+		},
+
+		"security_domain_quorum": {
+			Type:         pluginsdk.TypeInt,
+			Required:     true,
+			ValidateFunc: validation.IntBetween(2, 10),
+		},
+	}
+}
+
+func (r KeyVaultMHSMSecurityDomainResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"security_domain_encrypted_data": {
+			Type:      pluginsdk.TypeString,
+			Computed:  true,
+			Sensitive: true,
+		},
+	}
+}
+
+func (r KeyVaultMHSMSecurityDomainResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			kvClient := metadata.Client.ManagedHSMs
+			hsmClient := kvClient.ManagedHsmClient
+			keyVaultClient := metadata.Client.KeyVault.ManagementClient
+
+			var config KeyVaultMHSMSecurityDomainResourceSchema
+			if err := metadata.Decode(&config); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			managedHsmId, err := managedhsms.ParseManagedHSMID(config.ManagedHSMID)
+			if err != nil {
+				return err
+			}
+
+			resp, err := hsmClient.Get(ctx, *managedHsmId)
+			if err != nil || resp.Model == nil || resp.Model.Properties == nil || resp.Model.Properties.HsmUri == nil {
+				return fmt.Errorf("got nil HSMUri for %s: %+v", managedHsmId, err)
+			}
+
+			certs := make([]interface{}, len(config.CertificateIds))
+			for i, v := range config.CertificateIds {
+				certs[i] = v
+			}
+
+			encData, err := securityDomainDownload(ctx, kvClient.DataPlaneSecurityDomainsClient, *keyVaultClient, *resp.Model.Properties.HsmUri, certs, config.Quorum)
+			if err != nil {
+				return fmt.Errorf("downloading security domain for %q: %+v", managedHsmId, err)
+			}
+
+			config.EncryptedData = encData
+
+			metadata.SetID(managedHsmId)
+			return metadata.Encode(&config)
+		},
+	}
+}
+
+func (r KeyVaultMHSMSecurityDomainResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			hsmClient := metadata.Client.ManagedHSMs.ManagedHsmClient
+
+			managedHsmId, err := managedhsms.ParseManagedHSMID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			resp, err := hsmClient.Get(ctx, *managedHsmId)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return metadata.MarkAsGone(*managedHsmId)
+				}
+				return fmt.Errorf("retrieving %s: %+v", managedHsmId, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+// Update doesn't make any changes to the resource, it's only used for re-downloading the security domain.
+// e.g. Compromised keys, key rotation, etc.
+func (r KeyVaultMHSMSecurityDomainResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			kvClient := metadata.Client.ManagedHSMs
+			hsmClient := kvClient.ManagedHsmClient
+			keyVaultClient := metadata.Client.KeyVault.ManagementClient
+
+			var config KeyVaultMHSMSecurityDomainResourceSchema
+			if err := metadata.Decode(&config); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			managedHsmId, err := managedhsms.ParseManagedHSMID(config.ManagedHSMID)
+			if err != nil {
+				return err
+			}
+
+			resp, err := hsmClient.Get(ctx, *managedHsmId)
+			if err != nil || resp.Model == nil || resp.Model.Properties == nil || resp.Model.Properties.HsmUri == nil {
+				return fmt.Errorf("got nil HSMUri for %s: %+v", managedHsmId, err)
+			}
+
+			certs := make([]interface{}, len(config.CertificateIds))
+			for i, v := range config.CertificateIds {
+				certs[i] = v
+			}
+
+			encData, err := securityDomainDownload(ctx, kvClient.DataPlaneSecurityDomainsClient, *keyVaultClient, *resp.Model.Properties.HsmUri, certs, config.Quorum)
+			if err != nil {
+				return fmt.Errorf("downloading security domain for %q: %+v", managedHsmId, err)
+			}
+
+			config.EncryptedData = encData
+			return metadata.Encode(&config)
+		},
+	}
+}
+
+// Delete is not possible here as there's no _actual_ resource to manage, this resource facilitates a download of a security domain for HSM recovery purposes.
+func (r KeyVaultMHSMSecurityDomainResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			// No-op for delete, the state is simply removed.
+			return nil
+		},
+	}
+}

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_security_domain_resource_test.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_security_domain_resource_test.go
@@ -1,0 +1,169 @@
+package managedhsm_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/managedhsms"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type KeyVaultManagedHardwareSecurityModuleSecurityDomainResource struct{}
+
+func TestAccKeyVaultManagedHardwareSecurityModuleSecurityDomain_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_key_vault_managed_hardware_security_module_security_domain", "test")
+	r := KeyVaultManagedHardwareSecurityModuleSecurityDomainResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.update(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+	})
+}
+
+func (r KeyVaultManagedHardwareSecurityModuleSecurityDomainResource) basic(data acceptance.TestData) string {
+	return r.template(data, 3, 2)
+}
+
+func (r KeyVaultManagedHardwareSecurityModuleSecurityDomainResource) update(data acceptance.TestData) string {
+	return r.template(data, 4, 2)
+}
+
+func (r KeyVaultManagedHardwareSecurityModuleSecurityDomainResource) template(data acceptance.TestData, certCount int, quorum int) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-KV-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_key_vault" "test" {
+  name                       = "acctest%[3]s"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "standard"
+  soft_delete_retention_days = 7
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+    key_permissions = [
+      "Create",
+      "Delete",
+      "Get",
+      "Purge",
+      "Recover",
+      "Update",
+      "GetRotationPolicy",
+    ]
+    secret_permissions = [
+      "Delete",
+      "Get",
+      "Set",
+    ]
+    certificate_permissions = [
+      "Create",
+      "Delete",
+      "DeleteIssuers",
+      "Get",
+      "Purge",
+      "Update"
+    ]
+  }
+  tags = {
+    environment = "Production"
+  }
+}
+
+resource "azurerm_key_vault_certificate" "cert" {
+  count        = %[4]d
+  name         = "acchsmcert${count.index}"
+  key_vault_id = azurerm_key_vault.test.id
+  certificate_policy {
+    issuer_parameters {
+      name = "Self"
+    }
+    key_properties {
+      exportable = true
+      key_size   = 2048
+      key_type   = "RSA"
+      reuse_key  = true
+    }
+    lifetime_action {
+      action {
+        action_type = "AutoRenew"
+      }
+      trigger {
+        days_before_expiry = 30
+      }
+    }
+    secret_properties {
+      content_type = "application/x-pkcs12"
+    }
+    x509_certificate_properties {
+      extended_key_usage = []
+      key_usage = [
+        "cRLSign",
+        "dataEncipherment",
+        "digitalSignature",
+        "keyAgreement",
+        "keyCertSign",
+        "keyEncipherment",
+      ]
+      subject            = "CN=hello-world"
+      validity_in_months = 12
+    }
+  }
+}
+
+resource "azurerm_key_vault_managed_hardware_security_module" "test" {
+  name                     = "acctestkvHsm%[3]s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  sku_name                 = "Standard_B1"
+  tenant_id                = data.azurerm_client_config.current.tenant_id
+  admin_object_ids         = [data.azurerm_client_config.current.object_id]
+  purge_protection_enabled = false
+}
+
+resource "azurerm_key_vault_managed_hardware_security_module_security_domain" "test" {
+  managed_hsm_id                            = azurerm_key_vault_managed_hardware_security_module.test.id
+  security_domain_key_vault_certificate_ids = [for cert in azurerm_key_vault_certificate.cert : cert.id]
+  security_domain_quorum                    = %[5]d
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, certCount, quorum)
+}
+
+func (KeyVaultManagedHardwareSecurityModuleSecurityDomainResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := managedhsms.ParseManagedHSMID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.ManagedHSMs.ManagedHsmClient.Get(ctx, *id)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
+	}
+
+	return new(resp.Model != nil), nil
+}

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_security_domain_resource_test.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_security_domain_resource_test.go
@@ -26,8 +26,7 @@ func testAccKeyVaultManagedHardwareSecurityModuleSecurityDomain_basic(t *testing
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
-		},
-		data.ImportStep(),
+		}, // Note: ImportStep() is not required as the resource has no readable data.
 		{
 			Config: r.update(data),
 			Check: acceptance.ComposeTestCheckFunc(

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_security_domain_resource_test.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_security_domain_resource_test.go
@@ -14,7 +14,8 @@ import (
 
 type KeyVaultManagedHardwareSecurityModuleSecurityDomainResource struct{}
 
-func TestAccKeyVaultManagedHardwareSecurityModuleSecurityDomain_basic(t *testing.T) {
+// Note: Due to serialisation of this resource's testing, we're combining basic and update tests into a single test.
+func testAccKeyVaultManagedHardwareSecurityModuleSecurityDomain_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_key_vault_managed_hardware_security_module_security_domain", "test")
 	r := KeyVaultManagedHardwareSecurityModuleSecurityDomainResource{}
 
@@ -40,7 +41,7 @@ func (r KeyVaultManagedHardwareSecurityModuleSecurityDomainResource) basic(data 
 }
 
 func (r KeyVaultManagedHardwareSecurityModuleSecurityDomainResource) update(data acceptance.TestData) string {
-	return r.template(data, 4, 2)
+	return r.template(data, 5, 3)
 }
 
 func (r KeyVaultManagedHardwareSecurityModuleSecurityDomainResource) template(data acceptance.TestData, certCount int, quorum int) string {

--- a/internal/services/managedhsm/key_vault_managed_hardware_security_module_security_domain_resource_test.go
+++ b/internal/services/managedhsm/key_vault_managed_hardware_security_module_security_domain_resource_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-07-01/managedhsms"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
@@ -166,5 +167,5 @@ func (KeyVaultManagedHardwareSecurityModuleSecurityDomainResource) Exists(ctx co
 		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return new(resp.Model != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }

--- a/internal/services/managedhsm/registration.go
+++ b/internal/services/managedhsm/registration.go
@@ -62,6 +62,7 @@ func (r Registration) Resources() []sdk.Resource {
 		KeyVaultMHSMRoleDefinitionResource{},
 		KeyVaultManagedHSMRoleAssignmentResource{},
 		KeyVaultMHSMKeyRotationPolicyResource{},
+		KeyVaultMHSMSecurityDomainResource{},
 	}
 }
 

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -469,6 +469,12 @@ Please follow the format in the example below for listing breaking changes in re
 
 * The `contact` property is now Required.
 
+### `azurerm_key_vault_managed_hardware_security_module`
+
+* The deprecated `security_domain_key_vault_certificate_ids` property has been removed. Please use the `azurerm_key_vault_managed_hardware_security_module_security_domain` resource instead.
+* The deprecated `security_domain_quorum` property has been removed. Please use the `azurerm_key_vault_managed_hardware_security_module_security_domain` resource instead.
+* The deprecated `security_domain_encrypted_data` attribute has been removed. Please use the `azurerm_key_vault_managed_hardware_security_module_security_domain` resource instead.
+
 ### `azurerm_kubernetes_cluster`
 
 * The deprecated `default_node_pool.linux_os_config.transparent_huge_page_enabled` property has been removed in favour of the `default_node_pool.linux_os_config.transparent_huge_page` property.

--- a/website/docs/r/key_vault_managed_hardware_security_module.html.markdown
+++ b/website/docs/r/key_vault_managed_hardware_security_module.html.markdown
@@ -70,10 +70,6 @@ The following arguments are supported:
 
 * `network_acls` - (Optional) A `network_acls` block as defined below.
 
-* `security_domain_key_vault_certificate_ids` - (Optional) A list of KeyVault certificates resource IDs (minimum of three and up to a maximum of 10) to activate this Managed HSM. More information see [activate-your-managed-hsm](https://learn.microsoft.com/azure/key-vault/managed-hsm/quick-create-cli#activate-your-managed-hsm)
-
-* `security_domain_quorum` - (Optional) Specifies the minimum number of shares required to decrypt the security domain for recovery. This is required when `security_domain_key_vault_certificate_ids` is specified. Valid values are between 2 and 10.
-
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ---
@@ -91,8 +87,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 * `id` - The Key Vault Secret Managed Hardware Security Module ID.
 
 * `hsm_uri` - The URI of the Key Vault Managed Hardware Security Module, used for performing operations on keys.
-
-* `security_domain_encrypted_data` - This attribute can be used for disaster recovery or when creating another Managed HSM that shares the same security domain.
 
 ## Timeouts
 

--- a/website/docs/r/key_vault_managed_hardware_security_module_security_domain.html.markdown
+++ b/website/docs/r/key_vault_managed_hardware_security_module_security_domain.html.markdown
@@ -141,11 +141,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Key Vault Managed Hardware Security Module Security Domains can be imported using the `resource id`, e.g.
-
-```shell
-terraform import azurerm_key_vault_managed_hardware_security_module_security_domain.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.KeyVault/managedHSMs/hsm1
-```
+Key Vault Managed Hardware Security Module Security Domains cannot be imported.
 
 ## API Providers
 <!-- This section is generated, changes will be overwritten -->

--- a/website/docs/r/key_vault_managed_hardware_security_module_security_domain.html.markdown
+++ b/website/docs/r/key_vault_managed_hardware_security_module_security_domain.html.markdown
@@ -18,6 +18,7 @@ Manages a Key Vault Managed Hardware Security Module Security Domain.
 provider "azurerm" {
   features {}
 }
+
 data "azurerm_client_config" "current" {
 }
 

--- a/website/docs/r/key_vault_managed_hardware_security_module_security_domain.html.markdown
+++ b/website/docs/r/key_vault_managed_hardware_security_module_security_domain.html.markdown
@@ -146,3 +146,9 @@ Key Vault Managed Hardware Security Module Security Domains can be imported usin
 ```shell
 terraform import azurerm_key_vault_managed_hardware_security_module_security_domain.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.KeyVault/managedHSMs/hsm1
 ```
+
+## API Providers
+<!-- This section is generated, changes will be overwritten -->
+This resource uses the following Azure API Providers:
+
+* `Microsoft.KeyVault` - 2023-07-01

--- a/website/docs/r/key_vault_managed_hardware_security_module_security_domain.html.markdown
+++ b/website/docs/r/key_vault_managed_hardware_security_module_security_domain.html.markdown
@@ -1,0 +1,147 @@
+---
+subcategory: "Key Vault"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_key_vault_managed_hardware_security_module_security_domain"
+description: |-
+  Manages a Key Vault Managed Hardware Security Module Security Domain.
+---
+
+# azurerm_key_vault_managed_hardware_security_module_security_domain
+
+Manages a Key Vault Managed Hardware Security Module Security Domain.
+
+~> **Note:** The Security Domain download is an activation step that enables the Managed HSM. There is no Azure API operation to "delete" or "deactivate" a Security Domain once downloaded. Therefore, deleting this resource from Terraform will only remove it from the Terraform state and will not modify the underlying Managed HSM.
+
+## Example Usage
+
+```hcl
+provider "azurerm" {
+  features {}
+}
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_key_vault_managed_hardware_security_module" "example" {
+  name                       = "exampleKVHsm"
+  resource_group_name        = azurerm_resource_group.example.name
+  location                   = azurerm_resource_group.example.location
+  sku_name                   = "Standard_B1"
+  purge_protection_enabled   = false
+  soft_delete_retention_days = 90
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  admin_object_ids           = [data.azurerm_client_config.current.object_id]
+
+  tags = {
+    Env = "Test"
+  }
+}
+
+resource "azurerm_key_vault" "example" {
+  name                       = "exampleKV"
+  location                   = azurerm_resource_group.example.location
+  resource_group_name        = azurerm_resource_group.example.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "standard"
+  soft_delete_retention_days = 7
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+    certificate_permissions = [
+      "Create",
+      "Delete",
+      "DeleteIssuers",
+      "Get",
+      "Purge",
+      "Update"
+    ]
+  }
+}
+
+resource "azurerm_key_vault_certificate" "example" {
+  count        = 3
+  name         = "example-cert-${count.index}"
+  key_vault_id = azurerm_key_vault.example.id
+  certificate_policy {
+    issuer_parameters {
+      name = "Self"
+    }
+    key_properties {
+      exportable = true
+      key_size   = 2048
+      key_type   = "RSA"
+      reuse_key  = true
+    }
+    lifetime_action {
+      action {
+        action_type = "AutoRenew"
+      }
+      trigger {
+        days_before_expiry = 30
+      }
+    }
+    secret_properties {
+      content_type = "application/x-pkcs12"
+    }
+    x509_certificate_properties {
+      extended_key_usage = []
+      key_usage = [
+        "cRLSign",
+        "dataEncipherment",
+        "digitalSignature",
+        "keyAgreement",
+        "keyCertSign",
+        "keyEncipherment",
+      ]
+      subject            = "CN=hello-world"
+      validity_in_months = 12
+    }
+  }
+}
+
+resource "azurerm_key_vault_managed_hardware_security_module_security_domain" "example" {
+  managed_hsm_id                            = azurerm_key_vault_managed_hardware_security_module.example.id
+  security_domain_key_vault_certificate_ids = [for cert in azurerm_key_vault_certificate.example : cert.id]
+  security_domain_quorum                    = 2
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `managed_hsm_id` - (Required) The ID of the Key Vault Managed Hardware Security Module that should be activated. Changing this forces a new resource to be created.
+
+* `security_domain_key_vault_certificate_ids` - (Required) A list of KeyVault certificates resource IDs (minimum of three and up to a maximum of 10) to activate this Managed HSM. More information see [activate-your-managed-hsm](https://learn.microsoft.com/azure/key-vault/managed-hsm/quick-create-cli#activate-your-managed-hsm)
+
+* `security_domain_quorum` - (Required) Specifies the minimum number of shares required to decrypt the security domain for recovery. Valid values are between 2 and 10.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Key Vault Managed Hardware Security Module.
+
+* `security_domain_encrypted_data` - This attribute can be used for disaster recovery or when creating another Managed HSM that shares the same security domain.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/configure#define-operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Key Vault Managed Hardware Security Module Security Domain.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Key Vault Managed Hardware Security Module Security Domain.
+* `update` - (Defaults to 30 minutes) Used when updating the Key Vault Managed Hardware Security Module Security Domain.
+* `delete` - (Defaults to 5 minutes) Used when deleting the Key Vault Managed Hardware Security Module Security Domain.
+
+## Import
+
+Key Vault Managed Hardware Security Module Security Domains can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_key_vault_managed_hardware_security_module_security_domain.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.KeyVault/managedHSMs/hsm1
+```


### PR DESCRIPTION
## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Deprecates Security Domain properties from `azurerm_key_vault_managed_hardware_security_module` to avoid potential race condition in use of Private Endpoints. These properties are exposed instead as the new `azurerm_key_vault_managed_hardware_security_module_security_domain` resource that allows management of the keys and quorum size, and the downloading of the Security Domain data.

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* **New Resource:** - `azurerm_key_vault_managed_hardware_security_module_security_domain`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
