### PR TITLE
provider: deprecate `skip_provider_registration`

### DIFF
--- a/internal/provider/framework/config.go
+++ b/internal/provider/framework/config.go
@@ -574,14 +574,14 @@ func (p *ProviderConfig) Load(ctx context.Context, data *ProviderModel, tfVersio
 	resourceProviderRegistrationSet := getEnvStringOrDefault(data.ResourceProviderRegistrations, "ARM_RESOURCE_PROVIDER_REGISTRATIONS", resourceproviders.ProviderRegistrationsNone)
 	if !providerfeatures.FivePointOh() {
 		resourceProviderRegistrationSet = getEnvStringOrDefault(data.ResourceProviderRegistrations, "ARM_RESOURCE_PROVIDER_REGISTRATIONS", resourceproviders.ProviderRegistrationsLegacy)
-	}
 
-	if !data.SkipProviderRegistration.IsNull() && !data.SkipProviderRegistration.ValueBool() {
-		if resourceProviderRegistrationSet != resourceproviders.ProviderRegistrationsLegacy {
-			diags.Append(diag.NewErrorDiagnostic("resource provider registration misconfiguration", "provider property `skip_provider_registration` cannot be set at the same time as `resource_provider_registrations`, please remove `skip_provider_registration` from your configuration or unset the `ARM_SKIP_PROVIDER_REGISTRATION` environment variable"))
+		if !data.SkipProviderRegistration.IsNull() && !data.SkipProviderRegistration.ValueBool() {
+			if resourceProviderRegistrationSet != resourceproviders.ProviderRegistrationsLegacy {
+				diags.Append(diag.NewErrorDiagnostic("resource provider registration misconfiguration", "provider property `skip_provider_registration` cannot be set at the same time as `resource_provider_registrations`, please remove `skip_provider_registration` from your configuration or unset the `ARM_SKIP_PROVIDER_REGISTRATION` environment variable"))
+			}
+
+			resourceProviderRegistrationSet = resourceproviders.ProviderRegistrationsNone
 		}
-
-		resourceProviderRegistrationSet = resourceproviders.ProviderRegistrationsNone
 	}
 
 	requiredResourceProviders, err := resourceproviders.GetResourceProvidersSet(resourceProviderRegistrationSet)

--- a/internal/provider/framework/model.go
+++ b/internal/provider/framework/model.go
@@ -38,9 +38,10 @@ type ProviderModel struct {
 	StorageUseAzureAD              types.Bool   `tfsdk:"storage_use_azuread"`
 	EnhancedValidation             types.List   `tfsdk:"enhanced_validation"`
 	Features                       types.List   `tfsdk:"features"`
-	SkipProviderRegistration       types.Bool   `tfsdk:"skip_provider_registration"` // TODO - Remove in 5.0
 	ResourceProviderRegistrations  types.String `tfsdk:"resource_provider_registrations"`
 	ResourceProvidersToRegister    types.List   `tfsdk:"resource_providers_to_register"`
+
+	SkipProviderRegistration types.Bool `tfsdk:"skip_provider_registration"` // TODO - Remove in 5.0
 }
 
 type Features struct {
@@ -177,16 +178,18 @@ var TemplateDeploymentAttributes = map[string]attr.Type{
 
 type VirtualMachine struct {
 	DeleteOsDiskOnDeletion           types.Bool `tfsdk:"delete_os_disk_on_deletion"`
-	GracefulShutdown                 types.Bool `tfsdk:"graceful_shutdown"` // TODO: Remove in 5.0 - Currently not possible to deprecate feature block struct items via feature flagging. Feature made redundant/ineffective by a breaking API change.
 	SkipShutdownAndForceDelete       types.Bool `tfsdk:"skip_shutdown_and_force_delete"`
 	DetachImplicitDataDiskOnDeletion types.Bool `tfsdk:"detach_implicit_data_disk_on_deletion"`
+
+	GracefulShutdown types.Bool `tfsdk:"graceful_shutdown"` // TODO: Remove in 5.0 - Currently not possible to deprecate feature block struct items via feature flagging. Feature made redundant/ineffective by a breaking API change.
 }
 
 var VirtualMachineAttributes = map[string]attr.Type{
 	"delete_os_disk_on_deletion":            types.BoolType,
 	"detach_implicit_data_disk_on_deletion": types.BoolType,
-	"graceful_shutdown":                     types.BoolType, // TODO: Remove in 5.0 - Currently not possible to deprecate feature block struct items via feature flagging. Feature made redundant/ineffective by a breaking API change.
 	"skip_shutdown_and_force_delete":        types.BoolType,
+
+	"graceful_shutdown": types.BoolType, // TODO: Remove in 5.0 - Currently not possible to deprecate feature block struct items via feature flagging. Feature made redundant/ineffective by a breaking API change.
 }
 
 type VirtualMachineScaleSet struct {

--- a/internal/provider/framework/provider.go
+++ b/internal/provider/framework/provider.go
@@ -199,12 +199,6 @@ func (p *azureRmFrameworkProvider) Schema(_ context.Context, _ provider.SchemaRe
 			},
 
 			// Advanced feature flags
-			"skip_provider_registration": schema.BoolAttribute{
-				Optional:           true,
-				Description:        "Should the AzureRM Provider skip registering all of the Resource Providers that it supports, if they're not already registered?",
-				DeprecationMessage: "This property is deprecated and will be removed in v5.0 of the AzureRM provider. Please use the `resource_provider_registrations` property instead.",
-			},
-
 			"storage_use_azuread": schema.BoolAttribute{
 				Optional:    true,
 				Description: "Should the AzureRM Provider use Azure AD Authentication when accessing the Storage Data Plane APIs?",
@@ -539,6 +533,12 @@ func (p *azureRmFrameworkProvider) Schema(_ context.Context, _ provider.SchemaRe
 		response.Schema.Blocks["features"].(schema.ListNestedBlock).NestedObject.Blocks["virtual_machine"].(schema.ListNestedBlock).NestedObject.Attributes["graceful_shutdown"] = schema.BoolAttribute{
 			Optional:           true,
 			DeprecationMessage: "'graceful_shutdown' has been deprecated and will be removed from v5.0 of the AzureRM provider.",
+		}
+
+		response.Schema.Attributes["skip_provider_registration"] = schema.BoolAttribute{
+			Optional:           true,
+			Description:        "Should the AzureRM Provider skip registering all of the Resource Providers that it supports, if they're not already registered?",
+			DeprecationMessage: "This property is deprecated and will be removed in v5.0 of the AzureRM provider. Please use the `resource_provider_registrations` property instead.",
 		}
 	}
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -367,15 +367,6 @@ func azureProvider(supportLegacyTestSuite bool, testName string) *schema.Provide
 				},
 			},
 
-			// TODO: Remove `skip_provider_registration` in v5.0
-			"skip_provider_registration": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("ARM_SKIP_PROVIDER_REGISTRATION", nil),
-				Description: "Should the AzureRM Provider skip registering all of the Resource Providers that it supports, if they're not already registered?",
-				Deprecated:  "This property is deprecated and will be removed in v5.0 of the AzureRM provider. Please use the `resource_provider_registrations` property instead.",
-			},
-
 			"storage_use_azuread": {
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -414,6 +405,13 @@ func azureProvider(supportLegacyTestSuite bool, testName string) *schema.Provide
 
 	if !providerfeatures.FivePointOh() {
 		p.Schema["resource_provider_registrations"].DefaultFunc = schema.EnvDefaultFunc("ARM_RESOURCE_PROVIDER_REGISTRATIONS", resourceproviders.ProviderRegistrationsLegacy)
+		p.Schema["skip_provider_registration"] = &schema.Schema{
+			Type:        schema.TypeBool,
+			Optional:    true,
+			DefaultFunc: schema.EnvDefaultFunc("ARM_SKIP_PROVIDER_REGISTRATION", nil),
+			Description: "Should the AzureRM Provider skip registering all of the Resource Providers that it supports, if they're not already registered?",
+			Deprecated:  "This property is deprecated and will be removed in v5.0 of the AzureRM provider. Please use the `resource_provider_registrations` property instead.",
+		}
 	}
 
 	return p
@@ -536,12 +534,13 @@ func providerConfigure(p *schema.Provider, testName string) schema.ConfigureCont
 func buildClient(ctx context.Context, p *schema.Provider, d *schema.ResourceData, authConfig *auth.Credentials, testName string) (*clients.Client, diag.Diagnostics) {
 	providerRegistrations := d.Get("resource_provider_registrations").(string)
 
-	// TODO: Remove in v5.0
-	if d.Get("skip_provider_registration").(bool) {
-		if providerRegistrations != resourceproviders.ProviderRegistrationsLegacy {
-			return nil, diag.Errorf("provider property `skip_provider_registration` cannot be set at the same time as `resource_provider_registrations`, please remove `skip_provider_registration` from your configuration or unset the `ARM_SKIP_PROVIDER_REGISTRATION` environment variable")
+	if !providerfeatures.FivePointOh() {
+		if d.Get("skip_provider_registration").(bool) {
+			if providerRegistrations != resourceproviders.ProviderRegistrationsLegacy {
+				return nil, diag.Errorf("provider property `skip_provider_registration` cannot be set at the same time as `resource_provider_registrations`, please remove `skip_provider_registration` from your configuration or unset the `ARM_SKIP_PROVIDER_REGISTRATION` environment variable")
+			}
+			providerRegistrations = resourceproviders.ProviderRegistrationsNone
 		}
-		providerRegistrations = resourceproviders.ProviderRegistrationsNone
 	}
 
 	requiredResourceProviders, err := resourceproviders.GetResourceProvidersSet(providerRegistrations)

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -152,8 +152,11 @@ func TestAccProvider_resourceProviders_legacy(t *testing.T) {
 	}
 }
 
-// TODO: Remove this test in v5.0
 func TestAccProvider_resourceProviders_deprecatedSkip(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("skipping as `skip_provider_registrations` is no longer supported in 5.0")
+	}
+
 	if os.Getenv("TF_ACC") == "" {
 		t.Skip("TF_ACC not set")
 	}

--- a/internal/services/redhatopenshift/redhat_openshift_cluster_resource_test.go
+++ b/internal/services/redhatopenshift/redhat_openshift_cluster_resource_test.go
@@ -902,7 +902,6 @@ resource "azurerm_redhat_openshift_cluster" "test" {
 func (OpenShiftClusterResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
-  skip_provider_registration = true
   features {
     key_vault {
       recover_soft_deleted_key_vaults    = false

--- a/internal/services/resource/resource_provider_registration_resource_test.go
+++ b/internal/services/resource/resource_provider_registration_resource_test.go
@@ -140,7 +140,7 @@ func (ResourceProviderRegistrationResource) basic(name string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
-  skip_provider_registration = true
+  resource_provider_registrations = "none"
 }
 
 resource "azurerm_resource_provider_registration" "test" {
@@ -220,7 +220,7 @@ provider "azurerm" {
   subscription_id = "%[1]s"
 
   features {}
-  skip_provider_registration = true
+  resource_provider_registrations = "none"
 }
 
 resource "azurerm_resource_provider_registration" "test" {

--- a/internal/services/web/app_service_plan_resource.go
+++ b/internal/services/web/app_service_plan_resource.go
@@ -266,7 +266,6 @@ func resourceAppServicePlanRead(d *pluginsdk.ResourceData, meta interface{}) err
 	}
 
 	// A 404 doesn't error from the app service plan sdk so we'll add this check here to catch resource not found responses
-	// TODO This block can be removed if https://github.com/Azure/azure-sdk-for-go/issues/5407 gets addressed.
 	if utils.ResponseWasNotFound(resp.Response) {
 		log.Printf("[DEBUG] App Service Plan %q was not found in Resource Group %q - removing from state!", id.ServerFarmName, id.ResourceGroup)
 		d.SetId("")

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -49,6 +49,8 @@ More information on [how to pin the version of a Terraform Provider being used c
 
 In version 5.0, the default behaviour for Resource Provider registration has changed. The `resource_provider_registrations` property now defaults to `none` instead of `legacy`.
 
+Additionally, the `skip_provider_registration` property has been removed.
+
 ##### What this means
 
 Previously, the provider would automatically attempt to register a large set of Azure Resource Providers (~60 RPs) when initializing. This could:
@@ -74,6 +76,7 @@ provider "azurerm" {
   features {}
 }
 ```
+
 ##### How to replicate the previous behaviour
 
 If you want to maintain the v4.x behaviour and automatically register the same set of Resource Providers as before, explicitly set `resource_provider_registrations` to the `legacy` resource provider set in your provider block:


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Conditionally include `skip_provider_registration` field while in 4.x.

Note: there is no mechanism in the provider to remove the field from the model, this will need to be done prior to the 5.0 release


## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change





## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
