### PR TITLE
Compute - fix acceptance test failure due to generalization issue

### DIFF
--- a/internal/services/compute/image_resource_test.go
+++ b/internal/services/compute/image_resource_test.go
@@ -34,7 +34,7 @@ func TestAccImage_standaloneImage(t *testing.T) {
 			Config: r.setupUnmanagedDisks(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				data.CheckWithClientForResource(r.virtualMachineExists, "azurerm_virtual_machine.testsource"),
-				data.CheckWithClientForResource(r.generalizeVirtualMachine(data), "azurerm_virtual_machine.testsource"),
+				data.CheckWithClientForResource(r.generalizeVirtualMachine(), "azurerm_virtual_machine.testsource"),
 			),
 		},
 		{
@@ -57,7 +57,7 @@ func TestAccImage_standaloneImage_hyperVGeneration_V2(t *testing.T) {
 			Config: r.setupUnmanagedDisks(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				data.CheckWithClientForResource(r.virtualMachineExists, "azurerm_virtual_machine.testsource"),
-				data.CheckWithClientForResource(r.generalizeVirtualMachine(data), "azurerm_virtual_machine.testsource"),
+				data.CheckWithClientForResource(r.generalizeVirtualMachine(), "azurerm_virtual_machine.testsource"),
 			),
 		},
 		{
@@ -80,7 +80,7 @@ func TestAccImage_requiresImport(t *testing.T) {
 			Config: r.setupUnmanagedDisks(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				data.CheckWithClientForResource(r.virtualMachineExists, "azurerm_virtual_machine.testsource"),
-				data.CheckWithClientForResource(r.generalizeVirtualMachine(data), "azurerm_virtual_machine.testsource"),
+				data.CheckWithClientForResource(r.generalizeVirtualMachine(), "azurerm_virtual_machine.testsource"),
 			),
 		},
 		{
@@ -103,7 +103,7 @@ func TestAccImage_customImageFromVMWithUnmanagedDisks(t *testing.T) {
 			Config: r.setupUnmanagedDisks(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				data.CheckWithClientForResource(r.virtualMachineExists, "azurerm_virtual_machine.testsource"),
-				data.CheckWithClientForResource(r.generalizeVirtualMachine(data), "azurerm_virtual_machine.testsource"),
+				data.CheckWithClientForResource(r.generalizeVirtualMachine(), "azurerm_virtual_machine.testsource"),
 			),
 		},
 		{
@@ -126,7 +126,7 @@ func TestAccImage_customImageFromVMWithManagedDisks(t *testing.T) {
 			Destroy: false,
 			Check: acceptance.ComposeTestCheckFunc(
 				data.CheckWithClientForResource(r.virtualMachineExists, "azurerm_virtual_machine.testsource"),
-				data.CheckWithClientForResource(r.generalizeVirtualMachine(data), "azurerm_virtual_machine.testsource"),
+				data.CheckWithClientForResource(r.generalizeVirtualMachine(), "azurerm_virtual_machine.testsource"),
 			),
 		},
 		{
@@ -149,7 +149,7 @@ func TestAccImage_customImageFromVMSSWithUnmanagedDisks(t *testing.T) {
 			Destroy: false,
 			Check: acceptance.ComposeTestCheckFunc(
 				data.CheckWithClientForResource(r.virtualMachineExists, "azurerm_virtual_machine.testsource"),
-				data.CheckWithClientForResource(r.generalizeVirtualMachine(data), "azurerm_virtual_machine.testsource"),
+				data.CheckWithClientForResource(r.generalizeVirtualMachine(), "azurerm_virtual_machine.testsource"),
 			),
 		},
 		{
@@ -171,7 +171,7 @@ func TestAccImage_standaloneImageEncrypt(t *testing.T) {
 			Config: r.setupUnmanagedDisks(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				data.CheckWithClientForResource(r.virtualMachineExists, "azurerm_virtual_machine.testsource"),
-				data.CheckWithClientForResource(r.generalizeVirtualMachine(data), "azurerm_virtual_machine.testsource"),
+				data.CheckWithClientForResource(r.generalizeVirtualMachine(), "azurerm_virtual_machine.testsource"),
 			),
 		},
 		{
@@ -201,7 +201,7 @@ func (ImageResource) Exists(ctx context.Context, clients *clients.Client, state 
 	return pointer.To(resp.Model != nil), nil
 }
 
-func (ImageResource) generalizeVirtualMachine(data acceptance.TestData) func(context.Context, *clients.Client, *pluginsdk.InstanceState) error {
+func (ImageResource) generalizeVirtualMachine() func(context.Context, *clients.Client, *pluginsdk.InstanceState) error {
 	return func(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) error {
 		id, err := virtualmachines.ParseVirtualMachineID(state.ID)
 		if err != nil {
@@ -411,9 +411,9 @@ resource "azurerm_virtual_machine" "testsource" {
     admin_password = local.admin_password
 
     custom_data = base64encode(<<-EOT
-      #!/bin/bash
-      sudo waagent -verbose -deprovision+user -force
-    EOT
+#!/bin/bash
+sudo waagent -verbose -deprovision+user -force
+EOT
     )
   }
 

--- a/internal/services/compute/image_resource_test.go
+++ b/internal/services/compute/image_resource_test.go
@@ -12,15 +12,11 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-01/images"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-03-01/virtualmachines"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2024-11-01/virtualmachinescalesets"
-	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/networkinterfaces"
-	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2025-01-01/publicipaddresses"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/ssh"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -216,87 +212,6 @@ func (ImageResource) generalizeVirtualMachine(data acceptance.TestData) func(con
 			var cancel context.CancelFunc
 			ctx, cancel = context.WithTimeout(ctx, 15*time.Minute)
 			defer cancel()
-		}
-
-		// these are nested in a Set in the Legacy VM resource, simpler to compute them
-		userName := fmt.Sprintf("testadmin%d", data.RandomInteger)
-		password := fmt.Sprintf("Password1234!%d", data.RandomInteger)
-
-		// first retrieve the Virtual Machine, since we need to find
-		nicIdRaw := state.Attributes["network_interface_ids.0"]
-		nicId, err := commonids.ParseNetworkInterfaceID(nicIdRaw)
-		if err != nil {
-			return err
-		}
-
-		log.Printf("[DEBUG] Retrieving Network Interface..")
-		nic, err := client.Network.NetworkInterfaces.Get(ctx, *nicId, networkinterfaces.DefaultGetOperationOptions())
-		if err != nil {
-			return fmt.Errorf("retrieving %s: %+v", *nicId, err)
-		}
-
-		publicIpRaw := ""
-		if model := nic.Model; model != nil {
-			if props := model.Properties; props != nil {
-				if configs := props.IPConfigurations; configs != nil {
-					for _, config := range *props.IPConfigurations {
-						if configProps := config.Properties; configProps != nil {
-							if configProps.PublicIPAddress == nil {
-								continue
-							}
-
-							if configProps.PublicIPAddress.Id == nil {
-								continue
-							}
-
-							publicIpRaw = *configProps.PublicIPAddress.Id
-							break
-						}
-					}
-				}
-			}
-		}
-		if publicIpRaw == "" {
-			return fmt.Errorf("retrieving %s: could not determine Public IP Address ID", *nicId)
-		}
-
-		log.Printf("[DEBUG] Retrieving Public IP Address %q..", publicIpRaw)
-		publicIpId, err := commonids.ParsePublicIPAddressID(publicIpRaw)
-		if err != nil {
-			return err
-		}
-
-		publicIpAddress, err := client.Network.PublicIPAddresses.Get(ctx, *publicIpId, publicipaddresses.DefaultGetOperationOptions())
-		if err != nil {
-			return fmt.Errorf("retrieving %s: %+v", *publicIpId, err)
-		}
-		fqdn := ""
-
-		if model := publicIpAddress.Model; model != nil {
-			if props := model.Properties; props != nil {
-				if dns := props.DnsSettings; dns != nil {
-					if dns.Fqdn != nil {
-						fqdn = *dns.Fqdn
-					}
-				}
-			}
-		}
-		if fqdn == "" {
-			return fmt.Errorf("unable to determine FQDN for %q", *publicIpId)
-		}
-
-		log.Printf("[DEBUG] Running Generalization Command..")
-		sshGeneralizationCommand := ssh.Runner{
-			Hostname: fqdn,
-			Port:     22,
-			Username: userName,
-			Password: password,
-			CommandsToRun: []string{
-				ssh.LinuxAgentDeprovisionCommand,
-			},
-		}
-		if err := sshGeneralizationCommand.Run(ctx); err != nil {
-			return fmt.Errorf("Bad: running generalization command: %+v", err)
 		}
 
 		log.Printf("[DEBUG] Deallocating VM..")
@@ -499,6 +414,12 @@ resource "azurerm_virtual_machine" "testsource" {
   os_profile_linux_config {
     disable_password_authentication = false
   }
+
+  custom_data = base64encode(<<-EOT
+    #!/bin/bash
+    sudo waagent -verbose -deprovision+user -force
+  EOT
+  )
 
   tags = {
     environment = "Dev"

--- a/internal/services/compute/image_resource_test.go
+++ b/internal/services/compute/image_resource_test.go
@@ -409,17 +409,17 @@ resource "azurerm_virtual_machine" "testsource" {
     computer_name  = "mdimagetestsource"
     admin_username = local.admin_username
     admin_password = local.admin_password
+
+    custom_data = base64encode(<<-EOT
+      #!/bin/bash
+      sudo waagent -verbose -deprovision+user -force
+    EOT
+    )
   }
 
   os_profile_linux_config {
     disable_password_authentication = false
   }
-
-  custom_data = base64encode(<<-EOT
-    #!/bin/bash
-    sudo waagent -verbose -deprovision+user -force
-  EOT
-  )
 
   tags = {
     environment = "Dev"

--- a/internal/services/compute/images_data_source_test.go
+++ b/internal/services/compute/images_data_source_test.go
@@ -24,7 +24,7 @@ func TestAccDataSourceAzureRMImages_basic(t *testing.T) {
 			Config: ImageResource{}.setupUnmanagedDisks(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				data.CheckWithClientForResource(ImageResource{}.virtualMachineExists, "azurerm_virtual_machine.testsource"),
-				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(data), "azurerm_virtual_machine.testsource"),
+				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(), "azurerm_virtual_machine.testsource"),
 			),
 		},
 		{
@@ -47,7 +47,7 @@ func TestAccDataSourceAzureRMImages_tagsFilterError(t *testing.T) {
 			Config: ImageResource{}.setupUnmanagedDisks(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				data.CheckWithClientForResource(ImageResource{}.virtualMachineExists, "azurerm_virtual_machine.testsource"),
-				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(data), "azurerm_virtual_machine.testsource"),
+				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(), "azurerm_virtual_machine.testsource"),
 			),
 		},
 		{
@@ -67,7 +67,7 @@ func TestAccDataSourceAzureRMImages_tagsFilter(t *testing.T) {
 			Config: ImageResource{}.setupUnmanagedDisks(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				data.CheckWithClientForResource(ImageResource{}.virtualMachineExists, "azurerm_virtual_machine.testsource"),
-				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(data), "azurerm_virtual_machine.testsource"),
+				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(), "azurerm_virtual_machine.testsource"),
 			),
 		},
 		{

--- a/internal/services/compute/linux_virtual_machine_resource_images_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_images_test.go
@@ -27,7 +27,7 @@ func TestAccLinuxVirtualMachine_imageFromImage(t *testing.T) {
 			Config: r.imageFromExistingMachinePrep(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				data.CheckWithClientForResource(ImageResource{}.virtualMachineExists, "azurerm_linux_virtual_machine.source"),
-				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(data), "azurerm_linux_virtual_machine.source"),
+				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(), "azurerm_linux_virtual_machine.source"),
 			),
 		},
 		{
@@ -74,7 +74,7 @@ func TestAccLinuxVirtualMachine_imageFromCommunitySharedImageGallery(t *testing.
 			Config: r.imageFromExistingMachinePrep(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				data.CheckWithClientForResource(ImageResource{}.virtualMachineExists, "azurerm_linux_virtual_machine.source"),
-				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(data), "azurerm_linux_virtual_machine.source"),
+				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(), "azurerm_linux_virtual_machine.source"),
 			),
 		},
 		{
@@ -97,7 +97,7 @@ func TestAccLinuxVirtualMachine_imageFromSharedImageGallery(t *testing.T) {
 			Config: r.imageFromExistingMachinePrep(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				data.CheckWithClientForResource(ImageResource{}.virtualMachineExists, "azurerm_linux_virtual_machine.source"),
-				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(data), "azurerm_linux_virtual_machine.source"),
+				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(), "azurerm_linux_virtual_machine.source"),
 			),
 		},
 		{
@@ -230,9 +230,9 @@ resource "azurerm_linux_virtual_machine" "source" {
   }
 
   custom_data = base64encode(<<-EOT
-    #!/bin/bash
-    sudo waagent -verbose -deprovision+user -force
-  EOT
+#!/bin/bash
+sudo waagent -verbose -deprovision+user -force
+EOT
   )
 }
 `, r.imageFromExistingMachineDependencies(data), data.RandomInteger)

--- a/internal/services/compute/linux_virtual_machine_resource_images_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_images_test.go
@@ -228,6 +228,12 @@ resource "azurerm_linux_virtual_machine" "source" {
     sku       = "22_04-lts"
     version   = "latest"
   }
+
+  custom_data = base64encode(<<-EOT
+    #!/bin/bash
+    sudo waagent -verbose -deprovision+user -force
+  EOT
+  )
 }
 `, r.imageFromExistingMachineDependencies(data), data.RandomInteger)
 }

--- a/internal/services/compute/shared_image_version_data_source_test.go
+++ b/internal/services/compute/shared_image_version_data_source_test.go
@@ -23,7 +23,7 @@ func TestAccDataSourceSharedImageVersion_basic(t *testing.T) {
 			Config: SharedImageVersionResource{}.setup(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				data.CheckWithClientForResource(ImageResource{}.virtualMachineExists, "azurerm_virtual_machine.testsource"),
-				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(data), "azurerm_virtual_machine.testsource"),
+				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(), "azurerm_virtual_machine.testsource"),
 			),
 		},
 		{
@@ -47,7 +47,7 @@ func TestAccDataSourceSharedImageVersion_latest(t *testing.T) {
 			Config: SharedImageVersionResource{}.setup(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				data.CheckWithClientForResource(ImageResource{}.virtualMachineExists, "azurerm_virtual_machine.testsource"),
-				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(data), "azurerm_virtual_machine.testsource"),
+				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(), "azurerm_virtual_machine.testsource"),
 			),
 		},
 		{
@@ -74,7 +74,7 @@ func TestAccDataSourceSharedImageVersion_excludeFromLatest(t *testing.T) {
 			Config: SharedImageVersionResource{}.setup(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				data.CheckWithClientForResource(ImageResource{}.virtualMachineExists, "azurerm_virtual_machine.testsource"),
-				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(data), "azurerm_virtual_machine.testsource"),
+				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(), "azurerm_virtual_machine.testsource"),
 			),
 		},
 		{
@@ -100,7 +100,7 @@ func TestAccDataSourceSharedImageVersion_recent(t *testing.T) {
 			Destroy: false,
 			Check: acceptance.ComposeTestCheckFunc(
 				data.CheckWithClientForResource(ImageResource{}.virtualMachineExists, "azurerm_virtual_machine.testsource"),
-				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(data), "azurerm_virtual_machine.testsource"),
+				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(), "azurerm_virtual_machine.testsource"),
 			),
 		},
 		{
@@ -125,7 +125,7 @@ func TestAccDataSourceSharedImageVersion_sortVersionsBySemver(t *testing.T) {
 			Config: SharedImageVersionResource{}.setup(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				data.CheckWithClientForResource(ImageResource{}.virtualMachineExists, "azurerm_virtual_machine.testsource"),
-				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(data), "azurerm_virtual_machine.testsource"),
+				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(), "azurerm_virtual_machine.testsource"),
 			),
 		},
 		{

--- a/internal/services/compute/shared_image_version_resource_test.go
+++ b/internal/services/compute/shared_image_version_resource_test.go
@@ -30,7 +30,7 @@ func TestAccSharedImageVersion_basic(t *testing.T) {
 			Config: r.setup(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				data.CheckWithClientForResource(ImageResource{}.virtualMachineExists, "azurerm_virtual_machine.testsource"),
-				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(data), "azurerm_virtual_machine.testsource"),
+				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(), "azurerm_virtual_machine.testsource"),
 			),
 		},
 		{
@@ -64,7 +64,7 @@ func TestAccSharedImageVersion_storageAccountTypeLrs(t *testing.T) {
 			Destroy: false,
 			Check: acceptance.ComposeTestCheckFunc(
 				data.CheckWithClientForResource(ImageResource{}.virtualMachineExists, "azurerm_virtual_machine.testsource"),
-				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(data), "azurerm_virtual_machine.testsource"),
+				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(), "azurerm_virtual_machine.testsource"),
 			),
 		},
 		{
@@ -90,7 +90,7 @@ func TestAccSharedImageVersion_storageAccountTypeZrs(t *testing.T) {
 			Destroy: false,
 			Check: acceptance.ComposeTestCheckFunc(
 				data.CheckWithClientForResource(ImageResource{}.virtualMachineExists, "azurerm_virtual_machine.testsource"),
-				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(data), "azurerm_virtual_machine.testsource"),
+				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(), "azurerm_virtual_machine.testsource"),
 			),
 		},
 		{
@@ -164,7 +164,7 @@ func TestAccSharedImageVersion_diskEncryptionSetID(t *testing.T) {
 			Config: r.setup(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				data.CheckWithClientForResource(ImageResource{}.virtualMachineExists, "azurerm_virtual_machine.testsource"),
-				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(data), "azurerm_virtual_machine.testsource"),
+				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(), "azurerm_virtual_machine.testsource"),
 			),
 		},
 		{
@@ -190,7 +190,7 @@ func TestAccSharedImageVersion_endOfLifeDate(t *testing.T) {
 			Config: r.setup(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				data.CheckWithClientForResource(ImageResource{}.virtualMachineExists, "azurerm_virtual_machine.testsource"),
-				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(data), "azurerm_virtual_machine.testsource"),
+				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(), "azurerm_virtual_machine.testsource"),
 			),
 		},
 		{
@@ -220,7 +220,7 @@ func TestAccSharedImageVersion_replicationMode(t *testing.T) {
 			Config: r.setup(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				data.CheckWithClientForResource(ImageResource{}.virtualMachineExists, "azurerm_virtual_machine.testsource"),
-				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(data), "azurerm_virtual_machine.testsource"),
+				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(), "azurerm_virtual_machine.testsource"),
 			),
 		},
 		{
@@ -243,7 +243,7 @@ func TestAccSharedImageVersion_replicatedRegionDeletion(t *testing.T) {
 			Config: r.setup(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				data.CheckWithClientForResource(ImageResource{}.virtualMachineExists, "azurerm_virtual_machine.testsource"),
-				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(data), "azurerm_virtual_machine.testsource"),
+				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(), "azurerm_virtual_machine.testsource"),
 			),
 		},
 		{
@@ -267,7 +267,7 @@ func TestAccSharedImageVersion_requiresImport(t *testing.T) {
 			Destroy: false,
 			Check: acceptance.ComposeTestCheckFunc(
 				data.CheckWithClientForResource(ImageResource{}.virtualMachineExists, "azurerm_virtual_machine.testsource"),
-				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(data), "azurerm_virtual_machine.testsource"),
+				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(), "azurerm_virtual_machine.testsource"),
 			),
 		},
 		{

--- a/internal/services/compute/shared_image_versions_data_source_test.go
+++ b/internal/services/compute/shared_image_versions_data_source_test.go
@@ -25,7 +25,7 @@ func TestAccDataSourceSharedImageVersions_basic(t *testing.T) {
 			Destroy: false,
 			Check: acceptance.ComposeTestCheckFunc(
 				data.CheckWithClientForResource(ImageResource{}.virtualMachineExists, "azurerm_virtual_machine.testsource"),
-				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(data), "azurerm_virtual_machine.testsource"),
+				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(), "azurerm_virtual_machine.testsource"),
 			),
 		},
 		{
@@ -52,7 +52,7 @@ func TestAccDataSourceSharedImageVersions_tagsFilterError(t *testing.T) {
 			Destroy: false,
 			Check: acceptance.ComposeTestCheckFunc(
 				data.CheckWithClientForResource(ImageResource{}.virtualMachineExists, "azurerm_virtual_machine.testsource"),
-				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(data), "azurerm_virtual_machine.testsource"),
+				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(), "azurerm_virtual_machine.testsource"),
 			),
 		},
 		{
@@ -72,7 +72,7 @@ func TestAccDataSourceSharedImageVersions_tagsFilter(t *testing.T) {
 			Destroy: false,
 			Check: acceptance.ComposeTestCheckFunc(
 				data.CheckWithClientForResource(ImageResource{}.virtualMachineExists, "azurerm_virtual_machine.testsource"),
-				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(data), "azurerm_virtual_machine.testsource"),
+				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(), "azurerm_virtual_machine.testsource"),
 			),
 		},
 		{


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

The following compute tests fail due to the error below. This is due to failure to issue SSH command to the virtual machines to generalize them. To fix the issue, `custom_data` property is used to run generalization command instead of using SSH.

Error
```
    testcase.go:203: Step 1/2 error: Check failed: Check 2/2 error: Check 1/1 error: Bad: running generalization command: connecting to host: dial tcp REDACTED: connect: connection timed out
```

Failed tests
```
TestAccDataSourceAzureRMImages_basic
TestAccDataSourceAzureRMImages_tagsFilter
TestAccDataSourceAzureRMImages_tagsFilterError
TestAccDataSourceSharedImageVersion_basic
TestAccDataSourceSharedImageVersion_excludeFromLatest
TestAccDataSourceSharedImageVersion_latest
TestAccDataSourceSharedImageVersion_sortVersionsBySemver
TestAccDataSourceSharedImageVersions_basic
TestAccDataSourceSharedImageVersions_tagsFilter
TestAccDataSourceSharedImageVersions_tagsFilterError
TestAccImage_customImageFromVMSSWithUnmanagedDisks
TestAccImage_customImageFromVMWithManagedDisks
TestAccImage_customImageFromVMWithUnmanagedDisks
TestAccImage_requiresImport
TestAccImage_standaloneImage
TestAccImage_standaloneImageEncrypt
TestAccImage_standaloneImage_hyperVGeneration_V2
TestAccLinuxVirtualMachine_imageFromCommunitySharedImageGallery
TestAccLinuxVirtualMachine_imageFromImage
TestAccLinuxVirtualMachine_imageFromSharedImageGallery
TestAccSharedImageVersion_basic
TestAccSharedImageVersion_diskEncryptionSetID
TestAccSharedImageVersion_endOfLifeDate
TestAccSharedImageVersion_replicatedRegionDeletion
TestAccSharedImageVersion_replicationMode
TestAccSharedImageVersion_requiresImport
TestAccSharedImageVersion_storageAccountTypeLrs
TestAccSharedImageVersion_storageAccountTypeZrs
```


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] ~I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.~
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] ~I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).~
- [ ] ~I have written new tests for my resource or datasource changes & updated any relevant documentation.~
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] ~(For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.~


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

The failed tests are caused by other issues which are addressed in other PRs.

Version 4.0
https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_COMPUTE/682770?buildTab=overview
<img width="951" height="666" alt="image" src="https://github.com/user-attachments/assets/a54c2a53-1675-462d-bed4-6d210540bba0" />

Version 5.0
https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_COMPUTE/682774?buildTab=overview
<img width="952" height="668" alt="image" src="https://github.com/user-attachments/assets/5f1dd79d-877f-4792-9a3e-28d3c904991a" />


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* Compute resources - fix failed tests due to generalization issue


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
