### PR TITLE
New Example: Container App deployed into a VNET

### DIFF
--- a/examples/container-app/vnet/README.md
+++ b/examples/container-app/vnet/README.md
@@ -1,0 +1,15 @@
+## Example: Container App deployed into Virtual Network
+
+A container app deployed into a virtual network and only accessible from other resources in the virtual network, not from the public internet.
+
+An example of when this would be required is if API-Management (APIM) is used to manage access to the container app. APIM would be publicly accessible, but the container app would be internal-only.
+
+**Note:** An internal-only Azure Container Apps environment receives an IP address directly from the target subnet and, by default, there is no domain registration created with the internal load balancer. This means we need to configure DNS resolution for the environment endpoint. In Azure, this can be accomplished by creating and configuring an Azure Private DNS Zone.
+
+## Creates
+
+1. A Resource Group
+1. A [Virtual Network](https://azure.microsoft.com/en-us/products/virtual-network/) and subnet
+1. A Container App Environment deployed into the subnet
+1. A [Container App](https://azure.microsoft.com/en-us/products/container-apps/) only accessible from other resources within the virtual network
+1. A Private DNS Zone that maps the FQDN of the container app to the static IP address of the container app environment

--- a/examples/container-app/vnet/main.tf
+++ b/examples/container-app/vnet/main.tf
@@ -1,0 +1,106 @@
+# Copyright IBM Corp. 2014, 2025
+# SPDX-License-Identifier: MPL-2.0
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "${var.prefix}-resources"
+  location = var.location
+}
+
+resource "azurerm_network_security_group" "example" {
+  name                = "example-security-group"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+}
+
+resource "azurerm_virtual_network" "example" {
+  name                = "${var.prefix}-network"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  address_space       = ["10.0.0.0/16"]
+
+  subnet {
+    name             = "${var.prefix}-subnet"
+    address_prefixes = ["10.0.1.0/24"]
+    security_group   = azurerm_network_security_group.example.id
+    delegation {
+      name = "delegation"
+      service_delegation {
+        name    = "Microsoft.App/environments"
+        actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
+      }
+    }
+  }
+}
+
+resource "azurerm_container_app_environment" "example" {
+  name                           = "${var.prefix}-environment"
+  location                       = azurerm_resource_group.example.location
+  resource_group_name            = azurerm_resource_group.example.name
+  infrastructure_subnet_id       = azurerm_virtual_network.example.subnet.*.id[0]
+  internal_load_balancer_enabled = true
+
+  lifecycle {
+    ignore_changes = [
+      infrastructure_resource_group_name
+    ]
+  }
+}
+
+resource "azurerm_container_app" "example" {
+  name                         = "${var.prefix}-app"
+  resource_group_name          = azurerm_resource_group.example.name
+  container_app_environment_id = azurerm_container_app_environment.example.id
+  revision_mode                = "Single"
+
+  ingress {
+    external_enabled = true # allow access from outside the container app environment (e.g. from APIM)
+    target_port      = 80
+    traffic_weight {
+      latest_revision = true
+      percentage      = 100
+    }
+  }
+
+  template {
+    container {
+      name   = "examplecontainerapp"
+      image  = "mcr.microsoft.com/k8se/quickstart:latest"
+      cpu    = 0.25
+      memory = "0.5Gi"
+    }
+  }
+}
+
+# Create a private DNS zone and link it to the virtual network to allow other resources in the 
+# same virtual network (e.g. APIM) to resolve the container app's fqdn to its internal IP address.
+resource "azurerm_private_dns_zone" "example" {
+  name                = azurerm_container_app.example.ingress[0].fqdn
+  resource_group_name = azurerm_resource_group.example.name
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "example" {
+  name                  = "${var.prefix}-dnsvnetlink"
+  resource_group_name   = azurerm_resource_group.example.name
+  private_dns_zone_name = azurerm_private_dns_zone.example.name
+  virtual_network_id    = azurerm_virtual_network.example.id
+}
+
+resource "azurerm_private_dns_a_record" "example_wildcard" {
+  name                = "*"
+  resource_group_name = azurerm_resource_group.example.name
+  zone_name           = azurerm_private_dns_zone.example.name
+  ttl                 = 3600
+  records             = [azurerm_container_app_environment.example.static_ip_address]
+}
+
+resource "azurerm_private_dns_a_record" "example_naked" {
+  name                = "@"
+  zone_name           = azurerm_private_dns_zone.example.name
+  resource_group_name = azurerm_resource_group.example.name
+  ttl                 = 3600
+  records             = [azurerm_container_app_environment.example.static_ip_address]
+}

--- a/examples/container-app/vnet/outputs.tf
+++ b/examples/container-app/vnet/outputs.tf
@@ -1,0 +1,7 @@
+# Copyright IBM Corp. 2014, 2025
+# SPDX-License-Identifier: MPL-2.0
+
+output "container_app_url" {
+  value       = "http://${azurerm_container_app.example.ingress[0].fqdn}"
+  description = "This is the url that can be used to access the app from other resources in the same virtual network (e.g. APIM)"
+}

--- a/examples/container-app/vnet/variables.tf
+++ b/examples/container-app/vnet/variables.tf
@@ -1,0 +1,10 @@
+# Copyright IBM Corp. 2014, 2025
+# SPDX-License-Identifier: MPL-2.0
+
+variable "prefix" {
+  description = "The prefix used for all resources in this example"
+}
+
+variable "location" {
+  description = "The Azure location where all resources in this example should be created"
+}


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Adds an new example for a container app deployed into a virtual network and only accessible from other resources in the virtual network, not from the public internet.

An example of when this would be required is if API-Management (APIM) is used to manage access to the container app. APIM would be publicly accessible, but the container app would be internal-only.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”
