### PR TITLE
`azurerm_kubernetes_cluster` and `azurerm_kubernetes_cluster_node_pool` - support AzureContainerLinux and KataVmIsolation

### DIFF
--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -9,7 +9,6 @@ import (
 	"log"
 	"regexp"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -71,12 +70,11 @@ func resourceKubernetesClusterNodePool() *pluginsdk.Resource {
 				oldStr := old.(string)
 				newStr := new.(string)
 
-				// Ubuntu and AzureLinux are currently the only allowed Linux OSSKU Migration targets.
-				if !strings.HasPrefix(oldStr, string(agentpools.OSSKUUbuntu)) && !strings.HasPrefix(oldStr, string(agentpools.OSSKUAzureLinux)) {
+				if !kubernetesClusterNodePoolOSSKUSupportsInPlaceMigration(oldStr) {
 					return true
 				}
 
-				if !strings.HasPrefix(newStr, string(agentpools.OSSKUUbuntu)) && !strings.HasPrefix(newStr, string(agentpools.OSSKUAzureLinux)) {
+				if !kubernetesClusterNodePoolOSSKUSupportsInPlaceMigration(newStr) {
 					return true
 				}
 
@@ -347,18 +345,10 @@ func resourceKubernetesClusterNodePoolSchema() map[string]*pluginsdk.Schema {
 		},
 
 		"os_sku": {
-			Type:     pluginsdk.TypeString,
-			Optional: true,
-			Computed: true, // defaults to Ubuntu if using Linux
-			ValidateFunc: validation.StringInSlice([]string{
-				string(agentpools.OSSKUAzureLinux),
-				string(agentpools.OSSKUAzureLinuxThree),
-				string(agentpools.OSSKUUbuntu),
-				string(agentpools.OSSKUUbuntuTwoTwoZeroFour),
-				string(agentpools.OSSKUUbuntuTwoFourZeroFour),
-				string(agentpools.OSSKUWindowsTwoZeroOneNine),
-				string(agentpools.OSSKUWindowsTwoZeroTwoTwo),
-			}, false),
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			Computed:     true, // defaults to Ubuntu if using Linux
+			ValidateFunc: validation.StringInSlice(kubernetesClusterNodePoolOSSKUValues(), false),
 		},
 
 		"os_type": {
@@ -420,6 +410,8 @@ func resourceKubernetesClusterNodePoolSchema() map[string]*pluginsdk.Schema {
 			}, false),
 		},
 
+		"security_profile": schemaNodePoolSecurityProfile(),
+
 		"temporary_name_for_rotation": {
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
@@ -461,6 +453,7 @@ func resourceKubernetesClusterNodePoolSchema() map[string]*pluginsdk.Schema {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
 			ValidateFunc: validation.StringInSlice([]string{
+				string(agentpools.WorkloadRuntimeKataVMIsolation),
 				string(agentpools.WorkloadRuntimeOCIContainer),
 				string(agentpools.WorkloadRuntimeWasmWasi),
 			}, false),
@@ -613,6 +606,10 @@ func resourceKubernetesClusterNodePoolCreate(d *pluginsdk.ResourceData, meta int
 
 	if workloadRuntime := d.Get("workload_runtime").(string); workloadRuntime != "" {
 		profile.WorkloadRuntime = pointer.To(agentpools.WorkloadRuntime(workloadRuntime))
+	}
+
+	if securityProfile := expandAgentPoolSecurityProfile(d, d.Get("security_profile").([]interface{})); securityProfile != nil {
+		profile.SecurityProfile = securityProfile
 	}
 
 	if priority == string(managedclusters.ScaleSetPrioritySpot) {
@@ -917,6 +914,14 @@ func resourceKubernetesClusterNodePoolUpdate(d *pluginsdk.ResourceData, meta int
 		props.OsSKU = pointer.To(agentpools.OSSKU(d.Get("os_sku").(string)))
 	}
 
+	if d.HasChange("security_profile") {
+		securityProfile := expandAgentPoolSecurityProfile(d, d.Get("security_profile").([]interface{}))
+		if securityProfile != nil && props.SecurityProfile != nil {
+			securityProfile.SshAccess = props.SecurityProfile.SshAccess
+		}
+		props.SecurityProfile = securityProfile
+	}
+
 	if d.HasChange("pod_subnet_id") {
 		props.PodSubnetID = pointer.To(d.Get("pod_subnet_id").(string))
 	}
@@ -1025,15 +1030,15 @@ func resourceKubernetesClusterNodePoolUpdate(d *pluginsdk.ResourceData, meta int
 
 	// if the node pool name has changed, it means the initial attempt at resizing failed
 	cycleNodePool := d.HasChanges(cycleNodePoolProperties...)
-	// os_sku can only be updated if the current and new os_sku are either Ubuntu or AzureLinux
+	// os_sku can only be updated in place when the current and new os_sku are Linux migration targets.
 	if d.HasChange("os_sku") {
 		oldOsSkuRaw, newOsSkuRaw := d.GetChange("os_sku")
 		oldOsSku := oldOsSkuRaw.(string)
 		newOsSku := newOsSkuRaw.(string)
-		if !strings.HasPrefix(oldOsSku, string(managedclusters.OSSKUUbuntu)) && !strings.HasPrefix(oldOsSku, string(managedclusters.OSSKUAzureLinux)) {
+		if !kubernetesClusterNodePoolOSSKUSupportsInPlaceMigration(oldOsSku) {
 			cycleNodePool = true
 		}
-		if !strings.HasPrefix(newOsSku, string(managedclusters.OSSKUUbuntu)) && !strings.HasPrefix(newOsSku, string(managedclusters.OSSKUAzureLinux)) {
+		if !kubernetesClusterNodePoolOSSKUSupportsInPlaceMigration(newOsSku) {
 			cycleNodePool = true
 		}
 	}
@@ -1250,6 +1255,11 @@ func resourceKubernetesClusterNodePoolRead(d *pluginsdk.ResourceData, meta inter
 		if v := props.OsSKU; v != nil {
 			d.Set("os_sku", string(*v))
 		}
+
+		if err := d.Set("security_profile", flattenAgentPoolSecurityProfile(props.SecurityProfile)); err != nil {
+			return fmt.Errorf("setting `security_profile`: %+v", err)
+		}
+
 		d.Set("pod_subnet_id", props.PodSubnetID)
 
 		// not returned from the API if not Spot

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -984,6 +984,50 @@ func TestAccKubernetesClusterNodePool_osSkuAzureLinux(t *testing.T) {
 	})
 }
 
+func TestAccKubernetesClusterNodePool_osSkuAzureContainerLinux(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster_node_pool", "test")
+	r := KubernetesClusterNodePoolResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.osSkuAzureContainerLinux(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("os_sku").HasValue("AzureContainerLinux"),
+				check.That(data.ResourceName).Key("security_profile.0.enable_secure_boot").HasValue("true"),
+				check.That(data.ResourceName).Key("security_profile.0.enable_vtpm").HasValue("true"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccKubernetesClusterNodePool_osSkuAzureContainerLinuxMigration(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster_node_pool", "test")
+	r := KubernetesClusterNodePoolResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.osSkuAzureContainerLinuxMigration(data, "AzureLinux", false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("os_sku").HasValue("AzureLinux"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.osSkuAzureContainerLinuxMigration(data, "AzureContainerLinux", true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("os_sku").HasValue("AzureContainerLinux"),
+				check.That(data.ResourceName).Key("security_profile.0.enable_secure_boot").HasValue("true"),
+				check.That(data.ResourceName).Key("security_profile.0.enable_vtpm").HasValue("true"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccKubernetesClusterNodePool_osSkuMigration(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster_node_pool", "test")
 	r := KubernetesClusterNodePoolResource{}
@@ -1081,6 +1125,23 @@ func TestAccKubernetesClusterNodePool_workloadRuntime(t *testing.T) {
 			Config: r.workloadRuntime(data, "OCIContainer"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccKubernetesClusterNodePool_workloadRuntimeKataVmIsolation(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster_node_pool", "test")
+	r := KubernetesClusterNodePoolResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.workloadRuntimeKataVmIsolation(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("os_sku").HasValue("AzureLinux"),
+				check.That(data.ResourceName).Key("workload_runtime").HasValue("KataVmIsolation"),
 			),
 		},
 		data.ImportStep(),
@@ -3185,6 +3246,111 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, osSku)
 }
 
+func (KubernetesClusterNodePoolResource) osSkuAzureContainerLinux(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%d"
+  location = "%s"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
+  kubernetes_version  = %q
+
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_D2s_v3"
+    upgrade_settings {
+      max_surge = "10%%"
+    }
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_kubernetes_cluster_node_pool" "test" {
+  name                  = "internal"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
+  vm_size               = "Standard_D2s_v4"
+  os_sku                = "AzureContainerLinux"
+
+  security_profile {
+    enable_secure_boot = true
+    enable_vtpm        = true
+  }
+
+  upgrade_settings {
+    max_surge = "10%%"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, currentKubernetesVersion)
+}
+
+func (KubernetesClusterNodePoolResource) osSkuAzureContainerLinuxMigration(data acceptance.TestData, osSku string, securityProfile bool) string {
+	securityProfileConfig := ""
+	if securityProfile {
+		securityProfileConfig = `
+  security_profile {
+    enable_secure_boot = true
+    enable_vtpm        = true
+  }
+`
+	}
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%d"
+  location = "%s"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
+  kubernetes_version  = %q
+
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_D2s_v3"
+    upgrade_settings {
+      max_surge = "10%%"
+    }
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_kubernetes_cluster_node_pool" "test" {
+  name                  = "internal"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
+  vm_size               = "Standard_D2s_v4"
+  os_sku                = %q
+%s
+  upgrade_settings {
+    max_surge = "10%%"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, currentKubernetesVersion, osSku, securityProfileConfig)
+}
+
 func (KubernetesClusterNodePoolResource) dedicatedHost(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -3359,6 +3525,46 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, workloadRuntime)
+}
+
+func (KubernetesClusterNodePoolResource) workloadRuntimeKataVmIsolation(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%d"
+  location = "%s"
+}
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
+  kubernetes_version  = %q
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_D2s_v3"
+    upgrade_settings {
+      max_surge = "10%%"
+    }
+  }
+  identity {
+    type = "SystemAssigned"
+  }
+}
+resource "azurerm_kubernetes_cluster_node_pool" "test" {
+  name                  = "internal"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
+  vm_size               = "Standard_D4s_v3"
+  os_sku                = "AzureLinux"
+  workload_runtime      = "KataVmIsolation"
+  upgrade_settings {
+    max_surge = "10%%"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, currentKubernetesVersion)
 }
 
 func (KubernetesClusterNodePoolResource) windowsProfileOutboundNatEnabled(data acceptance.TestData) string {

--- a/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -766,6 +766,24 @@ func TestAccKubernetesCluster_osSku(t *testing.T) {
 	})
 }
 
+func TestAccKubernetesCluster_osSkuAzureContainerLinux(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
+	r := KubernetesClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.osSkuAzureContainerLinux(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("default_node_pool.0.os_sku").HasValue("AzureContainerLinux"),
+				check.That(data.ResourceName).Key("default_node_pool.0.security_profile.0.enable_secure_boot").HasValue("true"),
+				check.That(data.ResourceName).Key("default_node_pool.0.security_profile.0.enable_vtpm").HasValue("true"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccKubernetesCluster_osSkuUpdate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
 	r := KubernetesClusterResource{}
@@ -800,6 +818,23 @@ func TestAccKubernetesCluster_osSkuUpdate(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("default_node_pool.0.os_sku").HasValue("AzureLinux3"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccKubernetesCluster_workloadRuntimeKataVmIsolation(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
+	r := KubernetesClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.workloadRuntimeKataVmIsolation(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("default_node_pool.0.os_sku").HasValue("AzureLinux"),
+				check.That(data.ResourceName).Key("default_node_pool.0.workload_runtime").HasValue("KataVmIsolation"),
 			),
 		},
 		data.ImportStep(),
@@ -3076,6 +3111,84 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, osSKu)
+}
+
+func (KubernetesClusterResource) osSkuAzureContainerLinux(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%d"
+  location = "%s"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
+  kubernetes_version  = %q
+
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_D2s_v4"
+    os_sku     = "AzureContainerLinux"
+
+    security_profile {
+      enable_secure_boot = true
+      enable_vtpm        = true
+    }
+
+    upgrade_settings {
+      max_surge = "10%%"
+    }
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, currentKubernetesVersion)
+}
+
+func (KubernetesClusterResource) workloadRuntimeKataVmIsolation(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%d"
+  location = "%s"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
+  kubernetes_version  = %q
+
+  default_node_pool {
+    name             = "default"
+    node_count       = 1
+    vm_size          = "Standard_D4s_v3"
+    os_sku           = "AzureLinux"
+    workload_runtime = "KataVmIsolation"
+
+    upgrade_settings {
+      max_surge = "10%%"
+    }
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, currentKubernetesVersion)
 }
 
 func (KubernetesClusterResource) oidcIssuer(data acceptance.TestData, enabled bool) string {

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -2747,15 +2747,15 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 
 		// if the default node pool name has changed, it means the initial attempt at resizing failed
 		cycleNodePool := d.HasChanges(cycleNodePoolProperties...)
-		// os_sku could only be updated if the current and new os_sku are either Ubuntu or AzureLinux
+		// os_sku can only be updated in place when the current and new os_sku are Linux migration targets.
 		if d.HasChange("default_node_pool.0.os_sku") {
 			oldOsSkuRaw, newOsSkuRaw := d.GetChange("default_node_pool.0.os_sku")
 			oldOsSku := oldOsSkuRaw.(string)
 			newOsSku := newOsSkuRaw.(string)
-			if !strings.HasPrefix(oldOsSku, string(managedclusters.OSSKUUbuntu)) && !strings.HasPrefix(oldOsSku, string(managedclusters.OSSKUAzureLinux)) {
+			if !kubernetesClusterNodePoolOSSKUSupportsInPlaceMigration(oldOsSku) {
 				cycleNodePool = true
 			}
-			if !strings.HasPrefix(newOsSku, string(managedclusters.OSSKUUbuntu)) && !strings.HasPrefix(newOsSku, string(managedclusters.OSSKUAzureLinux)) {
+			if !kubernetesClusterNodePoolOSSKUSupportsInPlaceMigration(newOsSku) {
 				cycleNodePool = true
 			}
 		}

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -23,12 +23,34 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-11-01/publicipprefixes"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	computeValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
+
+const kubernetesClusterNodePoolOSSKUAzureContainerLinux = "AzureContainerLinux"
+
+func kubernetesClusterNodePoolOSSKUValues() []string {
+	return []string{
+		string(agentpools.OSSKUAzureLinux),
+		string(agentpools.OSSKUAzureLinuxThree),
+		kubernetesClusterNodePoolOSSKUAzureContainerLinux,
+		string(agentpools.OSSKUUbuntu),
+		string(agentpools.OSSKUUbuntuTwoTwoZeroFour),
+		string(agentpools.OSSKUUbuntuTwoFourZeroFour),
+		string(agentpools.OSSKUWindowsTwoZeroOneNine),
+		string(agentpools.OSSKUWindowsTwoZeroTwoTwo),
+	}
+}
+
+func kubernetesClusterNodePoolOSSKUSupportsInPlaceMigration(osSKU string) bool {
+	return strings.HasPrefix(osSKU, string(agentpools.OSSKUUbuntu)) ||
+		strings.HasPrefix(osSKU, string(agentpools.OSSKUAzureLinux)) ||
+		osSKU == kubernetesClusterNodePoolOSSKUAzureContainerLinux
+}
 
 func SchemaDefaultNodePool() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
@@ -183,18 +205,10 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 					},
 
 					"os_sku": {
-						Type:     pluginsdk.TypeString,
-						Optional: true,
-						Computed: true, // defaults to Ubuntu if using Linux
-						ValidateFunc: validation.StringInSlice([]string{
-							string(agentpools.OSSKUAzureLinux),
-							string(agentpools.OSSKUAzureLinuxThree),
-							string(agentpools.OSSKUUbuntu),
-							string(agentpools.OSSKUUbuntuTwoTwoZeroFour),
-							string(agentpools.OSSKUUbuntuTwoFourZeroFour),
-							string(agentpools.OSSKUWindowsTwoZeroOneNine),
-							string(agentpools.OSSKUWindowsTwoZeroTwoTwo),
-						}, false),
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						Computed:     true, // defaults to Ubuntu if using Linux
+						ValidateFunc: validation.StringInSlice(kubernetesClusterNodePoolOSSKUValues(), false),
 					},
 
 					"ultra_ssd_enabled": {
@@ -240,6 +254,8 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 						}, false),
 					},
 
+					"security_profile": schemaNodePoolSecurityProfile(),
+
 					"snapshot_id": {
 						Type:         pluginsdk.TypeString,
 						Optional:     true,
@@ -260,6 +276,7 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 						Optional: true,
 						Computed: true,
 						ValidateFunc: validation.StringInSlice([]string{
+							string(managedclusters.WorkloadRuntimeKataVMIsolation),
 							string(managedclusters.WorkloadRuntimeOCIContainer),
 						}, false),
 					},
@@ -282,6 +299,30 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 					},
 				}
 			}(),
+		},
+	}
+}
+
+func schemaNodePoolSecurityProfile() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		Computed: true,
+		MaxItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"enable_secure_boot": {
+					Type:     pluginsdk.TypeBool,
+					Optional: true,
+					Computed: true,
+				},
+
+				"enable_vtpm": {
+					Type:     pluginsdk.TypeBool,
+					Optional: true,
+					Computed: true,
+				},
+			},
 		},
 	}
 }
@@ -835,6 +876,17 @@ func ConvertDefaultNodePoolToAgentPool(input *[]managedclusters.ManagedClusterAg
 		agentpool.Properties.WorkloadRuntime = pointer.To(agentpools.WorkloadRuntime(string(*workloadRuntimeNodePool)))
 	}
 
+	if securityProfileRaw := defaultCluster.SecurityProfile; securityProfileRaw != nil {
+		securityProfile := agentpools.AgentPoolSecurityProfile{
+			EnableSecureBoot: securityProfileRaw.EnableSecureBoot,
+			EnableVTPM:       securityProfileRaw.EnableVTPM,
+		}
+		if securityProfileRaw.SshAccess != nil {
+			securityProfile.SshAccess = pointer.To(agentpools.AgentPoolSSHAccess(string(*securityProfileRaw.SshAccess)))
+		}
+		agentpool.Properties.SecurityProfile = &securityProfile
+	}
+
 	if creationData := defaultCluster.CreationData; creationData != nil {
 		if creationData.SourceResourceId != nil {
 			agentpool.Properties.CreationData = &agentpools.CreationData{
@@ -964,6 +1016,10 @@ func ExpandDefaultNodePool(d *pluginsdk.ResourceData) (*[]managedclusters.Manage
 		profile.WorkloadRuntime = pointer.To(managedclusters.WorkloadRuntime(workloadRunTime))
 	}
 
+	if securityProfile := expandDefaultNodePoolSecurityProfile(d, raw["security_profile"].([]interface{})); securityProfile != nil {
+		profile.SecurityProfile = securityProfile
+	}
+
 	if capacityReservationGroupId := raw["capacity_reservation_group_id"].(string); capacityReservationGroupId != "" {
 		profile.CapacityReservationGroupID = pointer.To(capacityReservationGroupId)
 	}
@@ -1045,6 +1101,61 @@ func ExpandDefaultNodePool(d *pluginsdk.ResourceData) (*[]managedclusters.Manage
 	return &[]managedclusters.ManagedClusterAgentPoolProfile{
 		profile,
 	}, nil
+}
+
+func nodePoolSecurityProfileConfigValueIsSet(d *pluginsdk.ResourceData, key string) bool {
+	raw, diags := d.GetRawConfigAt(sdk.ConstructCtyPath(key))
+	if diags.HasError() {
+		return false
+	}
+
+	return raw.IsKnown() && !raw.IsNull()
+}
+
+func expandDefaultNodePoolSecurityProfile(d *pluginsdk.ResourceData, input []interface{}) *managedclusters.AgentPoolSecurityProfile {
+	if len(input) == 0 || input[0] == nil {
+		return nil
+	}
+
+	raw := input[0].(map[string]interface{})
+	result := managedclusters.AgentPoolSecurityProfile{}
+
+	if nodePoolSecurityProfileConfigValueIsSet(d, "default_node_pool.0.security_profile.0.enable_secure_boot") {
+		result.EnableSecureBoot = pointer.To(raw["enable_secure_boot"].(bool))
+	}
+
+	if nodePoolSecurityProfileConfigValueIsSet(d, "default_node_pool.0.security_profile.0.enable_vtpm") {
+		result.EnableVTPM = pointer.To(raw["enable_vtpm"].(bool))
+	}
+
+	if result.EnableSecureBoot == nil && result.EnableVTPM == nil {
+		return nil
+	}
+
+	return &result
+}
+
+func expandAgentPoolSecurityProfile(d *pluginsdk.ResourceData, input []interface{}) *agentpools.AgentPoolSecurityProfile {
+	if len(input) == 0 || input[0] == nil {
+		return nil
+	}
+
+	raw := input[0].(map[string]interface{})
+	result := agentpools.AgentPoolSecurityProfile{}
+
+	if nodePoolSecurityProfileConfigValueIsSet(d, "security_profile.0.enable_secure_boot") {
+		result.EnableSecureBoot = pointer.To(raw["enable_secure_boot"].(bool))
+	}
+
+	if nodePoolSecurityProfileConfigValueIsSet(d, "security_profile.0.enable_vtpm") {
+		result.EnableVTPM = pointer.To(raw["enable_vtpm"].(bool))
+	}
+
+	if result.EnableSecureBoot == nil && result.EnableVTPM == nil {
+		return nil
+	}
+
+	return &result
 }
 
 func expandClusterNodePoolKubeletConfig(input []interface{}) *managedclusters.KubeletConfig {
@@ -1399,6 +1510,7 @@ func FlattenDefaultNodePool(input *[]managedclusters.ManagedClusterAgentPoolProf
 	}
 
 	upgradeSettings := flattenClusterNodePoolUpgradeSettings(agentPool.UpgradeSettings)
+	securityProfile := flattenDefaultNodePoolSecurityProfile(agentPool.SecurityProfile)
 	linuxOSConfig, err := flattenClusterNodePoolLinuxOSConfig(agentPool.LinuxOSConfig)
 	if err != nil {
 		return nil, err
@@ -1427,6 +1539,7 @@ func FlattenDefaultNodePool(input *[]managedclusters.ManagedClusterAgentPoolProf
 		"os_disk_type":                  string(osDiskType),
 		"os_sku":                        osSKU,
 		"scale_down_mode":               string(scaleDownMode),
+		"security_profile":              securityProfile,
 		"snapshot_id":                   snapshotId,
 		"tags":                          tags.Flatten(agentPool.Tags),
 		"temporary_name_for_rotation":   temporaryName,
@@ -1449,6 +1562,32 @@ func FlattenDefaultNodePool(input *[]managedclusters.ManagedClusterAgentPoolProf
 	return &[]interface{}{
 		out,
 	}, nil
+}
+
+func flattenDefaultNodePoolSecurityProfile(input *managedclusters.AgentPoolSecurityProfile) []interface{} {
+	if input == nil || (input.EnableSecureBoot == nil && input.EnableVTPM == nil) {
+		return []interface{}{}
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"enable_secure_boot": pointer.From(input.EnableSecureBoot),
+			"enable_vtpm":        pointer.From(input.EnableVTPM),
+		},
+	}
+}
+
+func flattenAgentPoolSecurityProfile(input *agentpools.AgentPoolSecurityProfile) []interface{} {
+	if input == nil || (input.EnableSecureBoot == nil && input.EnableVTPM == nil) {
+		return []interface{}{}
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"enable_secure_boot": pointer.From(input.EnableSecureBoot),
+			"enable_vtpm":        pointer.From(input.EnableVTPM),
+		},
+	}
 }
 
 func flattenClusterNodePoolUpgradeSettings(input *managedclusters.AgentPoolUpgradeSettings) []interface{} {

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -167,7 +167,7 @@ In addition, one of either `identity` or `service_principal` blocks must be spec
 
 ~> **Note:** `node_os_upgrade_channel` must be set to `NodeImage` if `automatic_upgrade_channel` has been set to `node-image`
 
-* `node_provisioning_profile` - (Required) A `node_provisioning_profile` block as defined below.
+* `node_provisioning_profile` - (Optional) A `node_provisioning_profile` block as defined below.
 
 * `node_resource_group` - (Optional) The name of the Resource Group where the Kubernetes Nodes should exist. Changing this forces a new resource to be created.
 
@@ -425,7 +425,7 @@ A `default_node_pool` block supports the following:
 
 * `os_disk_type` - (Optional) The type of disk which should be used for the Operating System. Possible values are `Ephemeral` and `Managed`. Defaults to `Managed`. `temporary_name_for_rotation` must be specified when attempting a change.
 
-* `os_sku` - (Optional) Specifies the OS SKU used by the agent pool. Possible values are `AzureLinux`, `AzureLinux3`, `Ubuntu`, `Ubuntu2204`, `Ubuntu2404`, `Windows2019` and `Windows2022`. If not specified, the default is `Ubuntu` when os_type=Linux or `Windows2019` if os_type=Windows (`Windows2022` Kubernetes ≥1.33). Changing between `AzureLinux` and `Ubuntu` does not replace the resource; otherwise `temporary_name_for_rotation` must be specified when attempting a change.
+* `os_sku` - (Optional) Specifies the OS SKU used by the agent pool. Possible values are `AzureLinux`, `AzureLinux3`, `AzureContainerLinux`, `Ubuntu`, `Ubuntu2204`, `Ubuntu2404`, `Windows2019` and `Windows2022`. If not specified, the default is `Ubuntu` when os_type=Linux or `Windows2019` if os_type=Windows (`Windows2022` Kubernetes ≥1.33). Changing between Linux OS SKUs `AzureLinux`, `AzureLinux3`, `AzureContainerLinux`, `Ubuntu`, `Ubuntu2204` and `Ubuntu2404` does not replace the resource; otherwise `temporary_name_for_rotation` must be specified when attempting a change.
 
 -> **Note:** `Windows2019` is deprecated and not supported for Kubernetes version ≥1.33.
 
@@ -434,6 +434,8 @@ A `default_node_pool` block supports the following:
 * `proximity_placement_group_id` - (Optional) The ID of the Proximity Placement Group. Changing this forces a new resource to be created.
 
 * `scale_down_mode` - (Optional) Specifies the autoscaling behaviour of the Kubernetes Cluster. Allowed values are `Delete` and `Deallocate`. Defaults to `Delete`.
+
+* `security_profile` - (Optional) A `security_profile` block as documented below.
 
 * `snapshot_id` - (Optional) The ID of the Snapshot which should be used to create this default Node Pool. `temporary_name_for_rotation` must be specified when changing this property.
 
@@ -455,7 +457,9 @@ A `default_node_pool` block supports the following:
 
 ~> **Note:** A Route Table must be configured on this Subnet.
 
-* `workload_runtime` - (Optional) Specifies the workload runtime used by the node pool. Possible value is `OCIContainer`.
+* `workload_runtime` - (Optional) Specifies the workload runtime used by the node pool. Possible values are `KataVmIsolation` and `OCIContainer`.
+
+~> **Note:** `KataVmIsolation` requires `os_sku` to be set to `AzureLinux` and the selected VM size must support nested virtualization.
 
 * `zones` - (Optional) Specifies a list of Availability Zones in which this Kubernetes Cluster should be located. `temporary_name_for_rotation` must be specified when changing this property.
 
@@ -568,6 +572,16 @@ An `allowed_host_ports` block supports the following:
 * `port_end` - (Optional) Specifies the end of the port range.
 
 * `protocol` - (Optional) Specifies the protocol of the port range. Possible values are `TCP` and `UDP`.
+
+---
+
+A `security_profile` block supports the following:
+
+* `enable_secure_boot` - (Optional) Specifies whether Secure Boot is enabled for the default Node Pool.
+
+* `enable_vtpm` - (Optional) Specifies whether vTPM is enabled for the default Node Pool.
+
+~> **Note:** When migrating an existing default Node Pool to `os_sku = "AzureContainerLinux"`, `enable_secure_boot` and `enable_vtpm` must be set to `true`.
 
 ---
 

--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -124,7 +124,7 @@ The following arguments are supported:
 
 * `pod_subnet_id` - (Optional) The ID of the Subnet where the pods in the Node Pool should exist. Changing this property requires specifying `temporary_name_for_rotation`.
 
-* `os_sku` - (Optional) Specifies the OS SKU used by the agent pool. Possible values are `AzureLinux`, `AzureLinux3`, `Ubuntu`, `Ubuntu2204`, `Ubuntu2404`, `Windows2019` and `Windows2022`. If not specified, the default is `Ubuntu` when os_type=Linux or `Windows2019` if os_type=Windows (`Windows2022` Kubernetes ≥1.33). Changing between `AzureLinux` and `Ubuntu` does not replace the resource; any other change forces a new resource to be created.
+* `os_sku` - (Optional) Specifies the OS SKU used by the agent pool. Possible values are `AzureLinux`, `AzureLinux3`, `AzureContainerLinux`, `Ubuntu`, `Ubuntu2204`, `Ubuntu2404`, `Windows2019` and `Windows2022`. If not specified, the default is `Ubuntu` when os_type=Linux or `Windows2019` if os_type=Windows (`Windows2022` Kubernetes ≥1.33). Changing between Linux OS SKUs `AzureLinux`, `AzureLinux3`, `AzureContainerLinux`, `Ubuntu`, `Ubuntu2204` and `Ubuntu2404` does not replace the resource; any other change forces a new resource to be created.
 
 -> **Note:** `Windows2019` is deprecated and not supported for Kubernetes version ≥1.33.
 
@@ -148,6 +148,8 @@ The following arguments are supported:
 
 * `scale_down_mode` - (Optional) Specifies how the node pool should deal with scaled-down nodes. Allowed values are `Delete` and `Deallocate`. Defaults to `Delete`.
 
+* `security_profile` - (Optional) A `security_profile` block as documented below.
+
 * `temporary_name_for_rotation` - (Optional) Specifies the name of the temporary node pool used to cycle the node pool when one of the relevant properties are updated.
 
 * `ultra_ssd_enabled` - (Optional) Used to specify whether the UltraSSD is enabled in the Node Pool. Defaults to `false`. See [the documentation](https://docs.microsoft.com/azure/aks/use-ultra-disks) for more information. Changing this property requires specifying `temporary_name_for_rotation`.
@@ -160,7 +162,9 @@ The following arguments are supported:
 
 * `windows_profile` - (Optional) A `windows_profile` block as documented below. Changing this forces a new resource to be created.
 
-* `workload_runtime` - (Optional) Used to specify the workload runtime. Allowed values are `OCIContainer` and `WasmWasi`.
+* `workload_runtime` - (Optional) Used to specify the workload runtime. Allowed values are `KataVmIsolation`, `OCIContainer` and `WasmWasi`.
+
+~> **Note:** `KataVmIsolation` requires `os_sku` to be set to `AzureLinux` and the selected VM size must support nested virtualization.
 
 ~> **Note:** WebAssembly System Interface node pools are in Public Preview - more information and details on how to opt into the preview can be found in [this article](https://docs.microsoft.com/azure/aks/use-wasi-node-pools)
 
@@ -239,6 +243,16 @@ An `allowed_host_ports` block supports the following:
 * `port_end` - (Optional) Specifies the end of the port range.
 
 * `protocol` - (Optional) Specifies the protocol of the port range. Possible values are `TCP` and `UDP`.
+
+---
+
+A `security_profile` block supports the following:
+
+* `enable_secure_boot` - (Optional) Specifies whether Secure Boot is enabled for this Node Pool.
+
+* `enable_vtpm` - (Optional) Specifies whether vTPM is enabled for this Node Pool.
+
+~> **Note:** When migrating an existing Node Pool to `os_sku = "AzureContainerLinux"`, `enable_secure_boot` and `enable_vtpm` must be set to `true`.
 
 ---
 


### PR DESCRIPTION
## Community Note
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

This adds AKS node pool support for:

* `AzureContainerLinux` as an `os_sku` value for the default node pool and standalone node pools.
* `security_profile.enable_secure_boot` and `security_profile.enable_vtpm` for the default node pool and standalone node pools.
* `KataVmIsolation` as a `workload_runtime` value for the default node pool and standalone node pools.

The current ContainerService SDK version already includes the required security profile fields and `KataVmIsolation` enum value. `AzureContainerLinux` is accepted by the AKS API but is not exposed as a generated enum constant in the current SDK, so this uses a local string constant for provider validation.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them.
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally.

## Testing

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass.

```console
$ PATH="$(go env GOPATH)/bin:$PATH" make build
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
...
go install
```

```console
$ PATH="$(go env GOPATH)/bin:$PATH" make website-lint
==> Checking documentation for .html.markdown extension present
==> Checking documentation spelling...
==> Checking documentation for errors...
==> Checking documentation terraform blocks are formatted...
```

```console
$ PATH="$(go env GOPATH)/bin:$PATH" go run internal/tools/document-lint/main.go check -resource azurerm_kubernetes_cluster,azurerm_kubernetes_cluster_node_pool
2026/06/10 22:42:10 Loaded upgrade guide from: /private/tmp/azurerm-hardening-20260610/aks-kata-acl/website/docs/5.0-upgrade-guide.html.markdown
2026/06/10 22:42:10 document linter runs success, time costs: 33.964458ms
```

```console
$ go test ./internal/services/containers -run '^$'
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/containers	1.265s [no tests to run]
```

```console
$ go test ./internal/services/containers -run 'TestAccKubernetesCluster_(osSkuAzureContainerLinux|workloadRuntimeKataVmIsolation)$|TestAccKubernetesClusterNodePool_(osSkuAzureContainerLinux|osSkuAzureContainerLinuxMigration|workloadRuntimeKataVmIsolation)$' -count=1
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/containers	2.467s
```

```console
$ PATH="$(go env GOPATH)/bin:$PATH" golangci-lint run --new-from-rev=upstream/main ./internal/services/containers/...
0 issues.
```

Acceptance tests:

```console
$ PATH="$(go env GOPATH)/bin:$PATH" TF_ACC=1 go test -v ./internal/services/containers -run 'TestAccKubernetesCluster_(osSkuAzureContainerLinux|workloadRuntimeKataVmIsolation)$|TestAccKubernetesClusterNodePool_(osSkuAzureContainerLinux|osSkuAzureContainerLinuxMigration|workloadRuntimeKataVmIsolation)$' -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
--- PASS: TestAccKubernetesClusterNodePool_workloadRuntimeKataVmIsolation (818.60s)
--- PASS: TestAccKubernetesCluster_workloadRuntimeKataVmIsolation (844.73s)
```

```console
$ PATH="$(go env GOPATH)/bin:$PATH" TF_ACC=1 go test -v ./internal/services/containers -run 'TestAccKubernetesCluster_osSkuAzureContainerLinux$|TestAccKubernetesClusterNodePool_(osSkuAzureContainerLinux|osSkuAzureContainerLinuxMigration)$' -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
--- PASS: TestAccKubernetesCluster_osSkuAzureContainerLinux (652.79s)
--- PASS: TestAccKubernetesClusterNodePool_osSkuAzureContainerLinux (783.54s)
--- PASS: TestAccKubernetesClusterNodePool_osSkuAzureContainerLinuxMigration (831.90s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/containers	833.265s
```

Additional live probes using the local provider build:

```console
# Created default and standalone AzureContainerLinux pools with security_profile omitted.
# ARM returned securityProfile.enableSecureBoot=true and securityProfile.enableVTPM=true for both.
```

```console
# AzureLinux -> AzureContainerLinux migration without security_profile failed in place:
code: InvalidOSSKU
message: OSSKU='AzureContainerLinux' is invalid, details: AzureContainerLinux requires secureboot and vTPM to be enabled
```

```console
# The same migration with enable_secure_boot=true and enable_vtpm=true succeeded in place.
Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

```console
# KataVmIsolation with os_sku="Ubuntu" failed at create:
code: InvalidWorkloadRuntimeSettingError
message: Kata: "KataVmIsolation" has to be used with OSSKU "AzureLinux".
```

```console
# Cleanup verification for the disposable resource groups:
test_rg_exists=false
managed_rg_exists=false
```

## Change Log

* `azurerm_kubernetes_cluster` - support `AzureContainerLinux` for `default_node_pool.os_sku`, `security_profile` for default node pools, and `KataVmIsolation` for `default_node_pool.workload_runtime`
* `azurerm_kubernetes_cluster_node_pool` - support `AzureContainerLinux` for `os_sku`, `security_profile`, and `KataVmIsolation` for `workload_runtime`

This is a:

- [ ] Bug Fix
- [x] New Feature
- [x] Enhancement
- [ ] Breaking Change

## Related Issue(s)

N/A

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

This exposes AKS node pool Secure Boot and vTPM settings through Terraform. It does not change provider authentication, authorization, logging, or data handling behavior.