### PR TITLE
`azurerm_kubernetes_cluster` and `azurerm_kubernetes_cluster_node_pool` - support KataVmIsolation workload runtime

### DIFF
--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -461,6 +461,7 @@ func resourceKubernetesClusterNodePoolSchema() map[string]*pluginsdk.Schema {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
 			ValidateFunc: validation.StringInSlice([]string{
+				string(agentpools.WorkloadRuntimeKataVMIsolation),
 				string(agentpools.WorkloadRuntimeOCIContainer),
 				string(agentpools.WorkloadRuntimeWasmWasi),
 			}, false),

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -1087,6 +1087,23 @@ func TestAccKubernetesClusterNodePool_workloadRuntime(t *testing.T) {
 	})
 }
 
+func TestAccKubernetesClusterNodePool_workloadRuntimeKataVmIsolation(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster_node_pool", "test")
+	r := KubernetesClusterNodePoolResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.workloadRuntimeKataVmIsolation(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("os_sku").HasValue("AzureLinux"),
+				check.That(data.ResourceName).Key("workload_runtime").HasValue("KataVmIsolation"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccKubernetesClusterNodePool_windowsProfileOutboundNatEnabled(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster_node_pool", "test")
 	r := KubernetesClusterNodePoolResource{}
@@ -3359,6 +3376,46 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, workloadRuntime)
+}
+
+func (KubernetesClusterNodePoolResource) workloadRuntimeKataVmIsolation(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%d"
+  location = "%s"
+}
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
+  kubernetes_version  = %q
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_D2s_v3"
+    upgrade_settings {
+      max_surge = "10%%"
+    }
+  }
+  identity {
+    type = "SystemAssigned"
+  }
+}
+resource "azurerm_kubernetes_cluster_node_pool" "test" {
+  name                  = "internal"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
+  vm_size               = "Standard_D4s_v3"
+  os_sku                = "AzureLinux"
+  workload_runtime      = "KataVmIsolation"
+  upgrade_settings {
+    max_surge = "10%%"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, currentKubernetesVersion)
 }
 
 func (KubernetesClusterNodePoolResource) windowsProfileOutboundNatEnabled(data acceptance.TestData) string {

--- a/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -806,6 +806,23 @@ func TestAccKubernetesCluster_osSkuUpdate(t *testing.T) {
 	})
 }
 
+func TestAccKubernetesCluster_workloadRuntimeKataVmIsolation(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
+	r := KubernetesClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.workloadRuntimeKataVmIsolation(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("default_node_pool.0.os_sku").HasValue("AzureLinux"),
+				check.That(data.ResourceName).Key("default_node_pool.0.workload_runtime").HasValue("KataVmIsolation"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccKubernetesCluster_microsoftDefender(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
 	r := KubernetesClusterResource{}
@@ -3076,6 +3093,43 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, osSKu)
+}
+
+func (KubernetesClusterResource) workloadRuntimeKataVmIsolation(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%d"
+  location = "%s"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
+  kubernetes_version  = %q
+
+  default_node_pool {
+    name             = "default"
+    node_count       = 1
+    vm_size          = "Standard_D4s_v3"
+    os_sku           = "AzureLinux"
+    workload_runtime = "KataVmIsolation"
+
+    upgrade_settings {
+      max_surge = "10%%"
+    }
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, currentKubernetesVersion)
 }
 
 func (KubernetesClusterResource) oidcIssuer(data acceptance.TestData, enabled bool) string {

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -260,6 +260,7 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 						Optional: true,
 						Computed: true,
 						ValidateFunc: validation.StringInSlice([]string{
+							string(managedclusters.WorkloadRuntimeKataVMIsolation),
 							string(managedclusters.WorkloadRuntimeOCIContainer),
 						}, false),
 					},

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -167,7 +167,7 @@ In addition, one of either `identity` or `service_principal` blocks must be spec
 
 ~> **Note:** `node_os_upgrade_channel` must be set to `NodeImage` if `automatic_upgrade_channel` has been set to `node-image`
 
-* `node_provisioning_profile` - (Required) A `node_provisioning_profile` block as defined below.
+* `node_provisioning_profile` - (Optional) A `node_provisioning_profile` block as defined below.
 
 * `node_resource_group` - (Optional) The name of the Resource Group where the Kubernetes Nodes should exist. Changing this forces a new resource to be created.
 
@@ -455,7 +455,9 @@ A `default_node_pool` block supports the following:
 
 ~> **Note:** A Route Table must be configured on this Subnet.
 
-* `workload_runtime` - (Optional) Specifies the workload runtime used by the node pool. Possible value is `OCIContainer`.
+* `workload_runtime` - (Optional) Specifies the workload runtime used by the node pool. Possible values are `KataVmIsolation` and `OCIContainer`.
+
+~> **Note:** `KataVmIsolation` requires `os_sku` to be set to `AzureLinux` and the selected VM size must support nested virtualization.
 
 * `zones` - (Optional) Specifies a list of Availability Zones in which this Kubernetes Cluster should be located. `temporary_name_for_rotation` must be specified when changing this property.
 

--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -160,7 +160,9 @@ The following arguments are supported:
 
 * `windows_profile` - (Optional) A `windows_profile` block as documented below. Changing this forces a new resource to be created.
 
-* `workload_runtime` - (Optional) Used to specify the workload runtime. Allowed values are `OCIContainer` and `WasmWasi`.
+* `workload_runtime` - (Optional) Used to specify the workload runtime. Allowed values are `KataVmIsolation`, `OCIContainer` and `WasmWasi`.
+
+~> **Note:** `KataVmIsolation` requires `os_sku` to be set to `AzureLinux` and the selected VM size must support nested virtualization.
 
 ~> **Note:** WebAssembly System Interface node pools are in Public Preview - more information and details on how to opt into the preview can be found in [this article](https://docs.microsoft.com/azure/aks/use-wasi-node-pools)
 


### PR DESCRIPTION
## Community Note
* Please vote on this PR by adding a :thumbsup: reaction to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

This adds support for `workload_runtime = "KataVmIsolation"` on `azurerm_kubernetes_cluster` default node pools and `azurerm_kubernetes_cluster_node_pool`.

AKS requires KataVmIsolation node pools to use `os_sku = "AzureLinux"` and a VM size that supports nested virtualization, so the docs and tests cover that combination.

## PR Checklist

- [x] I have followed the guidelines in our Contributing Documentation.
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them.
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally.

## Testing

```console
$ go test ./internal/services/containers -run '^$'
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/containers	1.335s [no tests to run]

$ go run internal/tools/document-lint/main.go check -resource azurerm_kubernetes_cluster,azurerm_kubernetes_cluster_node_pool
2026/06/11 10:50:22 document linter runs success, time costs: 35.051291ms

$ PATH="$(go env GOPATH)/bin:$PATH" make website-lint
==> Checking documentation for .html.markdown extension present
==> Checking documentation spelling...
==> Checking documentation for errors...
==> Checking documentation terraform blocks are formatted...
```

Acceptance tests added for:

```console
TestAccKubernetesCluster_workloadRuntimeKataVmIsolation
TestAccKubernetesClusterNodePool_workloadRuntimeKataVmIsolation
```

## Change Log

* `azurerm_kubernetes_cluster` - support `KataVmIsolation` for `default_node_pool.workload_runtime`
* `azurerm_kubernetes_cluster_node_pool` - support `KataVmIsolation` for `workload_runtime`

This is a:

- [ ] Bug Fix
- [ ] New Feature
- [x] Enhancement
- [ ] Breaking Change

## Related Issue(s)

None

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

No changes to security controls.
