### PR TITLE
`contributing guides` - clarify singular vs plural naming for block properties

### DIFF
--- a/contributing/topics/reference-naming.md
+++ b/contributing/topics/reference-naming.md
@@ -32,6 +32,55 @@ Here are some general guidelines you can turn to when naming properties:
 * Properties that represent percentage values should be appended with `_percentage` e.g.
 > `sampling_percentage`
 
+## Singular and Plural Block Property Naming Conventions
+
+* Blocks in resources should generally use singular names, since each block represents a single configured object, e.g.
+
+```go
+"rule": {
+	Type:     pluginsdk.TypeList,
+	Optional: true,
+	Elem: &pluginsdk.Resource{
+		Schema: map[string]*pluginsdk.Schema{
+			"name": {
+				Type:     pluginsdk.TypeString,
+				Required: true,
+                ValidateFunc: validation.StringIsNotEmpty,
+			},
+		},
+	},
+},
+```
+
+* Lists of primitive values should generally use plural names, since the property represents multiple values, e.g.
+
+```go
+"allowed_ip_ranges": {
+	Type:     pluginsdk.TypeList,
+	Optional: true,
+	Elem: &pluginsdk.Schema{
+		Type: pluginsdk.TypeString,
+	},
+},
+```
+
+* Computed-only attributes, including those in data sources, should generally use plural names when they return multiple values, since users are not defining the individual blocks in configuration, e.g.
+
+```go
+"rules": {
+	Type:     pluginsdk.TypeList,
+	Computed: true,
+	Elem: &pluginsdk.Resource{
+		Schema: map[string]*pluginsdk.Schema{
+			"name": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+		},
+	},
+},
+```
+
 ## Resource ID Reference
 
 Properties that are a reference to another resource's ID should be in the format of `{resource_name}_id` where `{resource_name}` is the full name minus the provider prefix (`azurerm_`). e.g.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR clarifies the naming conventions for block and list properties in the contributor documentation (`contributing/topics/reference-naming.md`), giving contributors and reviewers a clear reference for keeping new property names consistent.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
