### PR TITLE
`tooling` -  `golangci-lint` update to `v2.12.2` for `Go 1.26` coverage

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -333,9 +333,11 @@ jobs:
           go-version-file: ./.go-version
       - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
-          version: 'v2.4.0'
-          install-mode: 'goinstall'
-          args: -v ./...
+          version: 'v2.12.2'
+          # Use the default 'binary' install mode: it downloads the pre-built
+          # release binary instead of compiling golangci-lint from source
+          # (goinstall), which is significantly faster for a pinned version.
+          args: ./...
       - name: Guidance on failure
         if: failure()
         run: |

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,7 +19,6 @@ linters:
     - ineffassign
     - misspell
     - nilerr
-    - prealloc
     - predeclared
     - reassign
     - staticcheck
@@ -62,6 +61,7 @@ linters:
       - legacy
       - std-error-handling
     paths:
+      - vendor$
       - internal/services/.*/.*_gen.go$
       - /sdk/
       - third_party$
@@ -78,6 +78,7 @@ formatters:
   exclusions:
     generated: lax
     paths:
+      - vendor$
       - internal/services/.*/.*_gen.go$
       - /sdk/
       - third_party$

--- a/helpers/azure/error_output.go
+++ b/helpers/azure/error_output.go
@@ -19,12 +19,12 @@ func QuotedStringSlice(strs []string) string {
 	for i, str := range strs {
 		if i < (len(strs) - 1) {
 			if i == (len(strs) - 2) {
-				sb.WriteString(fmt.Sprint(`"`, str, `"`))
+				fmt.Fprint(&sb, `"`, str, `"`)
 			} else {
-				sb.WriteString(fmt.Sprint(`"`, str, `", `))
+				fmt.Fprint(&sb, `"`, str, `", `)
 			}
 		} else {
-			sb.WriteString(fmt.Sprint(` or "`, str, `"`))
+			fmt.Fprint(&sb, ` or "`, str, `"`)
 		}
 	}
 

--- a/internal/provider/services_test.go
+++ b/internal/provider/services_test.go
@@ -168,19 +168,19 @@ func TestTypedResourcesUsePointersForOptionalProperties(t *testing.T) {
 					if !ok {
 						continue
 					} else {
-						if v.Optional && field.Type.Kind() != reflect.Ptr {
+						if v.Optional && field.Type.Kind() != reflect.Pointer {
 							t.Logf("Optional field `%s` in model `%s` in resource `%s` should be a pointer!", property, modelType.Name(), resource.ResourceType())
 							fails = true
 							continue
 						}
 
-						if v.Required && field.Type.Kind() == reflect.Ptr {
+						if v.Required && field.Type.Kind() == reflect.Pointer {
 							t.Logf("Required field `%s` in model `%s` in resource `%s` should not be a pointer!", property, modelType.Name(), resource.ResourceType())
 							fails = true
 							continue
 						}
 
-						if v.Computed && !v.Required && !v.Optional && field.Type.Kind() == reflect.Ptr {
+						if v.Computed && !v.Required && !v.Optional && field.Type.Kind() == reflect.Pointer {
 							t.Logf("Computed Only field `%s` in model `%s` in resource `%s` should not be a pointer!", property, modelType.Name(), resource.ResourceType())
 						}
 

--- a/internal/services/analysisservices/analysis_services_server_resource.go
+++ b/internal/services/analysisservices/analysis_services_server_resource.go
@@ -422,8 +422,8 @@ func hashAnalysisServicesServerIPv4FirewallRule(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
 
-	buf.WriteString(fmt.Sprintf("%s-", strings.ToLower(m["name"].(string))))
-	buf.WriteString(fmt.Sprintf("%s-", m["range_start"].(string)))
+	fmt.Fprintf(&buf, "%s-", strings.ToLower(m["name"].(string)))
+	fmt.Fprintf(&buf, "%s-", m["range_start"].(string))
 	buf.WriteString(m["range_end"].(string))
 
 	return pluginsdk.HashString(buf.String())

--- a/internal/services/automation/helper/automation_job_schedule.go
+++ b/internal/services/automation/helper/automation_job_schedule.go
@@ -116,7 +116,7 @@ func ResourceAutomationJobScheduleDigest(v interface{}) string {
 		runOn = pointer.From(pointer.From(job.Runbook).Name)
 		paramString = pointer.From(job.Parameters)
 	}
-	buf.WriteString(fmt.Sprintf("%s-%s-", scheduleName, runOn))
+	fmt.Fprintf(&buf, "%s-%s-", scheduleName, runOn)
 
 	keys := make([]string, 0, len(paramString))
 	for k := range paramString {
@@ -125,7 +125,7 @@ func ResourceAutomationJobScheduleDigest(v interface{}) string {
 	}
 	sort.Strings(keys)
 	for _, k := range keys {
-		buf.WriteString(fmt.Sprintf("%s:%v;", strings.ToLower(k), paramString[k]))
+		fmt.Fprintf(&buf, "%s:%v;", strings.ToLower(k), paramString[k])
 	}
 	return buf.String()
 }

--- a/internal/services/compute/ssh_keys.go
+++ b/internal/services/compute/ssh_keys.go
@@ -198,8 +198,8 @@ func SSHKeySchemaHash(v interface{}) int {
 		if err != nil {
 			log.Printf("[DEBUG] error normalising ssh key %q: %+v", m["public_key"].(string), err)
 		}
-		buf.WriteString(fmt.Sprintf("%s-", *normalisedKey))
-		buf.WriteString(fmt.Sprintf("%s", m["username"]))
+		fmt.Fprintf(&buf, "%s-", *normalisedKey)
+		fmt.Fprintf(&buf, "%s", m["username"])
 	}
 
 	return pluginsdk.HashString(buf.String())

--- a/internal/services/compute/virtual_machine_scale_set.go
+++ b/internal/services/compute/virtual_machine_scale_set.go
@@ -1987,18 +1987,18 @@ func virtualMachineScaleSetExtensionHash(v interface{}) int {
 	var buf bytes.Buffer
 
 	if m, ok := v.(map[string]interface{}); ok {
-		buf.WriteString(fmt.Sprintf("%s-", m["name"].(string)))
-		buf.WriteString(fmt.Sprintf("%s-", m["publisher"].(string)))
-		buf.WriteString(fmt.Sprintf("%s-", m["type"].(string)))
-		buf.WriteString(fmt.Sprintf("%s-", m["type_handler_version"].(string)))
-		buf.WriteString(fmt.Sprintf("%t-", m["auto_upgrade_minor_version"].(bool)))
+		fmt.Fprintf(&buf, "%s-", m["name"].(string))
+		fmt.Fprintf(&buf, "%s-", m["publisher"].(string))
+		fmt.Fprintf(&buf, "%s-", m["type"].(string))
+		fmt.Fprintf(&buf, "%s-", m["type_handler_version"].(string))
+		fmt.Fprintf(&buf, "%t-", m["auto_upgrade_minor_version"].(bool))
 
 		if v, ok = m["force_update_tag"]; ok {
-			buf.WriteString(fmt.Sprintf("%s-", v))
+			fmt.Fprintf(&buf, "%s-", v)
 		}
 
 		if v, ok := m["provision_after_extensions"]; ok {
-			buf.WriteString(fmt.Sprintf("%s-", v))
+			fmt.Fprintf(&buf, "%s-", v)
 		}
 
 		// we need to ensure the whitespace is consistent
@@ -2008,7 +2008,7 @@ func virtualMachineScaleSetExtensionHash(v interface{}) int {
 			if err == nil {
 				serializedSettings, err := pluginsdk.FlattenJsonToString(expandedSettings)
 				if err == nil {
-					buf.WriteString(fmt.Sprintf("%s-", serializedSettings))
+					fmt.Fprintf(&buf, "%s-", serializedSettings)
 				}
 			}
 		}
@@ -2020,7 +2020,7 @@ func virtualMachineScaleSetExtensionHash(v interface{}) int {
 				if err == nil {
 					serializedSettings, err := pluginsdk.FlattenJsonToString(expandedSettings)
 					if err == nil {
-						buf.WriteString(fmt.Sprintf("%s-", serializedSettings))
+						fmt.Fprintf(&buf, "%s-", serializedSettings)
 					}
 				}
 			}
@@ -2029,8 +2029,8 @@ func virtualMachineScaleSetExtensionHash(v interface{}) int {
 		if v, ok := m["protected_settings_from_key_vault"]; ok {
 			protectedSettingsFromKeyVault := v.([]interface{})
 			if len(protectedSettingsFromKeyVault) > 0 {
-				buf.WriteString(fmt.Sprintf("%s-", protectedSettingsFromKeyVault[0].(map[string]interface{})["secret_url"].(string)))
-				buf.WriteString(fmt.Sprintf("%s-", protectedSettingsFromKeyVault[0].(map[string]interface{})["source_vault_id"].(string)))
+				fmt.Fprintf(&buf, "%s-", protectedSettingsFromKeyVault[0].(map[string]interface{})["secret_url"].(string))
+				fmt.Fprintf(&buf, "%s-", protectedSettingsFromKeyVault[0].(map[string]interface{})["source_vault_id"].(string))
 			}
 		}
 	}

--- a/internal/services/containers/container_group_resource.go
+++ b/internal/services/containers/container_group_resource.go
@@ -2007,8 +2007,8 @@ func resourceContainerGroupPortsHash(v interface{}) int {
 	var buf bytes.Buffer
 
 	if m, ok := v.(map[string]interface{}); ok {
-		buf.WriteString(fmt.Sprintf("%d-", m["port"].(int)))
-		buf.WriteString(fmt.Sprintf("%s-", m["protocol"].(string)))
+		fmt.Fprintf(&buf, "%d-", m["port"].(int))
+		fmt.Fprintf(&buf, "%s-", m["protocol"].(string))
 	}
 
 	return pluginsdk.HashString(buf.String())

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -4351,11 +4351,11 @@ func expandKubernetesClusterAutoScalerProfile(input []interface{}) *managedclust
 }
 
 func expandKubernetesClusterAzureKeyVaultKms(ctx context.Context, keyVaultsClient *keyVaultClient.Client, subscriptionId string, d *pluginsdk.ResourceData, input []interface{}) (*managedclusters.AzureKeyVaultKms, error) {
-	if ((input == nil) || len(input) == 0) && d.HasChanges("key_management_service") {
+	if len(input) == 0 && d.HasChanges("key_management_service") {
 		return &managedclusters.AzureKeyVaultKms{
 			Enabled: pointer.To(false),
 		}, nil
-	} else if (input == nil) || len(input) == 0 {
+	} else if len(input) == 0 {
 		return nil, nil
 	}
 
@@ -4818,7 +4818,7 @@ func flattenKubernetesClusterMicrosoftDefender(input *managedclusters.ManagedClu
 }
 
 func expandStorageProfile(input []interface{}) *managedclusters.ManagedClusterStorageProfile {
-	if (input == nil) || len(input) == 0 {
+	if len(input) == 0 {
 		return nil
 	}
 
@@ -4875,7 +4875,7 @@ func base64IsEncoded(data string) bool {
 }
 
 func expandKubernetesClusterServiceMeshProfile(input []interface{}, existing *managedclusters.ServiceMeshProfile) *managedclusters.ServiceMeshProfile {
-	if (input == nil) || len(input) == 0 {
+	if len(input) == 0 {
 		// explicitly disable istio if it was enabled before
 		if existing != nil && existing.Mode == managedclusters.ServiceMeshModeIstio {
 			return &managedclusters.ServiceMeshProfile{

--- a/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/internal/services/cosmos/cosmosdb_account_resource.go
@@ -1866,7 +1866,7 @@ func resourceAzureRMCosmosDBAccountGeoLocationHash(v interface{}) int {
 		priority := int32(m["failover_priority"].(int))
 		zone_redundant := m["zone_redundant"].(bool)
 
-		buf.WriteString(fmt.Sprintf("%s-%d-%t", location, priority, zone_redundant))
+		fmt.Fprintf(&buf, "%s-%d-%t", location, priority, zone_redundant)
 	}
 
 	return pluginsdk.HashString(buf.String())
@@ -1876,7 +1876,7 @@ func resourceAzureRMCosmosDBAccountCapabilitiesHash(v interface{}) int {
 	var buf bytes.Buffer
 
 	if m, ok := v.(map[string]interface{}); ok {
-		buf.WriteString(fmt.Sprintf("%s-", m["name"].(string)))
+		fmt.Fprintf(&buf, "%s-", m["name"].(string))
 	}
 
 	return pluginsdk.HashString(buf.String())

--- a/internal/services/datafactory/data_factory_integration_runtime_self_hosted_resource.go
+++ b/internal/services/datafactory/data_factory_integration_runtime_self_hosted_resource.go
@@ -289,9 +289,9 @@ func resourceDataFactoryIntegrationRuntimeSelfHostedRbacAuthorizationHash(v inte
 	if m, ok := v.(map[string]interface{}); ok {
 		if v, ok := m["resource_id"]; ok {
 			if !features.FivePointOh() {
-				buf.WriteString(fmt.Sprintf("%s-", strings.ToLower(v.(string))))
+				fmt.Fprintf(&buf, "%s-", strings.ToLower(v.(string)))
 			} else {
-				buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+				fmt.Fprintf(&buf, "%s-", v.(string))
 			}
 		}
 	}

--- a/internal/services/dns/dns_caa_record_resource.go
+++ b/internal/services/dns/dns_caa_record_resource.go
@@ -270,9 +270,9 @@ func resourceDnsCaaRecordHash(v interface{}) int {
 	var buf bytes.Buffer
 
 	if m, ok := v.(map[string]interface{}); ok {
-		buf.WriteString(fmt.Sprintf("%d-", m["flags"].(int)))
-		buf.WriteString(fmt.Sprintf("%s-", m["tag"].(string)))
-		buf.WriteString(fmt.Sprintf("%s-", m["value"].(string)))
+		fmt.Fprintf(&buf, "%d-", m["flags"].(int))
+		fmt.Fprintf(&buf, "%s-", m["tag"].(string))
+		fmt.Fprintf(&buf, "%s-", m["value"].(string))
 	}
 
 	return pluginsdk.HashString(buf.String())

--- a/internal/services/dns/dns_mx_record_resource.go
+++ b/internal/services/dns/dns_mx_record_resource.go
@@ -259,8 +259,8 @@ func resourceDnsMxRecordHash(v interface{}) int {
 	var buf bytes.Buffer
 
 	if m, ok := v.(map[string]interface{}); ok {
-		buf.WriteString(fmt.Sprintf("%s-", m["preference"].(string)))
-		buf.WriteString(fmt.Sprintf("%s-", m["exchange"].(string)))
+		fmt.Fprintf(&buf, "%s-", m["preference"].(string))
+		fmt.Fprintf(&buf, "%s-", m["exchange"].(string))
 	}
 
 	return pluginsdk.HashString(buf.String())

--- a/internal/services/dns/dns_srv_record_resource.go
+++ b/internal/services/dns/dns_srv_record_resource.go
@@ -322,10 +322,10 @@ func resourceDnsSrvRecordHash(v interface{}) int {
 	var buf bytes.Buffer
 
 	if m, ok := v.(map[string]interface{}); ok {
-		buf.WriteString(fmt.Sprintf("%d-", m["priority"].(int)))
-		buf.WriteString(fmt.Sprintf("%d-", m["weight"].(int)))
-		buf.WriteString(fmt.Sprintf("%d-", m["port"].(int)))
-		buf.WriteString(fmt.Sprintf("%s-", m["target"].(string)))
+		fmt.Fprintf(&buf, "%d-", m["priority"].(int))
+		fmt.Fprintf(&buf, "%d-", m["weight"].(int))
+		fmt.Fprintf(&buf, "%d-", m["port"].(int))
+		fmt.Fprintf(&buf, "%s-", m["target"].(string))
 	}
 
 	return pluginsdk.HashString(buf.String())

--- a/internal/services/dns/migration/caa_record_v0_to_v1.go
+++ b/internal/services/dns/migration/caa_record_v0_to_v1.go
@@ -100,9 +100,9 @@ func resourceDnsCaaRecordHash(v interface{}) int {
 	var buf bytes.Buffer
 
 	if m, ok := v.(map[string]interface{}); ok {
-		buf.WriteString(fmt.Sprintf("%d-", m["flags"].(int)))
-		buf.WriteString(fmt.Sprintf("%s-", m["tag"].(string)))
-		buf.WriteString(fmt.Sprintf("%s-", m["value"].(string)))
+		fmt.Fprintf(&buf, "%d-", m["flags"].(int))
+		fmt.Fprintf(&buf, "%s-", m["tag"].(string))
+		fmt.Fprintf(&buf, "%s-", m["value"].(string))
 	}
 
 	return pluginsdk.HashString(buf.String())

--- a/internal/services/dns/migration/mx_record_v0_to_v1.go
+++ b/internal/services/dns/migration/mx_record_v0_to_v1.go
@@ -97,8 +97,8 @@ func resourceDnsMxRecordHash(v interface{}) int {
 	var buf bytes.Buffer
 
 	if m, ok := v.(map[string]interface{}); ok {
-		buf.WriteString(fmt.Sprintf("%s-", m["preference"].(string)))
-		buf.WriteString(fmt.Sprintf("%s-", m["exchange"].(string)))
+		fmt.Fprintf(&buf, "%s-", m["preference"].(string))
+		fmt.Fprintf(&buf, "%s-", m["exchange"].(string))
 	}
 
 	return pluginsdk.HashString(buf.String())

--- a/internal/services/dns/migration/srv_record_v0_to_v1.go
+++ b/internal/services/dns/migration/srv_record_v0_to_v1.go
@@ -105,10 +105,10 @@ func resourceDnsSrvRecordHash(v interface{}) int {
 	var buf bytes.Buffer
 
 	if m, ok := v.(map[string]interface{}); ok {
-		buf.WriteString(fmt.Sprintf("%d-", m["priority"].(int)))
-		buf.WriteString(fmt.Sprintf("%d-", m["weight"].(int)))
-		buf.WriteString(fmt.Sprintf("%d-", m["port"].(int)))
-		buf.WriteString(fmt.Sprintf("%s-", m["target"].(string)))
+		fmt.Fprintf(&buf, "%d-", m["priority"].(int))
+		fmt.Fprintf(&buf, "%d-", m["weight"].(int))
+		fmt.Fprintf(&buf, "%d-", m["port"].(int))
+		fmt.Fprintf(&buf, "%s-", m["target"].(string))
 	}
 
 	return pluginsdk.HashString(buf.String())

--- a/internal/services/eventhub/eventhub_namespace_resource.go
+++ b/internal/services/eventhub/eventhub_namespace_resource.go
@@ -746,10 +746,10 @@ func resourceVnetRuleHash(v interface{}) int {
 
 	if m, ok := v.(map[string]interface{}); ok {
 		if v, ok := m["subnet_id"]; ok {
-			buf.WriteString(fmt.Sprintf("%s-", strings.ToLower(v.(string))))
+			fmt.Fprintf(&buf, "%s-", strings.ToLower(v.(string)))
 		}
 		if v, ok := m["ignore_missing_virtual_network_service_endpoint"]; ok {
-			buf.WriteString(fmt.Sprintf("%t-", v.(bool)))
+			fmt.Fprintf(&buf, "%t-", v.(bool))
 		}
 	}
 	return pluginsdk.HashString(buf.String())

--- a/internal/services/legacy/migration/legacy_vmss_v0_to_v1.go
+++ b/internal/services/legacy/migration/legacy_vmss_v0_to_v1.go
@@ -736,10 +736,10 @@ func resourceArmVirtualMachineScaleSetOsProfileWindowsConfigHash(v interface{}) 
 
 	if m, ok := v.(map[string]interface{}); ok {
 		if v, ok := m["provision_vm_agent"]; ok {
-			buf.WriteString(fmt.Sprintf("%t-", v.(bool)))
+			fmt.Fprintf(&buf, "%t-", v.(bool))
 		}
 		if v, ok := m["enable_automatic_upgrades"]; ok {
-			buf.WriteString(fmt.Sprintf("%t-", v.(bool)))
+			fmt.Fprintf(&buf, "%t-", v.(bool))
 		}
 	}
 
@@ -750,7 +750,7 @@ func resourceArmVirtualMachineScaleSetOsProfileLinuxConfigHash(v interface{}) in
 	var buf bytes.Buffer
 
 	if m, ok := v.(map[string]interface{}); ok {
-		buf.WriteString(fmt.Sprintf("%t-", m["disable_password_authentication"].(bool)))
+		fmt.Fprintf(&buf, "%t-", m["disable_password_authentication"].(bool))
 	}
 
 	return pluginsdk.HashString(buf.String())
@@ -760,8 +760,8 @@ func resourceArmVirtualMachineScaleSetNetworkConfigurationHash(v interface{}) in
 	var buf bytes.Buffer
 
 	if m, ok := v.(map[string]interface{}); ok {
-		buf.WriteString(fmt.Sprintf("%s-", m["name"].(string)))
-		buf.WriteString(fmt.Sprintf("%t-", m["primary"].(bool)))
+		fmt.Fprintf(&buf, "%s-", m["name"].(string))
+		fmt.Fprintf(&buf, "%t-", m["primary"].(bool))
 	}
 
 	return pluginsdk.HashString(buf.String())
@@ -771,10 +771,10 @@ func resourceArmVirtualMachineScaleSetStorageProfileOsDiskHash(v interface{}) in
 	var buf bytes.Buffer
 
 	if m, ok := v.(map[string]interface{}); ok {
-		buf.WriteString(fmt.Sprintf("%s-", m["name"].(string)))
+		fmt.Fprintf(&buf, "%s-", m["name"].(string))
 
 		if v, ok := m["vhd_containers"]; ok {
-			buf.WriteString(fmt.Sprintf("%s-", v.(*pluginsdk.Set).List()))
+			fmt.Fprintf(&buf, "%s-", v.(*pluginsdk.Set).List())
 		}
 	}
 
@@ -786,19 +786,19 @@ func resourceArmVirtualMachineScaleSetStorageProfileImageReferenceHash(v interfa
 
 	if m, ok := v.(map[string]interface{}); ok {
 		if v, ok := m["publisher"]; ok {
-			buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+			fmt.Fprintf(&buf, "%s-", v.(string))
 		}
 		if v, ok := m["offer"]; ok {
-			buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+			fmt.Fprintf(&buf, "%s-", v.(string))
 		}
 		if v, ok := m["sku"]; ok {
-			buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+			fmt.Fprintf(&buf, "%s-", v.(string))
 		}
 		if v, ok := m["version"]; ok {
-			buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+			fmt.Fprintf(&buf, "%s-", v.(string))
 		}
 		if v, ok := m["id"]; ok {
-			buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+			fmt.Fprintf(&buf, "%s-", v.(string))
 		}
 	}
 
@@ -809,17 +809,17 @@ func resourceArmVirtualMachineScaleSetExtensionHash(v interface{}) int {
 	var buf bytes.Buffer
 
 	if m, ok := v.(map[string]interface{}); ok {
-		buf.WriteString(fmt.Sprintf("%s-", m["name"].(string)))
-		buf.WriteString(fmt.Sprintf("%s-", m["publisher"].(string)))
-		buf.WriteString(fmt.Sprintf("%s-", m["type"].(string)))
-		buf.WriteString(fmt.Sprintf("%s-", m["type_handler_version"].(string)))
+		fmt.Fprintf(&buf, "%s-", m["name"].(string))
+		fmt.Fprintf(&buf, "%s-", m["publisher"].(string))
+		fmt.Fprintf(&buf, "%s-", m["type"].(string))
+		fmt.Fprintf(&buf, "%s-", m["type_handler_version"].(string))
 
 		if v, ok := m["auto_upgrade_minor_version"]; ok {
-			buf.WriteString(fmt.Sprintf("%t-", v.(bool)))
+			fmt.Fprintf(&buf, "%t-", v.(bool))
 		}
 
 		if v, ok := m["provision_after_extensions"]; ok {
-			buf.WriteString(fmt.Sprintf("%s-", v.(*pluginsdk.Set).List()))
+			fmt.Fprintf(&buf, "%s-", v.(*pluginsdk.Set).List())
 		}
 
 		// we need to ensure the whitespace is consistent
@@ -829,7 +829,7 @@ func resourceArmVirtualMachineScaleSetExtensionHash(v interface{}) int {
 			if err == nil {
 				serialisedSettings, err := pluginsdk.FlattenJsonToString(expandedSettings)
 				if err == nil {
-					buf.WriteString(fmt.Sprintf("%s-", serialisedSettings))
+					fmt.Fprintf(&buf, "%s-", serialisedSettings)
 				}
 			}
 		}

--- a/internal/services/legacy/virtual_machine_resource.go
+++ b/internal/services/legacy/virtual_machine_resource.go
@@ -1819,8 +1819,8 @@ func resourceVirtualMachineStorageOsProfileHash(v interface{}) int {
 	var buf bytes.Buffer
 
 	if m, ok := v.(map[string]interface{}); ok {
-		buf.WriteString(fmt.Sprintf("%s-", m["admin_username"].(string)))
-		buf.WriteString(fmt.Sprintf("%s-", m["computer_name"].(string)))
+		fmt.Fprintf(&buf, "%s-", m["admin_username"].(string))
+		fmt.Fprintf(&buf, "%s-", m["computer_name"].(string))
 	}
 
 	return pluginsdk.HashString(buf.String())
@@ -1831,13 +1831,13 @@ func resourceVirtualMachineStorageOsProfileWindowsConfigHash(v interface{}) int 
 
 	if m, ok := v.(map[string]interface{}); ok {
 		if v, ok := m["provision_vm_agent"]; ok {
-			buf.WriteString(fmt.Sprintf("%t-", v.(bool)))
+			fmt.Fprintf(&buf, "%t-", v.(bool))
 		}
 		if v, ok := m["enable_automatic_upgrades"]; ok {
-			buf.WriteString(fmt.Sprintf("%t-", v.(bool)))
+			fmt.Fprintf(&buf, "%t-", v.(bool))
 		}
 		if v, ok := m["timezone"]; ok {
-			buf.WriteString(fmt.Sprintf("%s-", strings.ToLower(v.(string))))
+			fmt.Fprintf(&buf, "%s-", strings.ToLower(v.(string)))
 		}
 	}
 
@@ -1849,7 +1849,7 @@ func resourceVirtualMachineStorageOsProfileLinuxConfigHash(v interface{}) int {
 
 	if m, ok := v.(map[string]interface{}); ok {
 		if v, ok := m["disable_password_authentication"]; ok {
-			buf.WriteString(fmt.Sprintf("%t-", v.(bool)))
+			fmt.Fprintf(&buf, "%t-", v.(bool))
 		}
 	}
 
@@ -1861,16 +1861,16 @@ func resourceVirtualMachineStorageImageReferenceHash(v interface{}) int {
 
 	if m, ok := v.(map[string]interface{}); ok {
 		if v, ok := m["publisher"]; ok {
-			buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+			fmt.Fprintf(&buf, "%s-", v.(string))
 		}
 		if v, ok := m["offer"]; ok {
-			buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+			fmt.Fprintf(&buf, "%s-", v.(string))
 		}
 		if v, ok := m["sku"]; ok {
-			buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+			fmt.Fprintf(&buf, "%s-", v.(string))
 		}
 		if v, ok := m["id"]; ok {
-			buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+			fmt.Fprintf(&buf, "%s-", v.(string))
 		}
 	}
 

--- a/internal/services/legacy/virtual_machine_scale_set_resource.go
+++ b/internal/services/legacy/virtual_machine_scale_set_resource.go
@@ -1514,19 +1514,19 @@ func resourceVirtualMachineScaleSetStorageProfileImageReferenceHash(v interface{
 
 	if m, ok := v.(map[string]interface{}); ok {
 		if v, ok := m["publisher"]; ok {
-			buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+			fmt.Fprintf(&buf, "%s-", v.(string))
 		}
 		if v, ok := m["offer"]; ok {
-			buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+			fmt.Fprintf(&buf, "%s-", v.(string))
 		}
 		if v, ok := m["sku"]; ok {
-			buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+			fmt.Fprintf(&buf, "%s-", v.(string))
 		}
 		if v, ok := m["version"]; ok {
-			buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+			fmt.Fprintf(&buf, "%s-", v.(string))
 		}
 		if v, ok := m["id"]; ok {
-			buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+			fmt.Fprintf(&buf, "%s-", v.(string))
 		}
 	}
 
@@ -1537,10 +1537,10 @@ func resourceVirtualMachineScaleSetStorageProfileOsDiskHash(v interface{}) int {
 	var buf bytes.Buffer
 
 	if m, ok := v.(map[string]interface{}); ok {
-		buf.WriteString(fmt.Sprintf("%s-", m["name"].(string)))
+		fmt.Fprintf(&buf, "%s-", m["name"].(string))
 
 		if v, ok := m["vhd_containers"]; ok {
-			buf.WriteString(fmt.Sprintf("%s-", v.(*pluginsdk.Set).List()))
+			fmt.Fprintf(&buf, "%s-", v.(*pluginsdk.Set).List())
 		}
 	}
 
@@ -1551,58 +1551,58 @@ func resourceVirtualMachineScaleSetNetworkConfigurationHash(v interface{}) int {
 	var buf bytes.Buffer
 
 	if m, ok := v.(map[string]interface{}); ok {
-		buf.WriteString(fmt.Sprintf("%s-", m["name"].(string)))
-		buf.WriteString(fmt.Sprintf("%t-", m["primary"].(bool)))
+		fmt.Fprintf(&buf, "%s-", m["name"].(string))
+		fmt.Fprintf(&buf, "%t-", m["primary"].(bool))
 
 		if v, ok := m["accelerated_networking"]; ok {
-			buf.WriteString(fmt.Sprintf("%t-", v.(bool)))
+			fmt.Fprintf(&buf, "%t-", v.(bool))
 		}
 		if v, ok := m["ip_forwarding"]; ok {
-			buf.WriteString(fmt.Sprintf("%t-", v.(bool)))
+			fmt.Fprintf(&buf, "%t-", v.(bool))
 		}
 		if v, ok := m["network_security_group_id"]; ok {
-			buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+			fmt.Fprintf(&buf, "%s-", v.(string))
 		}
 		if v, ok := m["dns_settings"].(map[string]interface{}); ok {
 			if k, ok := v["dns_servers"]; ok {
-				buf.WriteString(fmt.Sprintf("%s-", k))
+				fmt.Fprintf(&buf, "%s-", k)
 			}
 		}
 		if ipConfig, ok := m["ip_configuration"].([]interface{}); ok {
 			for _, it := range ipConfig {
 				config := it.(map[string]interface{})
 				if name, ok := config["name"]; ok {
-					buf.WriteString(fmt.Sprintf("%s-", name.(string)))
+					fmt.Fprintf(&buf, "%s-", name.(string))
 				}
 				if subnetid, ok := config["subnet_id"]; ok {
-					buf.WriteString(fmt.Sprintf("%s-", subnetid.(string)))
+					fmt.Fprintf(&buf, "%s-", subnetid.(string))
 				}
 				if appPoolId, ok := config["application_gateway_backend_address_pool_ids"]; ok {
-					buf.WriteString(fmt.Sprintf("%s-", appPoolId.(*pluginsdk.Set).List()))
+					fmt.Fprintf(&buf, "%s-", appPoolId.(*pluginsdk.Set).List())
 				}
 				if appSecGroup, ok := config["application_security_group_ids"]; ok {
-					buf.WriteString(fmt.Sprintf("%s-", appSecGroup.(*pluginsdk.Set).List()))
+					fmt.Fprintf(&buf, "%s-", appSecGroup.(*pluginsdk.Set).List())
 				}
 				if lbPoolIds, ok := config["load_balancer_backend_address_pool_ids"]; ok {
-					buf.WriteString(fmt.Sprintf("%s-", lbPoolIds.(*pluginsdk.Set).List()))
+					fmt.Fprintf(&buf, "%s-", lbPoolIds.(*pluginsdk.Set).List())
 				}
 				if lbInNatRules, ok := config["load_balancer_inbound_nat_rules_ids"]; ok {
-					buf.WriteString(fmt.Sprintf("%s-", lbInNatRules.(*pluginsdk.Set).List()))
+					fmt.Fprintf(&buf, "%s-", lbInNatRules.(*pluginsdk.Set).List())
 				}
 				if primary, ok := config["primary"]; ok {
-					buf.WriteString(fmt.Sprintf("%t-", primary.(bool)))
+					fmt.Fprintf(&buf, "%t-", primary.(bool))
 				}
 				if publicIPConfig, ok := config["public_ip_address_configuration"].([]interface{}); ok {
 					for _, publicIPIt := range publicIPConfig {
 						publicip := publicIPIt.(map[string]interface{})
 						if publicIPConfigName, ok := publicip["name"]; ok {
-							buf.WriteString(fmt.Sprintf("%s-", publicIPConfigName.(string)))
+							fmt.Fprintf(&buf, "%s-", publicIPConfigName.(string))
 						}
 						if idle_timeout, ok := publicip["idle_timeout"]; ok {
-							buf.WriteString(fmt.Sprintf("%d-", idle_timeout.(int)))
+							fmt.Fprintf(&buf, "%d-", idle_timeout.(int))
 						}
 						if dnsLabel, ok := publicip["domain_name_label"]; ok {
-							buf.WriteString(fmt.Sprintf("%s-", dnsLabel.(string)))
+							fmt.Fprintf(&buf, "%s-", dnsLabel.(string))
 						}
 					}
 				}
@@ -1617,16 +1617,16 @@ func resourceVirtualMachineScaleSetOsProfileLinuxConfigHash(v interface{}) int {
 	var buf bytes.Buffer
 
 	if m, ok := v.(map[string]interface{}); ok {
-		buf.WriteString(fmt.Sprintf("%t-", m["disable_password_authentication"].(bool)))
+		fmt.Fprintf(&buf, "%t-", m["disable_password_authentication"].(bool))
 
 		if sshKeys, ok := m["ssh_keys"].([]interface{}); ok {
 			for _, item := range sshKeys {
 				k := item.(map[string]interface{})
 				if path, ok := k["path"]; ok {
-					buf.WriteString(fmt.Sprintf("%s-", path.(string)))
+					fmt.Fprintf(&buf, "%s-", path.(string))
 				}
 				if data, ok := k["key_data"]; ok {
-					buf.WriteString(fmt.Sprintf("%s-", data.(string)))
+					fmt.Fprintf(&buf, "%s-", data.(string))
 				}
 			}
 		}
@@ -1640,10 +1640,10 @@ func resourceVirtualMachineScaleSetOsProfileWindowsConfigHash(v interface{}) int
 
 	if m, ok := v.(map[string]interface{}); ok {
 		if v, ok := m["provision_vm_agent"]; ok {
-			buf.WriteString(fmt.Sprintf("%t-", v.(bool)))
+			fmt.Fprintf(&buf, "%t-", v.(bool))
 		}
 		if v, ok := m["enable_automatic_upgrades"]; ok {
-			buf.WriteString(fmt.Sprintf("%t-", v.(bool)))
+			fmt.Fprintf(&buf, "%t-", v.(bool))
 		}
 	}
 
@@ -1654,17 +1654,17 @@ func resourceVirtualMachineScaleSetExtensionHash(v interface{}) int {
 	var buf bytes.Buffer
 
 	if m, ok := v.(map[string]interface{}); ok {
-		buf.WriteString(fmt.Sprintf("%s-", m["name"].(string)))
-		buf.WriteString(fmt.Sprintf("%s-", m["publisher"].(string)))
-		buf.WriteString(fmt.Sprintf("%s-", m["type"].(string)))
-		buf.WriteString(fmt.Sprintf("%s-", m["type_handler_version"].(string)))
+		fmt.Fprintf(&buf, "%s-", m["name"].(string))
+		fmt.Fprintf(&buf, "%s-", m["publisher"].(string))
+		fmt.Fprintf(&buf, "%s-", m["type"].(string))
+		fmt.Fprintf(&buf, "%s-", m["type_handler_version"].(string))
 
 		if v, ok := m["auto_upgrade_minor_version"]; ok {
-			buf.WriteString(fmt.Sprintf("%t-", v.(bool)))
+			fmt.Fprintf(&buf, "%t-", v.(bool))
 		}
 
 		if v, ok := m["provision_after_extensions"]; ok {
-			buf.WriteString(fmt.Sprintf("%s-", v.(*pluginsdk.Set).List()))
+			fmt.Fprintf(&buf, "%s-", v.(*pluginsdk.Set).List())
 		}
 
 		// we need to ensure the whitespace is consistent
@@ -1674,7 +1674,7 @@ func resourceVirtualMachineScaleSetExtensionHash(v interface{}) int {
 			if err == nil {
 				serializedSettings, err := pluginsdk.FlattenJsonToString(expandedSettings)
 				if err == nil {
-					buf.WriteString(fmt.Sprintf("%s-", serializedSettings))
+					fmt.Fprintf(&buf, "%s-", serializedSettings)
 				}
 			}
 		}

--- a/internal/services/monitor/monitor_diagnostic_setting_resource.go
+++ b/internal/services/monitor/monitor_diagnostic_setting_resource.go
@@ -824,19 +824,19 @@ func resourceMonitorDiagnosticLogSettingHash(input interface{}) int {
 	var buf bytes.Buffer
 	if rawData, ok := input.(map[string]interface{}); ok {
 		if category, ok := rawData["category"]; ok {
-			buf.WriteString(fmt.Sprintf("%s-", category.(string)))
+			fmt.Fprintf(&buf, "%s-", category.(string))
 		}
 		if categoryGroup, ok := rawData["category_group"]; ok {
-			buf.WriteString(fmt.Sprintf("%s-", categoryGroup.(string)))
+			fmt.Fprintf(&buf, "%s-", categoryGroup.(string))
 		}
 
 		if !features.FivePointOh() {
 			if policy, ok := rawData["retention_policy"].(map[string]interface{}); ok {
 				if policyEnabled, ok := policy["enabled"]; ok {
-					buf.WriteString(fmt.Sprintf("%t-", policyEnabled.(bool)))
+					fmt.Fprintf(&buf, "%t-", policyEnabled.(bool))
 				}
 				if days, ok := policy["days"]; ok {
-					buf.WriteString(fmt.Sprintf("%d-", days.(int)))
+					fmt.Fprintf(&buf, "%d-", days.(int))
 				}
 			}
 		}
@@ -848,19 +848,19 @@ func resourceMonitorDiagnosticMetricsSettingHash(input interface{}) int {
 	var buf bytes.Buffer
 	if rawData, ok := input.(map[string]interface{}); ok {
 		if category, ok := rawData["category"]; ok {
-			buf.WriteString(fmt.Sprintf("%s-", category.(string)))
+			fmt.Fprintf(&buf, "%s-", category.(string))
 		}
 		if !features.FivePointOh() {
 			if enabled, ok := rawData["enabled"]; ok {
-				buf.WriteString(fmt.Sprintf("%t-", enabled.(bool)))
+				fmt.Fprintf(&buf, "%t-", enabled.(bool))
 			}
 		}
 		if policy, ok := rawData["retention_policy"].(map[string]interface{}); ok {
 			if policyEnabled, ok := policy["enabled"]; ok {
-				buf.WriteString(fmt.Sprintf("%t-", policyEnabled.(bool)))
+				fmt.Fprintf(&buf, "%t-", policyEnabled.(bool))
 			}
 			if days, ok := policy["days"]; ok {
-				buf.WriteString(fmt.Sprintf("%d-", days.(int)))
+				fmt.Fprintf(&buf, "%d-", days.(int))
 			}
 		}
 	}

--- a/internal/services/monitor/monitor_metric_alert_resource.go
+++ b/internal/services/monitor/monitor_metric_alert_resource.go
@@ -907,9 +907,9 @@ func flattenMonitorMetricAlertAction(input *[]metricalerts.MetricAlertAction) (r
 func resourceMonitorMetricAlertActionHash(input interface{}) int {
 	var buf bytes.Buffer
 	if v, ok := input.(map[string]interface{}); ok {
-		buf.WriteString(fmt.Sprintf("%s-", v["action_group_id"].(string)))
+		fmt.Fprintf(&buf, "%s-", v["action_group_id"].(string))
 		if m, ok := v["webhook_properties"].(map[string]interface{}); ok && m != nil {
-			buf.WriteString(fmt.Sprintf("%v-", m))
+			fmt.Fprintf(&buf, "%v-", m)
 		}
 	}
 	return pluginsdk.HashString(buf.String())

--- a/internal/services/mssql/mssql_virtual_machine_availability_group_listener_resource.go
+++ b/internal/services/mssql/mssql_virtual_machine_availability_group_listener_resource.go
@@ -592,11 +592,11 @@ func ReplicaSchemaMsSqlVirtualMachineAvailabilityGroupListenerHash(v interface{}
 	var buf bytes.Buffer
 
 	if m, ok := v.(map[string]interface{}); ok {
-		buf.WriteString(fmt.Sprintf("%s-", strings.ToLower(m["sql_virtual_machine_id"].(string))))
-		buf.WriteString(fmt.Sprintf("%s-", m["role"].(string)))
-		buf.WriteString(fmt.Sprintf("%s-", m["commit"].(string)))
-		buf.WriteString(fmt.Sprintf("%s-", m["failover_mode"].(string)))
-		buf.WriteString(fmt.Sprintf("%s-", m["readable_secondary"].(string)))
+		fmt.Fprintf(&buf, "%s-", strings.ToLower(m["sql_virtual_machine_id"].(string)))
+		fmt.Fprintf(&buf, "%s-", m["role"].(string))
+		fmt.Fprintf(&buf, "%s-", m["commit"].(string))
+		fmt.Fprintf(&buf, "%s-", m["failover_mode"].(string))
+		fmt.Fprintf(&buf, "%s-", m["readable_secondary"].(string))
 	}
 
 	return pluginsdk.HashString(buf.String())

--- a/internal/services/network/application_gateway_resource.go
+++ b/internal/services/network/application_gateway_resource.go
@@ -5510,13 +5510,13 @@ func applicationGatewayHttpListnerHash(v interface{}) int {
 			buf.WriteString(v.(string))
 		}
 		if hostNames, ok := m["host_names"]; ok {
-			buf.WriteString(fmt.Sprintf("%s-", hostNames.(*pluginsdk.Set).List()))
+			fmt.Fprintf(&buf, "%s-", hostNames.(*pluginsdk.Set).List())
 		}
 		if v, ok := m["ssl_certificate_name"]; ok {
 			buf.WriteString(v.(string))
 		}
 		if v, ok := m["require_sni"]; ok {
-			buf.WriteString(fmt.Sprintf("%t", v.(bool)))
+			fmt.Fprintf(&buf, "%t", v.(bool))
 		}
 		if v, ok := m["firewall_policy_id"]; ok {
 			buf.WriteString(strings.ToLower(v.(string)))
@@ -5548,10 +5548,10 @@ func applicationGatewayBackendSettingsHash(v interface{}) int {
 
 	if m, ok := v.(map[string]interface{}); ok {
 		buf.WriteString(m["name"].(string))
-		buf.WriteString(fmt.Sprintf("%d", m["port"].(int)))
+		fmt.Fprintf(&buf, "%d", m["port"].(int))
 		buf.WriteString(m["protocol"].(string))
 		buf.WriteString(m["cookie_based_affinity"].(string))
-		buf.WriteString(fmt.Sprintf("%t", m["dedicated_backend_connection_enabled"].(bool)))
+		fmt.Fprintf(&buf, "%t", m["dedicated_backend_connection_enabled"].(bool))
 
 		if v, ok := m["path"]; ok {
 			buf.WriteString(v.(string))
@@ -5566,10 +5566,10 @@ func applicationGatewayBackendSettingsHash(v interface{}) int {
 			buf.WriteString(v.(string))
 		}
 		if v, ok := m["pick_host_name_from_backend_address"]; ok {
-			buf.WriteString(fmt.Sprintf("%t", v.(bool)))
+			fmt.Fprintf(&buf, "%t", v.(bool))
 		}
 		if v, ok := m["request_timeout"]; ok {
-			buf.WriteString(fmt.Sprintf("%d", v.(int)))
+			fmt.Fprintf(&buf, "%d", v.(int))
 		}
 		if authCert, ok := m["authentication_certificate"].([]interface{}); ok {
 			for _, ac := range authCert {
@@ -5586,18 +5586,18 @@ func applicationGatewayBackendSettingsHash(v interface{}) int {
 					continue
 				}
 				config := ac.(map[string]interface{})
-				buf.WriteString(fmt.Sprintf("%t", config["enabled"].(bool)))
-				buf.WriteString(fmt.Sprintf("%d", config["drain_timeout_sec"].(int)))
+				fmt.Fprintf(&buf, "%t", config["enabled"].(bool))
+				fmt.Fprintf(&buf, "%d", config["drain_timeout_sec"].(int))
 			}
 		}
 		if trustedRootCertificateNames, ok := m["trusted_root_certificate_names"]; ok {
-			buf.WriteString(fmt.Sprintf("%s", trustedRootCertificateNames.([]interface{})))
+			fmt.Fprintf(&buf, "%s", trustedRootCertificateNames.([]interface{}))
 		}
 		if v, ok := m["certificate_chain_validation_enabled"]; ok {
-			buf.WriteString(fmt.Sprintf("%t", v.(bool)))
+			fmt.Fprintf(&buf, "%t", v.(bool))
 		}
 		if v, ok := m["sni_validation_enabled"]; ok {
-			buf.WriteString(fmt.Sprintf("%t", v.(bool)))
+			fmt.Fprintf(&buf, "%t", v.(bool))
 		}
 		if v, ok := m["sni_name"]; ok {
 			buf.WriteString(v.(string))
@@ -5632,10 +5632,10 @@ func applicationGatewayBackendAddressPool(v interface{}) int {
 		buf.WriteString(m["name"].(string))
 
 		if fqdns, ok := m["fqdns"]; ok {
-			buf.WriteString(fmt.Sprintf("%s", fqdns.(*pluginsdk.Set).List()))
+			fmt.Fprintf(&buf, "%s", fqdns.(*pluginsdk.Set).List())
 		}
 		if ips, ok := m["ip_addresses"]; ok {
-			buf.WriteString(fmt.Sprintf("%s", ips.(*pluginsdk.Set).List()))
+			fmt.Fprintf(&buf, "%s", ips.(*pluginsdk.Set).List())
 		}
 	}
 
@@ -5648,24 +5648,24 @@ func applicationGatewayProbeHash(v interface{}) int {
 		buf.WriteString(m["name"].(string))
 		buf.WriteString(m["protocol"].(string))
 		buf.WriteString(m["path"].(string))
-		buf.WriteString(fmt.Sprintf("%d", m["interval"].(int)))
-		buf.WriteString(fmt.Sprintf("%d", m["timeout"].(int)))
-		buf.WriteString(fmt.Sprintf("%d", m["unhealthy_threshold"].(int)))
+		fmt.Fprintf(&buf, "%d", m["interval"].(int))
+		fmt.Fprintf(&buf, "%d", m["timeout"].(int))
+		fmt.Fprintf(&buf, "%d", m["unhealthy_threshold"].(int))
 
 		if v, ok := m["host"]; ok {
 			buf.WriteString(v.(string))
 		}
 		if v, ok := m["port"]; ok {
-			buf.WriteString(fmt.Sprintf("%d", v.(int)))
+			fmt.Fprintf(&buf, "%d", v.(int))
 		}
 		if v, ok := m["pick_host_name_from_backend_http_settings"]; ok {
-			buf.WriteString(fmt.Sprintf("%t", v.(bool)))
+			fmt.Fprintf(&buf, "%t", v.(bool))
 		}
 		if v, ok := m["minimum_servers"]; ok {
-			buf.WriteString(fmt.Sprintf("%d", v.(int)))
+			fmt.Fprintf(&buf, "%d", v.(int))
 		}
 		if v, ok := m["proxy_protocol_header_enabled"]; ok {
-			buf.WriteString(fmt.Sprintf("%t", v.(bool)))
+			fmt.Fprintf(&buf, "%t", v.(bool))
 		}
 		if match, ok := m["match"]; ok {
 			if attrs := match.([]interface{}); len(attrs) == 1 && attrs[0] != nil {
@@ -5676,7 +5676,7 @@ func applicationGatewayProbeHash(v interface{}) int {
 				// Only include in hash if it's not the default
 				defaultMatch := body == "" && len(statusCodes) == 1 && statusCodes[0].(string) == "200-399"
 				if !defaultMatch {
-					buf.WriteString(fmt.Sprintf("%s-%+v", body, statusCodes))
+					fmt.Fprintf(&buf, "%s-%+v", body, statusCodes)
 				}
 			}
 		}
@@ -5703,7 +5703,7 @@ func applicationGatewayListenerHash(v interface{}) int {
 		}
 
 		if hostNames, ok := m["host_names"]; ok {
-			buf.WriteString(fmt.Sprintf("%s-", hostNames.(*pluginsdk.Set).List()))
+			fmt.Fprintf(&buf, "%s-", hostNames.(*pluginsdk.Set).List())
 		}
 	}
 
@@ -5718,7 +5718,7 @@ func applicationGatewayRoutingRuleHash(v interface{}) int {
 		buf.WriteString(m["backend_address_pool_name"].(string))
 		buf.WriteString(m["backend_name"].(string))
 		buf.WriteString(m["listener_name"].(string))
-		buf.WriteString(fmt.Sprintf("%d", m["priority"].(int)))
+		fmt.Fprintf(&buf, "%d", m["priority"].(int))
 	}
 
 	return pluginsdk.HashString(buf.String())

--- a/internal/services/network/virtual_network_gateway_resource.go
+++ b/internal/services/network/virtual_network_gateway_resource.go
@@ -1636,8 +1636,8 @@ func hashVirtualNetworkGatewayRootCert(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
 
-	buf.WriteString(fmt.Sprintf("%s-", m["name"].(string)))
-	buf.WriteString(fmt.Sprintf("%s-", m["public_cert_data"].(string)))
+	fmt.Fprintf(&buf, "%s-", m["name"].(string))
+	fmt.Fprintf(&buf, "%s-", m["public_cert_data"].(string))
 
 	return pluginsdk.HashString(buf.String())
 }
@@ -1646,8 +1646,8 @@ func hashVirtualNetworkGatewayRevokedCert(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
 
-	buf.WriteString(fmt.Sprintf("%s-", m["name"].(string)))
-	buf.WriteString(fmt.Sprintf("%s-", m["thumbprint"].(string)))
+	fmt.Fprintf(&buf, "%s-", m["name"].(string))
+	fmt.Fprintf(&buf, "%s-", m["thumbprint"].(string))
 
 	return pluginsdk.HashString(buf.String())
 }

--- a/internal/services/privatedns/private_dns_mx_record_resource.go
+++ b/internal/services/privatedns/private_dns_mx_record_resource.go
@@ -257,8 +257,8 @@ func resourcePrivateDnsMxRecordHash(v interface{}) int {
 	var buf bytes.Buffer
 
 	if m, ok := v.(map[string]interface{}); ok {
-		buf.WriteString(fmt.Sprintf("%d-", m["preference"].(int)))
-		buf.WriteString(fmt.Sprintf("%s-", m["exchange"].(string)))
+		fmt.Fprintf(&buf, "%d-", m["preference"].(int))
+		fmt.Fprintf(&buf, "%s-", m["exchange"].(string))
 	}
 
 	return pluginsdk.HashString(buf.String())

--- a/internal/services/privatedns/private_dns_srv_record_resource.go
+++ b/internal/services/privatedns/private_dns_srv_record_resource.go
@@ -269,10 +269,10 @@ func resourcePrivateDnsSrvRecordHash(v interface{}) int {
 	var buf bytes.Buffer
 
 	if m, ok := v.(map[string]interface{}); ok {
-		buf.WriteString(fmt.Sprintf("%d-", m["priority"].(int)))
-		buf.WriteString(fmt.Sprintf("%d-", m["weight"].(int)))
-		buf.WriteString(fmt.Sprintf("%d-", m["port"].(int)))
-		buf.WriteString(fmt.Sprintf("%s-", m["target"].(string)))
+		fmt.Fprintf(&buf, "%d-", m["priority"].(int))
+		fmt.Fprintf(&buf, "%d-", m["weight"].(int))
+		fmt.Fprintf(&buf, "%d-", m["port"].(int))
+		fmt.Fprintf(&buf, "%s-", m["target"].(string))
 	}
 
 	return pluginsdk.HashString(buf.String())

--- a/internal/services/resource/resource_deployment_script_common.go
+++ b/internal/services/resource/resource_deployment_script_common.go
@@ -433,6 +433,6 @@ func flattenStorageAccountConfigurationModel(input *deploymentscripts.StorageAcc
 func hashEnvironmentVariables(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
-	buf.WriteString(fmt.Sprintf("%s-", strings.ToLower(m["name"].(string))))
+	fmt.Fprintf(&buf, "%s-", strings.ToLower(m["name"].(string)))
 	return pluginsdk.HashString(buf.String())
 }

--- a/internal/tools/document-fmt/cmd/cmds.go
+++ b/internal/tools/document-fmt/cmd/cmds.go
@@ -164,7 +164,7 @@ func printErrors(rd *data.TerraformNodeData) {
 	b.WriteString(sep)
 
 	for _, v := range rd.Errors {
-		b.WriteString(fmt.Sprintf("-> %s\n", v.Error()))
+		fmt.Fprintf(&b, "-> %s\n", v.Error())
 	}
 
 	b.WriteString("\n")

--- a/internal/tools/document-fmt/differror/error.go
+++ b/internal/tools/document-fmt/differror/error.go
@@ -27,7 +27,7 @@ func New(text, current, expected string) error {
 func (e DiffError) Error() string {
 	b := strings.Builder{}
 
-	b.WriteString(fmt.Sprintf("%s\n", e.t))
+	fmt.Fprintf(&b, "%s\n", e.t)
 	b.WriteString(util.Red(fmt.Sprintf("- %s\n", e.c)))
 	b.WriteString(util.Green(fmt.Sprintf("+ %s", e.e)))
 

--- a/internal/tools/document-lint/check/check_resource.go
+++ b/internal/tools/document-lint/check/check_resource.go
@@ -33,14 +33,10 @@ func (d *ResourceDiff) Diffs() []Checker {
 func (d *ResourceDiff) ToString() string {
 	var bs strings.Builder
 
-	bs.WriteString(
-		fmt.Sprintf(
-			"%s: %s:1 has %d issue[s]:\n",
-			util.Bold(d.tf.ResourceType),
-			d.tf.FilePathRel(),
-			len(d.Diff),
-		),
-	)
+	fmt.Fprintf(&bs, "%s: %s:1 has %d issue[s]:\n",
+		util.Bold(d.tf.ResourceType),
+		d.tf.FilePathRel(),
+		len(d.Diff))
 	file := d.MDFile + ":"
 	if idx := strings.Index(file, "website"); idx > 0 {
 		file = "./" + file[idx:]

--- a/internal/tools/document-lint/check/check_timeout.go
+++ b/internal/tools/document-lint/check/check_timeout.go
@@ -91,9 +91,9 @@ func newTimeoutDiff(checkBase checkBase, items []TimeoutDiffItem) *timeoutDiff {
 
 func (t timeoutDiff) String() string {
 	var bs strings.Builder
-	bs.WriteString(fmt.Sprintf("%d Document has incorrect or missing Timeouts. These should be:", t.Line()))
+	fmt.Fprintf(&bs, "%d Document has incorrect or missing Timeouts. These should be:", t.Line())
 	for _, item := range t.TimeoutDiff {
-		bs.WriteString(fmt.Sprintf("\n* `%s` - (Defaults to %s) Used when %s the xxx", item.Type, item.ValueString(), item.Type.IngString()))
+		fmt.Fprintf(&bs, "\n* `%s` - (Defaults to %s) Used when %s the xxx", item.Type, item.ValueString(), item.Type.IngString())
 	}
 	return bs.String()
 }

--- a/internal/tools/static-analysis/rules/typed_sdk_bit_check.go
+++ b/internal/tools/static-analysis/rules/typed_sdk_bit_check.go
@@ -41,7 +41,7 @@ func checkModelObject(resourceType string, modelObj interface{}) (errors []error
 		return nil
 	}
 
-	if modelType.Kind() != reflect.Ptr {
+	if modelType.Kind() != reflect.Pointer {
 		return []error{fmt.Errorf("%q cannot be bit checked, ModelObject did not return a pointer", resourceType)}
 	}
 

--- a/internal/tools/update-api-version/main.go
+++ b/internal/tools/update-api-version/main.go
@@ -11,15 +11,15 @@ import (
 	"go/format"
 	"go/parser"
 	"go/token"
-	"io/fs"
 	"log"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
 
-	"github.com/hashicorp/go-hclog"
 	"golang.org/x/tools/go/ast/astutil"
+
+	"github.com/hashicorp/go-hclog"
 )
 
 var logger hclog.Logger
@@ -97,24 +97,30 @@ func run(serviceName string, oldApiVersion string, newApiVersion string, working
 
 func updateImportsWithinDirectory(serviceName string, oldApiVersion string, newApiVersion string, workingDirectory string) error {
 	fileSet := token.NewFileSet()
-	files, err := parser.ParseDir(fileSet, workingDirectory, func(info fs.FileInfo) bool {
-		return true
-	}, parser.ParseComments)
+	entries, err := os.ReadDir(workingDirectory)
 	if err != nil {
-		return fmt.Errorf("parsing files within %q: %+v", workingDirectory, err)
+		return fmt.Errorf("reading directory %q: %+v", workingDirectory, err)
 	}
-	for pkgName, pkg := range files {
-		logger.Debug("Processing Go Package %q", pkgName)
-		for fileName, file := range pkg.Files {
-			logger.Info(fmt.Sprintf("Updating imports for File %q..", fileName))
-			updateImportsForFile(fileSet, file, serviceName, oldApiVersion, newApiVersion)
 
-			var buf bytes.Buffer
-			if err = format.Node(&buf, fileSet, file); err != nil {
-				return fmt.Errorf("error formatting new code: %w", err)
-			}
-			_ = os.WriteFile(fileName, buf.Bytes(), 0o600)
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") {
+			continue
 		}
+
+		fileName := filepath.Join(workingDirectory, entry.Name())
+		file, err := parser.ParseFile(fileSet, fileName, nil, parser.ParseComments)
+		if err != nil {
+			return fmt.Errorf("parsing file %q: %+v", fileName, err)
+		}
+
+		logger.Info(fmt.Sprintf("Updating imports for File %q..", fileName))
+		updateImportsForFile(fileSet, file, serviceName, oldApiVersion, newApiVersion)
+
+		var buf bytes.Buffer
+		if err = format.Node(&buf, fileSet, file); err != nil {
+			return fmt.Errorf("error formatting new code: %w", err)
+		}
+		_ = os.WriteFile(fileName, buf.Bytes(), 0o600)
 	}
 	return nil
 }


### PR DESCRIPTION
Notes: 
- removes `prealloc` linter as we don't do performance profiling, so the recommended is not to use it.
- contains all new "violations" fixed (auto-fixed where possible)