### PR TITLE
`azurerm_kubernetes_cluster` - update service mesh revision acceptance tests

### DIFF
--- a/internal/services/containers/kubernetes_cluster_addons_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_addons_resource_test.go
@@ -315,21 +315,21 @@ func TestAccKubernetesCluster_addonProfileServiceMeshProfile_revisions(t *testin
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.addonProfileServiceMeshProfileRevisionsConfig(data, `["asm-1-27"]`),
+			Config: r.addonProfileServiceMeshProfileRevisionsConfig(data, `["asm-1-28"]`),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.addonProfileServiceMeshProfileRevisionsConfig(data, `["asm-1-27", "asm-1-28"]`),
+			Config: r.addonProfileServiceMeshProfileRevisionsConfig(data, `["asm-1-28", "asm-1-29"]`),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.addonProfileServiceMeshProfileRevisionsConfig(data, `["asm-1-27"]`),
+			Config: r.addonProfileServiceMeshProfileRevisionsConfig(data, `["asm-1-28"]`),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -1529,7 +1529,7 @@ resource "azurerm_kubernetes_cluster" "test" {
   default_node_pool {
     name           = "default"
     node_count     = 2
-    vm_size        = "Standard_DS2_v2"
+    vm_size        = "Standard_D2s_v3"
     vnet_subnet_id = azurerm_subnet.test.id
     upgrade_settings {
       max_surge = "10%%"

--- a/internal/services/containers/kubernetes_cluster_data_source_test.go
+++ b/internal/services/containers/kubernetes_cluster_data_source_test.go
@@ -597,45 +597,45 @@ func TestAccDataSourceKubernetesCluster_serviceMeshRevisions(t *testing.T) {
 
 	data.DataSourceTest(t, []acceptance.TestStep{
 		{
-			// create a cluster with an istio revision with revision currently at asm-1-27
-			Config: r.serviceMeshRevisions(data, `["asm-1-27"]`),
+			// create a cluster with an istio revision with revision currently at asm-1-28
+			Config: r.serviceMeshRevisions(data, `["asm-1-28"]`),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("service_mesh_profile.0.mode").HasValue("Istio"),
 				check.That(data.ResourceName).Key("service_mesh_profile.0.internal_ingress_gateway_enabled").HasValue("false"),
 				check.That(data.ResourceName).Key("service_mesh_profile.0.external_ingress_gateway_enabled").HasValue("false"),
-				check.That(data.ResourceName).Key("service_mesh_profile.0.revisions.0").HasValue("asm-1-27"),
+				check.That(data.ResourceName).Key("service_mesh_profile.0.revisions.0").HasValue("asm-1-28"),
 			),
 		},
 		{
-			// start istio revision canary upgrade to asm-1-28
-			Config: r.serviceMeshRevisions(data, `["asm-1-27", "asm-1-28"]`),
+			// start istio revision canary upgrade to asm-1-29
+			Config: r.serviceMeshRevisions(data, `["asm-1-28", "asm-1-29"]`),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("service_mesh_profile.0.mode").HasValue("Istio"),
 				check.That(data.ResourceName).Key("service_mesh_profile.0.internal_ingress_gateway_enabled").HasValue("false"),
 				check.That(data.ResourceName).Key("service_mesh_profile.0.external_ingress_gateway_enabled").HasValue("false"),
-				check.That(data.ResourceName).Key("service_mesh_profile.0.revisions.0").HasValue("asm-1-27"),
-				check.That(data.ResourceName).Key("service_mesh_profile.0.revisions.1").HasValue("asm-1-28"),
+				check.That(data.ResourceName).Key("service_mesh_profile.0.revisions.0").HasValue("asm-1-28"),
+				check.That(data.ResourceName).Key("service_mesh_profile.0.revisions.1").HasValue("asm-1-29"),
 			),
 		},
 		{
-			// rollback the istio revision back to asm-1-27
-			Config: r.serviceMeshRevisions(data, `["asm-1-27"]`),
+			// rollback the istio revision back to asm-1-28
+			Config: r.serviceMeshRevisions(data, `["asm-1-28"]`),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("service_mesh_profile.0.mode").HasValue("Istio"),
 				check.That(data.ResourceName).Key("service_mesh_profile.0.internal_ingress_gateway_enabled").HasValue("false"),
 				check.That(data.ResourceName).Key("service_mesh_profile.0.external_ingress_gateway_enabled").HasValue("false"),
-				check.That(data.ResourceName).Key("service_mesh_profile.0.revisions.0").HasValue("asm-1-27"),
+				check.That(data.ResourceName).Key("service_mesh_profile.0.revisions.0").HasValue("asm-1-28"),
 			),
 		},
 		{
-			// start istio revision canary upgrade to asm-1-28
-			Config: r.serviceMeshRevisions(data, `["asm-1-27", "asm-1-28"]`),
+			// start istio revision canary upgrade to asm-1-29
+			Config: r.serviceMeshRevisions(data, `["asm-1-28", "asm-1-29"]`),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("service_mesh_profile.0.mode").HasValue("Istio"),
 				check.That(data.ResourceName).Key("service_mesh_profile.0.internal_ingress_gateway_enabled").HasValue("false"),
 				check.That(data.ResourceName).Key("service_mesh_profile.0.external_ingress_gateway_enabled").HasValue("false"),
-				check.That(data.ResourceName).Key("service_mesh_profile.0.revisions.0").HasValue("asm-1-27"),
-				check.That(data.ResourceName).Key("service_mesh_profile.0.revisions.1").HasValue("asm-1-28"),
+				check.That(data.ResourceName).Key("service_mesh_profile.0.revisions.0").HasValue("asm-1-28"),
+				check.That(data.ResourceName).Key("service_mesh_profile.0.revisions.1").HasValue("asm-1-29"),
 			),
 		},
 		{


### PR DESCRIPTION
## Description

TeamCity build 683453 showed the AKS service mesh revision tests failing because `asm-1-27` is no longer returned as a supported revision in `eastus`. This updates the resource and data source tests to use the currently available `asm-1-28` and `asm-1-29` revision pair.

The service mesh revision test helper also uses `Standard_D2s_v3` because `Standard_DS2_v2` is not available for this subscription in `eastus`.

## Testing

- `az aks mesh get-revisions --location eastus -o json`
  - returned `asm-1-28` and `asm-1-29`
- `make acctests SERVICE='containers' TESTARGS='-run=TestAccKubernetesCluster_addonProfileServiceMeshProfile_revisions -parallel=1' TESTTIMEOUT='120m'`
  - PASS: `--- PASS: TestAccKubernetesCluster_addonProfileServiceMeshProfile_revisions (945.03s)`
- `make acctests SERVICE='containers' TESTARGS='-run=TestAccDataSourceKubernetesCluster_serviceMeshRevisions -parallel=1' TESTTIMEOUT='120m'`
  - PASS: `--- PASS: TestAccDataSourceKubernetesCluster_serviceMeshRevisions (1376.12s)`