### PR TITLE
`azurerm_kubernetes_cluster` - update version-sensitive acceptance tests

### DIFF
--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -2797,12 +2797,14 @@ resource "azurerm_kubernetes_cluster" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   dns_prefix          = "acctestaks%d"
-  kubernetes_version  = "1.32.9"
+  kubernetes_version  = "1.32"
+  sku_tier            = "Premium"
+  support_plan        = "AKSLongTermSupport"
 
   default_node_pool {
     name       = "default"
     node_count = 1
-    vm_size    = "Standard_DS2_v2"
+    vm_size    = "Standard_D2s_v3"
     upgrade_settings {
       max_surge = "10%%"
     }
@@ -2828,7 +2830,7 @@ resource "azurerm_kubernetes_cluster" "test" {
 resource "azurerm_kubernetes_cluster_node_pool" "test" {
   name                  = "windoz"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
-  vm_size               = "Standard_DS2_v2"
+  vm_size               = "Standard_D2s_v3"
   node_count            = 1
   os_type               = "Windows"
   os_sku                = "Windows2019"

--- a/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -3836,14 +3836,14 @@ resource "azurerm_kubernetes_cluster" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   dns_prefix          = "acctestaks%[1]d"
-  kubernetes_version  = "1.32.4"
+  kubernetes_version  = %[4]q
 
   ai_toolchain_operator_enabled = %[3]t
 
   default_node_pool {
     name       = "default"
     node_count = 1
-    vm_size    = "Standard_DS2_v2"
+    vm_size    = "Standard_D2s_v3"
     upgrade_settings {
       max_surge = "10%%"
     }
@@ -3853,5 +3853,5 @@ resource "azurerm_kubernetes_cluster" "test" {
     type = "SystemAssigned"
   }
 }
-  `, data.RandomInteger, data.Locations.Primary, enabled)
+  `, data.RandomInteger, data.Locations.Primary, enabled, currentKubernetesVersion)
 }


### PR DESCRIPTION
## Description

TeamCity build 683453 showed two tests using hard-coded Kubernetes 1.32 patch versions that now require AKS long-term support. This keeps the Windows Server 2019 node pool test on 1.32 with the LTS support plan, updates the AI toolchain operator test to use the provider helper for the current Kubernetes version, and uses `Standard_D2s_v3` in the affected test configs because `Standard_DS2_v2` is not available in the local `eastus` test subscription.

## Testing

- `az aks get-versions --location eastus -o json`
  - showed 1.32 patch versions under `AKSLongTermSupport`, while newer current versions are under `KubernetesOfficial`
- `make acctests SERVICE='containers' TESTARGS='-run=TestAccKubernetesClusterNodePool_windows2019 -parallel=1' TESTTIMEOUT='120m'`
  - PASS: `--- PASS: TestAccKubernetesClusterNodePool_windows2019 (936.00s)`
- `make acctests SERVICE='containers' TESTARGS='-run=TestAccKubernetesCluster_aiToolchainOperatorProfileToggle -parallel=1' TESTTIMEOUT='120m'`
  - PASS: `--- PASS: TestAccKubernetesCluster_aiToolchainOperatorProfileToggle (1201.47s)`