### PR TITLE
`azurerm_kubernetes_cluster` - fix dedicated host acceptance test family

### DIFF
--- a/internal/services/containers/kubernetes_cluster_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_resource_test.go
@@ -618,7 +618,7 @@ resource "azurerm_dedicated_host" "test" {
   name                    = "acctest-DH-%[1]d"
   location                = azurerm_resource_group.test.location
   dedicated_host_group_id = azurerm_dedicated_host_group.test.id
-  sku_name                = "FSv2-Type2"
+  sku_name                = "DSv3-Type3"
   platform_fault_domain   = 0
 }
 


### PR DESCRIPTION
## Description

TeamCity build 683453 showed the AKS dedicated host test failing because the node pool VMSS uses the DSv3 resource family, while the test host group was created with an FSv2 host SKU. This switches the test host SKU to `DSv3-Type3`, matching the VM size family used by `Standard_D2s_v3`.

## Testing

- `make acctests SERVICE='containers' TESTARGS='-run=TestAccKubernetesCluster_dedicatedHost -parallel=1' TESTTIMEOUT='120m'`
  - Blocked before AKS create by local subscription quota on the dedicated host resource: `Current Limit: 48`, `Additional Required: 80`, `(Minimum) New Limit Required: 80` for `standardDSv3Family Cores`
  - Classification: subscription quota/environment blocker, not a provider regression from this change