### PR TITLE
`azurerm_managed_redis` - Attempt to cleanup the resource if creation fails

### DIFF
--- a/internal/services/managedredis/managed_redis_resource.go
+++ b/internal/services/managedredis/managed_redis_resource.go
@@ -343,6 +343,13 @@ func (r ManagedRedisResource) Create() sdk.ResourceFunc {
 			clusterParams.Identity = expandedIdentity
 
 			if err := clusterClient.CreateCallbackThenPoll(ctx, clusterId, clusterParams, metadata.SetIDCallback(&clusterId)); err != nil {
+				if strings.Contains(err.Error(), "OperationFailed") {
+					log.Printf("[DEBUG] Managed Redis create failed, attempting cleanup")
+					if deleteErr := clusterClient.DeleteThenPoll(ctx, clusterId); deleteErr != nil {
+						log.Printf("[WARN] Cleanup of failed Managed Redis %s failed: %s", clusterId, deleteErr)
+					}
+				}
+
 				return fmt.Errorf("creating %s: %+v", clusterId, err)
 			}
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Opening this more for discussion than as a full and complete fix. If it's desired/accepted then I'm happy to work on tests and documentation.

We've recently been experiencing regular failures when creating `azurerm_managed_redis` instances (error below), this leaves a resource in Azure as `Server status: Create failed`, but not in the terraform state. Which means that when a retry is done, terraform fails as a resource already exists, and it can't destroy either as it doesn't know about the resource.

```
│ Status: "Failed"
│ Code: "OperationFailed"
│ Message: "The operation failed."
```

This is part of an automated terraform run, so when this happens we then have to manually delete the redis instance, and then try the operation again. This PR is an attempt to rollback when the initial create fails, to avoid leaving a resource that needs manual intervention outside of terraform.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_managed_redis` - Attempt to cleanup the resource if creation fails


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## AI Assistance Disclosure

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

None