### PR TITLE
fix regression in dataPlaneEndpoint and add simple test coverage

### DIFF
--- a/internal/services/storage/client/helpers.go
+++ b/internal/services/storage/client/helpers.go
@@ -125,7 +125,7 @@ func (ad *AccountDetails) DataPlaneEndpoint(endpointType EndpointType) (*string,
 
 	if baseUri == nil {
 		if StorageDomainSuffix != nil && ad.StorageAccountId.StorageAccountName != "" {
-			uri := fmt.Sprintf("https://%s.%s.%s/", ad.StorageAccountId.StorageAccountName, endpointType, *StorageDomainSuffix)
+			uri := fmt.Sprintf("https://%s.%s.%s", ad.StorageAccountId.StorageAccountName, endpointType, *StorageDomainSuffix)
 			return &uri, nil
 		}
 		return nil, fmt.Errorf("determining %s endpoint for %s: missing primary endpoint", endpointType, ad.StorageAccountId)

--- a/internal/services/storage/client/helpers_test.go
+++ b/internal/services/storage/client/helpers_test.go
@@ -1,0 +1,27 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+)
+
+func TestAccountDetails_DataPlaneEndpoint(t *testing.T) {
+	StorageDomainSuffix = pointer.To("core.windows.net")
+	ad := AccountDetails{
+		StorageAccountId: commonids.StorageAccountId{
+			StorageAccountName: "exampleacct1234",
+		},
+	}
+
+	uri, err := ad.DataPlaneEndpoint(EndpointTypeQueue)
+	if err != nil {
+		t.Fatalf("expected no error, got %s", err)
+	}
+
+	expected := "https://exampleacct1234.queue.core.windows.net"
+	if *uri != expected {
+		t.Fatalf("expected URI to be %q, got %q", expected, *uri)
+	}
+}


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Addresses a regression in storage account for URI construction when bypassing `FindAccount()` functionality.


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_storage_account` - fixed a regression in malformed data plane URLs introduced in 4.77.0


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #32612


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
