### PR TITLE
Remove read-only field from PUT request and update error messages

### DIFF
--- a/internal/services/appservice/static_web_app_resource.go
+++ b/internal/services/appservice/static_web_app_resource.go
@@ -413,6 +413,9 @@ func (r StaticWebAppResource) Update() sdk.ResourceFunc {
 
 			model := *existing.Model
 
+			// Remove read-only field before sending back in PUT request
+			model.Properties.PrivateEndpointConnections = nil
+
 			if metadata.ResourceData.HasChange("identity") {
 				ident, err := identity.ExpandSystemAndUserAssignedMapFromModel(config.Identity)
 				if err != nil {
@@ -422,7 +425,7 @@ func (r StaticWebAppResource) Update() sdk.ResourceFunc {
 				// If we're changing to `Free` we must remove the Identity first
 				if strings.EqualFold(string(resourceproviders.SkuNameFree), config.SkuTier) {
 					if err := client.CreateOrUpdateStaticSiteThenPoll(ctx, *id, model); err != nil {
-						return fmt.Errorf("creating %s: %+v", id, err)
+						return fmt.Errorf("updating %s: %+v", id, err)
 					}
 					// Once removed, the identity payload needs to be nilled or the API validation for `Free` will reject the request
 					model.Identity = nil
@@ -461,7 +464,7 @@ func (r StaticWebAppResource) Update() sdk.ResourceFunc {
 			}
 
 			if err := client.CreateOrUpdateStaticSiteThenPoll(ctx, *id, model); err != nil {
-				return fmt.Errorf("creating %s: %+v", id, err)
+				return fmt.Errorf("updating %s: %+v", id, err)
 			}
 
 			if metadata.ResourceData.HasChange("app_settings") {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

drop a read-only field from the ARM response which retrieves the current state of the static web app at the beginning of the update function before it's used in the PUT request back to make the actual update.

Of note, simply reverting an older version of the provider (tried 4.74, 4.60, 4.50, and 4.10) did NOT seem to fix this issue. Te me this seems to indicate a change on the Microsoft/Azure side where the response from that _versioned_ REST endpoint had to have changed.  If somebody else can confirm they're seeing the same thing maybe we can make some sort of note somewhere else on this issue/fix to make it more easily searchable? Although the linked issue does an excellent job of detailing the issue and the error/use case/how to reproduce /shurg

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_static_web_app` - fixes an issue where updates can't be made to a static_web_app resource with a private endpoint attached


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #32523


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
