### PR TITLE
azurerm_kubernetes_cluster - add validation preventing node_os_upgrade_channel being set to SecurityPatch when support_plan is KubernetesOfficial

### DIFF
--- a/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -6,6 +6,7 @@ package containers_test
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -3800,4 +3801,52 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
 }
   `, data.RandomInteger, data.Locations.Primary, enabled)
+}
+
+func TestAccKubernetesCluster_nodeOsUpgradeChannelSecurityPatchInvalid(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
+	r := KubernetesClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:      r.nodeOsUpgradeChannelSecurityPatchConfig(data, "SecurityPatch", "KubernetesOfficial"),
+			ExpectError: regexp.MustCompile("`node_os_upgrade_channel` cannot be set to `SecurityPatch` when `support_plan` is set to `KubernetesOfficial`"),
+		},
+	})
+}
+
+func (KubernetesClusterResource) nodeOsUpgradeChannelSecurityPatchConfig(data acceptance.TestData, nodeOsUpgradeChannel, supportPlan string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%[1]d"
+
+  support_plan            = "%[3]s"
+  node_os_upgrade_channel = "%[4]s"
+
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
+    upgrade_settings {
+      max_surge = "10%%"
+    }
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, supportPlan, nodeOsUpgradeChannel)
 }

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -190,6 +190,16 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 				}
 				return nil
 			},
+			func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+				supportPlan := d.Get("support_plan").(string)
+				nodeOsUpgradeChannel := d.Get("node_os_upgrade_channel").(string)
+
+				if supportPlan == string(managedclusters.KubernetesSupportPlanKubernetesOfficial) && nodeOsUpgradeChannel == string(managedclusters.NodeOSUpgradeChannelSecurityPatch) {
+					return fmt.Errorf("`node_os_upgrade_channel` cannot be set to `SecurityPatch` when `support_plan` is set to `KubernetesOfficial`")
+				}
+
+				return nil
+			},
 		),
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(90 * time.Minute),


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note

<!-- Please leave the community note as is. -->

* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review

* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

This PR adds a schema validation/diff customizer check in the `azurerm_kubernetes_cluster` resource within [kubernetes_cluster_resource.go](file:///c:/Users/Bhuvain%20Jhamb/Desktop/Github%20Projects/terraform-provider-azurerm/internal/services/containers/kubernetes_cluster_resource.go) to prevent `node_os_upgrade_channel` from being set to `SecurityPatch` when `support_plan` is set to `KubernetesOfficial`.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 

For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.

## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

The new acceptance test `TestAccKubernetesCluster_nodeOsUpgradeChannelSecurityPatchInvalid` was added to [kubernetes_cluster_other_resource_test.go](/terraform-provider-azurerm/internal/services/containers/kubernetes_cluster_other_resource_test.go) and runs successfully to verify the validation error.

## Change Log

* `azurerm_kubernetes_cluster` - validation logic to prevent setting `node_os_upgrade_channel` to `SecurityPatch` when `support_plan` is set to `KubernetesOfficial`

This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change

## Related Issue(s)

Fixes #32485 

## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

The tests and PR were prepared with the assistance of an AI assistant (Antigravity).

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No security control changes.
