### PR TITLE
`azurerm_spring_cloud_connection` - remove `none` from the `client_type` argument in 5.0

### DIFF
--- a/internal/services/serviceconnector/spring_cloud_connection_resource.go
+++ b/internal/services/serviceconnector/spring_cloud_connection_resource.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/servicelinker/2024-04-01/servicelinker"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/springcloud/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -34,7 +35,7 @@ type SpringCloudConnectorResourceModel struct {
 }
 
 func (r SpringCloudConnectorResource) Arguments() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
+	args := map[string]*schema.Schema{
 		"name": {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
@@ -59,11 +60,7 @@ func (r SpringCloudConnectorResource) Arguments() map[string]*schema.Schema {
 		"client_type": {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
-			// TODO: remove `None` in 4.0, since this is Optional `None` == omitting the field
-			Default: string(servicelinker.ClientTypeNone),
 			ValidateFunc: validation.StringInSlice([]string{
-				// TODO: remove `None` in 4.0, since this is Optional `None` == omitting the field
-				string(servicelinker.ClientTypeNone),
 				string(servicelinker.ClientTypeDotnet),
 				string(servicelinker.ClientTypeJava),
 				string(servicelinker.ClientTypePython),
@@ -89,6 +86,28 @@ func (r SpringCloudConnectorResource) Arguments() map[string]*schema.Schema {
 
 		"authentication": authInfoSchema(),
 	}
+
+	if !features.FivePointOh() {
+		args["client_type"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Default:  string(servicelinker.ClientTypeNone),
+			ValidateFunc: validation.StringInSlice([]string{
+				string(servicelinker.ClientTypeNone),
+				string(servicelinker.ClientTypeDotnet),
+				string(servicelinker.ClientTypeJava),
+				string(servicelinker.ClientTypePython),
+				string(servicelinker.ClientTypeGo),
+				string(servicelinker.ClientTypePhp),
+				string(servicelinker.ClientTypeRuby),
+				string(servicelinker.ClientTypeDjango),
+				string(servicelinker.ClientTypeNodejs),
+				string(servicelinker.ClientTypeSpringBoot),
+			}, false),
+		}
+	}
+
+	return args
 }
 
 func (r SpringCloudConnectorResource) Attributes() map[string]*schema.Schema {
@@ -133,7 +152,8 @@ func (r SpringCloudConnectorResource) Create() sdk.ResourceFunc {
 			}
 
 			serviceConnectorProperties := servicelinker.LinkerProperties{
-				AuthInfo: authInfo,
+				AuthInfo:   authInfo,
+				ClientType: pointer.To(servicelinker.ClientTypeNone),
 			}
 
 			if storageAccountId, err := commonids.ParseStorageAccountID(model.TargetResourceId); err == nil {
@@ -153,8 +173,7 @@ func (r SpringCloudConnectorResource) Create() sdk.ResourceFunc {
 			}
 
 			if model.ClientType != "" {
-				clientType := servicelinker.ClientType(model.ClientType)
-				serviceConnectorProperties.ClientType = &clientType
+				serviceConnectorProperties.ClientType = pointer.ToEnum[servicelinker.ClientType](model.ClientType)
 			}
 
 			if model.VnetSolution != "" {
@@ -213,8 +232,10 @@ func (r SpringCloudConnectorResource) Read() sdk.ResourceFunc {
 					AuthInfo:         flattenServiceConnectorAuthInfo(props.AuthInfo, pwd),
 				}
 
-				if props.ClientType != nil {
-					state.ClientType = string(*props.ClientType)
+				if !features.FivePointOh() {
+					state.ClientType = pointer.FromEnum(props.ClientType)
+				} else if v := pointer.From(props.ClientType); v != servicelinker.ClientTypeNone {
+					state.ClientType = string(v)
 				}
 
 				if props.VNetSolution != nil && props.VNetSolution.Type != nil {

--- a/internal/services/serviceconnector/spring_cloud_connection_resource_test.go
+++ b/internal/services/serviceconnector/spring_cloud_connection_resource_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
@@ -132,6 +133,24 @@ func TestAccServiceConnectorSpringCloud_complete(t *testing.T) {
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccServiceConnectorSpringCloud_clientTypeNone(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as `client_type` no longer accepts `none` in 5.0")
+	}
+	data := acceptance.BuildTestData(t, "azurerm_spring_cloud_connection", "test")
+	r := ServiceConnectorSpringCloudResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.clientTypeNone(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -426,6 +445,22 @@ resource "azurerm_spring_cloud_connection" "test" {
   }
 }
 `, template, data.RandomInteger)
+}
+
+func (r ServiceConnectorSpringCloudResource) clientTypeNone(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_spring_cloud_connection" "test" {
+  name               = "acctestserviceconnector%[2]d"
+  spring_cloud_id    = azurerm_spring_cloud_java_deployment.test.id
+  target_resource_id = azurerm_cosmosdb_sql_database.test.id
+  client_type        = "none"
+  authentication {
+    type = "systemAssignedIdentity"
+  }
+}
+`, r.template(data), data.RandomInteger)
 }
 
 func (r ServiceConnectorSpringCloudResource) template(data acceptance.TestData) string {

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -684,6 +684,10 @@ Please follow the format in the example below for listing breaking changes in re
 
 * The property `minimum_tls_version` no longer accepts `1.0` or `1.1` as a value.
 
+### `azurerm_spring_cloud_connection`
+
+* The `client_type` property no longer accepts `none` as a value. Omitting the property sets `none` in the request.
+
 ### `azurerm_storage_account`
 
 * The deprecated `customer_managed_key.managed_hsm_key_id` has been removed in favour of the `customer_managed_key.key_vault_key_id` property.


### PR DESCRIPTION


<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

remove `none` from the `client_type` argument in 5.0

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change




## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
