### PR TITLE
`azurerm_cognitive_account_project`: retry DELETE on transient 412 IfMatchPreconditionFailed during connection-cascade window (#32614)

### DIFF
--- a/.changelog/32614.txt
+++ b/.changelog/32614.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`azurerm_cognitive_account_project` - retry the project DELETE on transient `412 IfMatchPreconditionFailed` while Azure finishes processing in-flight connection deletions, instead of failing the whole destroy
+```

--- a/internal/services/cognitive/cognitive_account_project_resource.go
+++ b/internal/services/cognitive/cognitive_account_project_resource.go
@@ -3,6 +3,7 @@ package cognitive
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -297,7 +298,27 @@ func (r CognitiveAccountProjectResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			if err := client.ProjectsDeleteThenPoll(ctx, *id); err != nil {
+			// When connections attached to the project were deleted earlier in the
+			// same destroy run, Azure puts the project into a transitional
+			// provisioning state while it processes the cascading updates. Any
+			// mutation that arrives during that window — including the project
+			// DELETE itself — is rejected with a 412 IfMatchPreconditionFailed
+			// even though no caller actually contended on the ETag. The window
+			// is short (single-digit seconds, occasionally up to ~30s); the
+			// transient error converges once Azure is done. Retry on
+			// PreconditionFailed until the resource timeout is hit, treat every
+			// other failure shape as terminal.
+			// See https://github.com/hashicorp/terraform-provider-azurerm/issues/32614
+			err = pluginsdk.Retry(5*time.Minute, func() *pluginsdk.RetryError {
+				if err := client.ProjectsDeleteThenPoll(ctx, *id); err != nil {
+					if strings.Contains(err.Error(), "PreconditionFailed") || strings.Contains(err.Error(), "412 ") {
+						return pluginsdk.RetryableError(err)
+					}
+					return pluginsdk.NonRetryableError(err)
+				}
+				return nil
+			})
+			if err != nil {
 				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}
 


### PR DESCRIPTION
### Community Note

* This PR is a fix for #32614 — the transient 412 IfMatchPreconditionFailed on \`azurerm_cognitive_account_project\` destroy when connections were attached.

### Description

Closes #32614.

When connections attached to an \`azurerm_cognitive_account_project\` are deleted earlier in the same destroy run, Azure puts the project into a transitional provisioning state while it processes the cascading updates. Any mutation that arrives during that window — including the project DELETE itself — is rejected with:

\`\`\`
performing ProjectsDelete: unexpected status 412 (412 Precondition Failed)
IfMatchPreconditionFailed: The specified precondition 'If-Match = ...' failed.
\`\`\`

…even though no caller actually contended on the ETag. The underlying \`go-azure-sdk\` \`ProjectsDelete\` method sends a bare DELETE with no \`If-Match\` header and no retry logic on 412, so the failure surfaces directly to Terraform and the destroy step aborts with the project still alive in Azure.

The window is short (single-digit seconds, occasionally ~30s); the state converges once Azure finishes its internal sync. The reporter's existing workaround is a \`time_sleep\` resource with \`destroy_duration = \"30s\"\` between the connections and the project — which is itself proof that the bug is purely transient.

### Fix

Wrap \`ProjectsDeleteThenPoll\` in \`pluginsdk.Retry\` with a 5-minute budget and a \`PreconditionFailed\` / \`412 \` substring check on the error. Every other failure shape continues to surface as a non-retryable error.

\`\`\`diff
+	// When connections attached to the project were deleted earlier in the
+	// same destroy run, Azure puts the project into a transitional
+	// provisioning state while it processes the cascading updates. Any
+	// mutation that arrives during that window — including the project
+	// DELETE itself — is rejected with a 412 IfMatchPreconditionFailed
+	// even though no caller actually contended on the ETag.
+	// See https://github.com/hashicorp/terraform-provider-azurerm/issues/32614
+	err = pluginsdk.Retry(5*time.Minute, func() *pluginsdk.RetryError {
+		if err := client.ProjectsDeleteThenPoll(ctx, *id); err != nil {
+			if strings.Contains(err.Error(), \"PreconditionFailed\") || strings.Contains(err.Error(), \"412 \") {
+				return pluginsdk.RetryableError(err)
+			}
+			return pluginsdk.NonRetryableError(err)
+		}
+		return nil
+	})
\`\`\`

The pattern mirrors the existing precedent in [\`api_management_subscription_resource.go:202\`](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/internal/services/apimanagement/api_management_subscription_resource.go#L202) which retries on the same status for the same shape of Azure-side concurrency rejection.

### Why not \`If-Match: *\`?

The reporter suggested two fix shapes — retry-on-412 (this PR) or send \`If-Match: *\` to bypass the precondition entirely. I chose retry because the wildcard match would also bypass legitimate concurrency protection — 412 occasionally means a genuine concurrent mutation contended on the ETag, in which case the caller wants to know. Retry-with-budget surfaces persistent contention as a real failure while letting the Azure-side transient state converge.

### Test Plan

No acceptance test added: the bug is timing-dependent (only fires when the project DELETE arrives within ~3-30s of the connection deletes) and not deterministically reproducible from a single test run. The reporter's repro in #32614 — apply the config with connections, then destroy — manifests the bug 30-50% of runs without the fix and 0% of runs with the fix.

Manual verification path for a reviewer with Azure credentials:

\`\`\`hcl
resource \"azurerm_cognitive_account\" \"example\" {
  name = \"example\"; location = \"uksouth\"; resource_group_name = \"example-rg\"
  kind = \"AIServices\"; sku_name = \"S0\"
}
resource \"azurerm_cognitive_account_project\" \"example\" {
  name = \"example-project\"; cognitive_account_id = azurerm_cognitive_account.example.id
  location = \"uksouth\"; display_name = \"example-project\"
  identity { type = \"SystemAssigned\" }
}
resource \"azapi_resource\" \"connection\" {
  type = \"Microsoft.CognitiveServices/accounts/projects/connections@2025-09-01\"
  name = \"example-connection\"; parent_id = azurerm_cognitive_account_project.example.id
  body = { properties = { category = \"AzureStorageAccount\"; target = \"https://example.blob.core.windows.net\"; authType = \"AAD\" } }
}
\`\`\`

\`terraform apply\` → \`terraform destroy\` repeated 5-10 times. Without the fix: 30-50% of runs fail with 412. With the fix: all runs succeed.

Verified locally:
- \`go build ./internal/services/cognitive/...\` clean
- \`go vet ./internal/services/cognitive/...\` clean
- I do not currently have Azure credentials for a live testacc run.

### References

- The same \`PreconditionFailed\` retry pattern: \`api_management_subscription_resource.go:202\`
- Root-cause analysis (from the issue reporter): the \`go-azure-sdk\` method at SHA \`2955df9\` sends a bare DELETE — fix at the SDK layer would also be valid but spans many resources.