### PR TITLE
`azurerm_dedicated_host` - remove `None` from the `license_type` property in 5.0

### DIFF
--- a/internal/services/compute/dedicated_host_resource.go
+++ b/internal/services/compute/dedicated_host_resource.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -29,7 +30,7 @@ import (
 //go:generate go run ../../tools/generator-tests resourceidentity -resource-name dedicated_host -service-package-name compute -properties "name" -compare-values "subscription_id:dedicated_host_group_id,resource_group_name:dedicated_host_group_id,host_group_name:dedicated_host_group_id"
 
 func resourceDedicatedHost() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
+	resource := &pluginsdk.Resource{
 		Create: resourceDedicatedHostCreate,
 		Read:   resourceDedicatedHostRead,
 		Update: resourceDedicatedHostUpdate,
@@ -134,17 +135,29 @@ func resourceDedicatedHost() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					// TODO: remove `None` in 4.0 in favour of this field being set to an empty string (since it's optional)
-					string(dedicatedhosts.DedicatedHostLicenseTypesNone),
 					string(dedicatedhosts.DedicatedHostLicenseTypesWindowsServerHybrid),
 					string(dedicatedhosts.DedicatedHostLicenseTypesWindowsServerPerpetual),
 				}, false),
-				Default: string(dedicatedhosts.DedicatedHostLicenseTypesNone),
 			},
 
 			"tags": commonschema.Tags(),
 		},
 	}
+
+	if !features.FivePointOh() {
+		resource.Schema["license_type"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				string(dedicatedhosts.DedicatedHostLicenseTypesNone),
+				string(dedicatedhosts.DedicatedHostLicenseTypesWindowsServerHybrid),
+				string(dedicatedhosts.DedicatedHostLicenseTypesWindowsServerPerpetual),
+			}, false),
+			Default: string(dedicatedhosts.DedicatedHostLicenseTypesNone),
+		}
+	}
+
+	return resource
 }
 
 func resourceDedicatedHostCreate(d *pluginsdk.ResourceData, meta interface{}) error {
@@ -170,18 +183,21 @@ func resourceDedicatedHostCreate(d *pluginsdk.ResourceData, meta interface{}) er
 		}
 	}
 
-	licenseType := dedicatedhosts.DedicatedHostLicenseTypes(d.Get("license_type").(string))
 	payload := dedicatedhosts.DedicatedHost{
 		Location: location.Normalize(d.Get("location").(string)),
 		Properties: &dedicatedhosts.DedicatedHostProperties{
 			AutoReplaceOnFailure: pointer.To(d.Get("auto_replace_on_failure").(bool)),
-			LicenseType:          &licenseType,
+			LicenseType:          pointer.To(dedicatedhosts.DedicatedHostLicenseTypesNone),
 			PlatformFaultDomain:  pointer.To(int64(d.Get("platform_fault_domain").(int))),
 		},
 		Sku: dedicatedhosts.Sku{
 			Name: pointer.To(d.Get("sku_name").(string)),
 		},
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
+	}
+
+	if v := d.Get("license_type").(string); v != "" {
+		payload.Properties.LicenseType = pointer.ToEnum[dedicatedhosts.DedicatedHostLicenseTypes](v)
 	}
 
 	if err := client.CreateOrUpdateCallbackThenPoll(ctx, id, payload, sdk.SetIDAndIdentityCallback(meta, &id, d)); err != nil {
@@ -225,7 +241,16 @@ func resourceDedicatedHostRead(d *pluginsdk.ResourceData, meta interface{}) erro
 		d.Set("sku_name", model.Sku.Name)
 		if props := model.Properties; props != nil {
 			d.Set("auto_replace_on_failure", props.AutoReplaceOnFailure)
-			d.Set("license_type", string(pointer.From(props.LicenseType)))
+
+			if !features.FivePointOh() {
+				d.Set("license_type", props.LicenseType)
+			} else {
+				licenseType := pointer.FromEnum(props.LicenseType)
+				if licenseType == string(dedicatedhosts.DedicatedHostLicenseTypesNone) {
+					licenseType = ""
+				}
+				d.Set("license_type", licenseType)
+			}
 
 			platformFaultDomain := 0
 			if props.PlatformFaultDomain != nil {
@@ -260,8 +285,11 @@ func resourceDedicatedHostUpdate(d *pluginsdk.ResourceData, meta interface{}) er
 			payload.Properties.AutoReplaceOnFailure = pointer.To(d.Get("auto_replace_on_failure").(bool))
 		}
 		if d.HasChange("license_type") {
-			licenseType := dedicatedhosts.DedicatedHostLicenseTypes(d.Get("license_type").(string))
-			payload.Properties.LicenseType = &licenseType
+			licenseType := dedicatedhosts.DedicatedHostLicenseTypesNone
+			if v := d.Get("license_type").(string); v != "" {
+				licenseType = dedicatedhosts.DedicatedHostLicenseTypes(v)
+			}
+			payload.Properties.LicenseType = pointer.To(licenseType)
 		}
 	}
 

--- a/internal/services/compute/dedicated_host_resource.go
+++ b/internal/services/compute/dedicated_host_resource.go
@@ -243,7 +243,7 @@ func resourceDedicatedHostRead(d *pluginsdk.ResourceData, meta interface{}) erro
 			d.Set("auto_replace_on_failure", props.AutoReplaceOnFailure)
 
 			if !features.FivePointOh() {
-				d.Set("license_type", props.LicenseType)
+				d.Set("license_type", pointer.FromEnum(props.LicenseType))
 			} else {
 				licenseType := pointer.FromEnum(props.LicenseType)
 				if licenseType == string(dedicatedhosts.DedicatedHostLicenseTypesNone) {

--- a/internal/services/compute/dedicated_host_resource_test.go
+++ b/internal/services/compute/dedicated_host_resource_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 

--- a/internal/services/compute/dedicated_host_resource_test.go
+++ b/internal/services/compute/dedicated_host_resource_test.go
@@ -87,7 +87,7 @@ func TestAccDedicatedHost_licenseType(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.licenceType(data, "None"),
+			Config: r.noLicenceType(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -107,6 +107,25 @@ func TestAccDedicatedHost_licenseType(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
+		{
+			Config: r.noLicenceType(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccDedicatedHost_licenseTypeNone(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("`license_type` no longer accepts `None` as a value in 5.0")
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_dedicated_host", "test")
+	r := DedicatedHostResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.licenceType(data, "None"),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -169,7 +188,7 @@ func TestAccDedicatedHost_requiresImport(t *testing.T) {
 	})
 }
 
-func (t DedicatedHostResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+func (r DedicatedHostResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := commonids.ParseDedicatedHostID(state.ID)
 	if err != nil {
 		return nil, err
@@ -239,6 +258,20 @@ resource "azurerm_dedicated_host" "test" {
   license_type            = %q
 }
 `, r.template(data), data.RandomInteger, licenseType)
+}
+
+func (r DedicatedHostResource) noLicenceType(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_dedicated_host" "test" {
+  name                    = "acctest-DH-%[2]d"
+  location                = azurerm_resource_group.test.location
+  dedicated_host_group_id = azurerm_dedicated_host_group.test.id
+  sku_name                = "FSv2-Type2"
+  platform_fault_domain   = 1
+}
+`, r.template(data), data.RandomInteger)
 }
 
 func (r DedicatedHostResource) complete(data acceptance.TestData) string {

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -463,6 +463,10 @@ Please follow the format in the example below for listing breaking changes in re
 
 * Validation for `rbac_authorization.resource_id` has been changed to validate for an integration runtime resource ID (case-sensitive) rather than validating for a non-empty string.
 
+### `azurerm_dedicated_host`
+
+* The `license_type` property no longer accepts `None` as a value. Omitting the property sets `None` in the request.
+
 ### `azurerm_disk_encryption_set`
 
 * The deprecated `managed_hsm_key_id` property has been removed in favour of the `key_vault_key_id` property.


### PR DESCRIPTION


<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Removes `None` from `license_type` in favour of omission indicating `None`

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
