### PR TITLE
`azurerm_virtual_network_gateway`: Add support for `max_scale_unit` and `min_scale_unit`

### DIFF
--- a/internal/services/network/virtual_network_gateway_resource.go
+++ b/internal/services/network/virtual_network_gateway_resource.go
@@ -642,6 +642,7 @@ func resourceVirtualNetworkGateway() *pluginsdk.Resource {
 			"maximum_scale_unit": {
 				Type:         pluginsdk.TypeInt,
 				Optional:     true,
+				Computed:     true,
 				ValidateFunc: validation.IntBetween(1, 40),
 				RequiredWith: []string{"maximum_scale_unit", "minimum_scale_unit"},
 			},
@@ -649,6 +650,7 @@ func resourceVirtualNetworkGateway() *pluginsdk.Resource {
 			"minimum_scale_unit": {
 				Type:         pluginsdk.TypeInt,
 				Optional:     true,
+				Computed:     true,
 				ValidateFunc: validation.IntBetween(1, 40),
 				RequiredWith: []string{"maximum_scale_unit", "minimum_scale_unit"},
 			},
@@ -706,13 +708,21 @@ func resourceVirtualNetworkGatewayCustomizeDiff(ctx context.Context, d *pluginsd
 	maxScaleUnit := d.Get("maximum_scale_unit").(int)
 	sku := d.Get("sku").(string)
 
-	if sku == string(virtualnetworkgateways.VirtualNetworkGatewaySkuNameErGwScale) {
-		if minScaleUnit == 0 || maxScaleUnit == 0 {
-			return fmt.Errorf("`minimum_scale_unit` and `maximum_scale_unit` must be set when `sku` is `%s`", virtualnetworkgateways.VirtualNetworkGatewaySkuNameErGwScale)
+	if features.FivePointOh() {
+		if sku == string(virtualnetworkgateways.VirtualNetworkGatewaySkuNameErGwScale) {
+			if minScaleUnit == 0 || maxScaleUnit == 0 {
+				return fmt.Errorf("`minimum_scale_unit` and `maximum_scale_unit` must be set when `sku` is `%s`", virtualnetworkgateways.VirtualNetworkGatewaySkuNameErGwScale)
+			}
 		}
 	}
 
-	if minScaleUnit > 0 {
+	// Use RawConfig to determine if the user explicitly set the scale unit fields,
+	// since these are Optional+Computed and d.Get() returns API-stored values from state
+	rawConfig := d.GetRawConfig().AsValueMap()
+	minIsSet := !rawConfig["minimum_scale_unit"].IsNull()
+	maxIsSet := !rawConfig["maximum_scale_unit"].IsNull()
+
+	if minIsSet || maxIsSet {
 		if sku != string(virtualnetworkgateways.VirtualNetworkGatewaySkuNameErGwScale) {
 			return fmt.Errorf("`minimum_scale_unit` and `maximum_scale_unit` are only supported when `sku` is set to `%s`", virtualnetworkgateways.VirtualNetworkGatewaySkuNameErGwScale)
 		}

--- a/internal/services/network/virtual_network_gateway_resource.go
+++ b/internal/services/network/virtual_network_gateway_resource.go
@@ -976,7 +976,7 @@ func resourceVirtualNetworkGatewayUpdate(d *pluginsdk.ResourceData, meta interfa
 	}
 
 	if d.HasChanges("minimum_scale_unit", "maximum_scale_unit") || d.HasChange("sku") {
-		payload.Properties.AutoScaleConfiguration = nil
+		payload.Properties.AutoScaleConfiguration = &virtualnetworkgateways.VirtualNetworkGatewayAutoScaleConfiguration{}
 		rawConfig := d.GetRawConfig().AsValueMap()
 		if !rawConfig["minimum_scale_unit"].IsNull() {
 			payload.Properties.AutoScaleConfiguration = expandVirtualNetworkGatewayAutoScaleConfiguration(d)

--- a/internal/services/network/virtual_network_gateway_resource.go
+++ b/internal/services/network/virtual_network_gateway_resource.go
@@ -975,8 +975,12 @@ func resourceVirtualNetworkGatewayUpdate(d *pluginsdk.ResourceData, meta interfa
 		payload.Properties.AllowVirtualWanTraffic = pointer.To(d.Get("virtual_wan_traffic_enabled").(bool))
 	}
 
-	if d.HasChanges("minimum_scale_unit", "maximum_scale_unit") {
-		payload.Properties.AutoScaleConfiguration = expandVirtualNetworkGatewayAutoScaleConfiguration(d)
+	if d.HasChanges("minimum_scale_unit", "maximum_scale_unit") || d.HasChange("sku") {
+		payload.Properties.AutoScaleConfiguration = nil
+		rawConfig := d.GetRawConfig().AsValueMap()
+		if !rawConfig["minimum_scale_unit"].IsNull() {
+			payload.Properties.AutoScaleConfiguration = expandVirtualNetworkGatewayAutoScaleConfiguration(d)
+		}
 	}
 
 	if d.HasChange("tags") {

--- a/internal/services/network/virtual_network_gateway_resource.go
+++ b/internal/services/network/virtual_network_gateway_resource.go
@@ -643,12 +643,14 @@ func resourceVirtualNetworkGateway() *pluginsdk.Resource {
 				Type:         pluginsdk.TypeInt,
 				Optional:     true,
 				ValidateFunc: validation.IntBetween(1, 40),
+				RequiredWith: []string{"max_scale_unit", "min_scale_unit"},
 			},
 
 			"min_scale_unit": {
 				Type:         pluginsdk.TypeInt,
 				Optional:     true,
 				ValidateFunc: validation.IntBetween(1, 40),
+				RequiredWith: []string{"max_scale_unit", "min_scale_unit"},
 			},
 
 			"remote_vnet_traffic_enabled": {
@@ -688,7 +690,6 @@ func resourceVirtualNetworkGateway() *pluginsdk.Resource {
 
 func resourceVirtualNetworkGatewayCustomizeDiff(ctx context.Context, d *pluginsdk.ResourceDiff, _ interface{}) error {
 	gatewayType := d.Get("type").(string)
-	sku := d.Get("sku").(string)
 
 	// Validate that public_ip_address_id is not set for ExpressRoute gateways
 	if gatewayType == string(virtualnetworkgateways.VirtualNetworkGatewayTypeExpressRoute) {
@@ -701,35 +702,23 @@ func resourceVirtualNetworkGatewayCustomizeDiff(ctx context.Context, d *pluginsd
 		}
 	}
 
-	minScaleUnitRaw, minScaleUnitOk := d.GetOk("min_scale_unit")
-	maxScaleUnitRaw, maxScaleUnitOk := d.GetOk("max_scale_unit")
-	if minScaleUnitOk || maxScaleUnitOk {
+	minScaleUnit := d.Get("min_scale_unit").(int)
+	maxScaleUnit := d.Get("max_scale_unit").(int)
+	sku := d.Get("sku").(string)
+
+	if sku == string(virtualnetworkgateways.VirtualNetworkGatewaySkuNameErGwScale) {
+		if minScaleUnit == 0 || maxScaleUnit == 0 {
+			return fmt.Errorf("`min_scale_unit` and `max_scale_unit` must be set when `sku` is `%s`", virtualnetworkgateways.VirtualNetworkGatewaySkuNameErGwScale)
+		}
+	}
+
+	if minScaleUnit > 0 {
 		if sku != string(virtualnetworkgateways.VirtualNetworkGatewaySkuNameErGwScale) {
 			return fmt.Errorf("`min_scale_unit` and `max_scale_unit` are only supported when `sku` is set to `%s`", virtualnetworkgateways.VirtualNetworkGatewaySkuNameErGwScale)
 		}
 
-		if maxScaleUnitOk {
-			maxScaleUnit := int64(maxScaleUnitRaw.(int))
-			if maxScaleUnit == 1 {
-				if !minScaleUnitOk {
-					return fmt.Errorf("when `max_scale_unit` is set to 1, `min_scale_unit` must also be set to 1")
-				}
-				minScaleUnit := int64(minScaleUnitRaw.(int))
-				if minScaleUnit != 1 {
-					return fmt.Errorf("when `max_scale_unit` is set to 1, `min_scale_unit` must also be set to 1")
-				}
-			}
-		}
-
-		if minScaleUnitOk && maxScaleUnitOk {
-			minScaleUnit := int64(minScaleUnitRaw.(int))
-			maxScaleUnit := int64(maxScaleUnitRaw.(int))
-			if minScaleUnit > maxScaleUnit {
-				return fmt.Errorf("`min_scale_unit` (%d) cannot be greater than `max_scale_unit` (%d)", minScaleUnit, maxScaleUnit)
-			}
-			if minScaleUnit != maxScaleUnit && minScaleUnit < 2 {
-				return fmt.Errorf("when configuring autoscaling `min_scale_unit` must be 2 or greater")
-			}
+		if minScaleUnit > maxScaleUnit {
+			return fmt.Errorf("`min_scale_unit` (%d) cannot be greater than `max_scale_unit` (%d)", minScaleUnit, maxScaleUnit)
 		}
 	}
 
@@ -1832,26 +1821,19 @@ func flattenVirtualNetworkGatewayPolicyGroupNames(input []virtualnetworkgateways
 }
 
 func expandVirtualNetworkGatewayAutoScaleConfiguration(d *pluginsdk.ResourceData) *virtualnetworkgateways.VirtualNetworkGatewayAutoScaleConfiguration {
-	minScaleUnit, minOk := d.GetOk("min_scale_unit")
-	maxScaleUnit, maxOk := d.GetOk("max_scale_unit")
+	minScaleUnit := d.Get("min_scale_unit").(int)
+	maxScaleUnit := d.Get("max_scale_unit").(int)
 
-	if !minOk && !maxOk {
+	if minScaleUnit == 0 {
 		return nil
 	}
 
-	result := &virtualnetworkgateways.VirtualNetworkGatewayAutoScaleConfiguration{
-		Bounds: &virtualnetworkgateways.VirtualNetworkGatewayAutoScaleBounds{},
+	return &virtualnetworkgateways.VirtualNetworkGatewayAutoScaleConfiguration{
+		Bounds: &virtualnetworkgateways.VirtualNetworkGatewayAutoScaleBounds{
+			Min: pointer.To(int64(minScaleUnit)),
+			Max: pointer.To(int64(maxScaleUnit)),
+		},
 	}
-
-	if minOk {
-		result.Bounds.Min = pointer.To(int64(minScaleUnit.(int)))
-	}
-
-	if maxOk {
-		result.Bounds.Max = pointer.To(int64(maxScaleUnit.(int)))
-	}
-
-	return result
 }
 
 func flattenVirtualNetworkGatewayAutoScaleConfiguration(input *virtualnetworkgateways.VirtualNetworkGatewayAutoScaleConfiguration) (interface{}, interface{}) {
@@ -1859,15 +1841,5 @@ func flattenVirtualNetworkGatewayAutoScaleConfiguration(input *virtualnetworkgat
 		return nil, nil
 	}
 
-	var min interface{}
-	if input.Bounds.Min != nil {
-		min = int(pointer.From(input.Bounds.Min))
-	}
-
-	var max interface{}
-	if input.Bounds.Max != nil {
-		max = int(pointer.From(input.Bounds.Max))
-	}
-
-	return min, max
+	return input.Bounds.Min, input.Bounds.Max
 }

--- a/internal/services/network/virtual_network_gateway_resource.go
+++ b/internal/services/network/virtual_network_gateway_resource.go
@@ -639,18 +639,18 @@ func resourceVirtualNetworkGateway() *pluginsdk.Resource {
 				Default:  true,
 			},
 
-			"max_scale_unit": {
+			"maximum_scale_unit": {
 				Type:         pluginsdk.TypeInt,
 				Optional:     true,
 				ValidateFunc: validation.IntBetween(1, 40),
-				RequiredWith: []string{"max_scale_unit", "min_scale_unit"},
+				RequiredWith: []string{"maximum_scale_unit", "minimum_scale_unit"},
 			},
 
-			"min_scale_unit": {
+			"minimum_scale_unit": {
 				Type:         pluginsdk.TypeInt,
 				Optional:     true,
 				ValidateFunc: validation.IntBetween(1, 40),
-				RequiredWith: []string{"max_scale_unit", "min_scale_unit"},
+				RequiredWith: []string{"maximum_scale_unit", "minimum_scale_unit"},
 			},
 
 			"remote_vnet_traffic_enabled": {
@@ -702,23 +702,23 @@ func resourceVirtualNetworkGatewayCustomizeDiff(ctx context.Context, d *pluginsd
 		}
 	}
 
-	minScaleUnit := d.Get("min_scale_unit").(int)
-	maxScaleUnit := d.Get("max_scale_unit").(int)
+	minScaleUnit := d.Get("minimum_scale_unit").(int)
+	maxScaleUnit := d.Get("maximum_scale_unit").(int)
 	sku := d.Get("sku").(string)
 
 	if sku == string(virtualnetworkgateways.VirtualNetworkGatewaySkuNameErGwScale) {
 		if minScaleUnit == 0 || maxScaleUnit == 0 {
-			return fmt.Errorf("`min_scale_unit` and `max_scale_unit` must be set when `sku` is `%s`", virtualnetworkgateways.VirtualNetworkGatewaySkuNameErGwScale)
+			return fmt.Errorf("`minimum_scale_unit` and `maximum_scale_unit` must be set when `sku` is `%s`", virtualnetworkgateways.VirtualNetworkGatewaySkuNameErGwScale)
 		}
 	}
 
 	if minScaleUnit > 0 {
 		if sku != string(virtualnetworkgateways.VirtualNetworkGatewaySkuNameErGwScale) {
-			return fmt.Errorf("`min_scale_unit` and `max_scale_unit` are only supported when `sku` is set to `%s`", virtualnetworkgateways.VirtualNetworkGatewaySkuNameErGwScale)
+			return fmt.Errorf("`minimum_scale_unit` and `maximum_scale_unit` are only supported when `sku` is set to `%s`", virtualnetworkgateways.VirtualNetworkGatewaySkuNameErGwScale)
 		}
 
 		if minScaleUnit > maxScaleUnit {
-			return fmt.Errorf("`min_scale_unit` (%d) cannot be greater than `max_scale_unit` (%d)", minScaleUnit, maxScaleUnit)
+			return fmt.Errorf("`minimum_scale_unit` (%d) cannot be greater than `maximum_scale_unit` (%d)", minScaleUnit, maxScaleUnit)
 		}
 	}
 
@@ -829,11 +829,11 @@ func resourceVirtualNetworkGatewayRead(d *pluginsdk.ResourceData, meta interface
 		}
 
 		minScaleUnit, maxScaleUnit := flattenVirtualNetworkGatewayAutoScaleConfiguration(props.AutoScaleConfiguration)
-		if err := d.Set("min_scale_unit", minScaleUnit); err != nil {
-			return fmt.Errorf("setting `min_scale_unit`: %+v", err)
+		if err := d.Set("minimum_scale_unit", minScaleUnit); err != nil {
+			return fmt.Errorf("setting `minimum_scale_unit`: %+v", err)
 		}
-		if err := d.Set("max_scale_unit", maxScaleUnit); err != nil {
-			return fmt.Errorf("setting: `max_scale_unit`: %+v", err)
+		if err := d.Set("maximum_scale_unit", maxScaleUnit); err != nil {
+			return fmt.Errorf("setting: `maximum_scale_unit`: %+v", err)
 		}
 
 		if err := d.Set("policy_group", flattenVirtualNetworkGatewayPolicyGroups(props.VirtualNetworkGatewayPolicyGroups)); err != nil {
@@ -972,16 +972,16 @@ func resourceVirtualNetworkGatewayUpdate(d *pluginsdk.ResourceData, meta interfa
 		payload.Properties.AutoScaleConfiguration.Bounds = &virtualnetworkgateways.VirtualNetworkGatewayAutoScaleBounds{}
 	}
 
-	if d.HasChange("min_scale_unit") {
-		if v, ok := d.GetOk("min_scale_unit"); ok {
+	if d.HasChange("minimum_scale_unit") {
+		if v, ok := d.GetOk("minimum_scale_unit"); ok {
 			payload.Properties.AutoScaleConfiguration.Bounds.Min = pointer.To(int64(v.(int)))
 		} else {
 			payload.Properties.AutoScaleConfiguration.Bounds.Min = nil
 		}
 	}
 
-	if d.HasChange("max_scale_unit") {
-		if v, ok := d.GetOk("max_scale_unit"); ok {
+	if d.HasChange("maximum_scale_unit") {
+		if v, ok := d.GetOk("maximum_scale_unit"); ok {
 			payload.Properties.AutoScaleConfiguration.Bounds.Max = pointer.To(int64(v.(int)))
 		} else {
 			payload.Properties.AutoScaleConfiguration.Bounds.Max = nil
@@ -1821,8 +1821,8 @@ func flattenVirtualNetworkGatewayPolicyGroupNames(input []virtualnetworkgateways
 }
 
 func expandVirtualNetworkGatewayAutoScaleConfiguration(d *pluginsdk.ResourceData) *virtualnetworkgateways.VirtualNetworkGatewayAutoScaleConfiguration {
-	minScaleUnit := d.Get("min_scale_unit").(int)
-	maxScaleUnit := d.Get("max_scale_unit").(int)
+	minScaleUnit := d.Get("minimum_scale_unit").(int)
+	maxScaleUnit := d.Get("maximum_scale_unit").(int)
 
 	if minScaleUnit == 0 {
 		return nil

--- a/internal/services/network/virtual_network_gateway_resource.go
+++ b/internal/services/network/virtual_network_gateway_resource.go
@@ -639,6 +639,18 @@ func resourceVirtualNetworkGateway() *pluginsdk.Resource {
 				Default:  true,
 			},
 
+			"max_scale_unit": {
+				Type:         pluginsdk.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(1, 40),
+			},
+
+			"min_scale_unit": {
+				Type:         pluginsdk.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(1, 40),
+			},
+
 			"remote_vnet_traffic_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
@@ -794,6 +806,14 @@ func resourceVirtualNetworkGatewayRead(d *pluginsdk.ResourceData, meta interface
 			return fmt.Errorf("setting `ip_configuration`: %+v", err)
 		}
 
+		minScaleUnit, maxScaleUnit := flattenVirtualNetworkGatewayAutoScaleConfiguration(props.AutoScaleConfiguration)
+		if err := d.Set("min_scale_unit", minScaleUnit); err != nil {
+			return fmt.Errorf("setting `min_scale_unit`: %+v", err)
+		}
+		if err := d.Set("max_scale_unit", maxScaleUnit); err != nil {
+			return fmt.Errorf("setting: `max_scale_unit`: %+v", err)
+		}
+
 		if err := d.Set("policy_group", flattenVirtualNetworkGatewayPolicyGroups(props.VirtualNetworkGatewayPolicyGroups)); err != nil {
 			return fmt.Errorf("setting `policy_group`: %+v", err)
 		}
@@ -923,6 +943,10 @@ func resourceVirtualNetworkGatewayUpdate(d *pluginsdk.ResourceData, meta interfa
 		payload.Properties.AllowVirtualWanTraffic = pointer.To(d.Get("virtual_wan_traffic_enabled").(bool))
 	}
 
+	if d.HasChanges("min_scale_unit", "max_scale_unit") {
+		payload.Properties.AutoScaleConfiguration = expandVirtualNetworkGatewayAutoScaleConfiguration(d)
+	}
+
 	if d.HasChange("tags") {
 		payload.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
 	}
@@ -987,6 +1011,8 @@ func getVirtualNetworkGatewayProperties(id virtualnetworkgateways.VirtualNetwork
 			Id: &gatewayDefaultSiteID,
 		}
 	}
+
+	props.AutoScaleConfiguration = expandVirtualNetworkGatewayAutoScaleConfiguration(d)
 
 	if v, ok := d.GetOk("policy_group"); ok {
 		props.VirtualNetworkGatewayPolicyGroups = expandVirtualNetworkGatewayPolicyGroups(v.([]interface{}))
@@ -1747,4 +1773,35 @@ func flattenVirtualNetworkGatewayPolicyGroupNames(input []virtualnetworkgateways
 	}
 
 	return results, nil
+}
+
+func expandVirtualNetworkGatewayAutoScaleConfiguration(d *pluginsdk.ResourceData) *virtualnetworkgateways.VirtualNetworkGatewayAutoScaleConfiguration {
+	minScaleUnit, minOk := d.GetOk("min_scale_unit")
+	maxScaleUnit, maxOk := d.GetOk("max_scale_unit")
+
+	if !minOk && !maxOk {
+		return nil
+	}
+
+	result := &virtualnetworkgateways.VirtualNetworkGatewayAutoScaleConfiguration{
+		Bounds: &virtualnetworkgateways.VirtualNetworkGatewayAutoScaleBounds{},
+	}
+
+	if minOk {
+		result.Bounds.Min = pointer.To(int64(minScaleUnit.(int)))
+	}
+
+	if maxOk {
+		result.Bounds.Max = pointer.To(int64(maxScaleUnit.(int)))
+	}
+
+	return result
+}
+
+func flattenVirtualNetworkGatewayAutoScaleConfiguration(input *virtualnetworkgateways.VirtualNetworkGatewayAutoScaleConfiguration) (int64, int64) {
+	if input == nil || input.Bounds == nil {
+		return 0, 0
+	}
+
+	return pointer.From(input.Bounds.Min), pointer.From(input.Bounds.Max)
 }

--- a/internal/services/network/virtual_network_gateway_resource.go
+++ b/internal/services/network/virtual_network_gateway_resource.go
@@ -965,31 +965,8 @@ func resourceVirtualNetworkGatewayUpdate(d *pluginsdk.ResourceData, meta interfa
 		payload.Properties.AllowVirtualWanTraffic = pointer.To(d.Get("virtual_wan_traffic_enabled").(bool))
 	}
 
-	if payload.Properties.AutoScaleConfiguration == nil {
-		payload.Properties.AutoScaleConfiguration = &virtualnetworkgateways.VirtualNetworkGatewayAutoScaleConfiguration{}
-	}
-	if payload.Properties.AutoScaleConfiguration.Bounds == nil {
-		payload.Properties.AutoScaleConfiguration.Bounds = &virtualnetworkgateways.VirtualNetworkGatewayAutoScaleBounds{}
-	}
-
-	if d.HasChange("minimum_scale_unit") {
-		if v, ok := d.GetOk("minimum_scale_unit"); ok {
-			payload.Properties.AutoScaleConfiguration.Bounds.Min = pointer.To(int64(v.(int)))
-		} else {
-			payload.Properties.AutoScaleConfiguration.Bounds.Min = nil
-		}
-	}
-
-	if d.HasChange("maximum_scale_unit") {
-		if v, ok := d.GetOk("maximum_scale_unit"); ok {
-			payload.Properties.AutoScaleConfiguration.Bounds.Max = pointer.To(int64(v.(int)))
-		} else {
-			payload.Properties.AutoScaleConfiguration.Bounds.Max = nil
-		}
-	}
-
-	if payload.Properties.AutoScaleConfiguration.Bounds.Min == nil && payload.Properties.AutoScaleConfiguration.Bounds.Max == nil {
-		payload.Properties.AutoScaleConfiguration = nil
+	if d.HasChanges("minimum_scale_unit", "maximum_scale_unit") {
+		payload.Properties.AutoScaleConfiguration = expandVirtualNetworkGatewayAutoScaleConfiguration(d)
 	}
 
 	if d.HasChange("tags") {

--- a/internal/services/network/virtual_network_gateway_resource.go
+++ b/internal/services/network/virtual_network_gateway_resource.go
@@ -688,6 +688,7 @@ func resourceVirtualNetworkGateway() *pluginsdk.Resource {
 
 func resourceVirtualNetworkGatewayCustomizeDiff(ctx context.Context, d *pluginsdk.ResourceDiff, _ interface{}) error {
 	gatewayType := d.Get("type").(string)
+	sku := d.Get("sku").(string)
 
 	// Validate that public_ip_address_id is not set for ExpressRoute gateways
 	if gatewayType == string(virtualnetworkgateways.VirtualNetworkGatewayTypeExpressRoute) {
@@ -696,6 +697,38 @@ func resourceVirtualNetworkGatewayCustomizeDiff(ctx context.Context, d *pluginsd
 			ipConfig := ipConfigRaw.(map[string]interface{})
 			if publicIPID, ok := ipConfig["public_ip_address_id"].(string); ok && publicIPID != "" {
 				return fmt.Errorf("`ip_configuration.%d.public_ip_address_id` cannot be set when `type` is set to `ExpressRoute`", i)
+			}
+		}
+	}
+
+	minScaleUnitRaw, minScaleUnitOk := d.GetOk("min_scale_unit")
+	maxScaleUnitRaw, maxScaleUnitOk := d.GetOk("max_scale_unit")
+	if minScaleUnitOk || maxScaleUnitOk {
+		if sku != string(virtualnetworkgateways.VirtualNetworkGatewaySkuNameErGwScale) {
+			return fmt.Errorf("`min_scale_unit` and `max_scale_unit` are only supported when `sku` is set to `%s`", virtualnetworkgateways.VirtualNetworkGatewaySkuNameErGwScale)
+		}
+
+		if maxScaleUnitOk {
+			maxScaleUnit := int64(maxScaleUnitRaw.(int))
+			if maxScaleUnit == 1 {
+				if !minScaleUnitOk {
+					return fmt.Errorf("when `max_scale_unit` is set to 1, `min_scale_unit` must also be set to 1")
+				}
+				minScaleUnit := int64(minScaleUnitRaw.(int))
+				if minScaleUnit != 1 {
+					return fmt.Errorf("when `max_scale_unit` is set to 1, `min_scale_unit` must also be set to 1")
+				}
+			}
+		}
+
+		if minScaleUnitOk && maxScaleUnitOk {
+			minScaleUnit := int64(minScaleUnitRaw.(int))
+			maxScaleUnit := int64(maxScaleUnitRaw.(int))
+			if minScaleUnit > maxScaleUnit {
+				return fmt.Errorf("`min_scale_unit` (%d) cannot be greater than `max_scale_unit` (%d)", minScaleUnit, maxScaleUnit)
+			}
+			if minScaleUnit != maxScaleUnit && minScaleUnit < 2 {
+				return fmt.Errorf("when configuring autoscaling `min_scale_unit` must be 2 or greater")
 			}
 		}
 	}
@@ -943,8 +976,31 @@ func resourceVirtualNetworkGatewayUpdate(d *pluginsdk.ResourceData, meta interfa
 		payload.Properties.AllowVirtualWanTraffic = pointer.To(d.Get("virtual_wan_traffic_enabled").(bool))
 	}
 
-	if d.HasChanges("min_scale_unit", "max_scale_unit") {
-		payload.Properties.AutoScaleConfiguration = expandVirtualNetworkGatewayAutoScaleConfiguration(d)
+	if payload.Properties.AutoScaleConfiguration == nil {
+		payload.Properties.AutoScaleConfiguration = &virtualnetworkgateways.VirtualNetworkGatewayAutoScaleConfiguration{}
+	}
+	if payload.Properties.AutoScaleConfiguration.Bounds == nil {
+		payload.Properties.AutoScaleConfiguration.Bounds = &virtualnetworkgateways.VirtualNetworkGatewayAutoScaleBounds{}
+	}
+
+	if d.HasChange("min_scale_unit") {
+		if v, ok := d.GetOk("min_scale_unit"); ok {
+			payload.Properties.AutoScaleConfiguration.Bounds.Min = pointer.To(int64(v.(int)))
+		} else {
+			payload.Properties.AutoScaleConfiguration.Bounds.Min = nil
+		}
+	}
+
+	if d.HasChange("max_scale_unit") {
+		if v, ok := d.GetOk("max_scale_unit"); ok {
+			payload.Properties.AutoScaleConfiguration.Bounds.Max = pointer.To(int64(v.(int)))
+		} else {
+			payload.Properties.AutoScaleConfiguration.Bounds.Max = nil
+		}
+	}
+
+	if payload.Properties.AutoScaleConfiguration.Bounds.Min == nil && payload.Properties.AutoScaleConfiguration.Bounds.Max == nil {
+		payload.Properties.AutoScaleConfiguration = nil
 	}
 
 	if d.HasChange("tags") {
@@ -1798,10 +1854,20 @@ func expandVirtualNetworkGatewayAutoScaleConfiguration(d *pluginsdk.ResourceData
 	return result
 }
 
-func flattenVirtualNetworkGatewayAutoScaleConfiguration(input *virtualnetworkgateways.VirtualNetworkGatewayAutoScaleConfiguration) (int64, int64) {
+func flattenVirtualNetworkGatewayAutoScaleConfiguration(input *virtualnetworkgateways.VirtualNetworkGatewayAutoScaleConfiguration) (interface{}, interface{}) {
 	if input == nil || input.Bounds == nil {
-		return 0, 0
+		return nil, nil
 	}
 
-	return pointer.From(input.Bounds.Min), pointer.From(input.Bounds.Max)
+	var min interface{}
+	if input.Bounds.Min != nil {
+		min = int(pointer.From(input.Bounds.Min))
+	}
+
+	var max interface{}
+	if input.Bounds.Max != nil {
+		max = int(pointer.From(input.Bounds.Max))
+	}
+
+	return min, max
 }

--- a/internal/services/network/virtual_network_gateway_resource.go
+++ b/internal/services/network/virtual_network_gateway_resource.go
@@ -733,7 +733,33 @@ func resourceVirtualNetworkGatewayCustomizeDiff(ctx context.Context, d *pluginsd
 		}
 	}
 
+	// The Azure API can't convert an ExpressRoute gateway between the
+	// availability-zone SKUs (ErGw1AZ/ErGw2AZ/ErGw3AZ/ErGwScale) and the
+	// non-availability-zone SKUs (Standard/HighPerformance/UltraPerformance) in
+	// place; the gateway must be deleted and recreated. An in-place change fails
+	// with `ExpressRouteVirtualNetworkGatewayAutoscaleBoundsNotValid`.
+	if d.Id() != "" && gatewayType == string(virtualnetworkgateways.VirtualNetworkGatewayTypeExpressRoute) && d.HasChange("sku") {
+		oldSku, newSku := d.GetChange("sku")
+		if expressRouteGatewaySkuIsAvailabilityZone(oldSku.(string)) != expressRouteGatewaySkuIsAvailabilityZone(newSku.(string)) {
+			if err := d.ForceNew("sku"); err != nil {
+				return err
+			}
+		}
+	}
+
 	return nil
+}
+
+func expressRouteGatewaySkuIsAvailabilityZone(sku string) bool {
+	switch virtualnetworkgateways.VirtualNetworkGatewaySkuName(sku) {
+	case virtualnetworkgateways.VirtualNetworkGatewaySkuNameErGwOneAZ,
+		virtualnetworkgateways.VirtualNetworkGatewaySkuNameErGwTwoAZ,
+		virtualnetworkgateways.VirtualNetworkGatewaySkuNameErGwThreeAZ,
+		virtualnetworkgateways.VirtualNetworkGatewaySkuNameErGwScale:
+		return true
+	default:
+		return false
+	}
 }
 
 func resourceVirtualNetworkGatewayCreate(d *pluginsdk.ResourceData, meta interface{}) error {
@@ -974,12 +1000,11 @@ func resourceVirtualNetworkGatewayUpdate(d *pluginsdk.ResourceData, meta interfa
 		payload.Properties.AllowVirtualWanTraffic = pointer.To(d.Get("virtual_wan_traffic_enabled").(bool))
 	}
 
-	if d.HasChanges("minimum_scale_unit", "maximum_scale_unit") || d.HasChange("sku") {
-		payload.Properties.AutoScaleConfiguration = &virtualnetworkgateways.VirtualNetworkGatewayAutoScaleConfiguration{}
-		rawConfig := d.GetRawConfig().AsValueMap()
-		if !rawConfig["minimum_scale_unit"].IsNull() {
-			payload.Properties.AutoScaleConfiguration = expandVirtualNetworkGatewayAutoScaleConfiguration(d)
-		}
+	// SKU changes that cross the availability-zone boundary are ForceNew (see
+	// resourceVirtualNetworkGatewayCustomizeDiff), so here we only need to push
+	// autoscale changes while the gateway stays on the ErGwScale SKU.
+	if d.HasChanges("minimum_scale_unit", "maximum_scale_unit") {
+		payload.Properties.AutoScaleConfiguration = expandVirtualNetworkGatewayAutoScaleConfiguration(d)
 	}
 
 	if d.HasChange("tags") {

--- a/internal/services/network/virtual_network_gateway_resource_test.go
+++ b/internal/services/network/virtual_network_gateway_resource_test.go
@@ -413,10 +413,52 @@ func TestAccVirtualNetworkGateway_validation(t *testing.T) {
 			Config:      r.validationMinGreaterThanMax(data),
 			ExpectError: regexp.MustCompile("`minimum_scale_unit` \\(10\\) cannot be greater than `maximum_scale_unit` \\(5\\)"),
 		},
+	})
+}
+
+func TestAccVirtualNetworkGateway_expressRouteErGwScaleWithoutScaleUnit(t *testing.T) {
+	if features.FivePointOh() {
+		t.Skip("Skipping as `minimum_scale_unit` and `maximum_scale_unit` are required for `ErGwScale` SKU in 5.0")
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_virtual_network_gateway", "test")
+	r := VirtualNetworkGatewayResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config:      r.validationErGwScaleWithoutScaleUnit(data),
-			ExpectError: regexp.MustCompile("`minimum_scale_unit` and `maximum_scale_unit` must be set when `sku` is `ErGwScale`"),
+			Config: r.validationErGwScaleWithoutScaleUnit(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("sku").HasValue("ErGwScale"),
+			),
 		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccVirtualNetworkGateway_erGwScaleToStandard(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_network_gateway", "test")
+	r := VirtualNetworkGatewayResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.expressRouteErGwScale(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("sku").HasValue("ErGwScale"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.expressRouteStandardFromErGwScale(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("sku").HasValue("Standard"),
+				check.That(data.ResourceName).Key("minimum_scale_unit").HasValue("0"),
+				check.That(data.ResourceName).Key("maximum_scale_unit").HasValue("0"),
+			),
+		},
+		data.ImportStep(),
 	})
 }
 
@@ -1742,6 +1784,57 @@ resource "azurerm_virtual_network_gateway" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (VirtualNetworkGatewayResource) expressRouteStandardFromErGwScale(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvn-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  address_space       = ["10.0.0.0/16"]
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "GatewaySubnet"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.1.0/24"]
+}
+
+resource "azurerm_public_ip" "test" {
+  name                = "acctestpip1-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
+
+resource "azurerm_virtual_network_gateway" "test" {
+  name                = "acctestvng-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  type     = "ExpressRoute"
+  vpn_type = "PolicyBased"
+  sku      = "Standard"
+
+  ip_configuration {
+    private_ip_address_allocation = "Dynamic"
+    subnet_id                     = azurerm_subnet.test.id
+    public_ip_address_id          = azurerm_public_ip.test.id
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
 func (VirtualNetworkGatewayResource) generation(data acceptance.TestData, generation string) string {

--- a/internal/services/network/virtual_network_gateway_resource_test.go
+++ b/internal/services/network/virtual_network_gateway_resource_test.go
@@ -1811,14 +1811,6 @@ resource "azurerm_subnet" "test" {
   address_prefixes     = ["10.0.1.0/24"]
 }
 
-resource "azurerm_public_ip" "test" {
-  name                = "acctestpip1-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  allocation_method   = "Static"
-  sku                 = "Standard"
-}
-
 resource "azurerm_virtual_network_gateway" "test" {
   name                = "acctestvng-%d"
   location            = azurerm_resource_group.test.location
@@ -1831,10 +1823,9 @@ resource "azurerm_virtual_network_gateway" "test" {
   ip_configuration {
     private_ip_address_allocation = "Dynamic"
     subnet_id                     = azurerm_subnet.test.id
-    public_ip_address_id          = azurerm_public_ip.test.id
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
 
 func (VirtualNetworkGatewayResource) generation(data acceptance.TestData, generation string) string {

--- a/internal/services/network/virtual_network_gateway_resource_test.go
+++ b/internal/services/network/virtual_network_gateway_resource_test.go
@@ -397,15 +397,6 @@ func TestAccVirtualNetworkGateway_autoScaleConfiguration(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
-		{
-			Config: r.autoScaleConfigurationRemoved(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("min_scale_unit").HasValue(""),
-				check.That(data.ResourceName).Key("max_scale_unit").HasValue(""),
-			),
-		},
-		data.ImportStep(),
 	})
 }
 
@@ -423,12 +414,8 @@ func TestAccVirtualNetworkGateway_validation(t *testing.T) {
 			ExpectError: regexp.MustCompile("`min_scale_unit` \\(10\\) cannot be greater than `max_scale_unit` \\(5\\)"),
 		},
 		{
-			Config:      r.validationMaxOneWithoutMin(data),
-			ExpectError: regexp.MustCompile("when `max_scale_unit` is set to 1, `min_scale_unit` must also be set to 1"),
-		},
-		{
-			Config:      r.validationAutoScaleMinLessThanTwo(data),
-			ExpectError: regexp.MustCompile("when configuring autoscaling `min_scale_unit` must be 2 or greater"),
+			Config:      r.validationErGwScaleWithoutScaleUnit(data),
+			ExpectError: regexp.MustCompile("`min_scale_unit` and `max_scale_unit` must be set when `sku` is `ErGwScale`"),
 		},
 	})
 }
@@ -1613,48 +1600,6 @@ resource "azurerm_virtual_network_gateway" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
 
-func (VirtualNetworkGatewayResource) autoScaleConfigurationRemoved(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_virtual_network" "test" {
-  name                = "acctestvn-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  address_space       = ["10.0.0.0/16"]
-}
-
-resource "azurerm_subnet" "test" {
-  name                 = "GatewaySubnet"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.1.0/24"]
-}
-
-resource "azurerm_virtual_network_gateway" "test" {
-  name                = "acctestvng-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-
-  type     = "ExpressRoute"
-  vpn_type = "PolicyBased"
-  sku      = "ErGwScale"
-
-  ip_configuration {
-    private_ip_address_allocation = "Dynamic"
-    subnet_id                     = azurerm_subnet.test.id
-  }
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
-}
-
 func (VirtualNetworkGatewayResource) validationScaleUnitWrongSku(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -1754,7 +1699,7 @@ resource "azurerm_virtual_network_gateway" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
 
-func (VirtualNetworkGatewayResource) validationMaxOneWithoutMin(data acceptance.TestData) string {
+func (VirtualNetworkGatewayResource) validationErGwScaleWithoutScaleUnit(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1787,53 +1732,6 @@ resource "azurerm_virtual_network_gateway" "test" {
   type     = "ExpressRoute"
   vpn_type = "PolicyBased"
   sku      = "ErGwScale"
-
-  max_scale_unit = 1
-
-  ip_configuration {
-    private_ip_address_allocation = "Dynamic"
-    subnet_id                     = azurerm_subnet.test.id
-  }
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
-}
-
-func (VirtualNetworkGatewayResource) validationAutoScaleMinLessThanTwo(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_virtual_network" "test" {
-  name                = "acctestvn-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  address_space       = ["10.0.0.0/16"]
-}
-
-resource "azurerm_subnet" "test" {
-  name                 = "GatewaySubnet"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.1.0/24"]
-}
-
-resource "azurerm_virtual_network_gateway" "test" {
-  name                = "acctestvng-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-
-  type     = "ExpressRoute"
-  vpn_type = "PolicyBased"
-  sku      = "ErGwScale"
-
-  min_scale_unit = 1
-  max_scale_unit = 10
 
   ip_configuration {
     private_ip_address_allocation = "Dynamic"

--- a/internal/services/network/virtual_network_gateway_resource_test.go
+++ b/internal/services/network/virtual_network_gateway_resource_test.go
@@ -383,8 +383,8 @@ func TestAccVirtualNetworkGateway_autoScaleConfiguration(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("type").HasValue("ExpressRoute"),
 				check.That(data.ResourceName).Key("sku").HasValue("ErGwScale"),
-				check.That(data.ResourceName).Key("min_scale_unit").HasValue("2"),
-				check.That(data.ResourceName).Key("max_scale_unit").HasValue("10"),
+				check.That(data.ResourceName).Key("minimum_scale_unit").HasValue("2"),
+				check.That(data.ResourceName).Key("maximum_scale_unit").HasValue("10"),
 			),
 		},
 		data.ImportStep(),
@@ -392,8 +392,8 @@ func TestAccVirtualNetworkGateway_autoScaleConfiguration(t *testing.T) {
 			Config: r.autoScaleConfigurationUpdate(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("min_scale_unit").HasValue("3"),
-				check.That(data.ResourceName).Key("max_scale_unit").HasValue("15"),
+				check.That(data.ResourceName).Key("minimum_scale_unit").HasValue("3"),
+				check.That(data.ResourceName).Key("maximum_scale_unit").HasValue("15"),
 			),
 		},
 		data.ImportStep(),
@@ -407,15 +407,15 @@ func TestAccVirtualNetworkGateway_validation(t *testing.T) {
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config:      r.validationScaleUnitWrongSku(data),
-			ExpectError: regexp.MustCompile("`min_scale_unit` and `max_scale_unit` are only supported when `sku` is set to `ErGwScale`"),
+			ExpectError: regexp.MustCompile("`minimum_scale_unit` and `maximum_scale_unit` are only supported when `sku` is set to `ErGwScale`"),
 		},
 		{
 			Config:      r.validationMinGreaterThanMax(data),
-			ExpectError: regexp.MustCompile("`min_scale_unit` \\(10\\) cannot be greater than `max_scale_unit` \\(5\\)"),
+			ExpectError: regexp.MustCompile("`minimum_scale_unit` \\(10\\) cannot be greater than `maximum_scale_unit` \\(5\\)"),
 		},
 		{
 			Config:      r.validationErGwScaleWithoutScaleUnit(data),
-			ExpectError: regexp.MustCompile("`min_scale_unit` and `max_scale_unit` must be set when `sku` is `ErGwScale`"),
+			ExpectError: regexp.MustCompile("`minimum_scale_unit` and `maximum_scale_unit` must be set when `sku` is `ErGwScale`"),
 		},
 	})
 }
@@ -1544,8 +1544,8 @@ resource "azurerm_virtual_network_gateway" "test" {
   vpn_type = "PolicyBased"
   sku      = "ErGwScale"
 
-  min_scale_unit = 2
-  max_scale_unit = 10
+  minimum_scale_unit = 2
+  maximum_scale_unit = 10
 
   ip_configuration {
     private_ip_address_allocation = "Dynamic"
@@ -1589,8 +1589,8 @@ resource "azurerm_virtual_network_gateway" "test" {
   vpn_type = "PolicyBased"
   sku      = "ErGwScale"
 
-  min_scale_unit = 3
-  max_scale_unit = 15
+  minimum_scale_unit = 3
+  maximum_scale_unit = 15
 
   ip_configuration {
     private_ip_address_allocation = "Dynamic"
@@ -1642,8 +1642,8 @@ resource "azurerm_virtual_network_gateway" "test" {
   vpn_type = "RouteBased"
   sku      = "VpnGw1"
 
-  min_scale_unit = 2
-  max_scale_unit = 10
+  minimum_scale_unit = 2
+  maximum_scale_unit = 10
 
   ip_configuration {
     private_ip_address_allocation = "Dynamic"
@@ -1688,8 +1688,8 @@ resource "azurerm_virtual_network_gateway" "test" {
   vpn_type = "PolicyBased"
   sku      = "ErGwScale"
 
-  min_scale_unit = 10
-  max_scale_unit = 5
+  minimum_scale_unit = 10
+  maximum_scale_unit = 5
 
   ip_configuration {
     private_ip_address_allocation = "Dynamic"

--- a/internal/services/network/virtual_network_gateway_resource_test.go
+++ b/internal/services/network/virtual_network_gateway_resource_test.go
@@ -6,6 +6,7 @@ package network_test
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -396,6 +397,39 @@ func TestAccVirtualNetworkGateway_autoScaleConfiguration(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
+		{
+			Config: r.autoScaleConfigurationRemoved(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("min_scale_unit").HasValue(""),
+				check.That(data.ResourceName).Key("max_scale_unit").HasValue(""),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccVirtualNetworkGateway_validation(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_network_gateway", "test")
+	r := VirtualNetworkGatewayResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:      r.validationScaleUnitWrongSku(data),
+			ExpectError: regexp.MustCompile("`min_scale_unit` and `max_scale_unit` are only supported when `sku` is set to `ErGwScale`"),
+		},
+		{
+			Config:      r.validationMinGreaterThanMax(data),
+			ExpectError: regexp.MustCompile("`min_scale_unit` \\(10\\) cannot be greater than `max_scale_unit` \\(5\\)"),
+		},
+		{
+			Config:      r.validationMaxOneWithoutMin(data),
+			ExpectError: regexp.MustCompile("when `max_scale_unit` is set to 1, `min_scale_unit` must also be set to 1"),
+		},
+		{
+			Config:      r.validationAutoScaleMinLessThanTwo(data),
+			ExpectError: regexp.MustCompile("when configuring autoscaling `min_scale_unit` must be 2 or greater"),
+		},
 	})
 }
 
@@ -1570,6 +1604,236 @@ resource "azurerm_virtual_network_gateway" "test" {
 
   min_scale_unit = 3
   max_scale_unit = 15
+
+  ip_configuration {
+    private_ip_address_allocation = "Dynamic"
+    subnet_id                     = azurerm_subnet.test.id
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (VirtualNetworkGatewayResource) autoScaleConfigurationRemoved(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvn-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  address_space       = ["10.0.0.0/16"]
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "GatewaySubnet"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.1.0/24"]
+}
+
+resource "azurerm_virtual_network_gateway" "test" {
+  name                = "acctestvng-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  type     = "ExpressRoute"
+  vpn_type = "PolicyBased"
+  sku      = "ErGwScale"
+
+  ip_configuration {
+    private_ip_address_allocation = "Dynamic"
+    subnet_id                     = azurerm_subnet.test.id
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (VirtualNetworkGatewayResource) validationScaleUnitWrongSku(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvn-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  address_space       = ["10.0.0.0/16"]
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "GatewaySubnet"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.1.0/24"]
+}
+
+resource "azurerm_public_ip" "test" {
+  name                = "acctestpip-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
+
+resource "azurerm_virtual_network_gateway" "test" {
+  name                = "acctestvng-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  type     = "Vpn"
+  vpn_type = "RouteBased"
+  sku      = "VpnGw1"
+
+  min_scale_unit = 2
+  max_scale_unit = 10
+
+  ip_configuration {
+    private_ip_address_allocation = "Dynamic"
+    subnet_id                     = azurerm_subnet.test.id
+    public_ip_address_id          = azurerm_public_ip.test.id
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (VirtualNetworkGatewayResource) validationMinGreaterThanMax(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvn-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  address_space       = ["10.0.0.0/16"]
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "GatewaySubnet"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.1.0/24"]
+}
+
+resource "azurerm_virtual_network_gateway" "test" {
+  name                = "acctestvng-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  type     = "ExpressRoute"
+  vpn_type = "PolicyBased"
+  sku      = "ErGwScale"
+
+  min_scale_unit = 10
+  max_scale_unit = 5
+
+  ip_configuration {
+    private_ip_address_allocation = "Dynamic"
+    subnet_id                     = azurerm_subnet.test.id
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (VirtualNetworkGatewayResource) validationMaxOneWithoutMin(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvn-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  address_space       = ["10.0.0.0/16"]
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "GatewaySubnet"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.1.0/24"]
+}
+
+resource "azurerm_virtual_network_gateway" "test" {
+  name                = "acctestvng-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  type     = "ExpressRoute"
+  vpn_type = "PolicyBased"
+  sku      = "ErGwScale"
+
+  max_scale_unit = 1
+
+  ip_configuration {
+    private_ip_address_allocation = "Dynamic"
+    subnet_id                     = azurerm_subnet.test.id
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (VirtualNetworkGatewayResource) validationAutoScaleMinLessThanTwo(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvn-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  address_space       = ["10.0.0.0/16"]
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "GatewaySubnet"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.1.0/24"]
+}
+
+resource "azurerm_virtual_network_gateway" "test" {
+  name                = "acctestvng-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  type     = "ExpressRoute"
+  vpn_type = "PolicyBased"
+  sku      = "ErGwScale"
+
+  min_scale_unit = 1
+  max_scale_unit = 10
 
   ip_configuration {
     private_ip_address_allocation = "Dynamic"

--- a/internal/services/network/virtual_network_gateway_resource_test.go
+++ b/internal/services/network/virtual_network_gateway_resource_test.go
@@ -1502,6 +1502,9 @@ resource "azurerm_virtual_network_gateway" "test" {
   vpn_type = "PolicyBased"
   sku      = "ErGwScale"
 
+  minimum_scale_unit = 1
+  maximum_scale_unit = 1
+
   ip_configuration {
     private_ip_address_allocation = "Dynamic"
     subnet_id                     = azurerm_subnet.test.id

--- a/internal/services/network/virtual_network_gateway_resource_test.go
+++ b/internal/services/network/virtual_network_gateway_resource_test.go
@@ -372,6 +372,33 @@ func TestAccVirtualNetworkGateway_expressRouteErGwScale(t *testing.T) {
 	})
 }
 
+func TestAccVirtualNetworkGateway_autoScaleConfiguration(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_network_gateway", "test")
+	r := VirtualNetworkGatewayResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.autoScaleConfiguration(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("type").HasValue("ExpressRoute"),
+				check.That(data.ResourceName).Key("sku").HasValue("ErGwScale"),
+				check.That(data.ResourceName).Key("min_scale_unit").HasValue("2"),
+				check.That(data.ResourceName).Key("max_scale_unit").HasValue("10"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.autoScaleConfigurationUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("min_scale_unit").HasValue("3"),
+				check.That(data.ResourceName).Key("max_scale_unit").HasValue("15"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccVirtualNetworkGateway_customRoute(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_network_gateway", "test")
 	r := VirtualNetworkGatewayResource{}
@@ -1453,6 +1480,96 @@ resource "azurerm_virtual_network_gateway" "test" {
   type     = "ExpressRoute"
   vpn_type = "PolicyBased"
   sku      = "ErGwScale"
+
+  ip_configuration {
+    private_ip_address_allocation = "Dynamic"
+    subnet_id                     = azurerm_subnet.test.id
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (VirtualNetworkGatewayResource) autoScaleConfiguration(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvn-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  address_space       = ["10.0.0.0/16"]
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "GatewaySubnet"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.1.0/24"]
+}
+
+resource "azurerm_virtual_network_gateway" "test" {
+  name                = "acctestvng-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  type     = "ExpressRoute"
+  vpn_type = "PolicyBased"
+  sku      = "ErGwScale"
+
+  min_scale_unit = 2
+  max_scale_unit = 10
+
+  ip_configuration {
+    private_ip_address_allocation = "Dynamic"
+    subnet_id                     = azurerm_subnet.test.id
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (VirtualNetworkGatewayResource) autoScaleConfigurationUpdate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvn-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  address_space       = ["10.0.0.0/16"]
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "GatewaySubnet"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.1.0/24"]
+}
+
+resource "azurerm_virtual_network_gateway" "test" {
+  name                = "acctestvng-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  type     = "ExpressRoute"
+  vpn_type = "PolicyBased"
+  sku      = "ErGwScale"
+
+  min_scale_unit = 3
+  max_scale_unit = 15
 
   ip_configuration {
     private_ip_address_allocation = "Dynamic"

--- a/internal/services/network/virtual_network_gateway_resource_test.go
+++ b/internal/services/network/virtual_network_gateway_resource_test.go
@@ -436,66 +436,6 @@ func TestAccVirtualNetworkGateway_expressRouteErGwScaleWithoutScaleUnit(t *testi
 	})
 }
 
-func TestAccVirtualNetworkGateway_expressRouteSkuUpdateWithinAZFamily(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_virtual_network_gateway", "test")
-	r := VirtualNetworkGatewayResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.expressRouteGatewayWithSku(data, "ErGw1AZ"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("sku").HasValue("ErGw1AZ"),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.expressRouteErGwScale(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("sku").HasValue("ErGwScale"),
-				check.That(data.ResourceName).Key("minimum_scale_unit").HasValue("1"),
-				check.That(data.ResourceName).Key("maximum_scale_unit").HasValue("1"),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.expressRouteGatewayWithSku(data, "ErGw2AZ"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("sku").HasValue("ErGw2AZ"),
-				check.That(data.ResourceName).Key("minimum_scale_unit").HasValue("0"),
-				check.That(data.ResourceName).Key("maximum_scale_unit").HasValue("0"),
-			),
-		},
-		data.ImportStep(),
-	})
-}
-
-func TestAccVirtualNetworkGateway_expressRouteSkuUpdateWithinNonAZFamily(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_virtual_network_gateway", "test")
-	r := VirtualNetworkGatewayResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.expressRouteGatewayWithSku(data, "Standard"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("sku").HasValue("Standard"),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.expressRouteGatewayWithSku(data, "HighPerformance"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("sku").HasValue("HighPerformance"),
-			),
-		},
-		data.ImportStep(),
-	})
-}
-
 func TestAccVirtualNetworkGateway_customRoute(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_network_gateway", "test")
 	r := VirtualNetworkGatewayResource{}
@@ -1831,48 +1771,6 @@ resource "azurerm_virtual_network_gateway" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
-}
-
-func (VirtualNetworkGatewayResource) expressRouteGatewayWithSku(data acceptance.TestData, sku string) string {
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_virtual_network" "test" {
-  name                = "acctestvn-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  address_space       = ["10.0.0.0/16"]
-}
-
-resource "azurerm_subnet" "test" {
-  name                 = "GatewaySubnet"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.1.0/24"]
-}
-
-resource "azurerm_virtual_network_gateway" "test" {
-  name                = "acctestvng-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-
-  type     = "ExpressRoute"
-  vpn_type = "PolicyBased"
-  sku      = "%s"
-
-  ip_configuration {
-    private_ip_address_allocation = "Dynamic"
-    subnet_id                     = azurerm_subnet.test.id
-  }
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, sku)
 }
 
 func (VirtualNetworkGatewayResource) generation(data acceptance.TestData, generation string) string {

--- a/internal/services/network/virtual_network_gateway_resource_test.go
+++ b/internal/services/network/virtual_network_gateway_resource_test.go
@@ -436,26 +436,60 @@ func TestAccVirtualNetworkGateway_expressRouteErGwScaleWithoutScaleUnit(t *testi
 	})
 }
 
-func TestAccVirtualNetworkGateway_erGwScaleToStandard(t *testing.T) {
+func TestAccVirtualNetworkGateway_expressRouteSkuUpdateWithinAZFamily(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_network_gateway", "test")
 	r := VirtualNetworkGatewayResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.expressRouteErGwScale(data),
+			Config: r.expressRouteGatewayWithSku(data, "ErGw1AZ"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("sku").HasValue("ErGwScale"),
+				check.That(data.ResourceName).Key("sku").HasValue("ErGw1AZ"),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.expressRouteStandardFromErGwScale(data),
+			Config: r.expressRouteErGwScale(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("sku").HasValue("ErGwScale"),
+				check.That(data.ResourceName).Key("minimum_scale_unit").HasValue("1"),
+				check.That(data.ResourceName).Key("maximum_scale_unit").HasValue("1"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.expressRouteGatewayWithSku(data, "ErGw2AZ"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("sku").HasValue("ErGw2AZ"),
+				check.That(data.ResourceName).Key("minimum_scale_unit").HasValue("0"),
+				check.That(data.ResourceName).Key("maximum_scale_unit").HasValue("0"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccVirtualNetworkGateway_expressRouteSkuUpdateWithinNonAZFamily(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_network_gateway", "test")
+	r := VirtualNetworkGatewayResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.expressRouteGatewayWithSku(data, "Standard"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("sku").HasValue("Standard"),
-				check.That(data.ResourceName).Key("minimum_scale_unit").HasValue("0"),
-				check.That(data.ResourceName).Key("maximum_scale_unit").HasValue("0"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.expressRouteGatewayWithSku(data, "HighPerformance"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("sku").HasValue("HighPerformance"),
 			),
 		},
 		data.ImportStep(),
@@ -1799,7 +1833,7 @@ resource "azurerm_virtual_network_gateway" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
 
-func (VirtualNetworkGatewayResource) expressRouteStandardFromErGwScale(data acceptance.TestData) string {
+func (VirtualNetworkGatewayResource) expressRouteGatewayWithSku(data acceptance.TestData, sku string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1831,14 +1865,14 @@ resource "azurerm_virtual_network_gateway" "test" {
 
   type     = "ExpressRoute"
   vpn_type = "PolicyBased"
-  sku      = "Standard"
+  sku      = "%s"
 
   ip_configuration {
     private_ip_address_allocation = "Dynamic"
     subnet_id                     = azurerm_subnet.test.id
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, sku)
 }
 
 func (VirtualNetworkGatewayResource) generation(data acceptance.TestData, generation string) string {

--- a/website/docs/r/virtual_network_gateway.html.markdown
+++ b/website/docs/r/virtual_network_gateway.html.markdown
@@ -146,9 +146,15 @@ The following arguments are supported:
 
 * `ip_sec_replay_protection_enabled` - (Optional) Is IP Sec Replay Protection enabled? Defaults to `true`.
 
-* `max_scale_unit` - (Optional) The maximum scale unit for auto scaling of the Virtual Network Gateway. This is only supported for the `ErGwScale` SKU.
+* `max_scale_unit` - (Optional) The maximum scale unit for the Virtual Network Gateway, possible values are `1` through `40`. 
 
-* `min_scale_unit` - (Optional) The minimum scale unit for auto scaling of the Virtual Network Gateway. This is only supported for the `ErGwScale` SKU.
+~> `max_scale_unit` is only supported for the `ErGwScale` SKU.
+
+* `min_scale_unit` - (Optional) The minimum scale unit for the Virtual Network Gateway, possible values are `1` through `40`. 
+
+~> `min_scale_unit` is only supported for the `ErGwScale` SKU.
+
+~> To configure a `fixed-size` gateway, set `min_scale_unit` and `max_scale_unit` to the same value. To enable `autoscaling`, set `min_scale_unit` to `2` or higher and `max_scale_unit` up to `40`. When `max_scale_unit` is set to `1`, `min_scale_unit` must also be set to `1`.
 
 * `policy_group` - (Optional) One or more `policy_group` blocks as defined below.
 

--- a/website/docs/r/virtual_network_gateway.html.markdown
+++ b/website/docs/r/virtual_network_gateway.html.markdown
@@ -148,13 +148,13 @@ The following arguments are supported:
 
 * `max_scale_unit` - (Optional) The maximum scale unit for the Virtual Network Gateway, possible values are `1` through `40`. 
 
-~> `max_scale_unit` is only supported for the `ErGwScale` SKU.
+~> **Note:** `max_scale_unit` is only supported for the `ErGwScale` SKU.
 
 * `min_scale_unit` - (Optional) The minimum scale unit for the Virtual Network Gateway, possible values are `1` through `40`. 
 
-~> `min_scale_unit` is only supported for the `ErGwScale` SKU.
+~> **Note:** `min_scale_unit` is only supported for the `ErGwScale` SKU.
 
-~> To configure a `fixed-size` gateway, set `min_scale_unit` and `max_scale_unit` to the same value. To enable `autoscaling`, set `min_scale_unit` to `2` or higher and `max_scale_unit` up to `40`. When `max_scale_unit` is set to `1`, `min_scale_unit` must also be set to `1`.
+~> **Note:** To configure a `fixed-size` gateway, set `min_scale_unit` and `max_scale_unit` to the same value. To enable `autoscaling`, set `min_scale_unit` to `2` or higher and `max_scale_unit` up to `40`. When `max_scale_unit` is set to `1`, `min_scale_unit` must also be set to `1`.
 
 * `policy_group` - (Optional) One or more `policy_group` blocks as defined below.
 

--- a/website/docs/r/virtual_network_gateway.html.markdown
+++ b/website/docs/r/virtual_network_gateway.html.markdown
@@ -146,6 +146,10 @@ The following arguments are supported:
 
 * `ip_sec_replay_protection_enabled` - (Optional) Is IP Sec Replay Protection enabled? Defaults to `true`.
 
+* `max_scale_unit` - (Optional) The maximum scale unit for auto scaling of the Virtual Network Gateway. This is only supported for the `ErGwScale` SKU.
+
+* `min_scale_unit` - (Optional) The minimum scale unit for auto scaling of the Virtual Network Gateway. This is only supported for the `ErGwScale` SKU.
+
 * `policy_group` - (Optional) One or more `policy_group` blocks as defined below.
 
 * `remote_vnet_traffic_enabled` - (Optional) Is remote vnet traffic that is used to configure this gateway to accept traffic from other Azure Virtual Networks enabled? Defaults to `false`.

--- a/website/docs/r/virtual_network_gateway.html.markdown
+++ b/website/docs/r/virtual_network_gateway.html.markdown
@@ -146,15 +146,15 @@ The following arguments are supported:
 
 * `ip_sec_replay_protection_enabled` - (Optional) Is IP Sec Replay Protection enabled? Defaults to `true`.
 
-* `max_scale_unit` - (Optional) The maximum scale unit for the Virtual Network Gateway, possible values are `1` through `40`. 
+* `maximum_scale_unit` - (Optional) The maximum scale unit for the Virtual Network Gateway, possible values are `1` through `40`. 
 
-~> **Note:** `max_scale_unit` is only supported for the `ErGwScale` SKU.
+~> **Note:** `maximum_scale_unit` is only supported for the `ErGwScale` SKU.
 
-* `min_scale_unit` - (Optional) The minimum scale unit for the Virtual Network Gateway, possible values are `1` through `40`. 
+* `minimum_scale_unit` - (Optional) The minimum scale unit for the Virtual Network Gateway, possible values are `1` through `40`. 
 
-~> **Note:** `min_scale_unit` is only supported for the `ErGwScale` SKU.
+~> **Note:** `minimum_scale_unit` is only supported for the `ErGwScale` SKU.
 
-~> **Note:** To configure a `fixed-size` gateway, set `min_scale_unit` and `max_scale_unit` to the same value. To enable `autoscaling`, set `min_scale_unit` to `2` or higher and `max_scale_unit` up to `40`. When `max_scale_unit` is set to `1`, `min_scale_unit` must also be set to `1`.
+~> **Note:** To configure a `fixed-size` gateway, set `minimum_scale_unit` and `maximum_scale_unit` to the same value. To enable `autoscaling`, set `minimum_scale_unit` to `2` or higher and `maximum_scale_unit` up to `40`. When `maximum_scale_unit` is set to `1`, `minimum_scale_unit` must also be set to `1`.
 
 * `policy_group` - (Optional) One or more `policy_group` blocks as defined below.
 

--- a/website/docs/r/virtual_network_gateway.html.markdown
+++ b/website/docs/r/virtual_network_gateway.html.markdown
@@ -156,6 +156,8 @@ The following arguments are supported:
 
 ~> **Note:** To configure a `fixed-size` gateway, set `minimum_scale_unit` and `maximum_scale_unit` to the same value. To enable `autoscaling`, set `minimum_scale_unit` to `2` or higher and `maximum_scale_unit` up to `40`. When `maximum_scale_unit` is set to `1`, `minimum_scale_unit` must also be set to `1`.
 
+~> **Note:** Changing the `sku` between an availability-zone SKU (`ErGwScale`, `ErGw1AZ`, `ErGw2AZ`, `ErGw3AZ`) and a non-availability-zone SKU (`Standard`, `HighPerformance`, `UltraPerformance`) forces a new resource to be created.
+
 * `policy_group` - (Optional) One or more `policy_group` blocks as defined below.
 
 * `remote_vnet_traffic_enabled` - (Optional) Is remote vnet traffic that is used to configure this gateway to accept traffic from other Azure Virtual Networks enabled? Defaults to `false`.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR adds supports for min_scale_unit and max_scale_unit in azurerm_virtual_network_gateway resource.

supersedes #31628

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

4.0: https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_NETWORK/688531?buildTab=
5.0: https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_NETWORK/688532?buildTab=

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* azurerm_virtual_network_gateway: Add support for max_scale_unit and min_scale_unit [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/31330


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
