### PR TITLE
Docs: add guidance to avoid reordering existing properties in the same PR

### DIFF
--- a/contributing/topics/guide-new-fields-to-data-source.md
+++ b/contributing/topics/guide-new-fields-to-data-source.md
@@ -16,7 +16,11 @@ The process is similar to [extending an existing Resource](guide-new-fields-to-r
 
 Building on the example from [adding a new data source](guide-new-data-source.md) the new property will need to be added into the `Attributes` list which contains a list of schema fields that are Computed only.
 
-The location of the new property within this list is determined based on the order found in [adding a new data source](guide-new-data-source.md#step-3-scaffold-an-emptynew-data-source). Taking the hypothetical property `public_network_access_enabled` as an example this would then end up looking like this in `Attributes`.
+The location of the new property within this list is determined based on the order found in [adding a new data source](guide-new-data-source.md#step-3-scaffold-an-emptynew-data-source). 
+
+> **Warning:** do not reorder existing properties in the same PR, as doing so degrades diff readability. Make any reordering changes in a separate follow-up PR instead.
+
+Taking the hypothetical property `public_network_access_enabled` as an example this would then end up looking like this in `Attributes`.
 
 ```go
 func (ResourceGroupExampleDataSource) Attributes() map[string]*pluginsdk.Schema {

--- a/contributing/topics/guide-new-fields-to-resource.md
+++ b/contributing/topics/guide-new-fields-to-resource.md
@@ -14,7 +14,11 @@ Building on the example found in [adding a new resource](guide-new-resource.md) 
 
 Our hypothetical property `logging_enabled` will be user configurable and thus will need to be added to the `Arguments` list.
 
-The position of the new property is determined based on the order found in [adding a new resource](guide-new-resource.md#step-3-scaffold-an-emptynew-resource) and will end up looking like the code block below. Here is an example for a typed resource:
+The position of the new property is determined based on the order found in [adding a new resource](guide-new-resource.md#step-3-scaffold-an-emptynew-resource).
+
+> **Warning:** do not reorder existing properties in the same PR, as doing so degrades diff readability. Make any reordering changes in a separate follow-up PR instead.
+
+Once added, the schema will end up looking like the code block below. Here is an example for a typed resource:
 
 ```go
 func (ResourceGroupExampleResource) Arguments() map[string]*pluginsdk.Schema {

--- a/contributing/topics/guide-opening-a-pr.md
+++ b/contributing/topics/guide-opening-a-pr.md
@@ -14,6 +14,8 @@ As a general rule, the smaller the PR the quicker it's merged - as such when upg
 2. Add the new property `new_feature` to the `azurerm_cosmosdb_*` resources.
 3. Introduce the New Resource `azurerm_cosmosdb_resource`.
 
+In the same vein, please do not reorder existing properties in the same PR, as doing so degrades diff readability. Make any reordering changes in a separate follow-up PR instead.
+
 We also recommend not opening a PR based on your `main` branch. By doing this any changed pushed to the PR may inadvertently be also pushed to your `main` branch without warning.
 
 Due to the high volume of PRs on the project and to ensure maintainers are able to focus on changes which are ready to review, please do not open Draft PRs or work that is not yet ready to be reviewed.


### PR DESCRIPTION
## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR adds contributor guidance recommending that existing properties not be reordered within the same PR, as doing so degrades diff readability. Any reordering should be done in a separate follow-up PR instead.

The guidance is added in three relevant places:

* `contributing/topics/guide-new-fields-to-resource.md` — when adding a new property to a resource's schema (also fixes an orphaned sentence fragment that resulted from the inserted note).
* `contributing/topics/guide-new-fields-to-data-source.md` — when adding a new property to a data source's `Attributes`.
* `contributing/topics/guide-opening-a-pr.md` — under the general PR Considerations section.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

This is a documentation-only change and does not require a changelog entry.


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

The documentation wording and edits were drafted with the assistance of AI/LLMs (documentation only). All changes were reviewed by the author.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

There are no changes to security controls (access controls, encryption, logging) in this pull request. This is a documentation-only change.

> [!NOTE]
> If this PR changes meaningfully during the course of review please update the title and description as required.
