### PR TITLE
`azurerm_maintenance_assignment_dynamic_scope` - fix `filter.tags` ordering drift

### DIFF
--- a/internal/services/maintenance/maintenance_assignment_dynamic_scope_resource.go
+++ b/internal/services/maintenance/maintenance_assignment_dynamic_scope_resource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/maintenance/2023-04-01/configurationassignments"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/maintenance/2023-04-01/maintenanceconfigurations"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/maintenance/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -396,4 +397,13 @@ func (MaintenanceDynamicScopeResource) Delete() sdk.ResourceFunc {
 
 func (MaintenanceDynamicScopeResource) IDValidationFunc() func(interface{}, string) ([]string, []error) {
 	return configurationassignments.ValidateConfigurationAssignmentID
+}
+
+func (MaintenanceDynamicScopeResource) StateUpgraders() sdk.StateUpgradeData {
+	return sdk.StateUpgradeData{
+		SchemaVersion: 1,
+		Upgraders: map[int]pluginsdk.StateUpgrade{
+			0: migration.AssignmentDynamicScopeV0ToV1{},
+		},
+	}
 }

--- a/internal/services/maintenance/maintenance_assignment_dynamic_scope_resource.go
+++ b/internal/services/maintenance/maintenance_assignment_dynamic_scope_resource.go
@@ -106,7 +106,7 @@ func (MaintenanceDynamicScopeResource) Arguments() map[string]*pluginsdk.Schema 
 						AtLeastOneOf: []string{"filter.0.locations", "filter.0.os_types", "filter.0.resource_groups", "filter.0.resource_types", "filter.0.tags"},
 					},
 					"tags": {
-						Type:     pluginsdk.TypeList,
+						Type:     pluginsdk.TypeSet,
 						Optional: true,
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{

--- a/internal/services/maintenance/maintenance_assignment_dynamic_scope_resource_test.go
+++ b/internal/services/maintenance/maintenance_assignment_dynamic_scope_resource_test.go
@@ -147,6 +147,14 @@ resource "azurerm_maintenance_assignment_dynamic_scope" "test" {
       tag    = "foo"
       values = ["barbar"]
     }
+    tags {
+      tag    = "environment"
+      values = ["dev"]
+    }
+    tags {
+      tag    = "service"
+      values = ["service-a"]
+    }
   }
 }
 `, r.template(data), data.RandomInteger, data.Locations.Primary)

--- a/internal/services/maintenance/migration/assignment_dynamic_scope_v0_to_v1.go
+++ b/internal/services/maintenance/migration/assignment_dynamic_scope_v0_to_v1.go
@@ -1,0 +1,91 @@
+package migration
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+var _ pluginsdk.StateUpgrade = AssignmentDynamicScopeV0ToV1{}
+
+type AssignmentDynamicScopeV0ToV1 struct{}
+
+func (AssignmentDynamicScopeV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+
+		"maintenance_configuration_id": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+		},
+
+		"filter": {
+			Type:     pluginsdk.TypeList,
+			Required: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"locations": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						Elem: &pluginsdk.Schema{
+							Type: pluginsdk.TypeString,
+						},
+					},
+					"os_types": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						Elem: &pluginsdk.Schema{
+							Type: pluginsdk.TypeString,
+						},
+					},
+					"resource_groups": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						Elem: &pluginsdk.Schema{
+							Type: pluginsdk.TypeString,
+						},
+					},
+					"resource_types": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						Elem: &pluginsdk.Schema{
+							Type: pluginsdk.TypeString,
+						},
+					},
+					"tags": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"tag": {
+									Type:     pluginsdk.TypeString,
+									Required: true,
+								},
+								"values": {
+									Type:     pluginsdk.TypeList,
+									Required: true,
+									Elem: &pluginsdk.Schema{
+										Type: pluginsdk.TypeString,
+									},
+								},
+							},
+						},
+					},
+					"tag_filter": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+					},
+				},
+			},
+		},
+	}
+}
+
+func (AssignmentDynamicScopeV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		return rawState, nil
+	}
+}


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR aims to fix a bug with `azurerm_maintenance_assignment_dynamic_scope`, where during the read function of the resource, `filter.tags` are read in a non-deterministic manner, which leads to drift when using multiple `tags`. To resolve this, `filter.tags` is changed from a `TypeList` to a `TypeSet`. 

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.

## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<b>v4.x</b>
<pre>
=== RUN   TestAccMaintenanceAssignmentDynamicScope_basic
=== PAUSE TestAccMaintenanceAssignmentDynamicScope_basic
=== RUN   TestAccMaintenanceAssignmentDynamicScope_complete
=== PAUSE TestAccMaintenanceAssignmentDynamicScope_complete
=== RUN   TestAccMaintenanceAssignmentDynamicScope_update
=== PAUSE TestAccMaintenanceAssignmentDynamicScope_update
=== RUN   TestAccMaintenanceAssignmentDynamicScope_requiresImport
=== PAUSE TestAccMaintenanceAssignmentDynamicScope_requiresImport
=== CONT  TestAccMaintenanceAssignmentDynamicScope_basic
=== CONT  TestAccMaintenanceAssignmentDynamicScope_update
=== CONT  TestAccMaintenanceAssignmentDynamicScope_complete
=== CONT  TestAccMaintenanceAssignmentDynamicScope_requiresImport
--- PASS: TestAccMaintenanceAssignmentDynamicScope_requiresImport (115.95s)
--- PASS: TestAccMaintenanceAssignmentDynamicScope_complete (129.21s)
--- PASS: TestAccMaintenanceAssignmentDynamicScope_basic (135.66s)
--- PASS: TestAccMaintenanceAssignmentDynamicScope_update (198.02s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/maintenance   198.051s
</pre>

<b>v5.0</b>
<pre>
=== RUN   TestAccMaintenanceAssignmentDynamicScope_basic
=== PAUSE TestAccMaintenanceAssignmentDynamicScope_basic
=== RUN   TestAccMaintenanceAssignmentDynamicScope_complete
=== PAUSE TestAccMaintenanceAssignmentDynamicScope_complete
=== RUN   TestAccMaintenanceAssignmentDynamicScope_update
=== PAUSE TestAccMaintenanceAssignmentDynamicScope_update
=== RUN   TestAccMaintenanceAssignmentDynamicScope_requiresImport
=== PAUSE TestAccMaintenanceAssignmentDynamicScope_requiresImport
=== CONT  TestAccMaintenanceAssignmentDynamicScope_basic
=== CONT  TestAccMaintenanceAssignmentDynamicScope_complete
=== CONT  TestAccMaintenanceAssignmentDynamicScope_requiresImport
=== CONT  TestAccMaintenanceAssignmentDynamicScope_update
--- PASS: TestAccMaintenanceAssignmentDynamicScope_requiresImport (98.73s)
--- PASS: TestAccMaintenanceAssignmentDynamicScope_complete (117.16s)
--- PASS: TestAccMaintenanceAssignmentDynamicScope_basic (119.52s)
--- PASS: TestAccMaintenanceAssignmentDynamicScope_update (191.24s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/maintenance   191.268s
</pre>

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_maintenance_assignment_dynamic_scope` - fix `filter.tags` ordering drift


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #32640 