### PR TITLE
New provider property `ignore_tags` to globally ignore tags across all resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -112,3 +112,5 @@ require (
 )
 
 go 1.26.4
+
+replace github.com/hashicorp/go-azure-helpers => github.com/cdobbyn/go-azure-helpers v0.80.1-0.20260707155757-74243bc250fe

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/btubbs/datetime v0.1.1 h1:KuV+F9tyq/hEnezmKZNGk8dzqMVsId6EpFVrQCfA3To
 github.com/btubbs/datetime v0.1.1/go.mod h1:n2BZ/2ltnRzNiz27aE3wUb2onNttQdC+WFxAoks5jJM=
 github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/FBatYVw=
 github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
+github.com/cdobbyn/go-azure-helpers v0.80.1-0.20260707155757-74243bc250fe h1:5XMgbm9m5YOdW3APGufMfeNLxLJN1u2VhWJSdqukiSI=
+github.com/cdobbyn/go-azure-helpers v0.80.1-0.20260707155757-74243bc250fe/go.mod h1:rcFXtMufiI7KFl37o7OZXK1nivEkZf2fjvy03hGJAeU=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
@@ -112,8 +114,6 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORR
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/go-azure-helpers v0.81.1 h1:hjBc+Nx+urH0U3JXskyr562UUGsRltxb9SQ2fADCtMw=
-github.com/hashicorp/go-azure-helpers v0.81.1/go.mod h1:rcFXtMufiI7KFl37o7OZXK1nivEkZf2fjvy03hGJAeU=
 github.com/hashicorp/go-azure-sdk/data-plane v0.20260709.1191450 h1:hyRqsQHd7/nKzPvm1Wq2QX5i9PWzX7UKcs8k69ByAXI=
 github.com/hashicorp/go-azure-sdk/data-plane v0.20260709.1191450/go.mod h1:sJ3vFcW3TRq2D65Live6T80TZNs6m0hVfMSfmpg/0po=
 github.com/hashicorp/go-azure-sdk/resource-manager v0.20260709.1191450 h1:V7Vf6nWIZOJn/oVoewv8/ocCaxpoQMuOxaaDXR9Xvus=

--- a/internal/provider/framework/model.go
+++ b/internal/provider/framework/model.go
@@ -37,6 +37,7 @@ type ProviderModel struct {
 	DisableTerraformPartnerId      types.Bool   `tfsdk:"disable_terraform_partner_id"`
 	StorageUseAzureAD              types.Bool   `tfsdk:"storage_use_azuread"`
 	Features                       types.List   `tfsdk:"features"`
+	IgnoreTags                     types.List   `tfsdk:"ignore_tags"`
 	ResourceProviderRegistrations  types.String `tfsdk:"resource_provider_registrations"`
 	ResourceProvidersToRegister    types.List   `tfsdk:"resource_providers_to_register"`
 

--- a/internal/provider/framework/provider.go
+++ b/internal/provider/framework/provider.go
@@ -234,6 +234,26 @@ func (p *azureRmFrameworkProvider) Schema(_ context.Context, _ provider.SchemaRe
 		},
 
 		Blocks: map[string]schema.Block{
+			"ignore_tags": schema.ListNestedBlock{
+				Description: "Globally ignore tag changes for the specified keys and key prefixes across all resources and data sources.",
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"keys": schema.SetAttribute{
+							ElementType: types.StringType,
+							Optional:    true,
+							Description: "A set of tag keys, matched exactly (case-sensitive), to ignore across all resources and data sources.",
+						},
+						"key_prefixes": schema.SetAttribute{
+							ElementType: types.StringType,
+							Optional:    true,
+							Description: "A set of tag key prefixes, matched case-sensitively, to ignore across all resources and data sources.",
+						},
+					},
+				},
+			},
 			"features": schema.ListNestedBlock{
 				Validators: []validator.List{
 					listvalidator.SizeBetween(1, 1),

--- a/internal/provider/ignore_tags.go
+++ b/internal/provider/ignore_tags.go
@@ -1,0 +1,72 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	rmtags "github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+// schemaIgnoreTags returns the schema for the provider-level `ignore_tags` block,
+// which lets a user globally ignore specific tag keys (and key prefixes) across
+// every resource and data source - mirroring the AWS provider's feature.
+func schemaIgnoreTags() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeList,
+		Optional:    true,
+		MaxItems:    1,
+		Description: "Globally ignore tag changes for the specified keys and key prefixes across all resources and data sources.",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"keys": {
+					Type:         schema.TypeSet,
+					Optional:     true,
+					Elem:         &schema.Schema{Type: schema.TypeString, ValidateFunc: validation.StringIsNotEmpty},
+					AtLeastOneOf: []string{"ignore_tags.0.keys", "ignore_tags.0.key_prefixes"},
+					Description:  "A set of tag keys, matched exactly (case-sensitive), to ignore across all resources and data sources.",
+				},
+				"key_prefixes": {
+					Type:         schema.TypeSet,
+					Optional:     true,
+					Elem:         &schema.Schema{Type: schema.TypeString, ValidateFunc: validation.StringIsNotEmpty},
+					AtLeastOneOf: []string{"ignore_tags.0.keys", "ignore_tags.0.key_prefixes"},
+					Description:  "A set of tag key prefixes, matched case-sensitively, to ignore across all resources and data sources.",
+				},
+			},
+		},
+	}
+}
+
+// expandIgnoreTags parses the `ignore_tags` provider block into an IgnoreConfig.
+// It returns nil when the block is absent or specifies no keys or key prefixes,
+// which preserves the default behavior of not ignoring any tags.
+func expandIgnoreTags(input []interface{}) *rmtags.IgnoreConfig {
+	if len(input) == 0 || input[0] == nil {
+		return nil
+	}
+
+	raw := input[0].(map[string]interface{})
+
+	var keys, keyPrefixes []string
+	if v, ok := raw["keys"].(*schema.Set); ok {
+		for _, k := range v.List() {
+			keys = append(keys, k.(string))
+		}
+	}
+	if v, ok := raw["key_prefixes"].(*schema.Set); ok {
+		for _, k := range v.List() {
+			keyPrefixes = append(keyPrefixes, k.(string))
+		}
+	}
+
+	if len(keys) == 0 && len(keyPrefixes) == 0 {
+		return nil
+	}
+
+	return &rmtags.IgnoreConfig{
+		Keys:        keys,
+		KeyPrefixes: keyPrefixes,
+	}
+}

--- a/internal/provider/ignore_tags_test.go
+++ b/internal/provider/ignore_tags_test.go
@@ -1,0 +1,105 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func ignoreTagsBlock(keys, prefixes []string) []interface{} {
+	toIface := func(in []string) []interface{} {
+		out := make([]interface{}, len(in))
+		for i, v := range in {
+			out[i] = v
+		}
+		return out
+	}
+	return []interface{}{
+		map[string]interface{}{
+			"keys":         schema.NewSet(schema.HashString, toIface(keys)),
+			"key_prefixes": schema.NewSet(schema.HashString, toIface(prefixes)),
+		},
+	}
+}
+
+func TestExpandIgnoreTags(t *testing.T) {
+	testCases := []struct {
+		name             string
+		input            []interface{}
+		expectNil        bool
+		expectedKeys     []string
+		expectedPrefixes []string
+	}{
+		{
+			name:      "absent block returns nil",
+			input:     []interface{}{},
+			expectNil: true,
+		},
+		{
+			name:      "empty block returns nil",
+			input:     ignoreTagsBlock(nil, nil),
+			expectNil: true,
+		},
+		{
+			name:         "keys only",
+			input:        ignoreTagsBlock([]string{"createdBy", "owner"}, nil),
+			expectedKeys: []string{"createdBy", "owner"},
+		},
+		{
+			name:             "prefixes only",
+			input:            ignoreTagsBlock(nil, []string{"azure-policy-"}),
+			expectedPrefixes: []string{"azure-policy-"},
+		},
+		{
+			name:             "keys and prefixes",
+			input:            ignoreTagsBlock([]string{"createdBy"}, []string{"internal:", "azure-policy-"}),
+			expectedKeys:     []string{"createdBy"},
+			expectedPrefixes: []string{"azure-policy-", "internal:"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := expandIgnoreTags(tc.input)
+			if tc.expectNil {
+				if result != nil {
+					t.Fatalf("expected nil, got %+v", result)
+				}
+				return
+			}
+			if result == nil {
+				t.Fatalf("expected non-nil IgnoreConfig")
+			}
+
+			gotKeys := append([]string{}, result.Keys...)
+			gotPrefixes := append([]string{}, result.KeyPrefixes...)
+			sort.Strings(gotKeys)
+			sort.Strings(gotPrefixes)
+			sort.Strings(tc.expectedKeys)
+			sort.Strings(tc.expectedPrefixes)
+
+			if !equalStringSlices(gotKeys, tc.expectedKeys) {
+				t.Fatalf("keys: expected %v, got %v", tc.expectedKeys, gotKeys)
+			}
+			if !equalStringSlices(gotPrefixes, tc.expectedPrefixes) {
+				t.Fatalf("key_prefixes: expected %v, got %v", tc.expectedPrefixes, gotPrefixes)
+			}
+		})
+	}
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	rmtags "github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/sdk/auth"
 	"github.com/hashicorp/go-azure-sdk/sdk/environments"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -342,6 +343,8 @@ func azureProvider(supportLegacyTestSuite bool, testName string) *schema.Provide
 
 			"features": schemaFeatures(supportLegacyTestSuite),
 
+			"ignore_tags": schemaIgnoreTags(),
+
 			// Advanced feature flags
 			"resource_provider_registrations": {
 				Type:        schema.TypeString,
@@ -579,6 +582,9 @@ func buildClient(ctx context.Context, p *schema.Provider, d *schema.ResourceData
 	} else if os.Getenv("ARM_PROVIDER_ENHANCED_VALIDATION") != "" {
 		return nil, diag.Errorf("the environment variable `ARM_PROVIDER_ENHANCED_VALIDATION` has been removed in v5.0 of the AzureRM Provider - please use the `enhanced_validation` block inside the `features` block or the replacement environment variables `ARM_PROVIDER_ENHANCED_VALIDATION_LOCATIONS` and `ARM_PROVIDER_ENHANCED_VALIDATION_RESOURCE_PROVIDERS` instead")
 	}
+
+	// configure the provider-level set of tag keys to ignore across all resources and data sources
+	rmtags.SetIgnore(expandIgnoreTags(d.Get("ignore_tags").([]interface{})))
 
 	clientBuilder := clients.ClientBuilder{
 		AuthConfig:                  authConfig,

--- a/internal/services/resource/resource_group_ignore_tags_test.go
+++ b/internal/services/resource/resource_group_ignore_tags_test.go
@@ -1,0 +1,109 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package resource_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/resources/2023-07-01/resourcegroups"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+// TestAccResourceGroup_providerIgnoreTags verifies that the provider-level
+// `ignore_tags` block prevents tags applied out-of-band (here, simulated via a
+// direct API call) from producing a perpetual plan diff, when their key matches
+// `keys` exactly or starts with one of `key_prefixes`.
+func TestAccResourceGroup_providerIgnoreTags(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_resource_group", "test")
+	r := ResourceGroupResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.providerIgnoreTags(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
+				check.That(data.ResourceName).Key("tags.environment").HasValue("Production"),
+				// apply tags out-of-band whose keys are ignored by the provider config
+				data.CheckWithClient(r.setTagsOutOfBand(map[string]string{
+					"ignoreThisKey":      "set-outside-terraform",
+					"ignore-prefix-team": "platform",
+				})),
+			),
+		},
+		{
+			// because the out-of-band tags match the provider `ignore_tags` block they
+			// are scrubbed from state on read, so the plan must be empty (no drift)
+			Config:             r.providerIgnoreTags(data),
+			PlanOnly:           true,
+			ExpectNonEmptyPlan: false,
+		},
+	})
+}
+
+func (r ResourceGroupResource) providerIgnoreTags(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+
+  ignore_tags {
+    keys         = ["ignoreThisKey"]
+    key_prefixes = ["ignore-prefix-"]
+  }
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+
+  tags = {
+    environment = "Production"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+// setTagsOutOfBand merges the supplied tags into the resource group via a direct
+// API call, simulating tags applied by an external system such as Azure Policy.
+func (r ResourceGroupResource) setTagsOutOfBand(extra map[string]string) acceptance.ClientCheckFunc {
+	return func(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) error {
+		id, err := commonids.ParseResourceGroupIDInsensitively(state.ID)
+		if err != nil {
+			return err
+		}
+
+		existing, err := client.Resource.ResourceGroupsClient.Get(ctx, *id)
+		if err != nil {
+			return fmt.Errorf("retrieving %s: %+v", *id, err)
+		}
+		if existing.Model == nil {
+			return fmt.Errorf("retrieving %s: `model` was nil", *id)
+		}
+
+		newTags := map[string]string{}
+		if existing.Model.Tags != nil {
+			for k, v := range *existing.Model.Tags {
+				newTags[k] = v
+			}
+		}
+		for k, v := range extra {
+			newTags[k] = v
+		}
+
+		patch := resourcegroups.ResourceGroupPatchable{
+			Tags: &newTags,
+		}
+		if _, err := client.Resource.ResourceGroupsClient.Update(ctx, *id, patch); err != nil {
+			return fmt.Errorf("setting tags out-of-band on %s: %+v", *id, err)
+		}
+
+		return nil
+	}
+}

--- a/internal/tags/expand.go
+++ b/internal/tags/expand.go
@@ -3,6 +3,10 @@
 
 package tags
 
+import (
+	rmtags "github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
+)
+
 func Expand(tagsMap map[string]interface{}) map[string]*string {
 	output := make(map[string]*string, len(tagsMap))
 
@@ -12,5 +16,6 @@ func Expand(tagsMap map[string]interface{}) map[string]*string {
 		output[i] = &value
 	}
 
-	return output
+	// exclude any provider-level ignored tag keys from the desired set
+	return rmtags.Ignore().ApplyMap(output)
 }

--- a/internal/tags/flatten.go
+++ b/internal/tags/flatten.go
@@ -6,10 +6,14 @@ package tags
 import (
 	"fmt"
 
+	rmtags "github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
 func Flatten(tagMap map[string]*string) map[string]interface{} {
+	// scrub any provider-level ignored tag keys before they reach state
+	tagMap = rmtags.Ignore().ApplyMap(tagMap)
+
 	// If tagsMap is nil, len(tagsMap) will be 0.
 	output := make(map[string]interface{}, len(tagMap))
 

--- a/internal/tags/ignore_test.go
+++ b/internal/tags/ignore_test.go
@@ -1,0 +1,61 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package tags
+
+import (
+	"testing"
+
+	rmtags "github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
+)
+
+func TestExpandHonoursIgnoreConfig(t *testing.T) {
+	t.Cleanup(func() { rmtags.SetIgnore(nil) })
+	rmtags.SetIgnore(&rmtags.IgnoreConfig{Keys: []string{"createdBy"}, KeyPrefixes: []string{"azure-policy-"}})
+
+	result := Expand(map[string]interface{}{
+		"environment":     "prod",
+		"createdBy":       "policy",
+		"azure-policy-id": "abc",
+	})
+
+	if len(result) != 1 {
+		t.Fatalf("expected ignored keys to be excluded on expand, got %v", result)
+	}
+	if result["environment"] == nil || *result["environment"] != "prod" {
+		t.Fatalf("expected environment=prod to be retained, got %v", result["environment"])
+	}
+}
+
+func TestExpandWithoutIgnoreConfigIsUnchanged(t *testing.T) {
+	t.Cleanup(func() { rmtags.SetIgnore(nil) })
+	rmtags.SetIgnore(nil)
+
+	result := Expand(map[string]interface{}{
+		"environment": "prod",
+		"createdBy":   "policy",
+	})
+
+	if len(result) != 2 {
+		t.Fatalf("expected no ignore filtering when unset, got %v", result)
+	}
+}
+
+func TestFlattenHonoursIgnoreConfig(t *testing.T) {
+	t.Cleanup(func() { rmtags.SetIgnore(nil) })
+	rmtags.SetIgnore(&rmtags.IgnoreConfig{KeyPrefixes: []string{"internal:"}})
+
+	prod := "prod"
+	owner := "x"
+	result := Flatten(map[string]*string{
+		"environment":    &prod,
+		"internal:owner": &owner,
+	})
+
+	if len(result) != 1 {
+		t.Fatalf("expected ignored prefix key to be scrubbed on flatten, got %v", result)
+	}
+	if result["environment"] != "prod" {
+		t.Fatalf("expected environment=prod, got %v", result)
+	}
+}

--- a/vendor/github.com/hashicorp/go-azure-helpers/framework/commonschema/tags.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/framework/commonschema/tags.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/framework/convert"
 	"github.com/hashicorp/go-azure-helpers/framework/typehelpers"
+	rmtags "github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	datasourceschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -48,11 +49,16 @@ func ExpandTags(ctx context.Context, input typehelpers.MapValueOf[types.String],
 
 	convert.Expand(ctx, input, &result, diags)
 
-	return &result
+	// exclude any provider-level ignored tag keys from the desired set
+	return rmtags.Ignore().ApplyPtrMap(&result)
 }
 
 func FlattenTags(ctx context.Context, tags *map[string]string, diags *diag.Diagnostics) typehelpers.MapValueOf[types.String] {
+	// scrub any provider-level ignored tag keys before they reach state
+	tags = rmtags.Ignore().ApplyPtrMap(tags)
+
 	result := typehelpers.NewMapValueOfNull[types.String](ctx)
+
 	if tags == nil {
 		return result
 	}

--- a/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/tags/expand.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/tags/expand.go
@@ -13,5 +13,6 @@ func Expand(input map[string]interface{}) *map[string]string {
 		output[tagKey] = tagValue
 	}
 
-	return &output
+	// exclude any provider-level ignored tag keys from the desired set
+	return Ignore().ApplyPtrMap(&output)
 }

--- a/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/tags/flatten.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/tags/flatten.go
@@ -12,6 +12,9 @@ import (
 // Flatten transforms the Tags specified via `input` into a map[string]interface{}
 // for compatibility with the Schema.
 func Flatten(input *map[string]string) map[string]interface{} {
+	// scrub any provider-level ignored tag keys before they reach state
+	input = Ignore().ApplyPtrMap(input)
+
 	output := make(map[string]interface{})
 	if input == nil {
 		return output

--- a/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/tags/ignore.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/resourcemanager/tags/ignore.go
@@ -1,0 +1,87 @@
+// Copyright IBM Corp. 2018, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package tags
+
+import "strings"
+
+// IgnoreConfig describes the set of tag keys that the provider should ignore on
+// every resource and data source. A key is ignored when it exactly matches an
+// entry in Keys (case-sensitive) or when it begins with an entry in KeyPrefixes.
+type IgnoreConfig struct {
+	Keys        []string
+	KeyPrefixes []string
+}
+
+// ignore is the process-wide IgnoreConfig set once when the provider is
+// configured. A nil value means no tags are ignored, preserving the default
+// behavior for anyone who does not configure the `ignore_tags` block.
+var ignore *IgnoreConfig
+
+// SetIgnore stores the provider-level IgnoreConfig so that the tag helpers in
+// this package (and the framework helpers that read Ignore()) apply it.
+func SetIgnore(config *IgnoreConfig) {
+	ignore = config
+}
+
+// Ignore returns the process-wide IgnoreConfig, or nil if none is configured.
+func Ignore() *IgnoreConfig {
+	return ignore
+}
+
+// ignored reports whether the tag key should be ignored under this config.
+func (c *IgnoreConfig) ignored(key string) bool {
+	if c == nil {
+		return false
+	}
+
+	for _, k := range c.Keys {
+		if key == k {
+			return true
+		}
+	}
+
+	for _, prefix := range c.KeyPrefixes {
+		if strings.HasPrefix(key, prefix) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// ApplyPtrMap returns a copy of input with every ignored key removed. A nil
+// receiver or a nil input is returned unchanged.
+func (c *IgnoreConfig) ApplyPtrMap(input *map[string]string) *map[string]string {
+	if c == nil || input == nil {
+		return input
+	}
+
+	output := make(map[string]string, len(*input))
+	for k, v := range *input {
+		if c.ignored(k) {
+			continue
+		}
+		output[k] = v
+	}
+
+	return &output
+}
+
+// ApplyMap returns a copy of input with every ignored key removed. A nil
+// receiver is returned unchanged.
+func (c *IgnoreConfig) ApplyMap(input map[string]*string) map[string]*string {
+	if c == nil {
+		return input
+	}
+
+	output := make(map[string]*string, len(input))
+	for k, v := range input {
+		if c.ignored(k) {
+			continue
+		}
+		output[k] = v
+	}
+
+	return output
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -139,7 +139,7 @@ github.com/google/uuid
 # github.com/hashicorp/errwrap v1.1.0
 ## explicit
 github.com/hashicorp/errwrap
-# github.com/hashicorp/go-azure-helpers v0.81.1
+# github.com/hashicorp/go-azure-helpers v0.81.1 => github.com/cdobbyn/go-azure-helpers v0.80.1-0.20260707155757-74243bc250fe
 ## explicit; go 1.26.4
 github.com/hashicorp/go-azure-helpers/eventhub
 github.com/hashicorp/go-azure-helpers/framework/commonschema
@@ -1885,3 +1885,4 @@ gopkg.in/yaml.v3
 ## explicit; go 1.19
 software.sslmate.com/src/go-pkcs12
 software.sslmate.com/src/go-pkcs12/internal/rc2
+# github.com/hashicorp/go-azure-helpers => github.com/cdobbyn/go-azure-helpers v0.80.1-0.20260707155757-74243bc250fe

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -209,11 +209,42 @@ For some advanced scenarios, such as where more granular permissions are necessa
 
 ~> **Note:** The Files Storage API does not support authenticating via AzureAD and will continue to use a SharedKey when AAD authentication is enabled.
 
+* `ignore_tags` - (Optional) An `ignore_tags` block as defined below which globally ignores changes to the specified tag keys and key prefixes across all resources and data sources managed by the provider. See [Ignoring Tag Changes](#ignoring-tag-changes) below for more information.
+
+The `ignore_tags` block supports the following:
+
+* `keys` - (Optional) A set of tag keys, matched exactly (case-sensitive), to ignore across all resources and data sources.
+
+* `key_prefixes` - (Optional) A set of tag key prefixes, matched case-sensitively (using a "starts with" comparison), to ignore across all resources and data sources.
+
+~> **Note:** At least one of `keys` or `key_prefixes` must be specified within an `ignore_tags` block.
+
 It's also possible to use multiple Provider blocks within a single Terraform configuration, for example, to work with resources across multiple Subscriptions - more information can be found [in the documentation for Providers](https://www.terraform.io/docs/configuration/providers.html#multiple-provider-instances).
 
 ## Features
 
 The `features` block allows configuring the behaviour of the Azure Provider, more information can be found on [the dedicated page for the `features` block](guides/features-block.html).
+
+## Ignoring Tag Changes
+
+Some Azure resources have tags applied to them out-of-band by external systems such as Azure Policy, governance tooling, or automation. Without intervention these tags appear as a persistent difference on every `terraform plan`. The `ignore_tags` block lets you globally ignore changes to specific tag keys across **all** resources and data sources managed by the provider, so they no longer produce a perpetual diff:
+
+```hcl
+provider "azurerm" {
+  features {}
+
+  ignore_tags {
+    keys         = ["createdBy"]
+    key_prefixes = ["azure-policy-", "internal:"]
+  }
+}
+```
+
+With the configuration above, a tag named `createdBy`, or any tag whose key begins with `azure-policy-` or `internal:`, is ignored: the provider neither writes it from configuration nor reports it as drift when it is present on the remote resource. Both `keys` (exact match) and `key_prefixes` (prefix match) are evaluated case-sensitively.
+
+~> **Note:** You should not also list an ignored tag key in a resource's own `tags` configuration. A key matched by `ignore_tags` is excluded from the set of tags the provider manages, so specifying it in both places results in a persistent diff.
+
+~> **Note:** When a tag whose key is ignored exists only on the remote resource (i.e. it is not in configuration), an unrelated change to the resource that replaces its full tag set may still remove that tag, because the AzureRM Provider does not compute a per-resource tag diff. The `ignore_tags` block reliably prevents the common case of a perpetual plan diff caused by externally-managed tags.
 
 ## Resource Provider Registrations
 


### PR DESCRIPTION
#### Community Note

* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review

#### PR Checklist

- [x] Have you followed the guidelines in our [Contributing Documentation](../contributing/README.md)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [x] Have you used a meaningful PR description to help maintainers and other users understand this change and help prevent duplicate work?
- [x] Do your changes close any open issues? (closes #28711)

#### New Feature Submissions

- [x] Does your submission include Test coverage as described in the Contribution Guide and the tests pass? (unit + mux-parity tests pass; the acceptance test requires Azure credentials — see Testing below)

#### Documentation Changes

- [x] Documentation is written in International English.
- [x] Documentation is written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.

#### Description

Adds a provider-level `ignore_tags` block to the AzureRM provider, mirroring the AWS provider's [ignoring changes in all resources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/resource-tagging#ignoring-changes-in-all-resources) feature. It lets a user globally ignore changes to specific tag `keys` and `key_prefixes` across **all** resources and data sources, so tags applied out-of-band (e.g. by Azure Policy or governance tooling) no longer produce a perpetual `terraform plan` diff.

```hcl
provider "azurerm" {
  features {}

  ignore_tags {
    keys         = ["createdBy"]
    key_prefixes = ["azure-policy-", "internal:"]
  }
}
```

**How it works.** Rather than touch ~800 tag call sites, the provider parses the block once and stores it via a package-level `tags.SetIgnore(...)`, which the tag Expand/Flatten helpers consult:

- **Read (Flatten):** ignored keys are scrubbed before being written to state, so an externally-applied tag never lands in state and never shows as drift.
- **Create/Update (Expand):** ignored keys are excluded from the desired set.

Applied symmetrically, an ignored tag is never added and is never reported as drift. Matching is **case-sensitive** — `keys` match exactly and `key_prefixes` match via a "starts with" comparison. The canonical `IgnoreConfig` type and package-level hook live in `go-azure-helpers/resourcemanager/tags`; the in-repo `internal/tags` and `framework/commonschema` consume the same value, so all taggable resources are covered (both the in-repo and vendored tag paths), not just a subset.

**⚠️ Upstream coordination needed before merge.** This depends on a matching addition to `hashicorp/go-azure-helpers` (the `IgnoreConfig`/`SetIgnore` hook in `resourcemanager/tags` and `framework/commonschema`), raised upstream as hashicorp/go-azure-helpers#280. To make the feature work end-to-end on this branch, `go.mod` **temporarily** `replace`s `go-azure-helpers` with that branch and vendors it. Before this can merge, hashicorp/go-azure-helpers#280 needs to be merged and released, then the `replace` dropped / version bumped. The implementation is complete and ready for review now; only the upstream release gates the actual merge — feedback on the approach is welcome.

**Known limitations** (documented in the website docs):

- *Remote-only ignored tag on a full-map update.* AzureRM has no central old-vs-new tag diff (unlike AWS `tags_all`). A resource that replaces its entire tag set on update may still drop an ignored tag that exists only on the remote. The common drift-prevention case (no perpetual plan diff) is fully handled.
- *Process-global config.* Multiple aliased `azurerm` provider blocks with *different* `ignore_tags` configurations share one process-level value (last configured wins).

**Testing.**

- Unit tests for `IgnoreConfig` (exact keys, key prefixes, union, case-sensitivity, nil/empty no-op, nil map) and for Expand/Flatten honouring an active config, on both the in-repo and vendored helpers.
- Unit test for `expandIgnoreTags` provider-block parsing.
- A mux schema-parity test (`internal/provider/framework`) guarding that the SDKv2 and Plugin-Framework provider schemas stay identical (required for `tf5muxserver`, since `ignore_tags` is declared in both halves).
- A `TF_ACC` acceptance test on `azurerm_resource_group` that applies an ignored tag out-of-band and asserts an empty plan.

> **Note on `depscheck`:** this PR is intentionally scoped to the feature only. At the time of writing, `main`'s vendor directory carries an orphaned `github.com/jackofallops/kermit/sdk/web/2022-09-01/web` package that nothing imports and that `go mod vendor` prunes — so `make depscheck` may report that unrelated removal. It is pre-existing on `main` and deliberately left out of this PR.

#### Related Issue(s)

Closes #28711

#### Change Log

Below is a suggested entry for the maintainer to use during merge (no `CHANGELOG.md` change is included in this PR):

* provider: support for the `ignore_tags` block to globally ignore changes to specific tag keys and key prefixes across all resources and data sources

- [ ] Bug Fix
- [x] New Feature

