### PR TITLE
azurerm_web_pubsub_network_acl - support for ip_rule

### DIFF
--- a/internal/services/signalr/web_pubsub_network_acl_resource.go
+++ b/internal/services/signalr/web_pubsub_network_acl_resource.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-09-01/privateendpoints"
@@ -91,6 +92,27 @@ func resourceWebpubsubNetworkACL() *pluginsdk.Resource {
 				},
 			},
 
+			"ip_rule": {
+				Type:     pluginsdk.TypeList,
+				Optional: true,
+				MaxItems: 30,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"action": {
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice(webpubsub.PossibleValuesForACLAction(), false),
+						},
+
+						"ip_range": {
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+					},
+				},
+			},
+
 			"private_endpoint": {
 				Type:     pluginsdk.TypeSet,
 				Optional: true,
@@ -166,6 +188,7 @@ func resourceWebPubsubNetworkACLCreateUpdate(d *pluginsdk.ResourceData, meta int
 		DefaultAction:    &defaultAction,
 		PublicNetwork:    expandWebpubsubPublicNetwork(d.Get("public_network").([]interface{})),
 		PrivateEndpoints: expandWebpubsubPrivateEndpoint(d.Get("private_endpoint").(*pluginsdk.Set).List(), payload.Properties.PrivateEndpointConnections),
+		IPRules:          expandWebpubsubIPRules(d.Get("ip_rule").([]interface{})),
 	}
 
 	if defaultAction == webpubsub.ACLActionAllow && networkACL.PublicNetwork.Allow != nil && len(*networkACL.PublicNetwork.Allow) != 0 {
@@ -189,7 +212,7 @@ func resourceWebPubsubNetworkACLCreateUpdate(d *pluginsdk.ResourceData, meta int
 	}
 	payload.Properties.NetworkACLs = &networkACL
 
-	if err := client.UpdateCallbackThenPoll(ctx, *id, payload, sdk.SetIDCallback(meta, id, d)); err != nil {
+	if err := client.CreateOrUpdateCallbackThenPoll(ctx, *id, payload, sdk.SetIDCallback(meta, id, d)); err != nil {
 		return fmt.Errorf("updating Network ACL configuration for %q: %+v", id, err)
 	}
 	d.SetId(id.ID())
@@ -230,6 +253,10 @@ func resourceWebPubsubNetworkACLRead(d *pluginsdk.ResourceData, meta interface{}
 
 				if err := d.Set("public_network", flattenWebpubsubPublicNetwork(props.NetworkACLs.PublicNetwork)); err != nil {
 					return fmt.Errorf("setting `public_network`: %+v", err)
+				}
+
+				if err := d.Set("ip_rule", flattenWebpubsubIPRules(props.NetworkACLs.IPRules)); err != nil {
+					return fmt.Errorf("setting `ip_rule`: %+v", err)
 				}
 
 				if err := d.Set("private_endpoint", flattenWebpubsubPrivateEndpoint(props.NetworkACLs.PrivateEndpoints, props.PrivateEndpointConnections)); err != nil {
@@ -346,6 +373,36 @@ func flattenWebpubsubPublicNetwork(input *webpubsub.NetworkACL) []interface{} {
 			"denied_request_types":  deny,
 		},
 	}
+}
+
+func expandWebpubsubIPRules(input []interface{}) *[]webpubsub.IPRule {
+	results := make([]webpubsub.IPRule, 0, len(input))
+
+	for _, item := range input {
+		v := item.(map[string]interface{})
+		results = append(results, webpubsub.IPRule{
+			Action: pointer.ToEnum[webpubsub.ACLAction](v["action"].(string)),
+			Value:  pointer.To(v["ip_range"].(string)),
+		})
+	}
+
+	return &results
+}
+
+func flattenWebpubsubIPRules(input *[]webpubsub.IPRule) []interface{} {
+	results := make([]interface{}, 0)
+	if input == nil {
+		return results
+	}
+
+	for _, item := range *input {
+		results = append(results, map[string]interface{}{
+			"action":   string(pointer.From(item.Action)),
+			"ip_range": pointer.From(item.Value),
+		})
+	}
+
+	return results
 }
 
 func expandWebpubsubPrivateEndpoint(input []interface{}, privateEndpointConnections *[]webpubsub.PrivateEndpointConnection) *[]webpubsub.PrivateEndpointACL {

--- a/internal/services/signalr/web_pubsub_network_acl_resource.go
+++ b/internal/services/signalr/web_pubsub_network_acl_resource.go
@@ -279,6 +279,9 @@ func resourceWebpubsubNetworkACLDelete(d *pluginsdk.ResourceData, meta interface
 		return err
 	}
 
+	locks.ByName(id.WebPubSubName, "azurerm_web_pubsub")
+	defer locks.UnlockByName(id.WebPubSubName, "azurerm_web_pubsub")
+
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
 		return fmt.Errorf("retrieving %q: %+v", id, err)
@@ -292,6 +295,9 @@ func resourceWebpubsubNetworkACLDelete(d *pluginsdk.ResourceData, meta interface
 			Allow: &defaultRequestTypes,
 			Deny:  &denyRequestTypes,
 		},
+		// IPRules must be an explicit empty slice so the PUT sends `[]` and clears existing rules;
+		// a nil slice is omitted from the request and Azure retains the stored `ip_rule` entries
+		IPRules: &[]webpubsub.IPRule{},
 	}
 
 	if resp.Model == nil {
@@ -315,7 +321,7 @@ func resourceWebpubsubNetworkACLDelete(d *pluginsdk.ResourceData, meta interface
 
 	payload.Properties.NetworkACLs = networkACL
 
-	if err := client.UpdateThenPoll(ctx, *id, payload); err != nil {
+	if err := client.CreateOrUpdateThenPoll(ctx, *id, payload); err != nil {
 		return fmt.Errorf("resetting the default Network ACL configuration for %q: %+v", id, err)
 	}
 

--- a/internal/services/signalr/web_pubsub_network_acl_resource_test.go
+++ b/internal/services/signalr/web_pubsub_network_acl_resource_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/webpubsub/2024-03-01/webpubsub"
@@ -144,6 +145,54 @@ func TestAccWebPubsubNetworkACL_ipRules(t *testing.T) {
 		},
 		data.ImportStep(),
 	})
+}
+
+func TestAccWebPubsubNetworkACL_ipRulesClearedOnDestroy(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_web_pubsub_network_acl", "test")
+	r := WebPubsubNetworkACLResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.ipRules(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("ip_rule.#").HasValue("2"),
+			),
+		},
+		data.ImportStep(),
+		{
+			// "destroy" must clear the IP rules from the parent Web PubSub rather than leave them behind
+			Config: r.template(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				data.CheckWithClientForResource(r.ipRulesClearedFromParent, "azurerm_web_pubsub.test"),
+			),
+		},
+	})
+}
+
+func (r WebPubsubNetworkACLResource) ipRulesClearedFromParent(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) error {
+	id, err := webpubsub.ParseWebPubSubID(state.Attributes["id"])
+	if err != nil {
+		return err
+	}
+
+	ctx2, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	resp, err := clients.SignalR.WebPubSubClient.WebPubSub.Get(ctx2, *id)
+	if err != nil {
+		return fmt.Errorf("retrieving %s: %+v", *id, err)
+	}
+
+	if model := resp.Model; model != nil {
+		if props := model.Properties; props != nil {
+			if acls := props.NetworkACLs; acls != nil && acls.IPRules != nil && len(*acls.IPRules) > 0 {
+				return fmt.Errorf("expected `ip_rule`s to be cleared from %s after destroying the network ACL, but found %d", *id, len(*acls.IPRules))
+			}
+		}
+	}
+
+	return nil
 }
 
 func (r WebPubsubNetworkACLResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
@@ -289,8 +338,6 @@ resource "azurerm_web_pubsub_network_acl" "test" {
     action   = "Allow"
     ip_range = "AzureFrontDoor.Backend"
   }
-
-  depends_on = [azurerm_web_pubsub.test]
 }
 `, r.template(data))
 }
@@ -306,8 +353,6 @@ resource "azurerm_web_pubsub_network_acl" "test" {
   public_network {
     allowed_request_types = ["ClientConnection"]
   }
-
-  depends_on = [azurerm_web_pubsub.test]
 }
 `, r.template(data))
 }

--- a/internal/services/signalr/web_pubsub_network_acl_resource_test.go
+++ b/internal/services/signalr/web_pubsub_network_acl_resource_test.go
@@ -122,6 +122,30 @@ func TestAccWebPubsubNetworkACL_updateMultiplePrivateEndpoints(t *testing.T) {
 	})
 }
 
+func TestAccWebPubsubNetworkACL_ipRules(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_web_pubsub_network_acl", "test")
+	r := WebPubsubNetworkACLResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.ipRules(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("ip_rule.#").HasValue("2"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.ipRulesRemoved(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("ip_rule.#").HasValue("0"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r WebPubsubNetworkACLResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := webpubsub.ParseWebPubSubID(state.ID)
 	if err != nil {
@@ -208,6 +232,16 @@ resource "azurerm_web_pubsub_network_acl" "test" {
     allowed_request_types = ["ClientConnection"]
   }
 
+  ip_rule {
+    action   = "Allow"
+    ip_range = "10.0.1.0/24"
+  }
+
+  ip_rule {
+    action   = "Allow"
+    ip_range = "AzureFrontDoor.Backend"
+  }
+
   private_endpoint {
     id                    = azurerm_private_endpoint.test.id
     allowed_request_types = ["ClientConnection"]
@@ -227,6 +261,50 @@ resource "azurerm_web_pubsub_network_acl" "test" {
   default_action = "Deny"
   public_network {
     allowed_request_types = ["ClientConnection", "RESTAPI"]
+  }
+
+  depends_on = [azurerm_web_pubsub.test]
+}
+`, r.template(data))
+}
+
+func (r WebPubsubNetworkACLResource) ipRules(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_web_pubsub_network_acl" "test" {
+  web_pubsub_id  = azurerm_web_pubsub.test.id
+  default_action = "Deny"
+
+  public_network {
+    allowed_request_types = ["ClientConnection"]
+  }
+
+  ip_rule {
+    action   = "Allow"
+    ip_range = "10.0.1.0/24"
+  }
+
+  ip_rule {
+    action   = "Allow"
+    ip_range = "AzureFrontDoor.Backend"
+  }
+
+  depends_on = [azurerm_web_pubsub.test]
+}
+`, r.template(data))
+}
+
+func (r WebPubsubNetworkACLResource) ipRulesRemoved(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_web_pubsub_network_acl" "test" {
+  web_pubsub_id  = azurerm_web_pubsub.test.id
+  default_action = "Deny"
+
+  public_network {
+    allowed_request_types = ["ClientConnection"]
   }
 
   depends_on = [azurerm_web_pubsub.test]

--- a/website/docs/r/web_pubsub_network_acl.html.markdown
+++ b/website/docs/r/web_pubsub_network_acl.html.markdown
@@ -110,7 +110,7 @@ An `ip_rule` block supports the following:
 
 * `action` - (Required) The action to take for the matched IP rule. Possible values are `Allow` and `Deny`.
 
-* `ip_range` - (Required) The value to match for this rule. This can be an IP address, a CIDR range, or a [service tag](https://docs.microsoft.com/azure/virtual-network/service-tags-overview).
+* `ip_range` - (Required) The value to match for this rule. This can be an IP address, a CIDR range, or a [service tag](https://learn.microsoft.com/azure/virtual-network/service-tags-overview).
 
 ---
 

--- a/website/docs/r/web_pubsub_network_acl.html.markdown
+++ b/website/docs/r/web_pubsub_network_acl.html.markdown
@@ -64,6 +64,11 @@ resource "azurerm_web_pubsub_network_acl" "example" {
     denied_request_types = ["ClientConnection"]
   }
 
+  ip_rule {
+    action   = "Deny"
+    ip_range = "10.0.1.0/24"
+  }
+
   private_endpoint {
     id                   = azurerm_private_endpoint.example.id
     denied_request_types = ["RESTAPI", "ClientConnection"]
@@ -85,6 +90,8 @@ The following arguments are supported:
 
 * `public_network` - (Required) A `public_network` block as defined below.
 
+* `ip_rule` - (Optional) One or more `ip_rule` blocks as defined below.
+
 * `private_endpoint` - (Optional) A `private_endpoint` block as defined below.
 
 ---
@@ -96,6 +103,14 @@ A `public_network` block supports the following:
 * `denied_request_types` - (Optional) The denied request types for the public network. Possible values are `ClientConnection`, `ServerConnection`, `RESTAPI` and `Trace`.
 
 -> **Note:** When `default_action` is `Allow`, `allowed_request_types`cannot be set. When `default_action` is `Deny`, `denied_request_types`cannot be set.
+
+---
+
+An `ip_rule` block supports the following:
+
+* `action` - (Required) The action to take for the matched IP rule. Possible values are `Allow` and `Deny`.
+
+* `ip_range` - (Required) The value to match for this rule. This can be an IP address, a CIDR range, or a [service tag](https://docs.microsoft.com/azure/virtual-network/service-tags-overview).
 
 ---
 


### PR DESCRIPTION
## Community Note

* Please vote on this PR by adding a 👍 reaction to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

This PR adds support for configuring `ip_rule` blocks on `azurerm_web_pubsub_network_acl`, allowing network access to the Web PubSub service to be restricted by client IP address, CIDR range, or service tag.

Each `ip_rule` block supports:

* `action` - `Allow` or `Deny`
* `ip_range` - an IP address, CIDR range, or service tag (the underlying API field is `value`; exposed as `ip_range` to align with the Azure Portal and other AzureRM IP-rule blocks). A maximum of 30 `ip_rule` blocks is supported, matching the Portal limit.

The update call was changed from `Update` (PATCH) to `CreateOrUpdate` (PUT) so that removing all `ip_rule` blocks correctly clears them rather than leaving stale rules behind (verified by the `ipRulesRemoved` test step).

## PR Checklist

- [x] I have followed the guidelines in our Contributing Documentation.
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate closing keywords below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them.
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.

## Testing

- [x] My submission includes Test coverage as described in the Contribution Guide and the tests pass.

Ran the full `signalr` acceptance suite (excluding `_list`, see note) against an Azure subscription. All 7 `WebPubsubNetworkACL` tests pass, including the new `ip_rule` coverage:

```
--- PASS: TestAccWebPubsubNetworkACL_basic (201.45s)
--- PASS: TestAccWebPubsubNetworkACL_complete (292.39s)
--- PASS: TestAccWebPubsubNetworkACL_complete_withoutPrivateEndpoint (202.57s)
--- PASS: TestAccWebPubsubNetworkACL_update (371.70s)
--- PASS: TestAccWebPubsubNetworkACL_updateMultiplePrivateEndpoints (403.98s)
--- PASS: TestAccWebPubsubNetworkACL_requiresImport (176.45s)
--- PASS: TestAccWebPubsubNetworkACL_ipRules (261.26s)
```

Note: `TestAccSignalRService_list_basic` (the Terraform 1.14 query/List Resource feature) hangs indefinitely in my environment and is unrelated to this change, so the `_list` tests were excluded. The remaining failures in the full run were environmental (subscription quota for WebPubSub units / VMs, and missing DNS test infrastructure for the custom-domain tests), not related to this change.

## Change Log

* `azurerm_web_pubsub_network_acl` - support for the `ip_rule` block [GH-00000]

This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change

## Related Issue(s)

Fixes #30811

## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

Code generation assistance, sanity-checking approaches, and troubleshooting the test environment.

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

This PR adds the ability to restrict network access to a Web PubSub service by IP address, CIDR range, or service tag via `ip_rule` blocks. This is an additive network access-control feature; it does not change any existing security defaults.
