### PR TITLE
test: `databricks`, `datashare`, `dataprotection`, `devtestlabs`, `digitaltwins`, `dns`, `dynatrace` - 5.0 testing fixes

### DIFF
--- a/internal/services/databricks/databricks_workspace_resource_test.go
+++ b/internal/services/databricks/databricks_workspace_resource_test.go
@@ -2198,7 +2198,7 @@ resource "azurerm_lb_outbound_rule" "test" {
   name                     = "OutboundRule-%[1]d"
   loadbalancer_id          = azurerm_lb.test.id
   protocol                 = "All"
-  enable_tcp_reset         = true
+  tcp_reset_enabled        = true
   allocated_outbound_ports = 1024
   idle_timeout_in_minutes  = 4
 

--- a/internal/services/databricks/databricks_workspace_resource_test.go
+++ b/internal/services/databricks/databricks_workspace_resource_test.go
@@ -1790,11 +1790,12 @@ resource "azurerm_storage_account" "test" {
   resource_group_name      = azurerm_resource_group.test.name
   account_tier             = "Standard"
   account_replication_type = "LRS"
+}
 
-  static_website {
-    error_404_document = "error.html"
-    index_document     = "index.html"
-  }
+resource "azurerm_storage_account_static_website" "test" {
+  storage_account_id = azurerm_storage_account.test.id
+  error_404_document = "error.html"
+  index_document     = "index.html"
 }
 
 resource "azurerm_machine_learning_workspace" "test" {

--- a/internal/services/dataprotection/data_protection_backup_instance_kubernetes_cluster_resource_test.go
+++ b/internal/services/dataprotection/data_protection_backup_instance_kubernetes_cluster_resource_test.go
@@ -124,6 +124,11 @@ resource "azurerm_kubernetes_cluster" "test" {
     }
   }
 
+  node_provisioning_profile {
+    mode               = "Manual"
+    default_node_pools = "Auto"
+  }
+
   identity {
     type = "SystemAssigned"
   }
@@ -293,6 +298,11 @@ resource "azurerm_kubernetes_cluster" "test" {
     upgrade_settings {
       max_surge = "10%%"
     }
+  }
+
+  node_provisioning_profile {
+    mode               = "Manual"
+    default_node_pools = "Auto"
   }
 
   identity {

--- a/internal/services/datashare/data_share_dataset_blob_storage_resource_test.go
+++ b/internal/services/datashare/data_share_dataset_blob_storage_resource_test.go
@@ -148,7 +148,7 @@ resource "azurerm_storage_account" "test" {
 
 resource "azurerm_storage_container" "test" {
   name                  = "acctest-sc-%[1]d"
-  storage_account_name  = azurerm_storage_account.test.name
+  storage_account_id    = azurerm_storage_account.test.id
   container_access_type = "container"
 }
 

--- a/internal/services/devtestlabs/dev_test_windows_virtual_machine_resource_test.go
+++ b/internal/services/devtestlabs/dev_test_windows_virtual_machine_resource_test.go
@@ -116,7 +116,7 @@ resource "azurerm_dev_test_windows_virtual_machine" "test" {
   gallery_image_reference {
     offer     = "WindowsServer"
     publisher = "MicrosoftWindowsServer"
-    sku       = "2012-Datacenter"
+    sku       = "2022-datacenter"
     version   = "latest"
   }
 }
@@ -142,7 +142,7 @@ resource "azurerm_dev_test_windows_virtual_machine" "import" {
   gallery_image_reference {
     offer     = "WindowsServer"
     publisher = "MicrosoftWindowsServer"
-    sku       = "2012-Datacenter"
+    sku       = "2022-datacenter"
     version   = "latest"
   }
 }
@@ -169,7 +169,7 @@ resource "azurerm_dev_test_windows_virtual_machine" "test" {
   gallery_image_reference {
     offer     = "WindowsServer"
     publisher = "MicrosoftWindowsServer"
-    sku       = "2012-Datacenter"
+    sku       = "2022-datacenter"
     version   = "latest"
   }
 

--- a/internal/services/digitaltwins/digital_twins_endpoint_eventgrid_resource_test.go
+++ b/internal/services/digitaltwins/digital_twins_endpoint_eventgrid_resource_test.go
@@ -219,7 +219,7 @@ resource "azurerm_storage_account" "test" {
 
 resource "azurerm_storage_container" "test" {
   name                  = "vhds"
-  storage_account_name  = azurerm_storage_account.test.name
+  storage_account_id    = azurerm_storage_account.test.id
   container_access_type = "private"
 }
 
@@ -249,7 +249,7 @@ resource "azurerm_storage_account" "test" {
 
 resource "azurerm_storage_container" "test" {
   name                  = "vhds"
-  storage_account_name  = azurerm_storage_account.test.name
+  storage_account_id    = azurerm_storage_account.test.id
   container_access_type = "private"
 }
 

--- a/internal/services/digitaltwins/digital_twins_endpoint_eventhub_resource_test.go
+++ b/internal/services/digitaltwins/digital_twins_endpoint_eventhub_resource_test.go
@@ -138,9 +138,8 @@ resource "azurerm_eventhub_namespace" "test" {
 }
 
 resource "azurerm_eventhub" "test" {
-  name                = "acctesteventhub-%[2]d"
-  namespace_name      = azurerm_eventhub_namespace.test.name
-  resource_group_name = azurerm_resource_group.test.name
+  name         = "acctesteventhub-%[2]d"
+  namespace_id = azurerm_eventhub_namespace.test.id
 
   partition_count   = 2
   message_retention = 1
@@ -190,9 +189,8 @@ func (r DigitalTwinsEndpointEventHubResource) updateEventHub(data acceptance.Tes
 %s
 
 resource "azurerm_eventhub" "test_alt" {
-  name                = "acctesteventhub-alt-%[2]d"
-  namespace_name      = azurerm_eventhub_namespace.test.name
-  resource_group_name = azurerm_resource_group.test.name
+  name         = "acctesteventhub-alt-%[2]d"
+  namespace_id = azurerm_eventhub_namespace.test.id
 
   partition_count   = 2
   message_retention = 1
@@ -223,9 +221,8 @@ func (r DigitalTwinsEndpointEventHubResource) updateEventHubRestore(data accepta
 %s
 
 resource "azurerm_eventhub" "test_alt" {
-  name                = "acctesteventhub-alt-%[2]d"
-  namespace_name      = azurerm_eventhub_namespace.test.name
-  resource_group_name = azurerm_resource_group.test.name
+  name         = "acctesteventhub-alt-%[2]d"
+  namespace_id = azurerm_eventhub_namespace.test.id
 
   partition_count   = 2
   message_retention = 1

--- a/internal/services/digitaltwins/digital_twins_endpoint_eventhub_resource_test.go
+++ b/internal/services/digitaltwins/digital_twins_endpoint_eventhub_resource_test.go
@@ -262,7 +262,7 @@ resource "azurerm_storage_account" "test" {
 
 resource "azurerm_storage_container" "test" {
   name                  = "vhds"
-  storage_account_name  = azurerm_storage_account.test.name
+  storage_account_id    = azurerm_storage_account.test.id
   container_access_type = "private"
 }
 
@@ -290,7 +290,7 @@ resource "azurerm_storage_account" "test" {
 
 resource "azurerm_storage_container" "test" {
   name                  = "vhds"
-  storage_account_name  = azurerm_storage_account.test.name
+  storage_account_id    = azurerm_storage_account.test.id
   container_access_type = "private"
 }
 

--- a/internal/services/digitaltwins/digital_twins_endpoint_servicebus_resource_test.go
+++ b/internal/services/digitaltwins/digital_twins_endpoint_servicebus_resource_test.go
@@ -260,7 +260,7 @@ resource "azurerm_storage_account" "test" {
 
 resource "azurerm_storage_container" "test" {
   name                  = "vhds"
-  storage_account_name  = azurerm_storage_account.test.name
+  storage_account_id    = azurerm_storage_account.test.id
   container_access_type = "private"
 }
 
@@ -288,7 +288,7 @@ resource "azurerm_storage_account" "test" {
 
 resource "azurerm_storage_container" "test" {
   name                  = "vhds"
-  storage_account_name  = azurerm_storage_account.test.name
+  storage_account_id    = azurerm_storage_account.test.id
   container_access_type = "private"
 }
 

--- a/internal/services/digitaltwins/digital_twins_time_series_database_connection_resource_test.go
+++ b/internal/services/digitaltwins/digital_twins_time_series_database_connection_resource_test.go
@@ -145,11 +145,10 @@ resource "azurerm_eventhub_namespace" "test" {
 }
 
 resource "azurerm_eventhub" "test" {
-  name                = "acctesteventhub-%[2]d"
-  namespace_name      = azurerm_eventhub_namespace.test.name
-  resource_group_name = azurerm_resource_group.test.name
-  partition_count     = 2
-  message_retention   = 7
+  name              = "acctesteventhub-%[2]d"
+  namespace_id      = azurerm_eventhub_namespace.test.id
+  partition_count   = 2
+  message_retention = 7
 }
 
 resource "azurerm_kusto_cluster" "test" {
@@ -193,6 +192,7 @@ resource "azurerm_kusto_database_principal_assignment" "test" {
   principal_type = "App"
   role           = "Admin"
 }
+
 
 `, data.Locations.Primary, data.RandomInteger, data.RandomString)
 }

--- a/internal/services/dns/dns_a_record_resource_test.go
+++ b/internal/services/dns/dns_a_record_resource_test.go
@@ -333,7 +333,7 @@ resource "azurerm_public_ip" "test" {
   name                = "mypublicip%d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  allocation_method   = "Dynamic"
+  allocation_method   = "Static"
   ip_version          = "IPv4"
 }
 
@@ -367,7 +367,7 @@ resource "azurerm_public_ip" "test2" {
   name                = "mypublicip%d2"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  allocation_method   = "Dynamic"
+  allocation_method   = "Static"
   ip_version          = "IPv4"
 }
 
@@ -401,7 +401,7 @@ resource "azurerm_public_ip" "test" {
   name                = "mypublicip%d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  allocation_method   = "Dynamic"
+  allocation_method   = "Static"
   ip_version          = "IPv4"
 }
 

--- a/internal/services/dns/dns_aaaa_record_resource_test.go
+++ b/internal/services/dns/dns_aaaa_record_resource_test.go
@@ -359,7 +359,7 @@ resource "azurerm_public_ip" "test" {
   name                = "mypublicip%d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  allocation_method   = "Dynamic"
+  allocation_method   = "Static"
   ip_version          = "IPv6"
 }
 
@@ -393,7 +393,7 @@ resource "azurerm_public_ip" "test2" {
   name                = "mypublicip%d2"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  allocation_method   = "Dynamic"
+  allocation_method   = "Static"
   ip_version          = "IPv6"
 }
 
@@ -427,7 +427,7 @@ resource "azurerm_public_ip" "test" {
   name                = "mypublicip%d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  allocation_method   = "Dynamic"
+  allocation_method   = "Static"
   ip_version          = "IPv6"
 }
 

--- a/internal/services/dynatrace/dynatrace_monitor_data_source_test.go
+++ b/internal/services/dynatrace/dynatrace_monitor_data_source_test.go
@@ -14,17 +14,19 @@ type MonitorsDataSource struct{}
 
 func TestAccDynatraceMonitorsDataSource_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_dynatrace_monitor", "test")
-	r := MonitorsDataSource{}
+	d := MonitorsDataSource{}
+	r := NewDynatraceMonitorResource()
+	r.preCheck(t)
 
 	data.DataSourceTest(t, []acceptance.TestStep{
 		{
-			Config: r.basic(data),
+			Config: d.basic(data, r),
 			Check:  acceptance.ComposeTestCheckFunc(),
 		},
 	})
 }
 
-func (d MonitorsDataSource) basic(data acceptance.TestData) string {
+func (d MonitorsDataSource) basic(data acceptance.TestData, resource MonitorsResource) string {
 	return fmt.Sprintf(`
 %s
 
@@ -32,5 +34,5 @@ data "azurerm_dynatrace_monitor" "test" {
   name                = azurerm_dynatrace_monitor.test.name
   resource_group_name = azurerm_resource_group.test.name
 }
-`, MonitorsResource{}.basic(data))
+`, resource.basic(data))
 }

--- a/internal/services/dynatrace/dynatrace_monitor_resource_test.go
+++ b/internal/services/dynatrace/dynatrace_monitor_resource_test.go
@@ -44,7 +44,7 @@ func NewDynatraceMonitorResource() MonitorsResource {
 
 func TestAccDynatraceMonitor_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_dynatrace_monitor", "test")
-	r := MonitorsResource{}
+	r := NewDynatraceMonitorResource()
 	r.preCheck(t)
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -61,7 +61,7 @@ func TestAccDynatraceMonitor_basic(t *testing.T) {
 
 func TestAccDynatraceMonitor_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_dynatrace_monitor", "test")
-	r := MonitorsResource{}
+	r := NewDynatraceMonitorResource()
 	r.preCheck(t)
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -91,7 +91,7 @@ func TestAccDynatraceMonitor_update(t *testing.T) {
 
 func TestAccDynatraceMonitor_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_dynatrace_monitor", "test")
-	r := MonitorsResource{}
+	r := NewDynatraceMonitorResource()
 	r.preCheck(t)
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -107,7 +107,7 @@ func TestAccDynatraceMonitor_complete(t *testing.T) {
 
 func TestAccDynatraceMonitor_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_dynatrace_monitor", "test")
-	r := MonitorsResource{}
+	r := NewDynatraceMonitorResource()
 	r.preCheck(t)
 
 	data.ResourceTest(t, r, []acceptance.TestStep{


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Test fixes for several packages addressing changes in both provider v5.0 and Azure.

Packages included:

- databricks
- datashare
- dataprotection
- devtestlabs
- digitaltwins
- dns
- dynatrace


## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
