### PR TITLE
`azurerm_kubernetes_cluster_node_pool` - lock the virtual network during node pool creation to fix vnet ownership race

### DIFF
--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -676,14 +676,20 @@ func resourceKubernetesClusterNodePoolCreate(d *pluginsdk.ResourceData, meta int
 
 	subnetIDsToLock := make([]string, 0)
 	if podSubnetID != nil {
-		// Lock pod subnet to avoid race condition with AKS
+		// Lock the pod subnet and its vnet to avoid a race condition with AKS setting
+		// vnet ownership across node pools that share the same virtual network.
 		profile.PodSubnetID = pointer.To(podSubnetID.ID())
+		podVnetID := commonids.NewVirtualNetworkID(podSubnetID.SubscriptionId, podSubnetID.ResourceGroupName, podSubnetID.VirtualNetworkName)
+		subnetIDsToLock = append(subnetIDsToLock, podVnetID.ID())
 		subnetIDsToLock = append(subnetIDsToLock, podSubnetID.ID())
 	}
 
 	if nodeSubnetID != nil {
-		// Lock node subnet to avoid race condition with AKS
+		// Lock the node subnet and its vnet to avoid a race condition with AKS setting
+		// vnet ownership across node pools that share the same virtual network.
 		profile.VnetSubnetID = pointer.To(nodeSubnetID.ID())
+		nodeVnetID := commonids.NewVirtualNetworkID(nodeSubnetID.SubscriptionId, nodeSubnetID.ResourceGroupName, nodeSubnetID.VirtualNetworkName)
+		subnetIDsToLock = append(subnetIDsToLock, nodeVnetID.ID())
 		subnetIDsToLock = append(subnetIDsToLock, nodeSubnetID.ID())
 	}
 	locks.MultipleByID(&subnetIDsToLock)


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->
regression of the fix from #25888, node pools that share a virtual network but use different subnets are no longer serialized on the vnet, so AKS races to set vnet ownership during concurrent creation and results with _VirtualNetworkNotInSucceededState_.

the vnet-level lock added in #25888 was lost (subnet-only locks in #29537, then name->ID in #32001). This restores it by also locking the parent virtual network ID during node pool creation. Locking by full vnet ID preserves the
cross-vnet parallelism introduced in #32001. only pools sharing the same vnet serialize.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_kubernetes_cluster_node_pool` - fix a regression causing `VirtualNetworkNotInSucceededState` errors when creating multiple node pools that share a virtual network


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #30769 


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
