### PR TITLE
billing: add azurerm_billing_ptu_reservation_order resource

### DIFF
--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -39,6 +39,7 @@ import (
 	automation "github.com/hashicorp/terraform-provider-azurerm/internal/services/automation/client"
 	azureStackHCI "github.com/hashicorp/terraform-provider-azurerm/internal/services/azurestackhci/client"
 	batch "github.com/hashicorp/terraform-provider-azurerm/internal/services/batch/client"
+	billing "github.com/hashicorp/terraform-provider-azurerm/internal/services/billing/client"
 	blueprints "github.com/hashicorp/terraform-provider-azurerm/internal/services/blueprints/client"
 	bot "github.com/hashicorp/terraform-provider-azurerm/internal/services/bot/client"
 	cdn "github.com/hashicorp/terraform-provider-azurerm/internal/services/cdn/client"
@@ -176,6 +177,7 @@ type Client struct {
 	Automation                        *automation.Client
 	AzureStackHCI                     *azurestackhci_v2024_01_01.Client
 	Batch                             *batch.Client
+	Billing                           *billing.Client
 	Blueprints                        *blueprints.Client
 	Bot                               *bot.Client
 	Cdn                               *cdn.Client
@@ -351,6 +353,9 @@ func (client *Client) Build(ctx context.Context, o *common.ClientOptions) error 
 	}
 	if client.Batch, err = batch.NewClient(o); err != nil {
 		return fmt.Errorf("building clients for Batch: %+v", err)
+	}
+	if client.Billing, err = billing.NewClient(o); err != nil {
+		return fmt.Errorf("building clients for Billing: %+v", err)
 	}
 	if client.Blueprints, err = blueprints.NewClient(o); err != nil {
 		return fmt.Errorf("building clients for BluePrints: %+v", err)

--- a/internal/provider/services.go
+++ b/internal/provider/services.go
@@ -154,6 +154,7 @@ func SupportedTypedServices() []sdk.TypedServiceRegistration {
 		advisor.Registration{},
 		azurestackhci.Registration{},
 		batch.Registration{},
+		billing.Registration{},
 		bot.Registration{},
 		cdn.Registration{},
 		codesigning.Registration{},

--- a/internal/services/billing/billing_ptu_reservation_order_resource.go
+++ b/internal/services/billing/billing_ptu_reservation_order_resource.go
@@ -1,0 +1,313 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package billing
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	billingClient "github.com/hashicorp/terraform-provider-azurerm/internal/services/billing/client"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/billing/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type BillingPtuReservationOrderResource struct{}
+
+var _ sdk.Resource = BillingPtuReservationOrderResource{}
+
+type BillingPtuReservationOrderResourceModel struct {
+	Name             string `tfschema:"name"`
+	Location         string `tfschema:"location"`
+	Capacity         int64  `tfschema:"capacity"`
+	BillingScopeId   string `tfschema:"billing_scope_id"`
+	SkuName          string `tfschema:"sku_name"`
+	Term             string `tfschema:"term"`
+	BillingPlan      string `tfschema:"billing_plan"`
+	AppliedScopeType string `tfschema:"applied_scope_type"`
+	Renew            bool   `tfschema:"renew"`
+	OrderId          string `tfschema:"order_id"`
+}
+
+func (r BillingPtuReservationOrderResource) ResourceType() string {
+	return "azurerm_billing_ptu_reservation_order"
+}
+
+func (r BillingPtuReservationOrderResource) ModelObject() interface{} {
+	return &BillingPtuReservationOrderResourceModel{}
+}
+
+func (r BillingPtuReservationOrderResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return parse.ValidatePtuReservationOrderID
+}
+
+func (r BillingPtuReservationOrderResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+			Description:  "Display name for the PTU reservation order.",
+		},
+
+		"location": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+			Description:  "Azure region where the PTU capacity is reserved (e.g. 'eastus').",
+		},
+
+		"capacity": {
+			Type:         pluginsdk.TypeInt,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.IntAtLeast(1),
+			Description:  "Number of PTUs (Provisioned Throughput Units) to reserve.",
+		},
+
+		"billing_scope_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+			Description:  "Billing scope for the reservation (e.g. '/subscriptions/{subscriptionId}').",
+		},
+
+		"sku_name": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			Default:      "DataZoneProvisionedManaged",
+			ValidateFunc: validation.StringIsNotEmpty,
+			Description:  "SKU name for the PTU reservation (e.g. 'DataZoneProvisionedManaged', 'openai_provisioned_managed_datazone').",
+		},
+
+		"term": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			Default:      "P1Y",
+			ValidateFunc: validation.StringIsNotEmpty,
+			Description:  "Reservation term in ISO 8601 duration format (e.g. 'P1M', 'P1Y', 'P3Y').",
+		},
+
+		"billing_plan": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ForceNew: true,
+			Default:  "Upfront",
+			ValidateFunc: validation.StringInSlice([]string{
+				"Upfront",
+				"Monthly",
+			}, false),
+			Description: "Billing plan for the reservation.",
+		},
+
+		"applied_scope_type": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ForceNew: true,
+			Default:  "Shared",
+			ValidateFunc: validation.StringInSlice([]string{
+				"Shared",
+				"Single",
+				"ManagementGroup",
+			}, false),
+			Description: "Scope type to which the reservation benefit is applied.",
+		},
+
+		"renew": {
+			Type:        pluginsdk.TypeBool,
+			Optional:    true,
+			ForceNew:    true,
+			Default:     true,
+			Description: "Whether the reservation auto-renews at the end of the term. Changing this forces a new resource to be created.",
+		},
+	}
+}
+
+func (r BillingPtuReservationOrderResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"order_id": {
+			Type:        pluginsdk.TypeString,
+			Computed:    true,
+			Description: "UUID of the reservation order in Azure.",
+		},
+	}
+}
+
+func (r BillingPtuReservationOrderResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Billing
+
+			var model BillingPtuReservationOrderResourceModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			// Build the payload without a reservation order ID first — CalculatePrice
+			// will open a purchase session and return the order ID we must use.
+			payload := billingClient.ReservationOrderPurchaseRequest{
+				Sku:      &billingClient.ReservationOrderSku{Name: model.SkuName},
+				Location: model.Location,
+				Properties: &billingClient.ReservationOrderPurchaseProperties{
+					DisplayName:          model.Name,
+					ReservedResourceType: "OpenAIPTU",
+					ReservedResourceProperties: &billingClient.ReservedResourceProperties{
+						InstanceFlexibility: "On",
+					},
+					Term:             model.Term,
+					BillingPlan:      model.BillingPlan,
+					BillingScopeId:   model.BillingScopeId,
+					AppliedScopeType: model.AppliedScopeType,
+					Quantity:         model.Capacity,
+					Renew:            model.Renew,
+				},
+			}
+
+			// Step 1: CalculatePrice opens the purchase session and returns the
+			// reservation order ID. This ID must be used in the subsequent PUT and
+			// both calls must happen within the session window (a few minutes).
+			orderID, err := client.CalculatePrice(ctx, payload)
+			if err != nil {
+				return fmt.Errorf("calculating price for PTU reservation %q: %+v", model.Name, err)
+			}
+
+			id := parse.NewPtuReservationOrderId(orderID)
+
+			// Step 2: Purchase — use the session-approved order ID immediately.
+			payload.Properties.ReservationOrderId = orderID
+			if _, err = client.CreateOrUpdate(ctx, id.ID(), payload); err != nil {
+				return fmt.Errorf("purchasing %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+	}
+}
+
+func (r BillingPtuReservationOrderResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Billing
+
+			id, err := parse.PtuReservationOrderID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			existing, err := client.Get(ctx, id.ID())
+			if err != nil {
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+			if existing == nil {
+				return metadata.MarkAsGone(id)
+			}
+
+			var state BillingPtuReservationOrderResourceModel
+			if err = metadata.Decode(&state); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			state.OrderId = id.OrderId
+			if existing.Properties != nil {
+				state.Name = existing.Properties.DisplayName
+				state.Capacity = existing.Properties.OriginalQuantity
+				state.Renew = existing.Properties.Renew
+				// Azure omits certain fields (e.g. appliedScopeType, term, billingPlan,
+				// billingScopeId) when they are at their default / "Shared" values. Only
+				// overwrite state when the API actually returns a non-empty value so we
+				// don't create a phantom diff against the config.
+				if existing.Properties.Term != "" {
+					state.Term = existing.Properties.Term
+				}
+				if existing.Properties.BillingPlan != "" {
+					state.BillingPlan = existing.Properties.BillingPlan
+				}
+				if existing.Properties.AppliedScopeType != "" {
+					state.AppliedScopeType = existing.Properties.AppliedScopeType
+				}
+				if existing.Properties.BillingScopeId != "" {
+					state.BillingScopeId = existing.Properties.BillingScopeId
+				}
+			}
+			if existing.Sku != nil {
+				state.SkuName = existing.Sku.Name
+			}
+			if existing.Location != "" {
+				state.Location = existing.Location
+			}
+
+			return metadata.Encode(&state)
+		},
+	}
+}
+
+func (r BillingPtuReservationOrderResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			return nil
+		},
+	}
+}
+
+func (r BillingPtuReservationOrderResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Billing
+
+			id, err := parse.PtuReservationOrderID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			// Azure only allows reservation returns within 30 days of purchase.
+			// If the return window has passed the API returns an error. We treat
+			// this as a warning rather than a hard failure so the resource can be
+			// removed from state when it can no longer be returned — operators
+			// should rely on `lifecycle { prevent_destroy = true }` to guard
+			// against accidental deletions during the active reservation term.
+			if returnErr := client.Return(ctx, id.ID()); returnErr != nil {
+				if IsReturnNotAllowed(returnErr) {
+					log.Printf("[WARN] azurerm_billing_ptu_reservation_order: cannot return %s (return window may have passed or reservation type does not support returns): %+v", id, returnErr)
+					log.Printf("[WARN] The reservation remains active in Azure until it expires. Only the Terraform state entry is being removed.")
+					return nil
+				}
+				return fmt.Errorf("returning %s: %+v", id, returnErr)
+			}
+
+			return nil
+		},
+	}
+}
+
+// IsReturnNotAllowed returns true for error messages that indicate a reservation
+// cannot be returned (expired window, unsupported type, etc.).
+func IsReturnNotAllowed(err error) bool {
+	msg := strings.ToLower(err.Error())
+	for _, kw := range []string{
+		"returnfailed",
+		"returnnotallowed",
+		"cannot be returned",
+		"refund period",
+		"is not eligible",
+	} {
+		if strings.Contains(msg, kw) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/services/billing/billing_ptu_reservation_order_resource_test.go
+++ b/internal/services/billing/billing_ptu_reservation_order_resource_test.go
@@ -1,0 +1,69 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package billing_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/billing"
+)
+
+func TestIsReturnNotAllowed(t *testing.T) {
+	testData := []struct {
+		Name     string
+		Err      error
+		Expected bool
+	}{
+		{
+			Name:     "ReturnFailed code",
+			Err:      fmt.Errorf("ReturnFailed: the reservation could not be returned"),
+			Expected: true,
+		},
+		{
+			Name:     "ReturnNotAllowed code",
+			Err:      fmt.Errorf("ReturnNotAllowed: this reservation type cannot be returned"),
+			Expected: true,
+		},
+		{
+			Name:     "cannot be returned phrase",
+			Err:      fmt.Errorf("the reservation cannot be returned after the refund window"),
+			Expected: true,
+		},
+		{
+			Name:     "refund period phrase",
+			Err:      fmt.Errorf("the refund period for this reservation has expired"),
+			Expected: true,
+		},
+		{
+			Name:     "is not eligible phrase",
+			Err:      fmt.Errorf("the reservation is not eligible for return"),
+			Expected: true,
+		},
+		{
+			Name:     "keywords are matched case-insensitively",
+			Err:      fmt.Errorf("RETURNFAILED due to policy"),
+			Expected: true,
+		},
+		{
+			Name:     "unrelated error returns false",
+			Err:      fmt.Errorf("internal server error"),
+			Expected: false,
+		},
+		{
+			Name:     "empty error message returns false",
+			Err:      fmt.Errorf(""),
+			Expected: false,
+		},
+	}
+
+	for _, v := range testData {
+		t.Run(v.Name, func(t *testing.T) {
+			actual := billing.IsReturnNotAllowed(v.Err)
+			if actual != v.Expected {
+				t.Fatalf("IsReturnNotAllowed(%q): expected %v but got %v", v.Err.Error(), v.Expected, actual)
+			}
+		})
+	}
+}

--- a/internal/services/billing/client/client.go
+++ b/internal/services/billing/client/client.go
@@ -1,0 +1,252 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	sdkclient "github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
+)
+
+const ptuReservationAPIVersion = "2022-11-01"
+
+// Client holds the HTTP client for the Microsoft.Capacity/reservationOrders API.
+// This API is not yet in go-azure-sdk so we use the base resourcemanager client directly.
+type Client struct {
+	ReservationOrdersClient *resourcemanager.Client
+}
+
+func NewClient(o *common.ClientOptions) (*Client, error) {
+	reservationOrdersClient, err := resourcemanager.NewClient(o.Environment.ResourceManager, "reservationOrders", ptuReservationAPIVersion)
+	if err != nil {
+		return nil, fmt.Errorf("building PTU Reservation Orders client: %+v", err)
+	}
+	o.Configure(reservationOrdersClient, o.Authorizers.ResourceManager)
+
+	return &Client{
+		ReservationOrdersClient: reservationOrdersClient,
+	}, nil
+}
+
+// -------------------------------------------------------------------
+// Request / Response types for Microsoft.Capacity/reservationOrders
+// -------------------------------------------------------------------
+
+type ReservationOrderSku struct {
+	Name string `json:"name"`
+}
+
+type ReservedResourceProperties struct {
+	InstanceFlexibility string `json:"instanceFlexibility"`
+}
+
+type ReservationOrderPurchaseProperties struct {
+	DisplayName                string                      `json:"displayName"`
+	ReservedResourceType       string                      `json:"reservedResourceType"`
+	ReservedResourceProperties *ReservedResourceProperties `json:"reservedResourceProperties,omitempty"`
+	Term                       string                      `json:"term"`
+	BillingPlan                string                      `json:"billingPlan"`
+	BillingScopeId             string                      `json:"billingScopeId"`
+	AppliedScopeType           string                      `json:"appliedScopeType"`
+	Quantity                   int64                       `json:"quantity"`
+	Renew                      bool                        `json:"renew"`
+	ReservationOrderId         string                      `json:"reservationOrderId,omitempty"`
+}
+
+type ReservationOrderPurchaseRequest struct {
+	Sku        *ReservationOrderSku                `json:"sku,omitempty"`
+	Location   string                              `json:"location"`
+	Properties *ReservationOrderPurchaseProperties `json:"properties,omitempty"`
+}
+
+type ReservationOrderResponseProperties struct {
+	DisplayName       string `json:"displayName"`
+	ProvisioningState string `json:"provisioningState"`
+	// Azure returns originalQuantity (not quantity) on the reservationOrder GET response.
+	OriginalQuantity int64  `json:"originalQuantity"`
+	Term             string `json:"term"`
+	BillingPlan      string `json:"billingPlan"`
+	BillingScopeId   string `json:"billingScopeId"`
+	AppliedScopeType string `json:"appliedScopeType"`
+	Renew            bool   `json:"renew"`
+}
+
+type ReservationOrderResponse struct {
+	Id         string                              `json:"id"`
+	Name       string                              `json:"name"`
+	Location   string                              `json:"location,omitempty"`
+	Sku        *ReservationOrderSku                `json:"sku,omitempty"`
+	Properties *ReservationOrderResponseProperties `json:"properties,omitempty"`
+}
+
+type ReservationReturnProperties struct {
+	ReturnReason string `json:"returnReason,omitempty"`
+	Message      string `json:"message,omitempty"`
+}
+
+type ReservationReturnRequest struct {
+	Properties *ReservationReturnProperties `json:"properties,omitempty"`
+}
+
+// CalculatePriceResponseProperties is the subset of the calculatePrice response we need.
+type CalculatePriceResponseProperties struct {
+	ReservationOrderId string `json:"reservationOrderId"`
+}
+
+type CalculatePriceResponse struct {
+	Properties *CalculatePriceResponseProperties `json:"properties,omitempty"`
+}
+
+// -------------------------------------------------------------------
+// Client methods
+// -------------------------------------------------------------------
+
+// CalculatePrice calls POST /providers/Microsoft.Capacity/calculatePrice to open
+// a purchase session and obtain the reservation order ID that must be used in the
+// subsequent CreateOrUpdate call. Both calls must use the same order ID and be
+// issued in quick succession (Azure expires the session after a few minutes).
+func (c *Client) CalculatePrice(ctx context.Context, input ReservationOrderPurchaseRequest) (string, error) {
+	opts := sdkclient.RequestOptions{
+		ContentType:         "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{http.StatusOK},
+		HttpMethod:          http.MethodPost,
+		Path:                "/providers/Microsoft.Capacity/calculatePrice",
+	}
+
+	req, err := c.ReservationOrdersClient.NewRequest(ctx, opts)
+	if err != nil {
+		return "", fmt.Errorf("building calculatePrice request: %+v", err)
+	}
+	if err = req.Marshal(input); err != nil {
+		return "", fmt.Errorf("marshaling calculatePrice request body: %+v", err)
+	}
+
+	resp, execErr := req.Execute(ctx)
+	if execErr != nil {
+		return "", fmt.Errorf("executing calculatePrice request: %+v", execErr)
+	}
+
+	var result CalculatePriceResponse
+	if err = resp.Unmarshal(&result); err != nil {
+		return "", fmt.Errorf("unmarshaling calculatePrice response: %+v", err)
+	}
+
+	if result.Properties == nil || result.Properties.ReservationOrderId == "" {
+		return "", fmt.Errorf("calculatePrice response did not include a reservationOrderId")
+	}
+
+	return result.Properties.ReservationOrderId, nil
+}
+
+// CreateOrUpdate purchases (PUT) a new PTU reservation order.
+// Returns the final state after creation completes.
+func (c *Client) CreateOrUpdate(ctx context.Context, path string, input ReservationOrderPurchaseRequest) (*ReservationOrderResponse, error) {
+	opts := sdkclient.RequestOptions{
+		ContentType:         "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{http.StatusOK, http.StatusCreated, http.StatusAccepted},
+		HttpMethod:          http.MethodPut,
+		Path:                path,
+	}
+
+	req, err := c.ReservationOrdersClient.NewRequest(ctx, opts)
+	if err != nil {
+		return nil, fmt.Errorf("building create request: %+v", err)
+	}
+	if err = req.Marshal(input); err != nil {
+		return nil, fmt.Errorf("marshaling create request body: %+v", err)
+	}
+
+	resp, execErr := req.Execute(ctx)
+	if execErr != nil {
+		return nil, fmt.Errorf("executing create request: %+v", execErr)
+	}
+
+	if resp.Response != nil && resp.Response.StatusCode == http.StatusAccepted {
+		poller, pollerErr := resourcemanager.PollerFromResponse(resp, c.ReservationOrdersClient)
+		if pollerErr != nil {
+			return nil, fmt.Errorf("building create poller: %+v", pollerErr)
+		}
+		if pollerErr = poller.PollUntilDone(ctx); pollerErr != nil {
+			return nil, fmt.Errorf("polling after create: %+v", pollerErr)
+		}
+	}
+
+	return c.Get(ctx, path)
+}
+
+// Get retrieves a PTU reservation order by its ARM path.
+// Returns (nil, nil) when the reservation order is not found (404).
+func (c *Client) Get(ctx context.Context, path string) (*ReservationOrderResponse, error) {
+	opts := sdkclient.RequestOptions{
+		ContentType:         "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{http.StatusOK},
+		HttpMethod:          http.MethodGet,
+		Path:                path,
+	}
+
+	req, err := c.ReservationOrdersClient.NewRequest(ctx, opts)
+	if err != nil {
+		return nil, fmt.Errorf("building get request: %+v", err)
+	}
+
+	resp, execErr := req.Execute(ctx)
+	if resp != nil && resp.Response != nil && response.WasNotFound(resp.Response) {
+		return nil, nil
+	}
+	if execErr != nil {
+		return nil, fmt.Errorf("executing get request: %+v", execErr)
+	}
+
+	var result ReservationOrderResponse
+	if err = resp.Unmarshal(&result); err != nil {
+		return nil, fmt.Errorf("unmarshaling get response: %+v", err)
+	}
+	return &result, nil
+}
+
+// Return attempts to return (cancel/refund) a PTU reservation order.
+// Azure only allows returns within the first 30 days of purchase.
+func (c *Client) Return(ctx context.Context, path string) error {
+	opts := sdkclient.RequestOptions{
+		ContentType:         "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{http.StatusOK, http.StatusAccepted},
+		HttpMethod:          http.MethodPost,
+		Path:                path + "/return",
+	}
+
+	req, err := c.ReservationOrdersClient.NewRequest(ctx, opts)
+	if err != nil {
+		return fmt.Errorf("building return request: %+v", err)
+	}
+	if err = req.Marshal(ReservationReturnRequest{
+		Properties: &ReservationReturnProperties{
+			ReturnReason: "Other",
+			Message:      "Destroyed by Terraform",
+		},
+	}); err != nil {
+		return fmt.Errorf("marshaling return request body: %+v", err)
+	}
+
+	resp, execErr := req.Execute(ctx)
+	if execErr != nil {
+		return fmt.Errorf("executing return request: %+v", execErr)
+	}
+
+	if resp.Response != nil && resp.Response.StatusCode == http.StatusAccepted {
+		poller, pollerErr := resourcemanager.PollerFromResponse(resp, c.ReservationOrdersClient)
+		if pollerErr != nil {
+			return fmt.Errorf("building return poller: %+v", pollerErr)
+		}
+		if pollerErr = poller.PollUntilDone(ctx); pollerErr != nil {
+			return fmt.Errorf("polling after return: %+v", pollerErr)
+		}
+	}
+
+	return nil
+}

--- a/internal/services/billing/parse/ptu_reservation_order_id.go
+++ b/internal/services/billing/parse/ptu_reservation_order_id.go
@@ -1,0 +1,67 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package parse
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+)
+
+type PtuReservationOrderId struct {
+	OrderId string
+}
+
+func NewPtuReservationOrderId(orderId string) PtuReservationOrderId {
+	return PtuReservationOrderId{OrderId: orderId}
+}
+
+func (id PtuReservationOrderId) ID() string {
+	return fmt.Sprintf("/providers/Microsoft.Capacity/reservationOrders/%s", id.OrderId)
+}
+
+func (id PtuReservationOrderId) String() string {
+	return fmt.Sprintf("PTU Reservation Order %q", id.OrderId)
+}
+
+func ValidatePtuReservationOrderID(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %q to be string", k))
+		return
+	}
+
+	if _, err := PtuReservationOrderID(v); err != nil {
+		errors = append(errors, fmt.Errorf("cannot parse %q as a PTU Reservation Order ID: %+v", k, err))
+	}
+
+	return
+}
+
+func PtuReservationOrderID(input string) (*PtuReservationOrderId, error) {
+	if input == "" {
+		return nil, fmt.Errorf("input was empty")
+	}
+
+	prefix := "/providers/Microsoft.Capacity/reservationOrders/"
+	if !strings.HasPrefix(strings.ToLower(input), strings.ToLower(prefix)) {
+		return nil, fmt.Errorf("expected ID to start with %q but got %q", prefix, input)
+	}
+
+	orderId := input[len(prefix):]
+	if orderId == "" {
+		return nil, fmt.Errorf("order ID segment was empty in %q", input)
+	}
+
+	if strings.Contains(orderId, "/") {
+		return nil, fmt.Errorf("expected order ID to be a single UUID segment but got %q in %q", orderId, input)
+	}
+
+	if _, err := uuid.ParseUUID(orderId); err != nil {
+		return nil, fmt.Errorf("expected order ID to be a valid UUID but got %q in %q", orderId, input)
+	}
+
+	return &PtuReservationOrderId{OrderId: orderId}, nil
+}

--- a/internal/services/billing/parse/ptu_reservation_order_id_test.go
+++ b/internal/services/billing/parse/ptu_reservation_order_id_test.go
@@ -1,0 +1,81 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package parse
+
+import "testing"
+
+func TestPtuReservationOrderIDFormatter(t *testing.T) {
+	actual := NewPtuReservationOrderId("10146e93-a8f3-458a-83ce-7e88f2300632").ID()
+	expected := "/providers/Microsoft.Capacity/reservationOrders/10146e93-a8f3-458a-83ce-7e88f2300632"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestPtuReservationOrderID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *PtuReservationOrderId
+	}{
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+		{
+			// wrong provider namespace
+			Input: "/providers/Microsoft.Billing/reservationOrders/10146e93-a8f3-458a-83ce-7e88f2300632",
+			Error: true,
+		},
+		{
+			// missing order ID value
+			Input: "/providers/Microsoft.Capacity/reservationOrders/",
+			Error: true,
+		},
+		{
+			// extra path segment after UUID
+			Input: "/providers/Microsoft.Capacity/reservationOrders/10146e93-a8f3-458a-83ce-7e88f2300632/reservations/abc",
+			Error: true,
+		},
+		{
+			// not a UUID
+			Input: "/providers/Microsoft.Capacity/reservationOrders/not-a-uuid",
+			Error: true,
+		},
+		{
+			// valid
+			Input: "/providers/Microsoft.Capacity/reservationOrders/10146e93-a8f3-458a-83ce-7e88f2300632",
+			Expected: &PtuReservationOrderId{
+				OrderId: "10146e93-a8f3-458a-83ce-7e88f2300632",
+			},
+		},
+		{
+			// valid — lowercase prefix (Azure API sometimes returns lowercase IDs)
+			Input: "/providers/microsoft.capacity/reservationorders/10146e93-a8f3-458a-83ce-7e88f2300632",
+			Expected: &PtuReservationOrderId{
+				OrderId: "10146e93-a8f3-458a-83ce-7e88f2300632",
+			},
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := PtuReservationOrderID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.OrderId != v.Expected.OrderId {
+			t.Fatalf("Expected OrderId %q but got %q", v.Expected.OrderId, actual.OrderId)
+		}
+	}
+}

--- a/internal/services/billing/registration.go
+++ b/internal/services/billing/registration.go
@@ -14,6 +14,7 @@ type Registration struct{}
 
 var (
 	_ sdk.FrameworkServiceRegistration               = Registration{}
+	_ sdk.TypedServiceRegistration                   = Registration{}
 	_ sdk.UntypedServiceRegistrationWithAGitHubLabel = Registration{}
 )
 
@@ -43,6 +44,18 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 
 func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 	return map[string]*pluginsdk.Resource{}
+}
+
+// DataSources returns a list of Data Sources supported by this Service
+func (r Registration) DataSources() []sdk.DataSource {
+	return []sdk.DataSource{}
+}
+
+// Resources returns a list of Resources supported by this Service
+func (r Registration) Resources() []sdk.Resource {
+	return []sdk.Resource{
+		BillingPtuReservationOrderResource{},
+	}
 }
 
 func (r Registration) Actions() []func() action.Action {

--- a/website/docs/r/billing_ptu_reservation_order.html.markdown
+++ b/website/docs/r/billing_ptu_reservation_order.html.markdown
@@ -1,0 +1,84 @@
+---
+subcategory: "Billing"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_billing_ptu_reservation_order"
+description: |-
+  Manages an Azure OpenAI PTU Reservation Order.
+---
+
+# azurerm_billing_ptu_reservation_order
+
+Manages an Azure OpenAI PTU (Provisioned Throughput Unit) Reservation Order.
+
+PTU reservations are billing commitments at the Azure subscription level that grant access to a fixed amount of provisioned throughput capacity for Azure OpenAI models. A single reservation order applies to all matching deployments within the specified scope.
+
+~> **Note:** PTU reservations with `billing_plan = "Upfront"` are non-refundable after the return window (typically 30 days). Use `lifecycle { prevent_destroy = true }` to guard against accidental deletion.
+
+~> **Note:** All arguments force a new resource to be created because Azure does not support in-place modification of reservation order properties.
+
+## Example Usage
+
+```hcl
+data "azurerm_subscription" "current" {}
+
+resource "azurerm_billing_ptu_reservation_order" "example" {
+  name              = "example-ptu-reservation"
+  location          = "eastus"
+  capacity          = 100
+  billing_scope_id  = data.azurerm_subscription.current.id
+  sku_name          = "DataZoneProvisionedManaged"
+  term              = "P1Y"
+  billing_plan      = "Monthly"
+  applied_scope_type = "Shared"
+  renew             = false
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The display name for the PTU reservation order. Changing this forces a new resource to be created.
+
+* `location` - (Required) The Azure region where the PTU capacity is reserved (e.g. `eastus`). Changing this forces a new resource to be created.
+
+* `capacity` - (Required) The number of PTUs (Provisioned Throughput Units) to reserve. Must be at least `1`. Changing this forces a new resource to be created.
+
+* `billing_scope_id` - (Required) The billing scope for the reservation, for example `/subscriptions/00000000-0000-0000-0000-000000000000`. Changing this forces a new resource to be created.
+
+---
+
+* `sku_name` - (Optional) The SKU name for the PTU reservation. Defaults to `DataZoneProvisionedManaged`. Changing this forces a new resource to be created.
+
+* `term` - (Optional) The reservation term expressed as an ISO 8601 duration. Possible values are `P1M`, `P1Y`, and `P3Y`. Defaults to `P1Y`. Changing this forces a new resource to be created.
+
+* `billing_plan` - (Optional) The billing plan for the reservation. Possible values are `Upfront` and `Monthly`. Defaults to `Upfront`. Changing this forces a new resource to be created.
+
+* `applied_scope_type` - (Optional) The scope type to which the reservation benefit is applied. Possible values are `Shared`, `Single`, and `ManagementGroup`. Defaults to `Shared`. Changing this forces a new resource to be created.
+
+* `renew` - (Optional) Whether the reservation automatically renews at the end of the term. Defaults to `true`. Changing this forces a new resource to be created.
+
+## Attributes Reference
+
+In addition to the Arguments listed above, the following Attributes are exported:
+
+* `id` - The ARM resource ID of the reservation order, in the format `/providers/Microsoft.Capacity/reservationOrders/<uuid>`.
+
+* `order_id` - The UUID of the reservation order in Azure.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the PTU Reservation Order.
+* `read` - (Defaults to 5 minutes) Used when retrieving the PTU Reservation Order.
+* `update` - (Defaults to 30 minutes) Used when updating the PTU Reservation Order.
+* `delete` - (Defaults to 30 minutes) Used when deleting the PTU Reservation Order.
+
+## Import
+
+PTU Reservation Orders can be imported using the `id`, e.g.
+
+```shell
+terraform import azurerm_billing_ptu_reservation_order.example /providers/Microsoft.Capacity/reservationOrders/00000000-0000-0000-0000-000000000000
+```


### PR DESCRIPTION
## Community Note
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

Adds a new resource `azurerm_billing_ptu_reservation_order` to manage Azure OpenAI PTU (Provisioned Throughput Unit) Reservation Orders.

PTU reservations are billing commitments at the Azure subscription level that grant access to a fixed amount of provisioned throughput capacity for Azure OpenAI models. A single reservation order applies to all matching deployments within the specified billing scope.

The resource uses the `Microsoft.Capacity/reservationOrders` API (`2022-11-01`) via a hand-rolled client, as this API is not yet available in `go-azure-sdk`. The purchase flow follows Azure's two-step pattern: `calculatePrice` (opens a session and returns the order ID) followed immediately by a `PUT` using that order ID.

Deletion triggers a reservation return. If the return window has passed (typically 30 days for Upfront plans), the resource is removed from state with a warning rather than failing, since the reservation remains active until expiry.

All arguments force a new resource because Azure does not support in-place modification of reservation order properties.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.

## Changes to existing Resource / Data Source

N/A — this is a new resource.

## Testing

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass.

Unit tests for the ID parser (`parse/ptu_reservation_order_id_test.go`) and the `IsReturnNotAllowed` helper pass locally. Acceptance tests require a live Azure subscription with PTU quota, which is not generally available; acceptance test scaffolding can be added once quota access is confirmed.

## Change Log

* `azurerm_billing_ptu_reservation_order` - initial support

## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made with the assistance of AI/LLMs (code generation and documentation).

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

No changes to security controls. The resource uses the existing `ResourceManager` authorizer and does not introduce new authentication mechanisms.