### PR TITLE
`azurerm_nat_gateway` - support for the `source_virtual_network_id` and `public_ip_address_ids_v6` properties

### DIFF
--- a/internal/services/network/nat_gateway_data_source.go
+++ b/internal/services/network/nat_gateway_data_source.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
@@ -52,6 +53,14 @@ func dataSourceNatGateway() *pluginsdk.Resource {
 				},
 			},
 
+			"public_ip_address_ids_v6": {
+				Type:     pluginsdk.TypeList,
+				Computed: true,
+				Elem: &pluginsdk.Schema{
+					Type: pluginsdk.TypeString,
+				},
+			},
+
 			"public_ip_prefix_ids": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
@@ -62,6 +71,11 @@ func dataSourceNatGateway() *pluginsdk.Resource {
 			},
 
 			"resource_guid": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"source_virtual_network_id": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
 			},
@@ -109,9 +123,22 @@ func dataSourceNatGatewayRead(d *pluginsdk.ResourceData, meta interface{}) error
 		if props := model.Properties; props != nil {
 			d.Set("idle_timeout_in_minutes", props.IdleTimeoutInMinutes)
 			d.Set("resource_guid", props.ResourceGuid)
+			sourceVirtualNetworkId := ""
+			if props.SourceVirtualNetwork != nil && props.SourceVirtualNetwork.Id != nil {
+				vnetId, err := commonids.ParseVirtualNetworkIDInsensitively(*props.SourceVirtualNetwork.Id)
+				if err != nil {
+					return err
+				}
+				sourceVirtualNetworkId = vnetId.ID()
+			}
+			d.Set("source_virtual_network_id", sourceVirtualNetworkId)
 
 			if err := d.Set("public_ip_address_ids", flattenNetworkSubResourceID(props.PublicIPAddresses)); err != nil {
 				return fmt.Errorf("setting `public_ip_address_ids`: %+v", err)
+			}
+
+			if err := d.Set("public_ip_address_ids_v6", flattenNetworkSubResourceID(props.PublicIPAddressesV6)); err != nil {
+				return fmt.Errorf("setting `public_ip_address_ids_v6`: %+v", err)
 			}
 
 			if err := d.Set("public_ip_prefix_ids", flattenNetworkSubResourceID(props.PublicIPPrefixes)); err != nil {

--- a/internal/services/network/nat_gateway_data_source.go
+++ b/internal/services/network/nat_gateway_data_source.go
@@ -53,7 +53,16 @@ func dataSourceNatGateway() *pluginsdk.Resource {
 				},
 			},
 
-			"public_ip_address_ids_v6": {
+			"public_ip_prefix_ids": {
+				Type:     pluginsdk.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &pluginsdk.Schema{
+					Type: pluginsdk.TypeString,
+				},
+			},
+
+			"public_ipv6_address_ids": {
 				Type:     pluginsdk.TypeList,
 				Computed: true,
 				Elem: &pluginsdk.Schema{
@@ -61,9 +70,8 @@ func dataSourceNatGateway() *pluginsdk.Resource {
 				},
 			},
 
-			"public_ip_prefix_ids": {
+			"public_ipv6_prefix_ids": {
 				Type:     pluginsdk.TypeList,
-				Optional: true,
 				Computed: true,
 				Elem: &pluginsdk.Schema{
 					Type: pluginsdk.TypeString,
@@ -75,12 +83,12 @@ func dataSourceNatGateway() *pluginsdk.Resource {
 				Computed: true,
 			},
 
-			"source_virtual_network_id": {
+			"sku_name": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
 			},
 
-			"sku_name": {
+			"source_virtual_network_id": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
 			},
@@ -137,12 +145,16 @@ func dataSourceNatGatewayRead(d *pluginsdk.ResourceData, meta interface{}) error
 				return fmt.Errorf("setting `public_ip_address_ids`: %+v", err)
 			}
 
-			if err := d.Set("public_ip_address_ids_v6", flattenNetworkSubResourceID(props.PublicIPAddressesV6)); err != nil {
-				return fmt.Errorf("setting `public_ip_address_ids_v6`: %+v", err)
+			if err := d.Set("public_ipv6_address_ids", flattenNetworkSubResourceID(props.PublicIPAddressesV6)); err != nil {
+				return fmt.Errorf("setting `public_ipv6_address_ids`: %+v", err)
 			}
 
 			if err := d.Set("public_ip_prefix_ids", flattenNetworkSubResourceID(props.PublicIPPrefixes)); err != nil {
 				return fmt.Errorf("setting `public_ip_prefix_ids`: %+v", err)
+			}
+
+			if err := d.Set("public_ipv6_prefix_ids", flattenNetworkSubResourceID(props.PublicIPPrefixesV6)); err != nil {
+				return fmt.Errorf("setting `public_ipv6_prefix_ids`: %+v", err)
 			}
 		}
 		return tags.FlattenAndSet(d, model.Tags)

--- a/internal/services/network/nat_gateway_resource.go
+++ b/internal/services/network/nat_gateway_resource.go
@@ -60,6 +60,12 @@ func resourceNatGateway() *pluginsdk.Resource {
 				}
 			}
 
+			if !diff.GetRawConfig().AsValueMap()["source_virtual_network_id"].IsNull() {
+				if diff.Get("sku_name").(string) != string(natgateways.NatGatewaySkuNameStandardVTwo) {
+					return fmt.Errorf("`source_virtual_network_id` can only be set when `sku_name` is set to `%s`", natgateways.NatGatewaySkuNameStandardVTwo)
+				}
+			}
+
 			return nil
 		},
 
@@ -109,16 +115,16 @@ func resourceNatGatewaySchema() map[string]*pluginsdk.Schema {
 			},
 		},
 
-		"resource_guid": {
-			Type:     pluginsdk.TypeString,
-			Computed: true,
-		},
-
 		"source_virtual_network_id": {
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
 			ForceNew:     true,
 			ValidateFunc: commonids.ValidateVirtualNetworkID,
+		},
+
+		"resource_guid": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
 		},
 
 		"tags": commonschema.Tags(),

--- a/internal/services/network/nat_gateway_resource.go
+++ b/internal/services/network/nat_gateway_resource.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
@@ -113,6 +114,13 @@ func resourceNatGatewaySchema() map[string]*pluginsdk.Schema {
 			Computed: true,
 		},
 
+		"source_virtual_network_id": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			ValidateFunc: commonids.ValidateVirtualNetworkID,
+		},
+
 		"tags": commonschema.Tags(),
 	}
 }
@@ -149,6 +157,12 @@ func resourceNatGatewayCreate(d *pluginsdk.ResourceData, meta interface{}) error
 			Name: pointer.To(natgateways.NatGatewaySkuName(d.Get("sku_name").(string))),
 		},
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
+	}
+
+	if v, ok := d.GetOk("source_virtual_network_id"); ok {
+		parameters.Properties.SourceVirtualNetwork = &natgateways.SubResource{
+			Id: pointer.To(v.(string)),
+		}
 	}
 
 	zones := zones.ExpandUntyped(d.Get("zones").(*schema.Set).List())
@@ -203,7 +217,10 @@ func resourceNatGatewayUpdate(d *pluginsdk.ResourceData, meta interface{}) error
 		Properties: &natgateways.NatGatewayPropertiesFormat{
 			IdleTimeoutInMinutes: props.IdleTimeoutInMinutes,
 			PublicIPAddresses:    props.PublicIPAddresses, // note: these can be managed via the separate resource
+			PublicIPAddressesV6:  props.PublicIPAddressesV6,
 			PublicIPPrefixes:     props.PublicIPPrefixes,
+			PublicIPPrefixesV6:   props.PublicIPPrefixesV6,
+			SourceVirtualNetwork: props.SourceVirtualNetwork,
 		},
 		Sku:   existing.Model.Sku,
 		Tags:  existing.Model.Tags,
@@ -269,6 +286,15 @@ func resourceNatGatewayFlatten(d *pluginsdk.ResourceData, id *natgateways.NatGat
 		if props := model.Properties; props != nil {
 			d.Set("idle_timeout_in_minutes", props.IdleTimeoutInMinutes)
 			d.Set("resource_guid", props.ResourceGuid)
+			sourceVirtualNetworkId := ""
+			if props.SourceVirtualNetwork != nil && props.SourceVirtualNetwork.Id != nil {
+				vnetId, err := commonids.ParseVirtualNetworkIDInsensitively(*props.SourceVirtualNetwork.Id)
+				if err != nil {
+					return err
+				}
+				sourceVirtualNetworkId = vnetId.ID()
+			}
+			d.Set("source_virtual_network_id", sourceVirtualNetworkId)
 		}
 		if err := tags.FlattenAndSet(d, model.Tags); err != nil {
 			return err

--- a/internal/services/network/nat_gateway_resource_test.go
+++ b/internal/services/network/nat_gateway_resource_test.go
@@ -90,6 +90,22 @@ func TestAccNatGateway_standardVTwo(t *testing.T) {
 	})
 }
 
+func TestAccNatGateway_sourceVirtualNetwork(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_nat_gateway", "test")
+	r := NatGatewayResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.sourceVirtualNetwork(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("source_virtual_network_id").Exists(),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (t NatGatewayResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := natgateways.ParseNatGatewayID(state.ID)
 	if err != nil {
@@ -242,4 +258,32 @@ resource "azurerm_nat_gateway" "test" {
   sku_name            = "StandardV2"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (NatGatewayResource) sourceVirtualNetwork(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-network-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvnet-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  address_space       = ["10.0.0.0/16"]
+}
+
+resource "azurerm_nat_gateway" "test" {
+  name                      = "acctestnatGateway-%d"
+  location                  = azurerm_resource_group.test.location
+  resource_group_name       = azurerm_resource_group.test.name
+  sku_name                  = "StandardV2"
+  source_virtual_network_id = azurerm_virtual_network.test.id
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }

--- a/website/docs/d/nat_gateway.html.markdown
+++ b/website/docs/d/nat_gateway.html.markdown
@@ -28,11 +28,15 @@ The following attributes are exported:
 
 * `public_ip_address_ids` - A list of existing Public IP Address resource IDs which the NAT Gateway is using.
 
+* `public_ip_address_ids_v6` - A list of existing IPv6 Public IP Address resource IDs which the NAT Gateway is using.
+
 * `public_ip_prefix_ids` - A list of existing Public IP Prefix resource IDs which the NAT Gateway is using.
 
 * `resource_guid` - The Resource GUID of the NAT Gateway.
 
 * `sku_name` - The SKU used by the NAT Gateway.
+
+* `source_virtual_network_id` - The ID of the Virtual Network which the NAT Gateway is attached to.
 
 * `tags` - A mapping of tags assigned to the resource.
 

--- a/website/docs/d/nat_gateway.html.markdown
+++ b/website/docs/d/nat_gateway.html.markdown
@@ -28,9 +28,11 @@ The following attributes are exported:
 
 * `public_ip_address_ids` - A list of existing Public IP Address resource IDs which the NAT Gateway is using.
 
-* `public_ip_address_ids_v6` - A list of existing IPv6 Public IP Address resource IDs which the NAT Gateway is using.
-
 * `public_ip_prefix_ids` - A list of existing Public IP Prefix resource IDs which the NAT Gateway is using.
+
+* `public_ipv6_address_ids` - A list of existing IPv6 Public IP Address resource IDs which the NAT Gateway is using.
+
+* `public_ipv6_prefix_ids` - A list of existing IPv6 Public IP Prefix resource IDs which the NAT Gateway is using.
 
 * `resource_guid` - The Resource GUID of the NAT Gateway.
 

--- a/website/docs/r/nat_gateway.html.markdown
+++ b/website/docs/r/nat_gateway.html.markdown
@@ -49,6 +49,10 @@ The following arguments are supported:
 
 ~> **Note:** `zones` must be omitted when `sku_name` is set to `StandardV2`. `StandardV2` NAT Gateways are zone-redundant by default and Azure automatically deploys across all available zones. For more information, please see the [Azure documentation](https://learn.microsoft.com/azure/nat-gateway/nat-overview#standardv2-nat-gateway).
 
+* `source_virtual_network_id` - (Optional) The ID of the Virtual Network which this NAT Gateway should be attached to. New subnets added to this Virtual Network automatically inherit the NAT Gateway. Changing this forces a new resource to be created.
+
+~> **Note:** `source_virtual_network_id` is only supported when `sku_name` is set to `StandardV2`. Replacing the source Virtual Network on an existing `StandardV2` NAT Gateway is not supported by Azure, so changing this value forces a new resource to be created.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource. 
 
 ## Attributes Reference


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR adds support for two NAT Gateway v2 (`StandardV2` SKU) properties to `azurerm_nat_gateway` and the `azurerm_nat_gateway` data source:

* `source_virtual_network_id` - allows using a `StandardV2` NAT gateway to a Virtual Network instead of individual subnets. 
* `public_ip_address_ids_v6` - support for associating IPv6 Public IP Address resource IDs with the NAT Gateway.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

<b>v4.x</b>
<pre>
=== RUN   TestAccNatGatewayPublicIpAssociation_basic
=== PAUSE TestAccNatGatewayPublicIpAssociation_basic
=== RUN   TestAccNatGatewayPublicIpAssociation_updateNatGateway
=== PAUSE TestAccNatGatewayPublicIpAssociation_updateNatGateway
=== RUN   TestAccNatGatewayPublicIpAssociation_ipv6
=== PAUSE TestAccNatGatewayPublicIpAssociation_ipv6
=== RUN   TestAccNatGatewayPublicIpAssociation_multipleAssociations
=== PAUSE TestAccNatGatewayPublicIpAssociation_multipleAssociations
=== RUN   TestAccNatGatewayPublicIpAssociation_requiresImport
=== PAUSE TestAccNatGatewayPublicIpAssociation_requiresImport
=== RUN   TestAccNatGatewayPublicIpAssociation_deleted
=== PAUSE TestAccNatGatewayPublicIpAssociation_deleted
=== RUN   TestAccNatGatewayPublicIpPrefixAssociation_basic
=== PAUSE TestAccNatGatewayPublicIpPrefixAssociation_basic
=== RUN   TestAccNatGatewayPublicIpPrefixAssociation_updateNatGateway
=== PAUSE TestAccNatGatewayPublicIpPrefixAssociation_updateNatGateway
=== RUN   TestAccNatGatewayPublicIpPrefixAssociation_ipv6
=== PAUSE TestAccNatGatewayPublicIpPrefixAssociation_ipv6
=== RUN   TestAccNatGatewayPublicIpPrefixAssociation_multipleAssociations
=== PAUSE TestAccNatGatewayPublicIpPrefixAssociation_multipleAssociations
=== RUN   TestAccNatGatewayPublicIpPrefixAssociation_requiresImport
=== PAUSE TestAccNatGatewayPublicIpPrefixAssociation_requiresImport
=== RUN   TestAccNatGatewayPublicIpPrefixAssociation_deleted
=== PAUSE TestAccNatGatewayPublicIpPrefixAssociation_deleted
=== RUN   TestAccNatGateway_resourceIdentity
=== PAUSE TestAccNatGateway_resourceIdentity
=== RUN   TestAccNatGateway_listBySubscriptionAndRG
--- PASS: TestAccNatGateway_listBySubscriptionAndRG (101.60s)
=== RUN   TestAccNatGateway_basic
=== PAUSE TestAccNatGateway_basic
=== RUN   TestAccNatGateway_complete
=== PAUSE TestAccNatGateway_complete
=== RUN   TestAccNatGateway_update
=== PAUSE TestAccNatGateway_update
=== RUN   TestAccNatGateway_standardVTwo
=== PAUSE TestAccNatGateway_standardVTwo
=== RUN   TestAccNatGateway_sourceVirtualNetwork
=== PAUSE TestAccNatGateway_sourceVirtualNetwork
=== CONT  TestAccNatGatewayPublicIpAssociation_basic
=== CONT  TestAccNatGatewayPublicIpPrefixAssociation_multipleAssociations
--- PASS: TestAccNatGatewayPublicIpAssociation_basic (184.30s)
=== CONT  TestAccNatGateway_complete
--- PASS: TestAccNatGatewayPublicIpPrefixAssociation_multipleAssociations (202.74s)
=== CONT  TestAccNatGateway_sourceVirtualNetwork
--- PASS: TestAccNatGateway_sourceVirtualNetwork (153.97s)
=== CONT  TestAccNatGateway_standardVTwo
--- PASS: TestAccNatGateway_complete (192.33s)
=== CONT  TestAccNatGateway_update
--- PASS: TestAccNatGateway_standardVTwo (126.61s)
=== CONT  TestAccNatGateway_resourceIdentity
--- PASS: TestAccNatGateway_update (211.95s)
=== CONT  TestAccNatGateway_basic
--- PASS: TestAccNatGateway_resourceIdentity (126.34s)
=== CONT  TestAccNatGatewayPublicIpPrefixAssociation_updateNatGateway
--- PASS: TestAccNatGateway_basic (121.78s)
=== CONT  TestAccNatGatewayPublicIpPrefixAssociation_ipv6
=== CONT  TestAccNatGatewayPublicIpPrefixAssociation_basic
--- PASS: TestAccNatGatewayPublicIpPrefixAssociation_updateNatGateway (219.27s)
--- PASS: TestAccNatGatewayPublicIpPrefixAssociation_ipv6 (183.96s)
=== CONT  TestAccNatGatewayPublicIpAssociation_requiresImport
=== CONT  TestAccNatGatewayPublicIpAssociation_ipv6
--- PASS: TestAccNatGatewayPublicIpPrefixAssociation_basic (191.38s)
--- PASS: TestAccNatGatewayPublicIpAssociation_requiresImport (213.28s)
=== CONT  TestAccNatGatewayPublicIpAssociation_updateNatGateway
--- PASS: TestAccNatGatewayPublicIpAssociation_updateNatGateway (226.27s)
=== CONT  TestAccNatGatewayPublicIpPrefixAssociation_deleted
--- PASS: TestAccNatGatewayPublicIpAssociation_ipv6 (363.26s)
=== CONT  TestAccNatGatewayPublicIpPrefixAssociation_requiresImport
--- PASS: TestAccNatGatewayPublicIpPrefixAssociation_deleted (152.58s)
=== CONT  TestAccNatGatewayPublicIpAssociation_multipleAssociations
--- PASS: TestAccNatGatewayPublicIpPrefixAssociation_requiresImport (152.28s)
=== CONT  TestAccNatGatewayPublicIpAssociation_deleted
--- PASS: TestAccNatGatewayPublicIpAssociation_deleted (143.59s)
--- PASS: TestAccNatGatewayPublicIpAssociation_multipleAssociations (235.54s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network       1823.677s
</pre>

<b>v5.0</b>
<pre>
=== RUN   TestAccNatGatewayPublicIpAssociation_basic
=== PAUSE TestAccNatGatewayPublicIpAssociation_basic
=== RUN   TestAccNatGatewayPublicIpAssociation_updateNatGateway
=== PAUSE TestAccNatGatewayPublicIpAssociation_updateNatGateway
=== RUN   TestAccNatGatewayPublicIpAssociation_ipv6
=== PAUSE TestAccNatGatewayPublicIpAssociation_ipv6
=== RUN   TestAccNatGatewayPublicIpAssociation_multipleAssociations
=== PAUSE TestAccNatGatewayPublicIpAssociation_multipleAssociations
=== RUN   TestAccNatGatewayPublicIpAssociation_requiresImport
=== PAUSE TestAccNatGatewayPublicIpAssociation_requiresImport
=== RUN   TestAccNatGatewayPublicIpAssociation_deleted
=== PAUSE TestAccNatGatewayPublicIpAssociation_deleted
=== RUN   TestAccNatGatewayPublicIpPrefixAssociation_basic
=== PAUSE TestAccNatGatewayPublicIpPrefixAssociation_basic
=== RUN   TestAccNatGatewayPublicIpPrefixAssociation_updateNatGateway
=== PAUSE TestAccNatGatewayPublicIpPrefixAssociation_updateNatGateway
=== RUN   TestAccNatGatewayPublicIpPrefixAssociation_ipv6
=== PAUSE TestAccNatGatewayPublicIpPrefixAssociation_ipv6
=== RUN   TestAccNatGatewayPublicIpPrefixAssociation_multipleAssociations
=== PAUSE TestAccNatGatewayPublicIpPrefixAssociation_multipleAssociations
=== RUN   TestAccNatGatewayPublicIpPrefixAssociation_requiresImport
=== PAUSE TestAccNatGatewayPublicIpPrefixAssociation_requiresImport
=== RUN   TestAccNatGatewayPublicIpPrefixAssociation_deleted
=== PAUSE TestAccNatGatewayPublicIpPrefixAssociation_deleted
=== RUN   TestAccNatGateway_resourceIdentity
=== PAUSE TestAccNatGateway_resourceIdentity
=== RUN   TestAccNatGateway_listBySubscriptionAndRG
--- PASS: TestAccNatGateway_listBySubscriptionAndRG (88.81s)
=== RUN   TestAccNatGateway_basic
=== PAUSE TestAccNatGateway_basic
=== RUN   TestAccNatGateway_complete
=== PAUSE TestAccNatGateway_complete
=== RUN   TestAccNatGateway_update
=== PAUSE TestAccNatGateway_update
=== RUN   TestAccNatGateway_standardVTwo
=== PAUSE TestAccNatGateway_standardVTwo
=== RUN   TestAccNatGateway_sourceVirtualNetwork
=== PAUSE TestAccNatGateway_sourceVirtualNetwork
=== CONT  TestAccNatGatewayPublicIpAssociation_basic
=== CONT  TestAccNatGatewayPublicIpPrefixAssociation_multipleAssociations
--- PASS: TestAccNatGatewayPublicIpAssociation_basic (266.44s)
=== CONT  TestAccNatGatewayPublicIpAssociation_deleted
--- PASS: TestAccNatGatewayPublicIpPrefixAssociation_multipleAssociations (304.83s)
=== CONT  TestAccNatGatewayPublicIpPrefixAssociation_ipv6
--- PASS: TestAccNatGatewayPublicIpAssociation_deleted (151.08s)
=== CONT  TestAccNatGatewayPublicIpPrefixAssociation_updateNatGateway
--- PASS: TestAccNatGatewayPublicIpPrefixAssociation_ipv6 (160.46s)
=== CONT  TestAccNatGatewayPublicIpPrefixAssociation_basic
--- PASS: TestAccNatGatewayPublicIpPrefixAssociation_basic (156.11s)
=== CONT  TestAccNatGatewayPublicIpAssociation_multipleAssociations
--- PASS: TestAccNatGatewayPublicIpPrefixAssociation_updateNatGateway (213.37s)
=== CONT  TestAccNatGatewayPublicIpAssociation_requiresImport
--- PASS: TestAccNatGatewayPublicIpAssociation_requiresImport (132.84s)
=== CONT  TestAccNatGateway_complete
--- PASS: TestAccNatGatewayPublicIpAssociation_multipleAssociations (217.43s)
=== CONT  TestAccNatGateway_sourceVirtualNetwork
--- PASS: TestAccNatGateway_complete (183.49s)
=== CONT  TestAccNatGateway_standardVTwo
--- PASS: TestAccNatGateway_sourceVirtualNetwork (140.33s)
=== CONT  TestAccNatGateway_update
--- PASS: TestAccNatGateway_standardVTwo (119.56s)
=== CONT  TestAccNatGatewayPublicIpAssociation_ipv6
--- PASS: TestAccNatGateway_update (200.01s)
=== CONT  TestAccNatGateway_resourceIdentity
--- PASS: TestAccNatGatewayPublicIpAssociation_ipv6 (185.47s)
=== CONT  TestAccNatGateway_basic
--- PASS: TestAccNatGateway_resourceIdentity (128.87s)
=== CONT  TestAccNatGatewayPublicIpAssociation_updateNatGateway
--- PASS: TestAccNatGateway_basic (132.34s)
=== CONT  TestAccNatGatewayPublicIpPrefixAssociation_deleted
--- PASS: TestAccNatGatewayPublicIpAssociation_updateNatGateway (210.42s)
=== CONT  TestAccNatGatewayPublicIpPrefixAssociation_requiresImport
--- PASS: TestAccNatGatewayPublicIpPrefixAssociation_deleted (149.92s)
--- PASS: TestAccNatGatewayPublicIpPrefixAssociation_requiresImport (150.69s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network       1758.030s
</pre>


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_nat_gateway` - support for the `source_virtual_network_id` and `public_ip_address_ids_v6` properties


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
