### PR TITLE
`azurerm_virtual_desktop_host_pool`: Support `MultiplePersistent` for `load_balancer_type`

### DIFF
--- a/internal/services/desktopvirtualization/virtual_desktop_host_pool_resource.go
+++ b/internal/services/desktopvirtualization/virtual_desktop_host_pool_resource.go
@@ -4,6 +4,7 @@
 package desktopvirtualization
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
@@ -48,6 +49,15 @@ func resourceVirtualDesktopHostPool() *pluginsdk.Resource {
 		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
 			0: migration.HostPoolV0ToV1{},
 		}),
+		CustomizeDiff: pluginsdk.CustomizeDiffShim(func(ctx context.Context, d *pluginsdk.ResourceDiff, meta interface{}) error {
+			if d.Get("type").(string) == string(hostpool.HostPoolTypePooled) {
+				loadBalancerType := d.Get("load_balancer_type").(string)
+				if loadBalancerType == string(hostpool.LoadBalancerTypePersistent) || loadBalancerType == string(hostpool.LoadBalancerTypeMultiplePersistent) {
+					return fmt.Errorf("`type` must be \"Personal\" when `load_balancer_type` is \"Persistent\" or \"MultiplePersistent\"")
+				}
+			}
+			return nil
+		}),
 
 		Schema: map[string]*pluginsdk.Schema{
 			"name": {
@@ -72,13 +82,9 @@ func resourceVirtualDesktopHostPool() *pluginsdk.Resource {
 			},
 
 			"load_balancer_type": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(hostpool.LoadBalancerTypeBreadthFirst),
-					string(hostpool.LoadBalancerTypeDepthFirst),
-					string(hostpool.LoadBalancerTypePersistent),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(hostpool.PossibleValuesForLoadBalancerType(), false),
 			},
 
 			"friendly_name": {

--- a/internal/services/desktopvirtualization/virtual_desktop_host_pool_resource_test.go
+++ b/internal/services/desktopvirtualization/virtual_desktop_host_pool_resource_test.go
@@ -6,6 +6,7 @@ package desktopvirtualization_test
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -183,6 +184,48 @@ func TestAccVirtualDesktopHostPool_requiresImport(t *testing.T) {
 			),
 		},
 		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func TestAccVirtualDesktopHostPool_multiplePersistent(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_desktop_host_pool", "test")
+	r := VirtualDesktopHostPoolResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.multiplePersistent(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("load_balancer_type").HasValue("MultiplePersistent"),
+			),
+		},
+	})
+}
+
+func TestAccVirtualDesktopHostPool_persistent(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_desktop_host_pool", "test")
+	r := VirtualDesktopHostPoolResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.persistent(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("load_balancer_type").HasValue("Persistent"),
+			),
+		},
+	})
+}
+
+func TestAccVirtualDesktopHostPool_multiplePersistentInvalid(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_desktop_host_pool", "test")
+	r := VirtualDesktopHostPoolResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:      r.multiplePersistentPooledInvalid(data),
+			ExpectError: regexp.MustCompile("`type` must be \"Personal\" when `load_balancer_type` is \"Persistent\" or \"MultiplePersistent\""),
+		},
 	})
 }
 
@@ -495,4 +538,72 @@ resource "azurerm_virtual_desktop_host_pool" "import" {
   load_balancer_type   = azurerm_virtual_desktop_host_pool.test.load_balancer_type
 }
 `, r.basic(data))
+}
+
+func (VirtualDesktopHostPoolResource) multiplePersistent(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-vdesktophp-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_desktop_host_pool" "test" {
+  name                             = "acctestHP%s"
+  location                         = azurerm_resource_group.test.location
+  resource_group_name              = azurerm_resource_group.test.name
+  type                             = "Personal"
+  personal_desktop_assignment_type = "Direct"
+  validate_environment             = true
+  load_balancer_type               = "MultiplePersistent"
+}
+`, data.RandomInteger, data.Locations.Secondary, data.RandomString)
+}
+
+func (VirtualDesktopHostPoolResource) persistent(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-vdesktophp-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_desktop_host_pool" "test" {
+  name                             = "acctestHP%s"
+  location                         = azurerm_resource_group.test.location
+  resource_group_name              = azurerm_resource_group.test.name
+  type                             = "Personal"
+  personal_desktop_assignment_type = "Direct"
+  validate_environment             = true
+  load_balancer_type               = "Persistent"
+}
+`, data.RandomInteger, data.Locations.Secondary, data.RandomString)
+}
+
+func (VirtualDesktopHostPoolResource) multiplePersistentPooledInvalid(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-vdesktophp-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_desktop_host_pool" "test" {
+  name                 = "acctestHP%s"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  type                 = "Pooled"
+  validate_environment = true
+  load_balancer_type   = "MultiplePersistent"
+}
+`, data.RandomInteger, data.Locations.Secondary, data.RandomString)
 }

--- a/website/docs/r/virtual_desktop_host_pool.html.markdown
+++ b/website/docs/r/virtual_desktop_host_pool.html.markdown
@@ -54,9 +54,9 @@ The following arguments are supported:
 
 * `type` - (Required) The type of the Virtual Desktop Host Pool. Valid options are `Personal` or `Pooled`. Changing the type forces a new resource to be created.
 
-* `load_balancer_type` - (Required) `BreadthFirst` load balancing distributes new user sessions across all available session hosts in the host pool. Possible values are `BreadthFirst`, `DepthFirst` and `Persistent`.
-    `DepthFirst` load balancing distributes new user sessions to an available session host with the highest number of connections but has not reached its maximum session limit threshold.
-    `Persistent` should be used if the host pool type is `Personal`
+* `load_balancer_type` - (Required) The type of the load balancer. Possible values are `BreadthFirst`, `DepthFirst`, `MultiplePersistent` and `Persistent`. Refer to the [Azure documentation](https://learn.microsoft.com/azure/virtual-desktop/host-pool-load-balancing) for more information.
+
+~> **Note:** `load_balancer_type` must be set to `Persistent` or `MultiplePersistent` if the `type` of your Virtual Desktop Host Pool is `Personal`.
 
 * `friendly_name` - (Optional) A friendly name for the Virtual Desktop Host Pool.
 


### PR DESCRIPTION


<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

Support new enum value `MultiplePersistent` for `load_balancer_type` prop. Both this and `Persistent` are only supported when `type` is `Personal`. An additional CustomizeDiff validator has been added to check this during plan time.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_virtual_desktop_host_pool`: Support `MultiplePersistent` for `load_balancer_type` [GH-29881]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #29881


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
