### PR TITLE
feat: add service principal attribute set resource

### DIFF
--- a/internal/services/authorization/client/client.go
+++ b/internal/services/authorization/client/client.go
@@ -20,16 +20,17 @@ import (
 )
 
 type Client struct {
-	RoleAssignmentScheduleRequestClient    *roleassignmentschedulerequests.RoleAssignmentScheduleRequestsClient
-	RoleAssignmentScheduleInstancesClient  *roleassignmentscheduleinstances.RoleAssignmentScheduleInstancesClient
-	RoleAssignmentSchedulesClient          *roleassignmentschedules.RoleAssignmentSchedulesClient
-	RoleEligibilityScheduleRequestClient   *roleeligibilityschedulerequests.RoleEligibilityScheduleRequestsClient
-	RoleEligibilityScheduleInstancesClient *roleeligibilityscheduleinstances.RoleEligibilityScheduleInstancesClient
-	RoleEligibilitySchedulesClient         *roleeligibilityschedules.RoleEligibilitySchedulesClient
-	RoleManagementPoliciesClient           *rolemanagementpolicies.RoleManagementPoliciesClient
-	RoleManagementPolicyAssignmentsClient  *rolemanagementpolicyassignments.RoleManagementPolicyAssignmentsClient
-	ScopedRoleAssignmentsClient            *roleassignments.RoleAssignmentsClient
-	ScopedRoleDefinitionsClient            *roledefinitions.RoleDefinitionsClient
+	RoleAssignmentScheduleRequestClient            *roleassignmentschedulerequests.RoleAssignmentScheduleRequestsClient
+	RoleAssignmentScheduleInstancesClient          *roleassignmentscheduleinstances.RoleAssignmentScheduleInstancesClient
+	RoleAssignmentSchedulesClient                  *roleassignmentschedules.RoleAssignmentSchedulesClient
+	RoleEligibilityScheduleRequestClient           *roleeligibilityschedulerequests.RoleEligibilityScheduleRequestsClient
+	RoleEligibilityScheduleInstancesClient         *roleeligibilityscheduleinstances.RoleEligibilityScheduleInstancesClient
+	RoleEligibilitySchedulesClient                 *roleeligibilityschedules.RoleEligibilitySchedulesClient
+	RoleManagementPoliciesClient                   *rolemanagementpolicies.RoleManagementPoliciesClient
+	RoleManagementPolicyAssignmentsClient          *rolemanagementpolicyassignments.RoleManagementPolicyAssignmentsClient
+	ScopedRoleAssignmentsClient                    *roleassignments.RoleAssignmentsClient
+	ScopedRoleDefinitionsClient                    *roledefinitions.RoleDefinitionsClient
+	ServicePrincipalCustomSecurityAttributesClient *ServicePrincipalCustomSecurityAttributesClient
 }
 
 func NewClient(o *common.ClientOptions) (*Client, error) {
@@ -94,16 +95,22 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 	}
 	o.Configure(scopedRoleDefinitionsClient.Client, o.Authorizers.ResourceManager)
 
+	servicePrincipalCustomSecurityAttributesClient, err := NewServicePrincipalCustomSecurityAttributesClient(o)
+	if err != nil {
+		return nil, fmt.Errorf("building Service Principal Custom Security Attributes Client: %+v", err)
+	}
+
 	return &Client{
-		RoleAssignmentScheduleRequestClient:    roleAssignmentScheduleRequestsClient,
-		RoleAssignmentScheduleInstancesClient:  roleAssignmentScheduleInstancesClient,
-		RoleAssignmentSchedulesClient:          roleAssignmentSchedulesClient,
-		RoleEligibilityScheduleRequestClient:   roleEligibilityScheduleRequestClient,
-		RoleEligibilityScheduleInstancesClient: roleEligibilityScheduleInstancesClient,
-		RoleEligibilitySchedulesClient:         roleEligibilitySchedulesClient,
-		RoleManagementPoliciesClient:           roleManagementPoliciesClient,
-		RoleManagementPolicyAssignmentsClient:  roleManagementPolicyAssignmentClient,
-		ScopedRoleAssignmentsClient:            scopedRoleAssignmentsClient,
-		ScopedRoleDefinitionsClient:            scopedRoleDefinitionsClient,
+		RoleAssignmentScheduleRequestClient:            roleAssignmentScheduleRequestsClient,
+		RoleAssignmentScheduleInstancesClient:          roleAssignmentScheduleInstancesClient,
+		RoleAssignmentSchedulesClient:                  roleAssignmentSchedulesClient,
+		RoleEligibilityScheduleRequestClient:           roleEligibilityScheduleRequestClient,
+		RoleEligibilityScheduleInstancesClient:         roleEligibilityScheduleInstancesClient,
+		RoleEligibilitySchedulesClient:                 roleEligibilitySchedulesClient,
+		RoleManagementPoliciesClient:                   roleManagementPoliciesClient,
+		RoleManagementPolicyAssignmentsClient:          roleManagementPolicyAssignmentClient,
+		ScopedRoleAssignmentsClient:                    scopedRoleAssignmentsClient,
+		ScopedRoleDefinitionsClient:                    scopedRoleDefinitionsClient,
+		ServicePrincipalCustomSecurityAttributesClient: servicePrincipalCustomSecurityAttributesClient,
 	}, nil
 }

--- a/internal/services/authorization/client/service_principal_custom_security_attributes_client.go
+++ b/internal/services/authorization/client/service_principal_custom_security_attributes_client.go
@@ -1,0 +1,163 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/msgraph"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
+)
+
+const customSecurityAttributeValueODataType = "#Microsoft.DirectoryServices.CustomSecurityAttributeValue"
+
+type graphRequestOptions struct {
+	query odata.Query
+}
+
+func (o graphRequestOptions) ToHeaders() *client.Headers {
+	h := client.Headers{}
+	h.AppendHeader(o.query.Headers())
+	return &h
+}
+
+func (o graphRequestOptions) ToOData() *odata.Query {
+	return &o.query
+}
+
+func (o graphRequestOptions) ToQuery() *client.QueryParams {
+	q := client.QueryParams{}
+	q.AppendValues(o.query.Values())
+	return &q
+}
+
+type ServicePrincipalCustomSecurityAttributesClient struct {
+	msGraphClient *msgraph.Client
+}
+
+type servicePrincipalModel struct {
+	ID                       *string                           `json:"id"`
+	CustomSecurityAttributes map[string]map[string]interface{} `json:"customSecurityAttributes"`
+}
+
+type servicePrincipalPatchModel struct {
+	CustomSecurityAttributes map[string]map[string]interface{} `json:"customSecurityAttributes"`
+}
+
+func NewServicePrincipalCustomSecurityAttributesClient(o *common.ClientOptions) (*ServicePrincipalCustomSecurityAttributesClient, error) {
+	graphClient, err := msgraph.NewClient(o.Environment.MicrosoftGraph, "ServicePrincipalCustomSecurityAttributes", msgraph.VersionOnePointZero)
+	if err != nil {
+		return nil, fmt.Errorf("building microsoft graph client: %+v", err)
+	}
+
+	graphAuthorizer, err := o.Authorizers.AuthorizerFunc(o.Environment.MicrosoftGraph)
+	if err != nil {
+		return nil, fmt.Errorf("building microsoft graph authorizer: %+v", err)
+	}
+	o.Configure(graphClient, graphAuthorizer)
+
+	return &ServicePrincipalCustomSecurityAttributesClient{
+		msGraphClient: graphClient,
+	}, nil
+}
+
+func (c *ServicePrincipalCustomSecurityAttributesClient) Get(ctx context.Context, servicePrincipalObjectId string) (*servicePrincipalModel, error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+			http.StatusNotFound,
+		},
+		HttpMethod: http.MethodGet,
+		OptionsObject: graphRequestOptions{
+			query: odata.Query{
+				Select: []string{"id", "customSecurityAttributes"},
+			},
+		},
+		Path: fmt.Sprintf("/servicePrincipals/%s", servicePrincipalObjectId),
+	}
+
+	req, err := c.msGraphClient.NewRequest(ctx, opts)
+	if err != nil {
+		return nil, fmt.Errorf("building request to get service principal custom attributes for %q: %+v", servicePrincipalObjectId, err)
+	}
+
+	resp, err := req.Execute(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("getting service principal custom attributes for %q: %+v", servicePrincipalObjectId, err)
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, nil
+	}
+
+	model := servicePrincipalModel{}
+	if err := resp.Unmarshal(&model); err != nil {
+		return nil, fmt.Errorf("unmarshaling service principal custom attributes for %q: %+v", servicePrincipalObjectId, err)
+	}
+
+	if model.CustomSecurityAttributes == nil {
+		model.CustomSecurityAttributes = map[string]map[string]interface{}{}
+	}
+
+	return &model, nil
+}
+
+func (c *ServicePrincipalCustomSecurityAttributesClient) Update(ctx context.Context, servicePrincipalObjectId string, customSecurityAttributes map[string]map[string]interface{}) error {
+	opts := client.RequestOptions{
+		ContentType: "application/json",
+		ExpectedStatusCodes: []int{
+			http.StatusNoContent,
+		},
+		HttpMethod:    http.MethodPatch,
+		OptionsObject: nil,
+		Path:          fmt.Sprintf("/servicePrincipals/%s", servicePrincipalObjectId),
+	}
+
+	req, err := c.msGraphClient.NewRequest(ctx, opts)
+	if err != nil {
+		return fmt.Errorf("building request to update service principal custom attributes for %q: %+v", servicePrincipalObjectId, err)
+	}
+
+	payload := servicePrincipalPatchModel{
+		CustomSecurityAttributes: normalizeCustomSecurityAttributesForPatch(customSecurityAttributes),
+	}
+	if err := req.Marshal(payload); err != nil {
+		return fmt.Errorf("marshaling request payload to update service principal custom attributes for %q: %+v", servicePrincipalObjectId, err)
+	}
+
+	if _, err := req.Execute(ctx); err != nil {
+		return fmt.Errorf("updating service principal custom attributes for %q: %+v", servicePrincipalObjectId, err)
+	}
+
+	return nil
+}
+
+func normalizeCustomSecurityAttributesForPatch(input map[string]map[string]interface{}) map[string]map[string]interface{} {
+	if input == nil {
+		return map[string]map[string]interface{}{}
+	}
+
+	output := make(map[string]map[string]interface{}, len(input))
+	for setName, attributes := range input {
+		normalized := map[string]interface{}{
+			"@odata.type": customSecurityAttributeValueODataType,
+		}
+
+		for key, value := range attributes {
+			if strings.EqualFold(key, "@odata.type") {
+				continue
+			}
+			normalized[key] = value
+		}
+
+		output[setName] = normalized
+	}
+
+	return output
+}

--- a/internal/services/authorization/client/service_principal_custom_security_attributes_client_test.go
+++ b/internal/services/authorization/client/service_principal_custom_security_attributes_client_test.go
@@ -1,0 +1,40 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package client
+
+import "testing"
+
+func TestNormalizeCustomSecurityAttributesForPatch_addsODataType(t *testing.T) {
+	t.Parallel()
+
+	input := map[string]map[string]interface{}{
+		"Engineering": {
+			"Environment": "Prod",
+		},
+	}
+
+	out := normalizeCustomSecurityAttributesForPatch(input)
+	if got := out["Engineering"]["@odata.type"]; got != customSecurityAttributeValueODataType {
+		t.Fatalf("expected @odata.type to be %q but got %v", customSecurityAttributeValueODataType, got)
+	}
+	if got := out["Engineering"]["Environment"]; got != "Prod" {
+		t.Fatalf("expected Environment to be preserved but got %v", got)
+	}
+}
+
+func TestNormalizeCustomSecurityAttributesForPatch_replacesExistingODataType(t *testing.T) {
+	t.Parallel()
+
+	input := map[string]map[string]interface{}{
+		"Engineering": {
+			"@odata.type": "unexpected",
+			"Environment": "Prod",
+		},
+	}
+
+	out := normalizeCustomSecurityAttributesForPatch(input)
+	if got := out["Engineering"]["@odata.type"]; got != customSecurityAttributeValueODataType {
+		t.Fatalf("expected @odata.type to be %q but got %v", customSecurityAttributeValueODataType, got)
+	}
+}

--- a/internal/services/authorization/parse/service_principal_attribute_set.go
+++ b/internal/services/authorization/parse/service_principal_attribute_set.go
@@ -1,0 +1,65 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package parse
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type ServicePrincipalAttributeSetId struct {
+	ServicePrincipalObjectId string
+	AttributeSetName         string
+}
+
+func NewServicePrincipalAttributeSetId(servicePrincipalObjectId string, attributeSetName string) ServicePrincipalAttributeSetId {
+	return ServicePrincipalAttributeSetId{
+		ServicePrincipalObjectId: servicePrincipalObjectId,
+		AttributeSetName:         attributeSetName,
+	}
+}
+
+func (id ServicePrincipalAttributeSetId) ID() string {
+	return fmt.Sprintf("%s|%s", id.ServicePrincipalObjectId, id.AttributeSetName)
+}
+
+func (id ServicePrincipalAttributeSetId) String() string {
+	return fmt.Sprintf("Service Principal Object ID %q / Attribute Set %q", id.ServicePrincipalObjectId, id.AttributeSetName)
+}
+
+func ServicePrincipalAttributeSetID(input string) (*ServicePrincipalAttributeSetId, error) {
+	parts := strings.SplitN(input, "|", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("parsing Service Principal Attribute Set ID: expected '<service_principal_object_id>|<attribute_set_name>' but got %q", input)
+	}
+
+	if _, errs := validation.IsUUID(parts[0], "service_principal_object_id"); len(errs) > 0 {
+		return nil, fmt.Errorf("parsing Service Principal Attribute Set ID: invalid service principal object ID %q", parts[0])
+	}
+
+	if parts[1] == "" {
+		return nil, fmt.Errorf("parsing Service Principal Attribute Set ID: attribute set name cannot be empty")
+	}
+
+	return &ServicePrincipalAttributeSetId{
+		ServicePrincipalObjectId: parts[0],
+		AttributeSetName:         parts[1],
+	}, nil
+}
+
+func ValidateServicePrincipalAttributeSetID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ServicePrincipalAttributeSetID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/internal/services/authorization/parse/service_principal_attribute_set_test.go
+++ b/internal/services/authorization/parse/service_principal_attribute_set_test.go
@@ -1,0 +1,50 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package parse
+
+import "testing"
+
+func TestServicePrincipalAttributeSetID(t *testing.T) {
+	t.Parallel()
+
+	input := "00000000-0000-0000-0000-000000000000|EngineeringAttributes"
+
+	id, err := ServicePrincipalAttributeSetID(input)
+	if err != nil {
+		t.Fatalf("expected no error but got: %+v", err)
+	}
+	if id.ServicePrincipalObjectId != "00000000-0000-0000-0000-000000000000" {
+		t.Fatalf("unexpected service principal object ID: %q", id.ServicePrincipalObjectId)
+	}
+	if id.AttributeSetName != "EngineeringAttributes" {
+		t.Fatalf("unexpected attribute set name: %q", id.AttributeSetName)
+	}
+	if got := id.ID(); got != input {
+		t.Fatalf("unexpected ID() value: %q", got)
+	}
+}
+
+func TestServicePrincipalAttributeSetID_requiresPipeSeparator(t *testing.T) {
+	t.Parallel()
+
+	if _, err := ServicePrincipalAttributeSetID("00000000-0000-0000-0000-000000000000"); err == nil {
+		t.Fatal("expected an error for invalid ID format but got nil")
+	}
+}
+
+func TestServicePrincipalAttributeSetID_requiresValidServicePrincipalObjectID(t *testing.T) {
+	t.Parallel()
+
+	if _, err := ServicePrincipalAttributeSetID("not-a-uuid|EngineeringAttributes"); err == nil {
+		t.Fatal("expected an error for invalid service principal object ID but got nil")
+	}
+}
+
+func TestServicePrincipalAttributeSetID_requiresAttributeSetName(t *testing.T) {
+	t.Parallel()
+
+	if _, err := ServicePrincipalAttributeSetID("00000000-0000-0000-0000-000000000000|"); err == nil {
+		t.Fatal("expected an error for empty attribute set name but got nil")
+	}
+}

--- a/internal/services/authorization/registration.go
+++ b/internal/services/authorization/registration.go
@@ -63,6 +63,7 @@ func (r Registration) Resources() []sdk.Resource {
 		RoleAssignmentMarketplaceResource{},
 		RoleDefinitionResource{},
 		RoleManagementPolicyResource{},
+		ServicePrincipalAttributeSetResource{},
 	}
 	return resources
 }

--- a/internal/services/authorization/service_principal_attribute_set_resource.go
+++ b/internal/services/authorization/service_principal_attribute_set_resource.go
@@ -1,0 +1,256 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package authorization
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/authorization/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+var (
+	_ sdk.Resource           = ServicePrincipalAttributeSetResource{}
+	_ sdk.ResourceWithUpdate = ServicePrincipalAttributeSetResource{}
+)
+
+type ServicePrincipalAttributeSetResource struct{}
+
+type ServicePrincipalAttributeSetModel struct {
+	ServicePrincipalObjectId string                 `tfschema:"service_principal_object_id"`
+	AttributeSetName         string                 `tfschema:"attribute_set_name"`
+	Attributes               map[string]interface{} `tfschema:"attributes"`
+}
+
+func (r ServicePrincipalAttributeSetResource) ModelObject() interface{} {
+	return &ServicePrincipalAttributeSetModel{}
+}
+
+func (r ServicePrincipalAttributeSetResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return parse.ValidateServicePrincipalAttributeSetID
+}
+
+func (r ServicePrincipalAttributeSetResource) ResourceType() string {
+	return "azurerm_service_principal_attribute_set"
+}
+
+func (r ServicePrincipalAttributeSetResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"service_principal_object_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.IsUUID,
+		},
+		"attribute_set_name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+		"attributes": {
+			Type:     pluginsdk.TypeMap,
+			Required: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+	}
+}
+
+func (r ServicePrincipalAttributeSetResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{}
+}
+
+func (r ServicePrincipalAttributeSetResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Authorization.ServicePrincipalCustomSecurityAttributesClient
+
+			var config ServicePrincipalAttributeSetModel
+			if err := metadata.Decode(&config); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			id := parse.NewServicePrincipalAttributeSetId(config.ServicePrincipalObjectId, config.AttributeSetName)
+			existing, err := client.Get(ctx, config.ServicePrincipalObjectId)
+			if err != nil {
+				return err
+			}
+			if existing == nil {
+				return fmt.Errorf("retrieving service principal %q: not found", config.ServicePrincipalObjectId)
+			}
+
+			if _, exists := existing.CustomSecurityAttributes[config.AttributeSetName]; exists {
+				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+			}
+
+			customSecurityAttributes, err := upsertManagedAttributeSet(existing.CustomSecurityAttributes, config.AttributeSetName, config.Attributes)
+			if err != nil {
+				return err
+			}
+
+			if err := client.Update(ctx, config.ServicePrincipalObjectId, customSecurityAttributes); err != nil {
+				return err
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+	}
+}
+
+func (r ServicePrincipalAttributeSetResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Authorization.ServicePrincipalCustomSecurityAttributesClient
+
+			id, err := parse.ServicePrincipalAttributeSetID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			existing, err := client.Get(ctx, id.ServicePrincipalObjectId)
+			if err != nil {
+				return err
+			}
+			if existing == nil {
+				return metadata.MarkAsGone(*id)
+			}
+
+			attributes, ok := existing.CustomSecurityAttributes[id.AttributeSetName]
+			if !ok {
+				return metadata.MarkAsGone(*id)
+			}
+
+			flattenedAttributes, err := flattenManagedAttributeSet(attributes)
+			if err != nil {
+				return err
+			}
+
+			state := ServicePrincipalAttributeSetModel{
+				ServicePrincipalObjectId: id.ServicePrincipalObjectId,
+				AttributeSetName:         id.AttributeSetName,
+				Attributes:               flattenedAttributes,
+			}
+
+			return metadata.Encode(&state)
+		},
+	}
+}
+
+func (r ServicePrincipalAttributeSetResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Authorization.ServicePrincipalCustomSecurityAttributesClient
+
+			var config ServicePrincipalAttributeSetModel
+			if err := metadata.Decode(&config); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			existing, err := client.Get(ctx, config.ServicePrincipalObjectId)
+			if err != nil {
+				return err
+			}
+			if existing == nil {
+				return fmt.Errorf("retrieving service principal %q: not found", config.ServicePrincipalObjectId)
+			}
+
+			customSecurityAttributes, err := upsertManagedAttributeSet(existing.CustomSecurityAttributes, config.AttributeSetName, config.Attributes)
+			if err != nil {
+				return err
+			}
+
+			return client.Update(ctx, config.ServicePrincipalObjectId, customSecurityAttributes)
+		},
+	}
+}
+
+func (r ServicePrincipalAttributeSetResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Authorization.ServicePrincipalCustomSecurityAttributesClient
+
+			id, err := parse.ServicePrincipalAttributeSetID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			existing, err := client.Get(ctx, id.ServicePrincipalObjectId)
+			if err != nil {
+				return err
+			}
+			if existing == nil {
+				return nil
+			}
+			if _, exists := existing.CustomSecurityAttributes[id.AttributeSetName]; !exists {
+				return nil
+			}
+
+			customSecurityAttributes := cloneCustomSecurityAttributes(existing.CustomSecurityAttributes)
+			delete(customSecurityAttributes, id.AttributeSetName)
+
+			return client.Update(ctx, id.ServicePrincipalObjectId, customSecurityAttributes)
+		},
+	}
+}
+
+func upsertManagedAttributeSet(existing map[string]map[string]interface{}, attributeSetName string, attributes map[string]interface{}) (map[string]map[string]interface{}, error) {
+	customSecurityAttributes := cloneCustomSecurityAttributes(existing)
+
+	updatedManagedSet := make(map[string]interface{}, len(attributes))
+	for key, value := range attributes {
+		stringValue, ok := value.(string)
+		if !ok {
+			return nil, fmt.Errorf("expected attribute %q in set %q to be a string but got %T", key, attributeSetName, value)
+		}
+		updatedManagedSet[key] = stringValue
+	}
+
+	customSecurityAttributes[attributeSetName] = updatedManagedSet
+	return customSecurityAttributes, nil
+}
+
+func flattenManagedAttributeSet(attributes map[string]interface{}) (map[string]interface{}, error) {
+	out := make(map[string]interface{}, len(attributes))
+	for key, value := range attributes {
+		if key == "@odata.type" {
+			continue
+		}
+
+		stringValue, ok := value.(string)
+		if !ok {
+			return nil, fmt.Errorf("expected attribute %q to be a string but got %T", key, value)
+		}
+		out[key] = stringValue
+	}
+
+	return out, nil
+}
+
+func cloneCustomSecurityAttributes(input map[string]map[string]interface{}) map[string]map[string]interface{} {
+	if input == nil {
+		return map[string]map[string]interface{}{}
+	}
+
+	out := make(map[string]map[string]interface{}, len(input))
+	for setName, values := range input {
+		clonedValues := make(map[string]interface{}, len(values))
+		for key, value := range values {
+			clonedValues[key] = value
+		}
+		out[setName] = clonedValues
+	}
+
+	return out
+}

--- a/internal/services/authorization/service_principal_attribute_set_resource_test.go
+++ b/internal/services/authorization/service_principal_attribute_set_resource_test.go
@@ -1,0 +1,64 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package authorization
+
+import "testing"
+
+func TestUpsertManagedAttributeSet_preservesOtherSets(t *testing.T) {
+	t.Parallel()
+
+	existing := map[string]map[string]interface{}{
+		"Finance": {
+			"CostCenter": "1234",
+		},
+	}
+	attributes := map[string]interface{}{
+		"Environment": "Prod",
+	}
+
+	out, err := upsertManagedAttributeSet(existing, "Engineering", attributes)
+	if err != nil {
+		t.Fatalf("unexpected error: %+v", err)
+	}
+
+	if got := out["Finance"]["CostCenter"]; got != "1234" {
+		t.Fatalf("expected Finance.CostCenter to be preserved as 1234 but got %v", got)
+	}
+	if got := out["Engineering"]["Environment"]; got != "Prod" {
+		t.Fatalf("expected Engineering.Environment to be Prod but got %v", got)
+	}
+}
+
+func TestUpsertManagedAttributeSet_requiresStringValues(t *testing.T) {
+	t.Parallel()
+
+	attributes := map[string]interface{}{
+		"Environment": 123,
+	}
+
+	if _, err := upsertManagedAttributeSet(map[string]map[string]interface{}{}, "Engineering", attributes); err == nil {
+		t.Fatal("expected an error for non-string attribute value but got nil")
+	}
+}
+
+func TestFlattenManagedAttributeSet_skipsODataType(t *testing.T) {
+	t.Parallel()
+
+	input := map[string]interface{}{
+		"@odata.type": "#Microsoft.DirectoryServices.CustomSecurityAttributeValue",
+		"Environment": "Prod",
+	}
+
+	out, err := flattenManagedAttributeSet(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %+v", err)
+	}
+
+	if _, exists := out["@odata.type"]; exists {
+		t.Fatal("expected @odata.type to be removed from flattened attributes")
+	}
+	if got := out["Environment"]; got != "Prod" {
+		t.Fatalf("expected Environment=Prod but got %v", got)
+	}
+}

--- a/website/docs/r/service_principal_attribute_set.html.markdown
+++ b/website/docs/r/service_principal_attribute_set.html.markdown
@@ -1,0 +1,56 @@
+---
+subcategory: "Authorization"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_service_principal_attribute_set"
+description: |-
+  Manages a custom security attribute set assignment on an existing Microsoft Entra service principal.
+
+---
+
+# azurerm_service_principal_attribute_set
+
+Manages a custom security attribute set assignment on an existing Microsoft Entra service principal.
+
+~> **Note:** This resource manages **one** attribute set per resource instance and is designed to avoid overwriting other attribute sets on the same service principal.
+
+## Example Usage (minimal inputs)
+
+```hcl
+resource "azurerm_service_principal_attribute_set" "example" {
+  service_principal_object_id = var.service_principal_object_id
+  attribute_set_name          = var.attribute_set_name
+
+  attributes = {
+    Environment = "Production"
+    Team        = "Platform"
+  }
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `service_principal_object_id` - (Required) The Object ID of the target Microsoft Entra service principal. Changing this forces a new resource to be created.
+
+* `attribute_set_name` - (Required) The custom security attribute set name to manage on the service principal. Changing this forces a new resource to be created.
+
+* `attributes` - (Required) A map of attribute names and string values to apply for this attribute set.
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following attributes are exported:
+
+* `id` - The Service Principal Attribute Set resource ID.
+
+## Import
+
+Service principal attribute sets can be imported using the resource ID in the format:
+
+```shell
+terraform import azurerm_service_principal_attribute_set.example "<service_principal_object_id>|<attribute_set_name>"
+```
+
+## Permissions
+
+The caller requires Microsoft Graph permissions that allow reading and updating service principals and custom security attributes in the tenant.


### PR DESCRIPTION
Add a new typed azurerm resource to manage one custom security attribute set on an existing Entra service principal through Microsoft Graph. Includes a reusable Graph client abstraction, parse/validation helpers, documentation, and focused unit tests.

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #0000


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
