### PR TITLE
`azurerm_virtual_network`, `azurerm_subnet` - preserve IPAM pool associations established outside of Terraform

### DIFF
--- a/internal/services/network/network_manager_resource_test.go
+++ b/internal/services/network/network_manager_resource_test.go
@@ -124,11 +124,12 @@ func TestAccNetworkManager(t *testing.T) {
 			"ipAddressPoolNumberUpdated": testAccSubnet_ipAddressPoolNumberUpdated,
 		},
 		"VNETIPANPool": {
-			"ipAddressPool":             testAccVirtualNetwork_ipAddressPool,
-			"ipAddressPoolIPv6":         testAccVirtualNetwork_ipAddressPoolIPv6,
-			"ipAddressPoolMultiple":     testAccVirtualNetwork_ipAddressPoolMultiple,
-			"ipAddressPoolUpdateBasic":  testAccVirtualNetwork_ipAddressPoolUpdateBasic,
-			"ipAddressPoolUpdateNumber": testAccVirtualNetwork_ipAddressPoolUpdateNumber,
+			"ipAddressPool":                testAccVirtualNetwork_ipAddressPool,
+			"ipAddressPoolIPv6":            testAccVirtualNetwork_ipAddressPoolIPv6,
+			"ipAddressPoolMultiple":        testAccVirtualNetwork_ipAddressPoolMultiple,
+			"ipAddressPoolUpdateBasic":     testAccVirtualNetwork_ipAddressPoolUpdateBasic,
+			"ipAddressPoolUpdateNumber":    testAccVirtualNetwork_ipAddressPoolUpdateNumber,
+			"ipAddressPoolAddedExternally": testAccVirtualNetwork_ipAddressPoolAddedExternally,
 		},
 	}
 

--- a/internal/services/network/subnet_resource.go
+++ b/internal/services/network/subnet_resource.go
@@ -241,8 +241,15 @@ func resourceSubnet() *pluginsdk.Resource {
 			},
 
 			"ip_address_pool": {
-				Type:         pluginsdk.TypeList,
-				Optional:     true,
+				Type:     pluginsdk.TypeList,
+				Optional: true,
+				// `addressPrefixes` and `ipamPoolPrefixAllocations` cannot both be specified when creating a
+				// Subnet, so an IP Address Management Pool can only be allocated to an existing address range
+				// outside of Terraform (e.g. in the Portal or an ARM template, when its Virtual Network is
+				// associated with the pool). Computed so that such an allocation is preserved rather than
+				// planned for removal when `ip_address_pool` has never been configured, consistent with the
+				// behaviour of ARM templates. Changing `address_prefixes` still removes the allocation.
+				Computed:     true,
 				MaxItems:     1,
 				ExactlyOneOf: []string{"address_prefixes", "ip_address_pool"},
 				Elem: &pluginsdk.Resource{
@@ -453,6 +460,15 @@ func resourceSubnetUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 			// return the `AddressPrefix` in response.
 			props.AddressPrefixes = utils.ExpandStringSlice(addressPrefixesRaw)
 			props.AddressPrefix = nil
+		}
+
+		if len(addressPrefixesRaw) > 0 {
+			// since `ip_address_pool` is Computed, removing the block in favour of `address_prefixes` doesn't
+			// register as a change to it, so the pool allocation is removed here instead
+			rawIpAddressPool := d.GetRawConfig().AsValueMap()["ip_address_pool"]
+			if rawIpAddressPool.IsNull() || (rawIpAddressPool.IsKnown() && len(rawIpAddressPool.AsValueSlice()) == 0) {
+				props.IPamPoolPrefixAllocations = nil
+			}
 		}
 	}
 

--- a/internal/services/network/virtual_network_resource.go
+++ b/internal/services/network/virtual_network_resource.go
@@ -163,8 +163,15 @@ func resourceVirtualNetworkSchema() map[string]*pluginsdk.Schema {
 		},
 
 		"ip_address_pool": {
-			Type:         pluginsdk.TypeList,
-			Optional:     true,
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			// `addressPrefixes` and `ipamPoolPrefixAllocations` cannot both be specified when creating a
+			// Virtual Network, so an IP Address Management Pool can only be associated with an existing
+			// address range outside of Terraform (e.g. in the Portal or via an ARM template). Computed so
+			// that such an association is preserved rather than planned for removal when `ip_address_pool`
+			// has never been configured, consistent with the behaviour of ARM templates. Changing
+			// `address_space` still removes the association.
+			Computed:     true,
 			MaxItems:     2,
 			ExactlyOneOf: []string{"address_space", "ip_address_pool"},
 			Elem: &pluginsdk.Resource{
@@ -531,6 +538,13 @@ func resourceVirtualNetworkUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 				payload.Properties.AddressSpace = &virtualnetworks.AddressSpace{}
 			}
 			payload.Properties.AddressSpace.AddressPrefixes = utils.ExpandStringSlice(v)
+
+			// since `ip_address_pool` is Computed, removing the block in favour of `address_space` doesn't
+			// register as a change to it, so the pool association is removed here instead
+			rawIpAddressPool := d.GetRawConfig().AsValueMap()["ip_address_pool"]
+			if rawIpAddressPool.IsNull() || (rawIpAddressPool.IsKnown() && len(rawIpAddressPool.AsValueSlice()) == 0) {
+				payload.Properties.AddressSpace.IPamPoolPrefixAllocations = nil
+			}
 		} else {
 			payload.Properties.AddressSpace.AddressPrefixes = nil
 		}

--- a/internal/services/network/virtual_network_resource_test.go
+++ b/internal/services/network/virtual_network_resource_test.go
@@ -370,6 +370,27 @@ func testAccVirtualNetwork_ipAddressPoolUpdateNumber(t *testing.T) {
 	})
 }
 
+func testAccVirtualNetwork_ipAddressPoolAddedExternally(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_network", "test")
+	r := VirtualNetworkResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.ipAddressPoolAddedExternally(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				data.CheckWithClient(r.associateIPAddressPool(data)),
+			),
+		},
+		{
+			// the IPAM pool association established outside of Terraform must be preserved,
+			// so re-planning the unchanged configuration must produce an empty plan
+			Config:   r.ipAddressPoolAddedExternally(data),
+			PlanOnly: true,
+		},
+	})
+}
+
 func TestAccVirtualNetwork_subnet(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_network", "test")
 	r := VirtualNetworkResource{}
@@ -691,6 +712,114 @@ resource "azurerm_virtual_network" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary)
+}
+
+func (VirtualNetworkResource) ipAddressPoolAddedExternally(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+data "azurerm_subscription" "current" {}
+
+resource "azurerm_network_manager" "test" {
+  name                = "acctest-nm-ipam-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  scope {
+    subscription_ids = [data.azurerm_subscription.current.id]
+  }
+}
+
+resource "azurerm_network_manager_ipam_pool" "test" {
+  name               = "acctest-ipampool-%[1]d"
+  network_manager_id = azurerm_network_manager.test.id
+  location           = azurerm_resource_group.test.location
+  display_name       = "ipampool1"
+  address_prefixes   = ["10.0.0.0/16"]
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  address_space       = ["10.0.0.0/24"]
+
+  depends_on = [azurerm_network_manager_ipam_pool.test]
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "internal"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.0.0/26"]
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+// associateIPAddressPool associates the Virtual Network with an IPAM pool outside of Terraform, which is
+// the only way of establishing IPAM ownership of an address range that was provisioned via `address_space`
+func (VirtualNetworkResource) associateIPAddressPool(data acceptance.TestData) acceptance.ClientCheckFunc {
+	return func(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) error {
+		client := clients.Network.VirtualNetworks
+
+		id, err := commonids.ParseVirtualNetworkID(state.ID)
+		if err != nil {
+			return err
+		}
+
+		existing, err := client.Get(ctx, *id, virtualnetworks.DefaultGetOperationOptions())
+		if err != nil {
+			return fmt.Errorf("retrieving %s: %+v", *id, err)
+		}
+		if existing.Model == nil || existing.Model.Properties == nil || existing.Model.Properties.AddressSpace == nil {
+			return fmt.Errorf("retrieving %s: `properties.addressSpace` was nil", *id)
+		}
+
+		poolId := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/networkManagers/acctest-nm-ipam-%d/ipamPools/acctest-ipampool-%d", id.SubscriptionId, id.ResourceGroupName, data.RandomInteger, data.RandomInteger)
+
+		payload := *existing.Model
+		payload.Properties.AddressSpace.IPamPoolPrefixAllocations = &[]virtualnetworks.IPamPoolPrefixAllocation{
+			{
+				NumberOfIPAddresses: pointer.To("256"),
+				Pool: &virtualnetworks.IPamPoolPrefixAllocationPool{
+					Id: pointer.To(poolId),
+				},
+			},
+		}
+
+		// associating a Virtual Network also allocates the prefixes of its subnets from the pool
+		if payload.Properties.Subnets != nil {
+			for i := range *payload.Properties.Subnets {
+				subnet := &(*payload.Properties.Subnets)[i]
+				if subnet.Properties == nil {
+					continue
+				}
+				subnet.Properties.IPamPoolPrefixAllocations = &[]virtualnetworks.IPamPoolPrefixAllocation{
+					{
+						NumberOfIPAddresses: pointer.To("64"),
+						Pool: &virtualnetworks.IPamPoolPrefixAllocationPool{
+							Id: pointer.To(poolId),
+						},
+					},
+				}
+			}
+		}
+
+		if err := client.CreateOrUpdateThenPoll(ctx, *id, payload); err != nil {
+			return fmt.Errorf("associating IPAM pool with %s: %+v", *id, err)
+		}
+
+		return nil
+	}
 }
 
 func (VirtualNetworkResource) ipAddressPoolMultiple(data acceptance.TestData) string {

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -71,6 +71,8 @@ The following arguments are supported:
 
 -> **Note:** Exactly one of `address_prefixes` or `ip_address_pool` must be specified.
 
+-> **Note:** An IP Address Management (IPAM) Pool allocation that was established outside of Terraform (e.g. for a Subnet created with `address_prefixes` whose Virtual Network was associated with an IPAM Pool afterwards) is preserved as long as `address_prefixes` remains unchanged, consistent with the behaviour of ARM templates. Changing `address_prefixes` removes such an allocation.
+
 * `private_endpoint_network_policies` - (Optional) Enable or Disable network policies for the private endpoint on the subnet. Possible values are `Disabled`, `Enabled`, `NetworkSecurityGroupEnabled` and `RouteTableEnabled`. Defaults to `Disabled`.
 
 -> **Note:** If you don't want to use network policies like user-defined Routes and Network Security Groups, you need to set `private_endpoint_network_policies` in the subnet to `Disabled`. This setting only applies to Private Endpoints in the Subnet and affects all Private Endpoints in the Subnet. For other resources in the Subnet, access is controlled based via the Network Security Group which can be configured using the `azurerm_subnet_network_security_group_association` resource.

--- a/website/docs/r/virtual_network.html.markdown
+++ b/website/docs/r/virtual_network.html.markdown
@@ -91,6 +91,8 @@ The following arguments are supported:
 
 -> **Note:** Exactly one of `address_space` or `ip_address_pool` must be specified.
 
+-> **Note:** An IP Address Management (IPAM) Pool association that was established outside of Terraform (e.g. for a Virtual Network created with `address_space`) is preserved as long as `address_space` remains unchanged, consistent with the behaviour of ARM templates. Changing `address_space` removes such an association.
+
 * `subnet` - (Optional) Can be specified multiple times to define multiple subnets. Each `subnet` block supports fields documented below.
 
 -> **Note:** Since `subnet` can be configured both inline and via the separate `azurerm_subnet` resource, we have to explicitly set it to empty slice (`[]`) to remove it.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

`addressPrefixes` and `ipamPoolPrefixAllocations` are mutually exclusive when creating a Virtual Network or Subnet, so associating an *existing* address range with an IP Address Management (IPAM) Pool is only possible outside of Terraform (e.g. in the Portal or via an ARM template). This is a supported Azure workflow, commonly performed by a central platform team that owns the IPAM pool in a different subscription.

Previously the provider treated such an association as drift: the refresh wrote the allocation into state, the plan showed `- ip_address_pool { ... } -> null`, and applying it failed with `400 SubnetsCannotReferToPoolsIfVnetDoeNot` while subnets still referred to the pool (or silently removed the association when they didn't - arguably worse, as it destroys IPAM ownership established by another team).

This PR marks `ip_address_pool` as `Computed` on `azurerm_virtual_network` and `azurerm_subnet`, so an association that was never configured is preserved, consistent with the behaviour of ARM/Bicep templates. Removing the association intentionally remains possible: explicitly changing `address_space` / `address_prefixes` removes it (handled in the update functions, since with `Computed` the block's removal from configuration no longer registers as a change). Behaviour when the block *is* configured is unchanged, including the existing `number_of_ip_addresses` decrease validation.

Two things reviewers may want to weigh in on:

* With `Computed`, creating a resource with only `address_space` renders `ip_address_pool` as `(known after apply)` in the plan, and intentional removal via an `address_space` change no longer renders an explicit `- ip_address_pool` line. Both are standard `Optional` + `Computed` trade-offs (same as `dns_servers` on the same resource).
* Since Terraform cannot distinguish "never configured" from "removed from configuration", removing the `ip_address_pool` block without changing `address_space` / `address_prefixes` now preserves the association rather than removing it. `ExactlyOneOf` requires one of the two to be configured, so in practice removal always comes with the other being (re)introduced.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
  - Unit tests pass locally and the fix was verified end-to-end against a live subscription (details under Testing below). I don't have access to a subscription suitable for running the full acceptance test suite locally, so a CI run of the `TestAccNetworkManager/VNETIPANPool` and `TestAccNetworkManager/SubnetIPAMPool` groups would be appreciated - the existing `ipAddressPoolUpdateBasic` / `ipAddressPoolNumberUpdated` tests exercise the changed update paths.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

Added `testAccVirtualNetwork_ipAddressPoolAddedExternally` (registered in the `VNETIPANPool` sequential group): creates a Virtual Network with `address_space` and a standalone Subnet with `address_prefixes`, associates the IPAM pool out-of-band via the SDK (mirroring the Portal workflow, including the subnet allocation), then asserts an empty plan - covering both resources. Without this fix the plan-only step fails with the destructive `ip_address_pool` removal.

Manually verified against a live subscription (VNet `10.0.0.0/24` + subnet `10.0.0.0/26`, IPAM pool `10.0.0.0/16`, association performed in the Portal):

* Before the fix (v4.x release): `terraform plan` showed `- ip_address_pool { ... } -> null` on both resources; applying failed with `400 SubnetsCannotReferToPoolsIfVnetDoeNot`, reproducing the linked issue exactly.
* With the fix: the same plan is empty ("No changes").
* An unrelated update (adding tags) applies successfully and the association is preserved.
* Intentional removal works in the order the API requires: changing `address_prefixes` on the subnet removes its allocation, then changing `address_space` on the Virtual Network removes the association. Changing the Virtual Network first is rejected by the API (subnet still refers to the pool), confirming the remaining constraint is service-side.
* Adopting the association into configuration (replacing `address_space` with an `ip_address_pool` block matching the existing allocation) produces an empty plan and takes ownership as expected.

<img width="1553" height="609" alt="image (1)" src="https://github.com/user-attachments/assets/036fe6e9-3586-4dd9-b157-a42dd25d59af" />

<img width="1639" height="163" alt="unnamed" src="https://github.com/user-attachments/assets/bbb52dce-1bf6-423a-a813-2e162249c6aa" />

<img width="1592" height="339" alt="image (2)" src="https://github.com/user-attachments/assets/9128cb8c-3501-4a94-9cbf-fb89c27d1264" />

<img width="1617" height="687" alt="image (3)" src="https://github.com/user-attachments/assets/8dc29abb-26e0-4c7b-8251-8e809718fe2c" />

<img width="1853" height="759" alt="image (4)" src="https://github.com/user-attachments/assets/28b9cbff-d1ea-4090-809a-2c6a5220b86f" />


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

* `azurerm_virtual_network` - preserve IPAM pool associations established outside of Terraform [GH-00000]
* `azurerm_subnet` - preserve IPAM pool allocations established outside of Terraform [GH-00000]


This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #32673


## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

AI assistance was used for root-cause analysis. I reproduced the issue, verified all behaviours end-to-end against a live Azure subscription, and reviewed the final changes.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No changes to security controls.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
