### PR TITLE
`azurerm_container_app_custom_domain` - Add support for in-place updates

### DIFF
--- a/internal/services/containerapps/container_app_custom_domain_resource.go
+++ b/internal/services/containerapps/container_app_custom_domain_resource.go
@@ -55,7 +55,6 @@ func (a ContainerAppCustomDomainResource) Arguments() map[string]*pluginsdk.Sche
 		"container_app_environment_certificate_id": {
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
-			ForceNew:     true,
 			RequiredWith: []string{"certificate_binding_type"},
 			ValidateFunc: managedenvironments.ValidateCertificateID,
 		},
@@ -63,7 +62,6 @@ func (a ContainerAppCustomDomainResource) Arguments() map[string]*pluginsdk.Sche
 		"certificate_binding_type": {
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
-			ForceNew:     true,
 			ValidateFunc: validation.StringInSlice(containerapps.PossibleValuesForBindingType(), false),
 			Description:  "The Binding type. Possible values include `Disabled` and `SniEnabled`.",
 		},
@@ -184,6 +182,115 @@ func (a ContainerAppCustomDomainResource) Create() sdk.ResourceFunc {
 			}
 
 			metadata.SetID(id)
+
+			return nil
+		},
+	}
+}
+
+func (a ContainerAppCustomDomainResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.ContainerApps.ContainerAppClient
+
+			model := ContainerAppCustomDomainResourceModel{}
+			if err := metadata.Decode(&model); err != nil {
+				return err
+			}
+
+			id, err := parse.ContainerAppCustomDomainID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			containerAppId := containerapps.NewContainerAppID(id.SubscriptionId, id.ResourceGroupName, id.ContainerAppName)
+
+			locks.ByID(containerAppId.ID())
+			defer locks.UnlockByID(containerAppId.ID())
+
+			var certificateId *managedenvironments.CertificateId
+			if model.CertificateId != "" {
+				certificateId, err = managedenvironments.ParseCertificateID(model.CertificateId)
+				if err != nil {
+					return err
+				}
+			}
+
+			containerApp, err := client.Get(ctx, containerAppId)
+			if err != nil || containerApp.Model == nil {
+				return fmt.Errorf("retrieving %s to update %s", containerAppId, *id)
+			}
+
+			props := containerApp.Model.Properties
+			if props == nil || props.Configuration == nil {
+				return fmt.Errorf("could not retrieve properties of %s", containerAppId)
+			}
+
+			config := *props.Configuration
+			if config.Ingress == nil {
+				return fmt.Errorf("specified Container App (%s) has no Ingress configuration for Custom Domains", containerAppId)
+			}
+
+			// Delta-updates need the secrets back from the list API, or we'll end up removing them or erroring out.
+			secretsResp, err := client.ListSecrets(ctx, containerAppId)
+			if err != nil || secretsResp.Model == nil {
+				if !response.WasStatusCode(secretsResp.HttpResponse, http.StatusNoContent) {
+					return fmt.Errorf("retrieving secrets for update for %s: %+v", containerAppId, err)
+				}
+			}
+			props.Configuration.Secrets = helpers.UnpackContainerSecretsCollection(secretsResp.Model)
+
+			ingress := *config.Ingress
+			if ingress.CustomDomains == nil {
+				return fmt.Errorf("could not locate Custom Domain %q on %s", id.CustomDomainName, containerAppId)
+			}
+
+			customDomains := *ingress.CustomDomains
+			found := false
+			for i := range customDomains {
+				if strings.EqualFold(customDomains[i].Name, id.CustomDomainName) {
+					found = true
+					if certificateId != nil {
+						customDomains[i].CertificateId = pointer.To(certificateId.ID())
+						customDomains[i].BindingType = pointer.To(containerapps.BindingType(model.BindingType))
+					}
+					break
+				}
+			}
+
+			if !found {
+				return fmt.Errorf("could not locate Custom Domain %q on %s", id.CustomDomainName, containerAppId)
+			}
+
+			containerApp.Model.Properties.Configuration.Ingress.CustomDomains = pointer.To(customDomains)
+
+			if err := client.CreateOrUpdateThenPoll(ctx, containerAppId, *containerApp.Model); err != nil {
+				return fmt.Errorf("updating %s: %+v", *id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func (a ContainerAppCustomDomainResource) CustomizeDiff() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			if metadata.ResourceDiff == nil {
+				return nil
+			}
+
+			// Removing an explicit certificate (switching to an Azure-managed certificate) cannot be
+			// expressed as an in-place update: the Update path only writes the certificate when one is
+			// configured, so clearing it would leave the previous certificate bound at Azure and
+			// produce an inconsistent result after apply. Force a new resource for that transition.
+			if metadata.ResourceDiff.HasChange("container_app_environment_certificate_id") {
+				oldCertID, newCertID := metadata.ResourceDiff.GetChange("container_app_environment_certificate_id")
+				if oldCertID.(string) != "" && newCertID.(string) == "" {
+					return metadata.ResourceDiff.ForceNew("container_app_environment_certificate_id")
+				}
+			}
 
 			return nil
 		},

--- a/internal/services/containerapps/container_app_custom_domain_resource_test.go
+++ b/internal/services/containerapps/container_app_custom_domain_resource_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2025-07-01/containerapps"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -146,6 +148,78 @@ func TestAccContainerAppCustomDomainResource_update(t *testing.T) {
 	})
 }
 
+func TestAccContainerAppCustomDomainResource_updateCertificateInPlace(t *testing.T) {
+	if os.Getenv("ARM_TEST_DNS_ZONE") == "" || os.Getenv("ARM_TEST_DATA_RESOURCE_GROUP") == "" {
+		t.Skipf("Skipping as either ARM_TEST_DNS_ZONE or ARM_TEST_DATA_RESOURCE_GROUP is not set")
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_container_app_custom_domain", "test")
+	r := ContainerAppCustomDomainResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("container_app_environment_certificate_id").MatchesOtherKey(
+					check.That("azurerm_container_app_environment_certificate.test").Key("id"),
+				),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.updateCertificate(data),
+			ConfigPlanChecks: resource.ConfigPlanChecks{
+				PreApply: []plancheck.PlanCheck{
+					plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionUpdate),
+				},
+			},
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("container_app_environment_certificate_id").MatchesOtherKey(
+					check.That("azurerm_container_app_environment_certificate.test2").Key("id"),
+				),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccContainerAppCustomDomainResource_updateRemoveCertificateForcesNew(t *testing.T) {
+	if os.Getenv("ARM_TEST_DNS_ZONE") == "" || os.Getenv("ARM_TEST_DATA_RESOURCE_GROUP") == "" {
+		t.Skipf("Skipping as either ARM_TEST_DNS_ZONE or ARM_TEST_DATA_RESOURCE_GROUP is not set")
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_container_app_custom_domain", "test")
+	r := ContainerAppCustomDomainResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			// Clearing the explicit certificate switches the domain to an Azure-managed certificate,
+			// which cannot be done in place and must force a new resource rather than a no-op update.
+			// The managed certificate is then assigned asynchronously by Azure, so a perpetual diff is
+			// expected unless the certificate fields are ignored (see the resource documentation).
+			Config: r.removeCertificate(data),
+			ConfigPlanChecks: resource.ConfigPlanChecks{
+				PreApply: []plancheck.PlanCheck{
+					plancheck.ExpectResourceAction(data.ResourceName, plancheck.ResourceActionReplace),
+				},
+			},
+			ExpectNonEmptyPlan: true,
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+	})
+}
+
 func (r ContainerAppCustomDomainResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider azurerm {
@@ -225,6 +299,45 @@ resource "azurerm_container_app_custom_domain" "test2" {
   certificate_binding_type                 = "SniEnabled"
 }
 `, r.template(data), data.RandomInteger)
+}
+
+func (r ContainerAppCustomDomainResource) updateCertificate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider azurerm {
+  features {}
+}
+
+%s
+
+resource "azurerm_container_app_environment_certificate" "test2" {
+  name                         = "acctest-cacert%[2]d-2"
+  container_app_environment_id = azurerm_container_app_environment.test.id
+  certificate_blob_base64      = filebase64("testdata/testacc.pfx")
+  certificate_password         = "TestAcc"
+}
+
+resource "azurerm_container_app_custom_domain" "test" {
+  name                                     = trimprefix(azurerm_dns_txt_record.test.fqdn, "asuid.")
+  container_app_id                         = azurerm_container_app.test.id
+  container_app_environment_certificate_id = azurerm_container_app_environment_certificate.test2.id
+  certificate_binding_type                 = "SniEnabled"
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r ContainerAppCustomDomainResource) removeCertificate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider azurerm {
+  features {}
+}
+
+%s
+
+resource "azurerm_container_app_custom_domain" "test" {
+  name             = trimprefix(azurerm_dns_txt_record.test.fqdn, "asuid.")
+  container_app_id = azurerm_container_app.test.id
+}
+`, r.template(data))
 }
 
 func (r ContainerAppCustomDomainResource) template(data acceptance.TestData) string {

--- a/website/docs/r/container_app_custom_domain.html.markdown
+++ b/website/docs/r/container_app_custom_domain.html.markdown
@@ -116,11 +116,11 @@ The following arguments are supported:
 
 * `container_app_id` - (Required) The ID of the Container App to which this Custom Domain should be bound. Changing this forces a new resource to be created.
 
-* `container_app_environment_certificate_id` - (Optional) The ID of the Container App Environment Certificate to use. Changing this forces a new resource to be created.
+* `container_app_environment_certificate_id` - (Optional) The ID of the Container App Environment Certificate to use. Removing this value (switching to an Azure Managed certificate) forces a new resource to be created.
 
 -> **Note:** Omit this value if you wish to use an Azure Managed certificate. You must create the relevant DNS verification steps before this process will be successful.
 
-* `certificate_binding_type` - (Optional) The Certificate Binding type. Possible values are `Auto`, `Disabled` and `SniEnabled`. Required with `container_app_environment_certificate_id`. Changing this forces a new resource to be created.
+* `certificate_binding_type` - (Optional) The Certificate Binding type. Possible values are `Auto`, `Disabled` and `SniEnabled`. Required with `container_app_environment_certificate_id`.
 
 !> **Note:** If using an Azure Managed Certificate `container_app_environment_certificate_id` and `certificate_binding_type` should be added to `ignore_changes` to prevent resource recreation due to these values being modified asynchronously outside of Terraform.
 
@@ -136,6 +136,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 * `create` - (Defaults to 30 minutes) Used when creating the Container App.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Container App.
+* `update` - (Defaults to 30 minutes) Used when updating the Container App.
 * `delete` - (Defaults to 30 minutes) Used when deleting the Container App.
 
 ## Import


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description
Updating the `container_app_environment_certificate_id` or `certificate_binding_type` property on the `azurerm_container_app_custom_domain` resource should not require deleting and re-creating the custom domain.

Currently, because `container_app_environment_certificate_id` and `certificate_binding_type` are marked ForceNew, updating that property in Terraform causes the provider to delete and re-create the entire custom domain for the Container App. This results in downtime for the domain after it is deleted but before it is re-created.

However, this is not necessary; updating the Certificate ID or binding type for a Custom Domain using the Azure REST API directly does not cause downtime.

This PR adds in-place updates for `azurerm_container_app_custom_domain`.

## PR Checklist

- [X] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [X] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [X] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [X] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [X] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [X] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [X] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [X] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
~~- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.~~


## Testing 

- [X] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 
```shell
judasz@Jonaszs-MBP hashicorp-terraform-provider-azurerm % TF_ACC=1 ARM_SUBSCRIPTION_ID="redacted" ARM_TENANT_ID="redacted" ARM_CLIENT_ID="redacted" ARM_CLIENT_SECRET="redacted" ARM_TEST_DNS_ZONE="azuree2e.upbound.io" ARM_TEST_DATA_RESOURCE_GROUP="e2e-public-dns" ARM_TEST_LOCATION="westeurope" ARM_TEST_LOCATION_ALT="northeurope" ARM_TEST_LOCATION_ALT2="westeurope" go test -v -timeout 180m ./internal/services/containerapps/ -run TestAccContainerAppCustomDomainResource_updateCertificateInPlace
=== RUN   TestAccContainerAppCustomDomainResource_updateCertificateInPlace
=== PAUSE TestAccContainerAppCustomDomainResource_updateCertificateInPlace
=== CONT  TestAccContainerAppCustomDomainResource_updateCertificateInPlace
--- PASS: TestAccContainerAppCustomDomainResource_updateCertificateInPlace (786.83s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/containerapps 788.369s
```


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_container_app_custom_domain` - Add support for in-place updates of `container_app_environment_certificate_id` and `certificate_binding_type`


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [X] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #27148 


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [X] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->
Used Claude Opus to help me navigate through the repository and describe the testing process that I need to implement/run. Implementation was done on my onw.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
