### PR TITLE
5.0: `maps` - resolve TODO 4.0

### DIFF
--- a/internal/services/legacy/migration/legacy_vmss_v0_to_v1.go
+++ b/internal/services/legacy/migration/legacy_vmss_v0_to_v1.go
@@ -253,7 +253,6 @@ func (LegacyVMSSV0ToV1) Schema() map[string]*pluginsdk.Schema {
 						Type:     pluginsdk.TypeBool,
 						Optional: true,
 					},
-					// TODO 4.0: change this from enable_* to *_enabled
 					"enable_automatic_upgrades": {
 						Type:     pluginsdk.TypeBool,
 						Optional: true,

--- a/internal/services/managedhsm/parse/data_plane_helpers.go
+++ b/internal/services/managedhsm/parse/data_plane_helpers.go
@@ -21,7 +21,6 @@ func (e ManagedHSMDataPlaneEndpoint) BaseURI() string {
 }
 
 func ManagedHSMEndpoint(input string, domainSuffix *string) (*ManagedHSMDataPlaneEndpoint, error) {
-	// NOTE: this function can be removed in 4.0
 	uri, err := url.Parse(input)
 	if err != nil {
 		return nil, fmt.Errorf("parsing %q: %+v", input, err)

--- a/internal/services/maps/maps_account_resource.go
+++ b/internal/services/maps/maps_account_resource.go
@@ -27,7 +27,7 @@ import (
 )
 
 func resourceMapsAccount() *pluginsdk.Resource {
-	resource := &pluginsdk.Resource{
+	return &pluginsdk.Resource{
 		Create: resourceMapsAccountCreate,
 		Read:   resourceMapsAccountRead,
 		Update: resourceMapsAccountUpdate,
@@ -129,8 +129,6 @@ func resourceMapsAccount() *pluginsdk.Resource {
 			},
 		},
 	}
-
-	return resource
 }
 
 func resourceMapsAccountCreate(d *pluginsdk.ResourceData, meta interface{}) error {
@@ -159,13 +157,8 @@ func resourceMapsAccountCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 		return fmt.Errorf("expanding `data_store`: %+v", err)
 	}
 
-	loc := "global"
-	if v, ok := d.GetOk("location"); ok {
-		loc = location.Normalize(v.(string))
-	}
-
 	parameters := accounts.MapsAccount{
-		Location: loc,
+		Location: location.Normalize(d.Get("location").(string)),
 		Sku: accounts.Sku{
 			Name: accounts.Name(d.Get("sku_name").(string)),
 		},
@@ -177,9 +170,7 @@ func resourceMapsAccountCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 		},
 	}
 
-	// setting anything into identity returns a 400 Bad Request error if the location of the maps account is `global` which is
-	// what we were defaulting to previously - when `location` becomes Required in 4.0 we can remove this check and set
-	// identity in the payload like we do elsewhere
+	// setting anything into identity returns a 400 Bad Request error if the location of the maps account is `global`
 	if v, ok := d.GetOk("identity"); ok {
 		identityExpanded, err := identity.ExpandSystemAndUserAssignedMap(v.([]interface{}))
 		if err != nil {

--- a/internal/services/maps/maps_account_resource_test.go
+++ b/internal/services/maps/maps_account_resource_test.go
@@ -118,17 +118,17 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_maps_account" "test" {
-  name                = "accMapsAccount-%d"
+  name                = "accMapsAccount-%[1]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   sku_name            = "G2"
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (MapsAccountResource) complete(data acceptance.TestData) string {
@@ -138,12 +138,12 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_storage_account" "test" {
-  name                     = "testaccsa%s"
+  name                     = "testaccsa%[3]s"
   resource_group_name      = azurerm_resource_group.test.name
   location                 = azurerm_resource_group.test.location
   account_tier             = "Standard"
@@ -151,7 +151,7 @@ resource "azurerm_storage_account" "test" {
 }
 
 resource "azurerm_maps_account" "test" {
-  name                = "accMapsAccount-%d"
+  name                = "accMapsAccount-%[1]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   sku_name            = "G2"
@@ -176,7 +176,7 @@ resource "azurerm_maps_account" "test" {
     environment = "testing"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
 
 func (MapsAccountResource) update(data acceptance.TestData) string {
@@ -186,12 +186,12 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_storage_account" "test" {
-  name                     = "testaccsa%s"
+  name                     = "testaccsa%[3]s"
   resource_group_name      = azurerm_resource_group.test.name
   location                 = azurerm_resource_group.test.location
   account_tier             = "Standard"
@@ -199,7 +199,7 @@ resource "azurerm_storage_account" "test" {
 }
 
 resource "azurerm_storage_account" "test2" {
-  name                     = "testaccsa2%s"
+  name                     = "testaccsa2%[3]s"
   resource_group_name      = azurerm_resource_group.test.name
   location                 = azurerm_resource_group.test.location
   account_tier             = "Standard"
@@ -207,7 +207,7 @@ resource "azurerm_storage_account" "test2" {
 }
 
 resource "azurerm_maps_account" "test" {
-  name                = "accMapsAccount-%d"
+  name                = "accMapsAccount-%[1]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   sku_name            = "G2"
@@ -237,7 +237,7 @@ resource "azurerm_maps_account" "test" {
     service     = "maps"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
 
 func (MapsAccountResource) corsAndDataStoresRemoved(data acceptance.TestData) string {
@@ -247,12 +247,12 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_maps_account" "test" {
-  name                = "accMapsAccount-%d"
+  name                = "accMapsAccount-%[1]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   sku_name            = "G2"
@@ -261,7 +261,7 @@ resource "azurerm_maps_account" "test" {
     type = "SystemAssigned"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (MapsAccountResource) disableLocalAuth(data acceptance.TestData) string {
@@ -271,18 +271,18 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_maps_account" "test" {
-  name                         = "accMapsAccount-%d"
+  name                         = "accMapsAccount-%[1]d"
   resource_group_name          = azurerm_resource_group.test.name
   location                     = azurerm_resource_group.test.location
   sku_name                     = "G2"
   local_authentication_enabled = false
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (MapsAccountResource) enableLocalAuth(data acceptance.TestData) string {
@@ -292,18 +292,18 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_maps_account" "test" {
-  name                         = "accMapsAccount-%d"
+  name                         = "accMapsAccount-%[1]d"
   resource_group_name          = azurerm_resource_group.test.name
   location                     = azurerm_resource_group.test.location
   sku_name                     = "G2"
   local_authentication_enabled = true
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (MapsAccountResource) userAssignedIdentity(data acceptance.TestData) string {
@@ -313,18 +313,18 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_user_assigned_identity" "test" {
-  name                = "acctest%s"
+  name                = "acctest%[3]s"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
 }
 
 resource "azurerm_maps_account" "test" {
-  name                = "accMapsAccount-%d"
+  name                = "accMapsAccount-%[1]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   sku_name            = "G2"
@@ -335,5 +335,5 @@ resource "azurerm_maps_account" "test" {
   }
 
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

- Resolve TODO 4.0 for `azurerm_maps_account`
- Removes TODO 4.0 from managed HSM helper (cannot be done without larger refactor, not necessary)


## PR Checklist

- [ ] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [ ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [ ] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [ ] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change




## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [ ] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
