### PR TITLE
`azurerm_dashboard_grafana` - update `grafana_major_version` possible values to `12` and `13`

### DIFF
--- a/internal/services/dashboard/dashboard_grafana_data_source_test.go
+++ b/internal/services/dashboard/dashboard_grafana_data_source_test.go
@@ -22,7 +22,7 @@ func TestAccDashboardGrafanaDataSource_basic(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("resource_group_name").Exists(),
-				check.That(data.ResourceName).Key("grafana_major_version").HasValue("12"),
+				check.That(data.ResourceName).Key("grafana_major_version").HasValue("13"),
 			),
 		},
 	})

--- a/internal/services/dashboard/dashboard_grafana_managed_private_endpoint_resource_test.go
+++ b/internal/services/dashboard/dashboard_grafana_managed_private_endpoint_resource_test.go
@@ -107,7 +107,7 @@ resource "azurerm_dashboard_grafana" "test" {
   name                  = "a-dg-%d"
   resource_group_name   = azurerm_resource_group.test.name
   location              = azurerm_resource_group.test.location
-  grafana_major_version = "12"
+  grafana_major_version = "13"
 }
 
 resource "azurerm_monitor_workspace" "test" {

--- a/internal/services/dashboard/dashboard_grafana_resource.go
+++ b/internal/services/dashboard/dashboard_grafana_resource.go
@@ -202,7 +202,7 @@ func (r DashboardGrafanaResource) Arguments() map[string]*pluginsdk.Schema {
 			Type:     pluginsdk.TypeString,
 			Required: true,
 			ValidateFunc: validation.StringInSlice([]string{
-				"11", "12",
+				"12", "13",
 			}, false),
 		},
 

--- a/internal/services/dashboard/dashboard_grafana_resource_test.go
+++ b/internal/services/dashboard/dashboard_grafana_resource_test.go
@@ -173,7 +173,7 @@ resource "azurerm_dashboard_grafana" "test" {
   name                  = "a-dg-%d"
   resource_group_name   = azurerm_resource_group.test.name
   location              = azurerm_resource_group.test.location
-  grafana_major_version = "12"
+  grafana_major_version = "13"
 }
 `, template, data.RandomInteger)
 }
@@ -187,7 +187,7 @@ resource "azurerm_dashboard_grafana" "test" {
   name                  = "a-dg-%d"
   resource_group_name   = azurerm_resource_group.test.name
   location              = azurerm_resource_group.test.location
-  grafana_major_version = "11"
+  grafana_major_version = "12"
 
   sku = "Essential"
 }
@@ -203,7 +203,7 @@ resource "azurerm_dashboard_grafana" "test" {
   name                  = "a-dg-%d"
   resource_group_name   = azurerm_resource_group.test.name
   location              = azurerm_resource_group.test.location
-  grafana_major_version = "12"
+  grafana_major_version = "13"
 
   sku      = "Standard"
   sku_size = "X1"
@@ -220,7 +220,7 @@ resource "azurerm_dashboard_grafana" "import" {
   name                  = azurerm_dashboard_grafana.test.name
   resource_group_name   = azurerm_dashboard_grafana.test.resource_group_name
   location              = azurerm_dashboard_grafana.test.location
-  grafana_major_version = "12"
+  grafana_major_version = "13"
 }
 `, config)
 }
@@ -242,7 +242,7 @@ resource "azurerm_dashboard_grafana" "test" {
   api_key_enabled                   = true
   deterministic_outbound_ip_enabled = true
   public_network_access_enabled     = false
-  grafana_major_version             = "12"
+  grafana_major_version             = "13"
   smtp {
     enabled          = true
     host             = "localhost:25"
@@ -284,7 +284,7 @@ resource "azurerm_dashboard_grafana" "test" {
   name                  = "a-dg-%d"
   resource_group_name   = azurerm_resource_group.test.name
   location              = azurerm_resource_group.test.location
-  grafana_major_version = "12"
+  grafana_major_version = "13"
 
   identity {
     type = "SystemAssigned"
@@ -349,7 +349,7 @@ resource "azurerm_dashboard_grafana" "test" {
   api_key_enabled                   = true
   deterministic_outbound_ip_enabled = true
   public_network_access_enabled     = false
-  grafana_major_version             = "12"
+  grafana_major_version             = "13"
   smtp {
     enabled          = true
     host             = "localhost:25"

--- a/website/docs/5.0-upgrade-guide.html.markdown
+++ b/website/docs/5.0-upgrade-guide.html.markdown
@@ -490,6 +490,7 @@ Please follow the format in the example below for listing breaking changes in re
 ### `azurerm_dashboard_grafana`
 
 * The deprecated `Essential` value for the `sku` property has been removed.
+* The `grafana_major_version` property no longer accepts `11` as a value.
 
 ### `azurerm_datadog_monitor_sso_configuration`
 

--- a/website/docs/r/dashboard_grafana.html.markdown
+++ b/website/docs/r/dashboard_grafana.html.markdown
@@ -22,7 +22,7 @@ resource "azurerm_dashboard_grafana" "example" {
   name                              = "example-dg"
   resource_group_name               = azurerm_resource_group.example.name
   location                          = "West Europe"
-  grafana_major_version             = 12
+  grafana_major_version             = 13
   api_key_enabled                   = true
   deterministic_outbound_ip_enabled = true
   public_network_access_enabled     = false
@@ -49,7 +49,7 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the Azure Region where the Dashboard Grafana should exist. Changing this forces a new Dashboard Grafana to be created.
 
-* `grafana_major_version` - (Required) Which major version of Grafana to deploy. Possible values are `11`, `12`.
+* `grafana_major_version` - (Required) Which major version of Grafana to deploy. Possible values are `12`, `13`.
 
 * `api_key_enabled` - (Optional) Whether to enable the api key setting of the Grafana instance. Defaults to `false`.
 

--- a/website/docs/r/dashboard_grafana_managed_private_endpoint.html.markdown
+++ b/website/docs/r/dashboard_grafana_managed_private_endpoint.html.markdown
@@ -31,7 +31,7 @@ resource "azurerm_dashboard_grafana" "example" {
   name                          = "example-dg"
   resource_group_name           = azurerm_resource_group.example.name
   location                      = azurerm_resource_group.example.location
-  grafana_major_version         = 12
+  grafana_major_version         = 13
   public_network_access_enabled = false
 
   azure_monitor_workspace_integrations {


### PR DESCRIPTION
## Community Note

* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

Azure Managed Grafana has added support for Grafana major version `13` and is deprecating major version `11`. This updates the `grafana_major_version` property validation on `azurerm_dashboard_grafana` so it accepts `12` and `13` instead of `11` and `12`, keeping the provider aligned with the versions the service currently offers.

This mirrors the previously merged PR #31653, which bumped the allowed values from `10`, `11` to `11`, `12`. Existing `11` deployments are upgraded in place by the service, and `13` becomes selectable as Azure enables it, so no state migration is required.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.

## Testing

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass.

The acceptance test configurations for `azurerm_dashboard_grafana`, its data source, and the managed private endpoint resource have been updated to use a supported `grafana_major_version`. This is a validation-only change to an existing property, consistent with PR #31653.

Acceptance tests were run locally against Azure (`ARM_TEST_LOCATION=australiaeast`). `TestAccDashboardGrafana_update` provisions a Grafana instance at `12` and performs an in-place upgrade to `13`, exercising both new values end to end:

```
$ TF_ACC=1 go test ./internal/services/dashboard -v -run ''^TestAccDashboardGrafana_basic$'' -timeout 180m
=== RUN   TestAccDashboardGrafana_basic
--- PASS: TestAccDashboardGrafana_basic (895.51s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/dashboard

$ TF_ACC=1 go test ./internal/services/dashboard -v -run ''^TestAccDashboardGrafana_update$'' -timeout 3h
=== RUN   TestAccDashboardGrafana_update
--- PASS: TestAccDashboardGrafana_update (1731.11s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/dashboard     1762.820s
```

## Change Log

* `azurerm_dashboard_grafana` - update `grafana_major_version` possible values to `12` and `13` [GH-00000]

This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change

## Related Issue(s)

N/A

## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

AI was used to help identify the files requiring changes and to draft the code, test, and documentation updates. All changes were reviewed for correctness against the existing pattern established by PR #31653.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

No. There are no changes to access controls, encryption, or logging in this pull request.
