### PR TITLE
`azurerm_container_app_job` - accept the default workload profile when `workload_profile_name` is omitted

### DIFF
--- a/internal/services/containerapps/container_app_job_resource.go
+++ b/internal/services/containerapps/container_app_job_resource.go
@@ -85,8 +85,9 @@ func (r ContainerAppJobResource) Arguments() map[string]*schema.Schema {
 		},
 
 		"workload_profile_name": {
-			Type:         pluginsdk.TypeString,
-			Optional:     true,
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			// NOTE: O+C Azure return different value for V1 and V2 Container App Env
 			Computed:     true,
 			ValidateFunc: validation.StringIsNotEmpty,
 		},

--- a/internal/services/containerapps/container_app_job_resource.go
+++ b/internal/services/containerapps/container_app_job_resource.go
@@ -87,6 +87,7 @@ func (r ContainerAppJobResource) Arguments() map[string]*schema.Schema {
 		"workload_profile_name": {
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
+			Computed:     true,
 			ValidateFunc: validation.StringIsNotEmpty,
 		},
 

--- a/internal/services/containerapps/container_app_job_resource.go
+++ b/internal/services/containerapps/container_app_job_resource.go
@@ -87,7 +87,7 @@ func (r ContainerAppJobResource) Arguments() map[string]*schema.Schema {
 		"workload_profile_name": {
 			Type:     pluginsdk.TypeString,
 			Optional: true,
-			// NOTE: O+C Azure return different value for V1 and V2 Container App Env
+			// NOTE: O+C Azure returns default workload_profile_name for v2 Container App Envs
 			Computed:     true,
 			ValidateFunc: validation.StringIsNotEmpty,
 		},

--- a/internal/services/containerapps/container_app_job_resource_test.go
+++ b/internal/services/containerapps/container_app_job_resource_test.go
@@ -63,10 +63,6 @@ func TestAccContainerAppJob_workloadProfileDefault(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
-		{
-			Config:   r.workloadProfileDefault(data),
-			PlanOnly: true,
-		},
 	})
 }
 

--- a/internal/services/containerapps/container_app_job_resource_test.go
+++ b/internal/services/containerapps/container_app_job_resource_test.go
@@ -50,6 +50,26 @@ func TestAccContainerAppJob_basic(t *testing.T) {
 	})
 }
 
+func TestAccContainerAppJob_workloadProfileDefault(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app_job", "test")
+	r := ContainerAppJobResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.workloadProfileDefault(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("workload_profile_name").HasValue("Consumption"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config:   r.workloadProfileDefault(data),
+			PlanOnly: true,
+		},
+	})
+}
+
 func TestAccContainerAppJob_withWorkloadProfile(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_container_app_job", "test")
 	r := ContainerAppJobResource{}
@@ -1519,6 +1539,35 @@ resource "azurerm_container_app_job" "test" {
   }
 }
 `, r.templateWorkloadProfile(data), data.RandomInteger)
+}
+
+func (r ContainerAppJobResource) workloadProfileDefault(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_container_app_job" "test" {
+  name                         = "acctest-cajob%[2]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  location                     = azurerm_resource_group.test.location
+  container_app_environment_id = azurerm_container_app_environment.test.id
+
+  replica_timeout_in_seconds = 10
+  replica_retry_limit        = 10
+  manual_trigger_config {
+    parallelism              = 4
+    replica_completion_count = 1
+  }
+
+  template {
+    container {
+      image  = "jackofallops/azure-containerapps-python-acctest:v0.0.1"
+      name   = "testcontainerappsjob0"
+      cpu    = 0.5
+      memory = "1Gi"
+    }
+  }
+}
+`, ContainerAppEnvironmentResource{}.consumptionWorkloadProfile(data), data.RandomInteger)
 }
 
 func (r ContainerAppJobResource) complete(data acceptance.TestData) string {


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Updates `workload_profile_name` on `azurerm_container_app_job` to be `Optional` and `Computed`.

In workload profiles environments(V2), Azure defaults the omitted value to `Consumption`. The provider previously stored this value in state while treating its absence from the configuration as a removal, causing a perpetual diff.

An acceptance test has been added to verify the service-provided default and ensure subsequent plans are empty.

Why O+C: A static default cannot be used because Azure returns `null` for `Consumption-only`(V1) environments and "Consumption" for workload profiles(V2) environments. Making the property `required` would affect current user and would not provide a valid value for `Consumption-only` environments.

## PR Checklist

- [x] I have followed the guidelines in our Contributing Documentation
- [x] I have checked to ensure there aren't other open Pull Requests
- [x] I have checked if my changes close any open issues.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them.
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Testing 

- [x] My submission includes Test coverage as described in the Contribution Guide
```
TF_ACC=1 go test -v ./internal/services/containerapps -run=TestAccContainerAppJob_basic -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccContainerAppJob_basic
=== PAUSE TestAccContainerAppJob_basic
=== CONT  TestAccContainerAppJob_basic
--- PASS: TestAccContainerAppJob_basic (1420.65s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/containerapps	1420.678s
TF_ACC=1 go test -v ./internal/services/containerapps -run=TestAccContainerAppJob_workloadProfileDefault -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccContainerAppJob_workloadProfileDefault
=== PAUSE TestAccContainerAppJob_workloadProfileDefault
=== CONT  TestAccContainerAppJob_workloadProfileDefault
--- PASS: TestAccContainerAppJob_workloadProfileDefault (2151.29s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/containerapps	2151.323s
```

## Change Log
* `azurerm_container_app_job` - accept the default workload profile when `workload_profile_name` is omitted [GH-32799]

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #32760 


## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

## Rollback Plan
NA

## Changes to Security Controls
NA
