### PR TITLE
`azurerm_container_app`: Adding `additional_port_mapping`

### DIFF
--- a/internal/services/containerapps/container_app_resource_test.go
+++ b/internal/services/containerapps/container_app_resource_test.go
@@ -390,6 +390,38 @@ func TestAccContainerAppResource_completeTcpExposedPort(t *testing.T) {
 	})
 }
 
+func TestAccContainerAppResource_additionalPortMappings(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app", "test")
+	r := ContainerAppResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.additionalPortMappings(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("ingress.0.additional_port_mapping.#").HasValue("1"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.additionalPortMappingsUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("ingress.0.additional_port_mapping.#").HasValue("2"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.additionalPortMappingsRemoved(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("ingress.0.additional_port_mapping.#").HasValue("0"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccContainerAppResource_removeDaprAppPort(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_container_app", "test")
 	r := ContainerAppResource{}
@@ -2435,6 +2467,151 @@ resource "azurerm_container_app" "test" {
   }
 }
 `, r.templateWithVnet(data), data.RandomInteger, revisionSuffix)
+}
+
+func (r ContainerAppResource) templateWithDelegatedVnet(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_container_app_environment" "test" {
+  name                       = "acctest-CAEnv%[2]d"
+  resource_group_name        = azurerm_resource_group.test.name
+  location                   = azurerm_resource_group.test.location
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  logs_destination           = "log-analytics"
+  infrastructure_subnet_id   = azurerm_subnet.control.id
+
+  workload_profile {
+    name                  = "Consumption"
+    workload_profile_type = "Consumption"
+  }
+}
+`, ContainerAppEnvironmentResource{}.templateVNet(data), data.RandomInteger)
+}
+
+func (r ContainerAppResource) additionalPortMappings(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_container_app" "test" {
+  name                         = "acctest-capp-%[2]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  container_app_environment_id = azurerm_container_app_environment.test.id
+  revision_mode                = "Single"
+  workload_profile_name        = "Consumption"
+
+  template {
+    container {
+      name   = "acctest-cont-%[2]d"
+      image  = "jackofallops/azure-containerapps-python-acctest:v0.0.1"
+      cpu    = 0.25
+      memory = "0.5Gi"
+    }
+  }
+
+  ingress {
+    external_enabled = true
+    target_port      = 5000
+    exposed_port     = 5555
+    transport        = "tcp"
+
+    additional_port_mapping {
+      external_enabled = true
+      target_port      = 5001
+      exposed_port     = 5556
+    }
+
+    traffic_weight {
+      latest_revision = true
+      percentage      = 100
+    }
+  }
+}
+`, r.templateWithDelegatedVnet(data), data.RandomInteger)
+}
+
+func (r ContainerAppResource) additionalPortMappingsUpdate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_container_app" "test" {
+  name                         = "acctest-capp-%[2]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  container_app_environment_id = azurerm_container_app_environment.test.id
+  revision_mode                = "Single"
+  workload_profile_name        = "Consumption"
+
+  template {
+    container {
+      name   = "acctest-cont-%[2]d"
+      image  = "jackofallops/azure-containerapps-python-acctest:v0.0.1"
+      cpu    = 0.25
+      memory = "0.5Gi"
+    }
+  }
+
+  ingress {
+    external_enabled = true
+    target_port      = 5000
+    exposed_port     = 5555
+    transport        = "tcp"
+
+    additional_port_mapping {
+      external_enabled = true
+      target_port      = 5001
+      exposed_port     = 5557
+    }
+
+    additional_port_mapping {
+      target_port = 5002
+    }
+
+    traffic_weight {
+      latest_revision = true
+      percentage      = 100
+    }
+  }
+}
+`, r.templateWithDelegatedVnet(data), data.RandomInteger)
+}
+
+func (r ContainerAppResource) additionalPortMappingsRemoved(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_container_app" "test" {
+  name                         = "acctest-capp-%[2]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  container_app_environment_id = azurerm_container_app_environment.test.id
+  revision_mode                = "Single"
+  workload_profile_name        = "Consumption"
+
+  template {
+    container {
+      name   = "acctest-cont-%[2]d"
+      image  = "jackofallops/azure-containerapps-python-acctest:v0.0.1"
+      cpu    = 0.25
+      memory = "0.5Gi"
+    }
+  }
+
+  ingress {
+    external_enabled = true
+    target_port      = 5000
+    exposed_port     = 5555
+    transport        = "tcp"
+
+    traffic_weight {
+      latest_revision = true
+      percentage      = 100
+    }
+  }
+}
+`, r.templateWithDelegatedVnet(data), data.RandomInteger)
 }
 
 func (r ContainerAppResource) scaleRules(data acceptance.TestData) string {

--- a/internal/services/containerapps/helpers/container_apps.go
+++ b/internal/services/containerapps/helpers/container_apps.go
@@ -149,6 +149,7 @@ func FlattenContainerAppRegistries(input *[]containerapps.RegistryCredentials) [
 }
 
 type Ingress struct {
+	AdditionalPortMappings []IngressPortMapping    `tfschema:"additional_port_mapping"`
 	AllowInsecure          bool                    `tfschema:"allow_insecure_connections"`
 	CustomDomains          []CustomDomain          `tfschema:"custom_domain"`
 	IsExternal             bool                    `tfschema:"external_enabled"`
@@ -160,6 +161,12 @@ type Ingress struct {
 	IpSecurityRestrictions []IpSecurityRestriction `tfschema:"ip_security_restriction"`
 	ClientCertificateMode  string                  `tfschema:"client_certificate_mode"`
 	Cors                   []Cors                  `tfschema:"cors"`
+}
+
+type IngressPortMapping struct {
+	External    bool  `tfschema:"external_enabled"`
+	TargetPort  int64 `tfschema:"target_port"`
+	ExposedPort int64 `tfschema:"exposed_port"`
 }
 
 type Cors struct {
@@ -178,6 +185,8 @@ func ContainerAppIngressSchema() *pluginsdk.Schema {
 		MaxItems: 1,
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
+				"additional_port_mapping": ContainerAppIngressAdditionalPortMapping(),
+
 				"allow_insecure_connections": {
 					Type:        pluginsdk.TypeBool,
 					Optional:    true,
@@ -296,6 +305,8 @@ func ContainerAppIngressSchemaComputed() *pluginsdk.Schema {
 		Computed: true,
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
+				"additional_port_mapping": ContainerAppIngressAdditionalPortMappingComputed(),
+
 				"allow_insecure_connections": {
 					Type:        pluginsdk.TypeBool,
 					Computed:    true,
@@ -401,6 +412,7 @@ func ExpandContainerAppIngress(input []Ingress, appName string) *containerapps.I
 
 	ingress := input[0]
 	result := &containerapps.Ingress{
+		AdditionalPortMappings: expandContainerAppIngressAdditionalPortMappings(ingress.AdditionalPortMappings),
 		AllowInsecure:          pointer.To(ingress.AllowInsecure),
 		CustomDomains:          expandContainerAppIngressCustomDomain(ingress.CustomDomains),
 		External:               pointer.To(ingress.IsExternal),
@@ -471,6 +483,7 @@ func FlattenContainerAppIngress(input *containerapps.Ingress, appName string) []
 
 	ingress := *input
 	result := Ingress{
+		AdditionalPortMappings: flattenContainerAppIngressAdditionalPortMappings(ingress.AdditionalPortMappings),
 		AllowInsecure:          pointer.From(ingress.AllowInsecure),
 		CustomDomains:          flattenContainerAppIngressCustomDomain(ingress.CustomDomains),
 		IsExternal:             pointer.From(ingress.External),
@@ -573,6 +586,43 @@ func flattenContainerAppIngressCustomDomain(input *[]containerapps.CustomDomain)
 	return result
 }
 
+func expandContainerAppIngressAdditionalPortMappings(input []IngressPortMapping) *[]containerapps.IngressPortMapping {
+	// The Update operation is a PATCH, so an empty slice is sent rather than nil to ensure removed port mappings are deleted
+	result := make([]containerapps.IngressPortMapping, 0)
+
+	for _, v := range input {
+		mapping := containerapps.IngressPortMapping{
+			External:   v.External,
+			TargetPort: v.TargetPort,
+		}
+
+		if v.ExposedPort != 0 {
+			mapping.ExposedPort = pointer.To(v.ExposedPort)
+		}
+
+		result = append(result, mapping)
+	}
+
+	return &result
+}
+
+func flattenContainerAppIngressAdditionalPortMappings(input *[]containerapps.IngressPortMapping) []IngressPortMapping {
+	if input == nil {
+		return []IngressPortMapping{}
+	}
+
+	result := make([]IngressPortMapping, 0)
+	for _, v := range *input {
+		result = append(result, IngressPortMapping{
+			ExposedPort: pointer.From(v.ExposedPort),
+			External:    v.External,
+			TargetPort:  v.TargetPort,
+		})
+	}
+
+	return result
+}
+
 func flattenContainerAppIngressIpSecurityRestrictions(input *[]containerapps.IPSecurityRestrictionRule) []IpSecurityRestriction {
 	if input == nil {
 		return []IpSecurityRestriction{}
@@ -605,6 +655,66 @@ type IpSecurityRestriction struct {
 	Description    string `tfschema:"description"`
 	IpAddressRange string `tfschema:"ip_address_range"`
 	Name           string `tfschema:"name"`
+}
+
+func ContainerAppIngressAdditionalPortMapping() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"external_enabled": {
+					Type:        pluginsdk.TypeBool,
+					Optional:    true,
+					Default:     false,
+					Description: "Is the port mapping accessible from outside the Container App Environment.",
+				},
+
+				"target_port": {
+					Type:         pluginsdk.TypeInt,
+					Required:     true,
+					ValidateFunc: validation.IntBetween(1, 65535),
+					Description:  "The target port on the container for the additional Ingress traffic.",
+				},
+
+				"exposed_port": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.IntBetween(1, 65535),
+					Description:  "The exposed port on the container for the additional Ingress traffic. Defaults to `target_port` if not set.",
+				},
+			},
+		},
+	}
+}
+
+func ContainerAppIngressAdditionalPortMappingComputed() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Computed: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"external_enabled": {
+					Type:        pluginsdk.TypeBool,
+					Computed:    true,
+					Description: "Is the port mapping accessible from outside the Container App Environment.",
+				},
+
+				"target_port": {
+					Type:        pluginsdk.TypeInt,
+					Computed:    true,
+					Description: "The target port on the container for the additional Ingress traffic.",
+				},
+
+				"exposed_port": {
+					Type:        pluginsdk.TypeInt,
+					Computed:    true,
+					Description: "The exposed port on the container for the additional Ingress traffic.",
+				},
+			},
+		},
+	}
 }
 
 func ContainerAppIngressIpSecurityRestriction() *pluginsdk.Schema {

--- a/website/docs/d/container_app.html.markdown
+++ b/website/docs/d/container_app.html.markdown
@@ -275,6 +275,8 @@ An `identity` block exports the following:
 
 An `ingress` block exports the following:
 
+* `additional_port_mapping` - One or more `additional_port_mapping` blocks as detailed below.
+
 * `allow_insecure_connections` - Should this ingress allow insecure connections?
 
 * `client_certificate_mode` - The client certificate mode for the Ingress.
@@ -294,6 +296,16 @@ An `ingress` block exports the following:
 * `traffic_weight` - A `traffic_weight` block as detailed below.
 
 * `transport` - The transport method for the Ingress.
+
+---
+
+An `additional_port_mapping` block exports the following:
+
+* `external_enabled` - Are connections to this port mapping from outside the Container App Environment enabled?
+
+* `target_port` - The target TCP port on the container for the additional Ingress traffic.
+
+* `exposed_port` - The TCP port exposed for the additional Ingress traffic.
 
 ---
 

--- a/website/docs/r/container_app.html.markdown
+++ b/website/docs/r/container_app.html.markdown
@@ -386,6 +386,8 @@ An `identity` block supports the following:
 
 An `ingress` block supports the following:
 
+* `additional_port_mapping` - (Optional) One or more `additional_port_mapping` blocks as defined below.
+
 * `allow_insecure_connections` - (Optional) Should this ingress allow insecure connections?
 
 * `cors` - (Optional) A `cors` block as defined below.
@@ -409,6 +411,18 @@ An `ingress` block supports the following:
 ~> **Note:** if `transport` is set to `tcp`, `exposed_port` and `target_port` should be set at the same time.
 
 * `client_certificate_mode` - (Optional) The client certificate mode for the Ingress. Possible values are `require`, `accept`, and `ignore`.
+
+---
+
+An `additional_port_mapping` block supports the following:
+
+* `external_enabled` - (Optional) Are connections to this port mapping from outside the Container App Environment enabled? Defaults to `false`.
+
+~> **Note:** `external_enabled` can only be set to `true` when `external_enabled` on the `ingress` block is also set to `true`.
+
+* `target_port` - (Required) The target TCP port on the container for the additional Ingress traffic.
+
+* `exposed_port` - (Optional) The TCP port exposed for the additional Ingress traffic. Defaults to `target_port` if not set. External exposed ports must be unique across the Container App Environment; internal ones may be shared by multiple apps.
 
 ---
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR exposes [the `additional_port_mappings` on the Container App](https://learn.microsoft.com/en-us/azure/container-apps/ingress-overview#additional-tcp-ports) instances.

```
resource "azurerm_container_app" "test" {
  name                         = "acctest-capp-%[2]d"
  resource_group_name          = azurerm_resource_group.test.name
  container_app_environment_id = azurerm_container_app_environment.test.id
  revision_mode                = "Single"
  workload_profile_name        = "Consumption"

  template {
    container {
      name   = "acctest-cont-%[2]d"
      image  = "jackofallops/azure-containerapps-python-acctest:v0.0.1"
      cpu    = 0.25
      memory = "0.5Gi"
    }
  }

  ingress {
    external_enabled = true
    target_port      = 5000
    exposed_port     = 5555
    transport        = "tcp"

    # New:
    additional_port_mapping {
      external_enabled = true
      target_port      = 5001
      exposed_port     = 5556
    }

    traffic_weight {
      latest_revision = true
      percentage      = 100
    }
  }
}
```


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_container_app` - support for the `additional_port_mapping` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

- Fixes #23442
- Inspired by #28148

## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

The making of this merge request was done using the help of Claude (Fable model). It produced most of the code and docs.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

- [x] No Changes

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
