### PR TITLE
Update virtual_network_peering with the ability to use subscription_id

### DIFF
--- a/internal/services/network/virtual_network_peering_resource.go
+++ b/internal/services/network/virtual_network_peering_resource.go
@@ -60,7 +60,15 @@ func resourceVirtualNetworkPeering() *pluginsdk.Resource {
 				Optional:     true,
 				ForceNew:     true,
 				Computed:     true,
-				ValidateFunc: commonids.ValidateSubscriptionID,
+				ValidateFunc: validation.Any(validation.IsUUID, commonids.ValidateSubscriptionID),
+				DiffSuppressFunc: func(k, old, new string, d *pluginsdk.ResourceData) bool {
+					normOld, err1 := parseSubscriptionId(old)
+					normNew, err2 := parseSubscriptionId(new)
+					if err1 != nil || err2 != nil {
+						return false
+					}
+					return strings.EqualFold(normOld, normNew)
+				},
 			},
 
 			"virtual_network_name": {
@@ -146,7 +154,11 @@ func resourceVirtualNetworkPeeringCreate(d *pluginsdk.ResourceData, meta interfa
 	client := meta.(*clients.Client).Network.VirtualNetworkPeerings
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	if v, ok := d.GetOk("subscription_id"); ok && v.(string) != "" {
-		subscriptionId = v.(string)
+		parsed, err := parseSubscriptionId(v.(string))
+		if err != nil {
+			return fmt.Errorf("parsing `subscription_id`: %+v", err)
+		}
+		subscriptionId = parsed
 	}
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -362,4 +374,15 @@ func resourceVirtualNetworkPeeringDelete(d *pluginsdk.ResourceData, meta interfa
 	}
 
 	return err
+}
+
+func parseSubscriptionId(in string) (string, error) {
+	if strings.HasPrefix(strings.ToLower(in), "/subscriptions/") {
+		parsed, err := commonids.ParseSubscriptionID(in)
+		if err != nil {
+			return "", err
+		}
+		return parsed.SubscriptionId, nil
+	}
+	return in, nil
 }

--- a/internal/services/network/virtual_network_peering_resource.go
+++ b/internal/services/network/virtual_network_peering_resource.go
@@ -55,6 +55,14 @@ func resourceVirtualNetworkPeering() *pluginsdk.Resource {
 
 			"resource_group_name": commonschema.ResourceGroupName(),
 
+			"subscription_id": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Computed:     true,
+				ValidateFunc: commonids.ValidateSubscriptionID,
+			},
+
 			"virtual_network_name": {
 				Type:     pluginsdk.TypeString,
 				Required: true,
@@ -137,6 +145,9 @@ func resourceVirtualNetworkPeering() *pluginsdk.Resource {
 func resourceVirtualNetworkPeeringCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.VirtualNetworkPeerings
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	if v, ok := d.GetOk("subscription_id"); ok && v.(string) != "" {
+		subscriptionId = v.(string)
+	}
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -305,6 +316,7 @@ func resourceVirtualNetworkPeeringFlatten(d *pluginsdk.ResourceData, id *virtual
 	d.Set("name", id.VirtualNetworkPeeringName)
 	d.Set("resource_group_name", id.ResourceGroupName)
 	d.Set("virtual_network_name", id.VirtualNetworkName)
+	d.Set("subscription_id", id.SubscriptionId)
 
 	if model != nil {
 		if peer := model.Properties; peer != nil {

--- a/internal/services/network/virtual_network_peering_resource_test.go
+++ b/internal/services/network/virtual_network_peering_resource_test.go
@@ -52,6 +52,15 @@ func TestAccVirtualNetworkPeering_subscriptionId(t *testing.T) {
 				check.That(secondResourceName).Key("subscription_id").HasValue(data.Subscriptions.Primary),
 			),
 		},
+		{
+			Config: r.subscriptionIdFormat(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(secondResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("subscription_id").HasValue(data.Subscriptions.Primary),
+				check.That(secondResourceName).Key("subscription_id").HasValue(data.Subscriptions.Primary),
+			),
+		},
 		data.ImportStep(),
 	})
 }
@@ -356,6 +365,35 @@ provider "azurerm" {
 resource "azurerm_virtual_network_peering" "test" {
   name                         = "acctestpeer-1-%[2]d"
   subscription_id              = "%[3]s"
+  resource_group_name          = azurerm_resource_group.test.name
+  virtual_network_name         = azurerm_virtual_network.test.name
+  remote_virtual_network_id    = azurerm_virtual_network.test2.id
+  allow_virtual_network_access = true
+}
+
+resource "azurerm_virtual_network_peering" "test2" {
+  name                         = "acctestpeer-2-%[2]d"
+  subscription_id              = "%[3]s"
+  resource_group_name          = azurerm_resource_group.test.name
+  virtual_network_name         = azurerm_virtual_network.test2.name
+  remote_virtual_network_id    = azurerm_virtual_network.test.id
+  allow_virtual_network_access = true
+}
+`, template, data.RandomInteger, data.Subscriptions.Primary)
+}
+
+func (r VirtualNetworkPeeringResource) subscriptionIdFormat(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_virtual_network_peering" "test" {
+  name                         = "acctestpeer-1-%[2]d"
+  subscription_id              = "/subscriptions/%[3]s"
   resource_group_name          = azurerm_resource_group.test.name
   virtual_network_name         = azurerm_virtual_network.test.name
   remote_virtual_network_id    = azurerm_virtual_network.test2.id

--- a/internal/services/network/virtual_network_peering_resource_test.go
+++ b/internal/services/network/virtual_network_peering_resource_test.go
@@ -37,6 +37,25 @@ func TestAccVirtualNetworkPeering_basic(t *testing.T) {
 	})
 }
 
+func TestAccVirtualNetworkPeering_subscriptionId(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_network_peering", "test")
+	r := VirtualNetworkPeeringResource{}
+	secondResourceName := "azurerm_virtual_network_peering.test2"
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.subscriptionId(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(secondResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("subscription_id").HasValue(data.Subscriptions.Primary),
+				check.That(secondResourceName).Key("subscription_id").HasValue(data.Subscriptions.Primary),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccVirtualNetworkPeering_withTriggers(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_network_peering", "test")
 	r := VirtualNetworkPeeringResource{}
@@ -323,4 +342,33 @@ resource "azurerm_virtual_network_peering" "test" {
   remote_subnet_names                    = [azurerm_subnet.test2.name]
 }
 `, r.template(data), data.RandomInteger)
+}
+
+func (r VirtualNetworkPeeringResource) subscriptionId(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_virtual_network_peering" "test" {
+  name                         = "acctestpeer-1-%[2]d"
+  subscription_id              = "%[3]s"
+  resource_group_name          = azurerm_resource_group.test.name
+  virtual_network_name         = azurerm_virtual_network.test.name
+  remote_virtual_network_id    = azurerm_virtual_network.test2.id
+  allow_virtual_network_access = true
+}
+
+resource "azurerm_virtual_network_peering" "test2" {
+  name                         = "acctestpeer-2-%[2]d"
+  subscription_id              = "%[3]s"
+  resource_group_name          = azurerm_resource_group.test.name
+  virtual_network_name         = azurerm_virtual_network.test2.name
+  remote_virtual_network_id    = azurerm_virtual_network.test.id
+  allow_virtual_network_access = true
+}
+`, template, data.RandomInteger, data.Subscriptions.Primary)
 }

--- a/website/docs/r/virtual_network_peering.html.markdown
+++ b/website/docs/r/virtual_network_peering.html.markdown
@@ -168,6 +168,8 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the resource group in which to create the virtual network peering. Changing this forces a new resource to be created.
 
+* `subscription_id` - (Optional) The Subscription ID of the Virtual Network. Changing this forces a new resource to be created. If not specified, the subscription ID of the provider configuration will be used.
+
 * `allow_virtual_network_access` - (Optional) Controls if the traffic from the local virtual network can reach the remote virtual network. Defaults to `true`.
 
 * `allow_forwarded_traffic` - (Optional) Controls if forwarded traffic from VMs in the remote virtual network is allowed. Defaults to `false`.


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR adds an optional, computed `subscription_id` field to the `azurerm_virtual_network_peering` resource. 

This enables managing cross-subscription virtual network peerings when using a single provider config (e.g. a service principal that holds roles/permissions on both target subscriptions), without requiring users to configure and maintain an aliased provider for each subscription.

The `subscription_id` field accepts either a raw UUID (e.g. `12345678-1234-5678-abcd-123456789012`) or a fully qualified subscription resource ID (e.g. `/subscriptions/12345678-1234-5678-abcd-123456789012`).


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`virtual_network_peering` - adding optional property `subscription_id`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

The new acceptance test `TestAccVirtualNetworkPeering_subscriptionId` has been run and passed successfully, testing both the raw UUID format and `/subscriptions/` format configurations:

Test result: PASS (TestAccVirtualNetworkPeering_subscriptionId)


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_virtual_network_peering` - support for the `subscription_id` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

AI (Antigravity assistant) was used to analyze the codebase, implement schema changes, create the subscription fallback and parsing logic, generate the corresponding acceptance test cases, and document the new parameter.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

There are no changes to security controls in this pull request.