### PR TITLE
Container App Environment: allow cross-subscription Log Analytics workspace

### DIFF
--- a/internal/services/containerapps/container_app_environment_resource.go
+++ b/internal/services/containerapps/container_app_environment_resource.go
@@ -397,13 +397,17 @@ func (r ContainerAppEnvironmentResource) Read() sdk.ResourceFunc {
 							workspaceId, err := findWorkspaceResourceIDFromCustomerID(ctx, metadata, *appLogsConfig.LogAnalyticsConfiguration.CustomerId)
 							// During refreshing stage, `GetRawConfig()` may return null value.
 
-							if err == nil {
-								if workspaceId != nil {
-									state.LogAnalyticsWorkspaceId = workspaceId.ID()
-								} else {
-									state.LogAnalyticsWorkspaceId = existingState.LogAnalyticsWorkspaceId
-								}
-							}
+							// NOTE: `findWorkspaceResourceIDFromCustomerID` only lists Log Analytics
+							// Workspaces within the provider's configured/default subscription, so it
+							// cannot resolve a Workspace that lives in a different subscription than the
+							// Container App Environment - a supported cross-subscription configuration.
+							// That lookup either finds no match (workspaceId == nil, err == nil) or, if
+							// that subscription has no Log Analytics Workspaces of its own at all, returns
+							// an error. In both cases fall back to the value already known to Terraform
+							// rather than discarding it, otherwise `log_analytics_workspace_id` is
+							// persisted as an empty string and every subsequent plan shows a perpetual
+							// diff. See https://github.com/hashicorp/terraform-provider-azurerm/issues/32705
+							state.LogAnalyticsWorkspaceId = resolveLogAnalyticsWorkspaceId(workspaceId, err, existingState.LogAnalyticsWorkspaceId)
 						}
 					}
 
@@ -681,6 +685,26 @@ func findWorkspaceResourceIDFromCustomerID(ctx context.Context, meta sdk.Resourc
 	}
 
 	return nil, nil
+}
+
+// resolveLogAnalyticsWorkspaceId determines the value that should be persisted to
+// `log_analytics_workspace_id` in state, given the outcome of attempting to resolve the ARM
+// resource ID of a Log Analytics Workspace from its `customerId` (a GUID, which is all the
+// Container App Environment API returns - see `findWorkspaceResourceIDFromCustomerID`).
+//
+// That lookup is scoped to a single subscription (the provider's configured/default
+// subscription) and therefore cannot resolve a Workspace that lives in a different subscription
+// than the Container App Environment. When that happens the lookup either finds no match
+// (workspaceId == nil, lookupErr == nil) or - if that subscription contains no Log Analytics
+// Workspaces of its own at all - returns an error. In either case the previously known value
+// must be preserved rather than discarded, otherwise the field is persisted as an empty string
+// and every subsequent plan shows a perpetual diff.
+func resolveLogAnalyticsWorkspaceId(workspaceId *workspaces.WorkspaceId, lookupErr error, existingValue string) string {
+	if lookupErr == nil && workspaceId != nil {
+		return workspaceId.ID()
+	}
+
+	return existingValue
 }
 
 func getSharedKeyForWorkspace(ctx context.Context, meta sdk.ResourceMetaData, workspaceID string) (*string, *string, error) {

--- a/internal/services/containerapps/container_app_environment_resource_unit_test.go
+++ b/internal/services/containerapps/container_app_environment_resource_unit_test.go
@@ -1,0 +1,82 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package containerapps
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/workspaces"
+)
+
+// TestResolveLogAnalyticsWorkspaceId covers the state-resolution logic that fixes
+// https://github.com/hashicorp/terraform-provider-azurerm/issues/32705, where a
+// `log_analytics_workspace_id` pointing at a Workspace in a *different* subscription to the
+// Container App Environment produced a perpetual diff. The API only ever returns a `customerId`
+// GUID, so the provider has to resolve that back to an ARM resource ID by listing Workspaces in
+// its own configured subscription (`findWorkspaceResourceIDFromCustomerID`) - which can never
+// succeed for a cross-subscription Workspace. In that case the previously known value must be
+// preserved instead of being overwritten with an empty string.
+func TestResolveLogAnalyticsWorkspaceId(t *testing.T) {
+	crossSubWorkspaceId := "/subscriptions/aaaaaaaa-0000-0000-0000-aaaaaaaaaaaa/resourceGroups/rg-myapp-dev/providers/Microsoft.App/managedEnvironments/cenv-myapp-dev"
+	resolvedId := workspaces.NewWorkspaceID("bbbbbbbb-0000-0000-0000-bbbbbbbbbbbb", "rg-monitoring-shared", "log-central-mgt")
+
+	testCases := []struct {
+		name          string
+		workspaceId   *workspaces.WorkspaceId
+		lookupErr     error
+		existingValue string
+		expected      string
+	}{
+		{
+			name:          "workspace resolved successfully in the current subscription",
+			workspaceId:   &resolvedId,
+			lookupErr:     nil,
+			existingValue: "",
+			expected:      resolvedId.ID(),
+		},
+		{
+			name:          "workspace resolved takes precedence over existing state",
+			workspaceId:   &resolvedId,
+			lookupErr:     nil,
+			existingValue: crossSubWorkspaceId,
+			expected:      resolvedId.ID(),
+		},
+		{
+			name:          "no matching workspace found in current subscription: fall back to existing state",
+			workspaceId:   nil,
+			lookupErr:     nil,
+			existingValue: crossSubWorkspaceId,
+			expected:      crossSubWorkspaceId,
+		},
+		{
+			// This is the exact scenario from #32705: the provider's configured subscription has
+			// no Log Analytics Workspaces of its own at all (they all live in a shared/monitoring
+			// subscription), so `findWorkspaceResourceIDFromCustomerID` returns an error rather
+			// than `nil, nil`. Before this fix that error caused the state value to be silently
+			// dropped (persisted as ""), which is what produced the perpetual diff.
+			name:          "lookup errors because current subscription has no workspaces at all: fall back to existing state",
+			workspaceId:   nil,
+			lookupErr:     errors.New("could not resolve Log Analytics Workspace ID for customer-id, no Log Analytics Workspaces found in subscription"),
+			existingValue: crossSubWorkspaceId,
+			expected:      crossSubWorkspaceId,
+		},
+		{
+			name:          "lookup errors and there is no existing state: value stays empty",
+			workspaceId:   nil,
+			lookupErr:     errors.New("some transient API error"),
+			existingValue: "",
+			expected:      "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := resolveLogAnalyticsWorkspaceId(tc.workspaceId, tc.lookupErr, tc.existingValue)
+			if actual != tc.expected {
+				t.Fatalf("expected %q, got %q", tc.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### Community Note

* Please vote on this PR by adding a :thumbsup: reaction to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments

#### PR Checklist

- [x] Have you followed the guidelines in our Contributing Documentation?
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change? (searched issue #32705 and PR search for related keywords - none found as of 2026-07-17)
- [x] Have you used a meaningful PR description to help maintainers and other users understand this change?

#### Changes to existing Resource

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your resource or datasource changes? (unit test only - see Testing section, honest limitation noted below)
- [x] Have you successfully run tests with your changes locally? (unit test + `go build` + `go vet` + `gofmt` all pass locally; acceptance test NOT run - see below)

#### Description

`azurerm_container_app_environment` shows a perpetual plan diff on `log_analytics_workspace_id` when the referenced Log Analytics Workspace lives in a **different subscription** than the Container App Environment itself.

**Root cause:** the Container App Environment API never returns the Workspace's ARM resource ID for `log_analytics_workspace_id` — it only returns the Workspace's `customerId` GUID. To turn that GUID back into a resource ID, `Read()` calls `findWorkspaceResourceIDFromCustomerID`, which lists Log Analytics Workspaces **only within the provider's configured/default subscription** (`internal/services/containerapps/container_app_environment_resource.go`, `findWorkspaceResourceIDFromCustomerID`, using `meta.Client.Account.SubscriptionId`). That lookup can never find a Workspace that lives in a different subscription.

There was already a partial mitigation for this: when the lookup finds no match (`workspaceId == nil`, no error), `Read()` falls back to preserving the value already known from state/config (`existingState.LogAnalyticsWorkspaceId`). This works fine as long as the provider's own subscription happens to contain *some* Log Analytics Workspaces (just not the matching one).

The bug in #32705: when the provider's configured subscription has **no Log Analytics Workspaces of its own at all** (a common pattern — e.g. a dedicated shared "monitoring" subscription holds all the workspaces, while application subscriptions have none), `findWorkspaceResourceIDFromCustomerID`'s `client.List` call returns zero results and the function returns an **error** instead of `nil, nil`. `Read()`'s fallback logic only ran on the no-error path (`if err == nil { ... }`), so the error case silently skipped setting `state.LogAnalyticsWorkspaceId` at all, leaving it as the zero value (`""`). That empty string then gets persisted to state on every refresh, producing a permanent diff against the configured value on every subsequent `plan`.

**Fix:** extract the state-resolution decision into a small pure helper, `resolveLogAnalyticsWorkspaceId(workspaceId, lookupErr, existingValue)`, and use it uniformly for *both* failure modes (not-found and error) — always falling back to the previously known value unless the lookup actually resolved a match. This is a minimal, behavior-preserving change: the success path (`err == nil && workspaceId != nil`) is untouched, and the "no match found" path behaves exactly as before; only the previously-uncovered "lookup error" path now also falls back correctly instead of dropping the value.

#### Testing

Acceptance tests (`TestAccContainerAppEnvironment_*`) require live Azure credentials and `TF_ACC=1`, which are not available in this environment, so they were **not** run. I did not fabricate acceptance test output.

What **was** verified locally:
- `gofmt -l` — clean
- `go build ./internal/services/containerapps/...` — succeeds
- `go vet ./internal/services/containerapps/...` — clean
- New unit test `TestResolveLogAnalyticsWorkspaceId` in `container_app_environment_resource_unit_test.go`, covering:
  - successful resolution in the current subscription (existing behavior, unchanged)
  - resolved value takes precedence over existing state (existing behavior, unchanged)
  - no match found in current subscription → falls back to existing state (existing behavior, unchanged)
  - **lookup errors because the current subscription has no workspaces at all → falls back to existing state (this is the actual fix for #32705)**
  - lookup errors and there is no existing state → value stays empty (documents the residual limitation: a fresh cross-subscription resource whose very first read hits this error path with no prior state to fall back on)

A maintainer with Azure access should still confirm end-to-end via `TestAccContainerAppEnvironment_logAnalyticsCrossSubscription` (not included here, since I cannot run it) to close the loop with a live `plan`-after-`apply` check showing no diff.

#### Related Issue(s)

Fixes #32705

#### Change Log

* `azurerm_container_app_environment` - fix a perpetual diff on `log_analytics_workspace_id` when the referenced Log Analytics Workspace is in a different subscription and the provider's own subscription has no Log Analytics Workspaces of its own [GH-32705]

- [x] Bug Fix
- [ ] New Feature

---

**Credit:** root-caused and reported by the author of #32705, who did excellent work isolating this to `customerId` vs. resource-ID and confirming via direct ARM API calls and state inspection. This PR builds directly on that diagnosis.

**Note on coverage:** this fix is unit-tested for the state-resolution logic in isolation, not end-to-end against live Azure. I'm flagging that honestly rather than claiming acceptance-test coverage I don't have.
