### PR TITLE
azurerm_data_factory_linked_service_postgresql - support for the `key_vault_connection_string` block

### DIFF
--- a/internal/services/datafactory/data_factory_linked_service_postgresql_resource.go
+++ b/internal/services/datafactory/data_factory_linked_service_postgresql_resource.go
@@ -264,14 +264,6 @@ func resourceDataFactoryLinkedServicePostgreSQLRead(d *pluginsdk.ResourceData, m
 				return fmt.Errorf("setting `connection_string`: %+v", err)
 			}
 		}
-
-		if password := properties.Password; password != nil {
-			if keyVaultPassword, ok := password.AsAzureKeyVaultSecretReference(); ok {
-				if err := d.Set("key_vault_password", flattenAzureKeyVaultSecretReference(keyVaultPassword)); err != nil {
-					return fmt.Errorf("setting `key_vault_password`: %+v", err)
-				}
-			}
-		}
 	}
 
 	return nil

--- a/internal/services/datafactory/data_factory_linked_service_postgresql_resource.go
+++ b/internal/services/datafactory/data_factory_linked_service_postgresql_resource.go
@@ -55,9 +55,32 @@ func resourceDataFactoryLinkedServicePostgreSQL() *pluginsdk.Resource {
 
 			"connection_string": {
 				Type:             pluginsdk.TypeString,
-				Required:         true,
+				Optional:         true,
+				ExactlyOneOf:     []string{"connection_string", "key_vault_connection_string"},
 				DiffSuppressFunc: azureRmDataFactoryLinkedServiceConnectionStringDiff,
 				ValidateFunc:     validation.StringIsNotEmpty,
+			},
+
+			"key_vault_connection_string": {
+				Type:         pluginsdk.TypeList,
+				Optional:     true,
+				ExactlyOneOf: []string{"connection_string", "key_vault_connection_string"},
+				MaxItems:     1,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"linked_service_name": {
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+
+						"secret_name": {
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+					},
+				},
 			},
 
 			"description": {
@@ -127,15 +150,7 @@ func resourceDataFactoryLinkedServicePostgreSQLCreateUpdate(d *pluginsdk.Resourc
 		}
 	}
 
-	connectionString := d.Get("connection_string").(string)
-	secureString := datafactory.SecureString{
-		Value: &connectionString,
-		Type:  datafactory.TypeSecureString,
-	}
-
-	postgresqlProperties := &datafactory.PostgreSQLLinkedServiceTypeProperties{
-		ConnectionString: &secureString,
-	}
+	postgresqlProperties := &datafactory.PostgreSQLLinkedServiceTypeProperties{}
 
 	description := d.Get("description").(string)
 
@@ -157,9 +172,22 @@ func resourceDataFactoryLinkedServicePostgreSQLCreateUpdate(d *pluginsdk.Resourc
 		postgresqlLinkedService.AdditionalProperties = v.(map[string]interface{})
 	}
 
+	if v, ok := d.GetOk("connection_string"); ok {
+		connectionString := v.(string)
+		secureString := datafactory.SecureString{
+			Value: &connectionString,
+			Type:  datafactory.TypeSecureString,
+		}
+		postgresqlLinkedService.ConnectionString = secureString
+	}
+
 	if v, ok := d.GetOk("annotations"); ok {
 		annotations := v.([]interface{})
 		postgresqlLinkedService.Annotations = &annotations
+	}
+
+	if v, ok := d.GetOk("key_vault_connection_string"); ok {
+		postgresqlLinkedService.ConnectionString = expandAzureKeyVaultSecretReference(v.([]interface{}))
 	}
 
 	linkedService := datafactory.LinkedServiceResource{
@@ -221,6 +249,28 @@ func resourceDataFactoryLinkedServicePostgreSQLRead(d *pluginsdk.ResourceData, m
 	if connectVia := postgresql.ConnectVia; connectVia != nil {
 		if connectVia.ReferenceName != nil {
 			d.Set("integration_runtime_name", connectVia.ReferenceName)
+		}
+	}
+
+	if properties := postgresql.PostgreSQLLinkedServiceTypeProperties; properties != nil {
+		if properties.ConnectionString != nil {
+			if val, ok := properties.ConnectionString.(map[string]interface{}); ok {
+				if err := d.Set("key_vault_connection_string", flattenAzureKeyVaultConnectionString(val)); err != nil {
+					return fmt.Errorf("setting `key_vault_connection_string`: %+v", err)
+				}
+			} else if val, ok := properties.ConnectionString.(string); ok {
+				d.Set("connection_string", val)
+			} else {
+				return fmt.Errorf("setting `connection_string`: %+v", err)
+			}
+		}
+
+		if password := properties.Password; password != nil {
+			if keyVaultPassword, ok := password.AsAzureKeyVaultSecretReference(); ok {
+				if err := d.Set("key_vault_password", flattenAzureKeyVaultSecretReference(keyVaultPassword)); err != nil {
+					return fmt.Errorf("setting `key_vault_password`: %+v", err)
+				}
+			}
 		}
 	}
 

--- a/internal/services/datafactory/data_factory_linked_service_postgresql_resource_test.go
+++ b/internal/services/datafactory/data_factory_linked_service_postgresql_resource_test.go
@@ -62,6 +62,23 @@ func TestAccDataFactoryLinkedServicePostgreSQL_update(t *testing.T) {
 	})
 }
 
+func TestAccDataFactoryLinkedServicePostgreSQL_ConnectionStringKeyVaultReference(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_factory_linked_service_postgresql", "test")
+	r := LinkedServicePostgreSQLResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.connection_string_key_vault_reference(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("key_vault_connection_string.0.linked_service_name").HasValue("linkkv"),
+				check.That(data.ResourceName).Key("key_vault_connection_string.0.secret_name").HasValue("connection_string"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (t LinkedServicePostgreSQLResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.LinkedServiceID(state.ID)
 	if err != nil {
@@ -136,6 +153,52 @@ resource "azurerm_data_factory_linked_service_postgresql" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (LinkedServicePostgreSQLResource) connection_string_key_vault_reference(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-df-%d"
+  location = "%s"
+}
+
+resource "azurerm_key_vault" "test" {
+  name                       = "acctest%s"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  rbac_authorization_enabled = false
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "standard"
+}
+
+resource "azurerm_data_factory" "test" {
+  name                = "acctestdf%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_data_factory_linked_service_key_vault" "test" {
+  name            = "linkkv"
+  data_factory_id = azurerm_data_factory.test.id
+  key_vault_id    = azurerm_key_vault.test.id
+}
+
+resource "azurerm_data_factory_linked_service_postgresql" "test" {
+  name            = "linkpostgresql"
+  data_factory_id = azurerm_data_factory.test.id
+
+  key_vault_connection_string {
+    linked_service_name = azurerm_data_factory_linked_service_key_vault.test.name
+    secret_name         = "connection_string"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger)
 }
 
 func (LinkedServicePostgreSQLResource) update2(data acceptance.TestData) string {

--- a/website/docs/r/data_factory_linked_service_postgresql.html.markdown
+++ b/website/docs/r/data_factory_linked_service_postgresql.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Manages a Linked Service (connection) between PostgreSQL and Azure Data Factory.
 
-~> **Note:** All arguments including the connection_string will be stored in the raw state as plain-text. [Read more about sensitive data in state](/docs/state/sensitive-data.html).
+~> **Note:** All arguments including the `connection_string` will be stored in the raw state as plain-text. Use `key_vault_connection_string` to avoid storing credentials in state. [Read more about sensitive data in state](/docs/state/sensitive-data.html).
 
 ## Example Usage
 
@@ -41,7 +41,9 @@ The following arguments are supported:
 
 * `data_factory_id` - (Required) The Data Factory ID in which to associate the Linked Service with. Changing this forces a new resource.
 
-* `connection_string` - (Required) The connection string in which to authenticate with PostgreSQL.
+* `connection_string` - (Optional) The connection string in which to authenticate with PostgreSQL. Exactly one of either `connection_string` or `key_vault_connection_string` is required.
+
+* `key_vault_connection_string` - (Optional) A `key_vault_connection_string` block as defined below. Exactly one of either `connection_string` or `key_vault_connection_string` is required.
 
 * `description` - (Optional) The description for the Data Factory Linked Service PostgreSQL.
 


### PR DESCRIPTION
…t_connection_string

<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 
Adds support for `key_vault_connection_string` block to `azurerm_data_factory_linked_service_postgresql`, allowing the connection string to be stored securely in Azure Key Vault instead of plaintext state.
If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [ ] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 
issue (#17147 ) where Azure deprecated the PostgreSQL linked service type. All tests for resource fail w/ 400


For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_data_factory_linked_service_postgresql` - support for the `key_vault_connection_string` block [GH-16500]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #16500  
Depends on a change for #17147 


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->
Used for guidance and discussion only, no code generation.
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
