### PR TITLE
Add Support for Windows 2025 Node Pools

### DIFF
--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -358,6 +358,7 @@ func resourceKubernetesClusterNodePoolSchema() map[string]*pluginsdk.Schema {
 				string(agentpools.OSSKUUbuntuTwoFourZeroFour),
 				string(agentpools.OSSKUWindowsTwoZeroOneNine),
 				string(agentpools.OSSKUWindowsTwoZeroTwoTwo),
+				string(agentpools.OSSKUWindowsTwoZeroTwoFive),
 			}, false),
 		},
 

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -833,6 +833,22 @@ func TestAccKubernetesClusterNodePool_windows2022(t *testing.T) {
 	})
 }
 
+func TestAccKubernetesClusterNodePool_windows2025(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster_node_pool", "test")
+	r := KubernetesClusterNodePoolResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.windows2025Config(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("tags.Os").HasValue("Windows"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccKubernetesClusterNodePool_windowsAndLinux(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster_node_pool", "test")
 	r := KubernetesClusterNodePoolResource{}
@@ -2904,6 +2920,31 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   node_count            = 1
   os_type               = "Windows"
   os_sku                = "Windows2022"
+  tags = {
+    Os = "Windows"
+  }
+  upgrade_settings {
+    max_surge = "10%%"
+  }
+}
+`, r.templateWindowsConfig(data))
+}
+
+func (r KubernetesClusterNodePoolResource) windows2025Config(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_kubernetes_cluster_node_pool" "test" {
+  name                  = "windoz"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
+  vm_size               = "Standard_DS2_v2"
+  node_count            = 1
+  os_type               = "Windows"
+  os_sku                = "Windows2025"
   tags = {
     Os = "Windows"
   }

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -194,6 +194,7 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 							string(agentpools.OSSKUUbuntuTwoFourZeroFour),
 							string(agentpools.OSSKUWindowsTwoZeroOneNine),
 							string(agentpools.OSSKUWindowsTwoZeroTwoTwo),
+							string(agentpools.OSSKUWindowsTwoZeroTwoFive),
 						}, false),
 					},
 

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2025-10-01/agentpools/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2025-10-01/agentpools/constants.go
@@ -659,6 +659,7 @@ const (
 	OSSKUUbuntuTwoTwoZeroFour  OSSKU = "Ubuntu2204"
 	OSSKUWindowsTwoZeroOneNine OSSKU = "Windows2019"
 	OSSKUWindowsTwoZeroTwoTwo  OSSKU = "Windows2022"
+	OSSKUWindowsTwoZeroTwoFive OSSKU = "Windows2025"
 )
 
 func PossibleValuesForOSSKU() []string {
@@ -671,6 +672,7 @@ func PossibleValuesForOSSKU() []string {
 		string(OSSKUUbuntuTwoTwoZeroFour),
 		string(OSSKUWindowsTwoZeroOneNine),
 		string(OSSKUWindowsTwoZeroTwoTwo),
+		string(OSSKUWindowsTwoZeroTwoFive),
 	}
 }
 
@@ -697,6 +699,7 @@ func parseOSSKU(input string) (*OSSKU, error) {
 		"ubuntu2204":  OSSKUUbuntuTwoTwoZeroFour,
 		"windows2019": OSSKUWindowsTwoZeroOneNine,
 		"windows2022": OSSKUWindowsTwoZeroTwoTwo,
+		"windows2025": OSSKUWindowsTwoZeroTwoFive,
 	}
 	if v, ok := vals[strings.ToLower(input)]; ok {
 		return &v, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2025-10-01/managedclusters/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2025-10-01/managedclusters/constants.go
@@ -1644,6 +1644,7 @@ const (
 	OSSKUUbuntuTwoTwoZeroFour  OSSKU = "Ubuntu2204"
 	OSSKUWindowsTwoZeroOneNine OSSKU = "Windows2019"
 	OSSKUWindowsTwoZeroTwoTwo  OSSKU = "Windows2022"
+	OSSKUWindowsTwoZeroTwoFive OSSKU = "Windows2025"
 )
 
 func PossibleValuesForOSSKU() []string {
@@ -1656,6 +1657,7 @@ func PossibleValuesForOSSKU() []string {
 		string(OSSKUUbuntuTwoTwoZeroFour),
 		string(OSSKUWindowsTwoZeroOneNine),
 		string(OSSKUWindowsTwoZeroTwoTwo),
+		string(OSSKUWindowsTwoZeroTwoFive),
 	}
 }
 
@@ -1682,6 +1684,7 @@ func parseOSSKU(input string) (*OSSKU, error) {
 		"ubuntu2204":  OSSKUUbuntuTwoTwoZeroFour,
 		"windows2019": OSSKUWindowsTwoZeroOneNine,
 		"windows2022": OSSKUWindowsTwoZeroTwoTwo,
+		"windows2025": OSSKUWindowsTwoZeroTwoFive,
 	}
 	if v, ok := vals[strings.ToLower(input)]; ok {
 		return &v, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2025-10-01/snapshots/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2025-10-01/snapshots/constants.go
@@ -20,6 +20,7 @@ const (
 	OSSKUUbuntuTwoTwoZeroFour  OSSKU = "Ubuntu2204"
 	OSSKUWindowsTwoZeroOneNine OSSKU = "Windows2019"
 	OSSKUWindowsTwoZeroTwoTwo  OSSKU = "Windows2022"
+	OSSKUWindowsTwoZeroTwoFive OSSKU = "Windows2025"
 )
 
 func PossibleValuesForOSSKU() []string {
@@ -32,6 +33,7 @@ func PossibleValuesForOSSKU() []string {
 		string(OSSKUUbuntuTwoTwoZeroFour),
 		string(OSSKUWindowsTwoZeroOneNine),
 		string(OSSKUWindowsTwoZeroTwoTwo),
+		string(OSSKUWindowsTwoZeroTwoFive),
 	}
 }
 
@@ -58,6 +60,7 @@ func parseOSSKU(input string) (*OSSKU, error) {
 		"ubuntu2204":  OSSKUUbuntuTwoTwoZeroFour,
 		"windows2019": OSSKUWindowsTwoZeroOneNine,
 		"windows2022": OSSKUWindowsTwoZeroTwoTwo,
+		"windows2025": OSSKUWindowsTwoZeroTwoFive,
 	}
 	if v, ok := vals[strings.ToLower(input)]; ok {
 		return &v, nil

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -425,7 +425,7 @@ A `default_node_pool` block supports the following:
 
 * `os_disk_type` - (Optional) The type of disk which should be used for the Operating System. Possible values are `Ephemeral` and `Managed`. Defaults to `Managed`. `temporary_name_for_rotation` must be specified when attempting a change.
 
-* `os_sku` - (Optional) Specifies the OS SKU used by the agent pool. Possible values are `AzureLinux`, `AzureLinux3`, `Ubuntu`, `Ubuntu2204`, `Ubuntu2404`, `Windows2019` and `Windows2022`. If not specified, the default is `Ubuntu` when os_type=Linux or `Windows2019` if os_type=Windows (`Windows2022` Kubernetes ≥1.33). Changing between `AzureLinux` and `Ubuntu` does not replace the resource; otherwise `temporary_name_for_rotation` must be specified when attempting a change.
+* `os_sku` - (Optional) Specifies the OS SKU used by the agent pool. Possible values are `AzureLinux`, `AzureLinux3`, `Ubuntu`, `Ubuntu2204`, `Ubuntu2404`, `Windows2019`, `Windows2022` and `Windows2025`. If not specified, the default is `Ubuntu` when os_type=Linux or `Windows2019` if os_type=Windows (`Windows2022` Kubernetes ≥1.33). Changing between `AzureLinux` and `Ubuntu` does not replace the resource; otherwise `temporary_name_for_rotation` must be specified when attempting a change.
 
 -> **Note:** `Windows2019` is deprecated and not supported for Kubernetes version ≥1.33.
 

--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -124,7 +124,7 @@ The following arguments are supported:
 
 * `pod_subnet_id` - (Optional) The ID of the Subnet where the pods in the Node Pool should exist. Changing this property requires specifying `temporary_name_for_rotation`.
 
-* `os_sku` - (Optional) Specifies the OS SKU used by the agent pool. Possible values are `AzureLinux`, `AzureLinux3`, `Ubuntu`, `Ubuntu2204`, `Ubuntu2404`, `Windows2019` and `Windows2022`. If not specified, the default is `Ubuntu` when os_type=Linux or `Windows2019` if os_type=Windows (`Windows2022` Kubernetes ≥1.33). Changing between `AzureLinux` and `Ubuntu` does not replace the resource; any other change forces a new resource to be created.
+* `os_sku` - (Optional) Specifies the OS SKU used by the agent pool. Possible values are `AzureLinux`, `AzureLinux3`, `Ubuntu`, `Ubuntu2204`, `Ubuntu2404`, `Windows2019`, `Windows2022` and `Windows2025`. If not specified, the default is `Ubuntu` when os_type=Linux or `Windows2019` if os_type=Windows (`Windows2022` Kubernetes ≥1.33). Changing between `AzureLinux` and `Ubuntu` does not replace the resource; any other change forces a new resource to be created.
 
 -> **Note:** `Windows2019` is deprecated and not supported for Kubernetes version ≥1.33.
 


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Adding support to the provider for deploying Windows 2025 AKS node pools

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->


## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

* `azurerm_kubernetes_cluster_node_pool` - extend `os_sku` to support Windows2025

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #31036


## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

- Used to discover existing logic for node pool creation and to create test for TDD

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
