### PR TITLE
`azurerm_storage_account`: Support `key_policy`

### DIFF
--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -698,6 +698,22 @@ func resourceStorageAccount() *pluginsdk.Resource {
 				},
 			},
 
+			"key_policy": {
+				Type:     pluginsdk.TypeList,
+				Optional: true,
+				MinItems: 1,
+				MaxItems: 1,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"expiration_period_in_days": {
+							Type:         pluginsdk.TypeInt,
+							Required:     true,
+							ValidateFunc: validation.IntAtLeast(1),
+						},
+					},
+				},
+			},
+
 			"allowed_copy_scope": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
@@ -1446,6 +1462,7 @@ func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 			NetworkAcls:                  expandAccountNetworkRules(d.Get("network_rules").([]interface{}), tenantId),
 			PublicNetworkAccess:          pointer.To(publicNetworkAccess),
 			SasPolicy:                    expandAccountSASPolicy(d.Get("sas_policy").([]interface{})),
+			KeyPolicy:                    expandAccountKeyPolicy(d.Get("key_policy").([]interface{})),
 		},
 		Sku: storageaccounts.Sku{
 			Name: storageaccounts.SkuName(fmt.Sprintf("%s%s_%s", string(accountTier), provisionedBillingModelVersion, replicationType)),
@@ -1888,6 +1905,9 @@ func resourceStorageAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 		// TODO: Currently, there is no way to represent a `null` value in the payload - instead it will be omitted, `sas_policy` can not be disabled once enabled.
 		props.SasPolicy = expandAccountSASPolicy(d.Get("sas_policy").([]interface{}))
 	}
+	if d.HasChange("key_policy") {
+		props.KeyPolicy = expandAccountKeyPolicy(d.Get("key_policy").([]interface{}))
+	}
 	if d.HasChange("sftp_enabled") {
 		props.IsSftpEnabled = pointer.To(d.Get("sftp_enabled").(bool))
 	}
@@ -2298,6 +2318,10 @@ func resourceStorageAccountFlatten(ctx context.Context, d *pluginsdk.ResourceDat
 
 		if err := d.Set("sas_policy", flattenAccountSASPolicy(props.SasPolicy)); err != nil {
 			return fmt.Errorf("setting `sas_policy`: %+v", err)
+		}
+
+		if err := d.Set("key_policy", flattenAccountKeyPolicy(props.KeyPolicy)); err != nil {
+			return fmt.Errorf("setting `key_policy`: %+v", err)
 		}
 
 		supportLevel = availableFunctionalityForAccount(accountKind, accountTier, accountReplicationType)
@@ -3633,6 +3657,29 @@ func flattenAccountSASPolicy(input *storageaccounts.SasPolicy) []interface{} {
 		output = append(output, map[string]interface{}{
 			"expiration_action": string(input.ExpirationAction),
 			"expiration_period": input.SasExpirationPeriod,
+		})
+	}
+
+	return output
+}
+
+func expandAccountKeyPolicy(input []interface{}) *storageaccounts.KeyPolicy {
+	if len(input) == 0 {
+		return nil
+	}
+
+	raw := input[0].(map[string]interface{})
+	return &storageaccounts.KeyPolicy{
+		KeyExpirationPeriodInDays: int64(raw["expiration_period_in_days"].(int)),
+	}
+}
+
+func flattenAccountKeyPolicy(input *storageaccounts.KeyPolicy) []interface{} {
+	output := make([]interface{}, 0)
+
+	if input != nil {
+		output = append(output, map[string]interface{}{
+			"expiration_period_in_days": input.KeyExpirationPeriodInDays,
 		})
 	}
 

--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -1722,6 +1722,35 @@ func TestAccStorageAccount_sasPolicy(t *testing.T) {
 	})
 }
 
+func TestAccStorageAccount_keyPolicy(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
+	r := StorageAccountResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.keyPolicy(data, 30),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.keyPolicy(data, 60),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccStorageAccount_allowedCopyScope(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
 	r := StorageAccountResource{}
@@ -5005,6 +5034,32 @@ resource "azurerm_storage_account" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, action)
+}
+
+func (r StorageAccountResource) keyPolicy(data acceptance.TestData, expirationPeriodInDays int) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-storage-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                = "unlikely23exst2acct%s"
+  resource_group_name = azurerm_resource_group.test.name
+
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  key_policy {
+    expiration_period_in_days = %d
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, expirationPeriodInDays)
 }
 
 func (r StorageAccountResource) allowedCopyScope(data acceptance.TestData, scope string) string {

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -168,6 +168,8 @@ The following arguments are supported:
 
 * `immutability_policy` - (Optional) An `immutability_policy` block as defined below. Changing this forces a new resource to be created.
 
+* `key_policy` - (Optional) A `key_policy` block as defined below.
+
 * `sas_policy` - (Optional) A `sas_policy` block as defined below.
 
 * `allowed_copy_scope` - (Optional) The permitted scope for copy operations between storage accounts. Possible values are `AAD`, `PrivateLink` and `All`.
@@ -358,6 +360,12 @@ A `routing` block supports the following:
 * `publish_microsoft_endpoints` - (Optional) Should Microsoft routing storage endpoints be published? Defaults to `false`.
 
 * `choice` - (Optional) Specifies the kind of network routing opted by the user. Possible values are `InternetRouting` and `MicrosoftRouting`. Defaults to `MicrosoftRouting`.
+
+---
+
+A `key_policy` block supports the following:
+
+* `expiration_period_in_days` - (Required) The expiration period in days for the storage account keys.
 
 ---
 


### PR DESCRIPTION
<!--  All Submissions -->


## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

This PR supports a new nested block `key_policy` for `azurerm_storage_account`.

Note that due to the same [API issue](https://github.com/Azure/azure-rest-api-specs/issues/31949) as `sas_policy`, once `key_policy` is set, it can't be unset.

## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work. 
For example: “`resource_name_here` - description of change e.g. adding property `new_property_name_here`”


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Testing 

- [x] My submission includes Test coverage as described in the [Contribution Guide](../blob/main/contributing/topics/guide-new-resource.md) and the tests pass. (if this is not possible for any reason, please include details of why you did or could not add test coverage)

<!-- Please include testing logs or evidence here or an explanation on why no testing evidence can be provided. 

For state migrations please test the changes locally and provide details here, such as the versions involved in testing the migration path. For further details on testing state migration changes please see our guide on [state migrations](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/topics/guide-state-migrations.md#testing) in the contributor documentation. -->

```shell
terraform-provider-azurerm main*​ ⇡≡3m8s
❯ TF_ACC=1 go test -v -timeout=20h -run='TestAccStorageAccount_keyPolicy' ./internal/services/storage

=== RUN   TestAccStorageAccount_keyPolicy
=== PAUSE TestAccStorageAccount_keyPolicy
=== CONT  TestAccStorageAccount_keyPolicy
--- PASS: TestAccStorageAccount_keyPolicy (143.78s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/storage	143.808s
```

## Change Log

Below please provide what should go into the changelog (if anything) conforming to the [Changelog Format documented here](../blob/main/contributing/topics/maintainer-merging.md).

<!-- Replace the changelog example below with your entry. One resource per line. -->

* `azurerm_resource` - support for the `thing1` property [GH-00000]


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking Change


## Related Issue(s)

Fixes #32859


## AI Assistance Disclosure

<!-- 
IMPORTANT!

If you are using any kind of AI/LLM assistance to contribute to the AzureRM provider, this must be disclosed in the pull request.

If this is the case, please check the box below, and include the extent to which AI was used. (e.g. documentation only, code generation, etc.)

If responses to this pull request are/will be generated using AI, disclose this as well.
-->

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

<!-- extent of AI usage can be described here -->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
