### PR TITLE
`azurerm_app_service_environment_v3` - fix `Read` failure when platform returns `400`/`51019` for `inboundNetworkDependenciesEndpoints`

### DIFF
--- a/internal/services/appservice/app_service_environment_v3_resource.go
+++ b/internal/services/appservice/app_service_environment_v3_resource.go
@@ -6,6 +6,8 @@ package appservice
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -642,6 +644,15 @@ func expandClusterSettingsModel(input []ClusterSettingModel) *[]appserviceenviro
 func flattenInboundNetworkDependencies(ctx context.Context, client *appserviceenvironments.AppServiceEnvironmentsClient, id *commonids.AppServiceEnvironmentId) (*[]AppServiceV3InboundDependencies, error) {
 	inboundNetworking, err := client.GetInboundNetworkDependenciesEndpointsComplete(ctx, *id)
 	if err != nil {
+		// The `inboundNetworkDependenciesEndpoints` API is no longer supported by the platform for some ASEv3
+		// hosting environments and returns a 400 with ExtendedCode 51019 ("Operation not supported ... with kind
+		// ASEV3"). The addresses this resource exposes are already sourced from the `configurations/networking`
+		// endpoint, so treat this as an empty result rather than failing the whole Read.
+		// https://github.com/hashicorp/terraform-provider-azurerm/issues/32616
+		if resp := inboundNetworking.LatestHttpResponse; resp != nil && resp.StatusCode == http.StatusBadRequest && strings.Contains(err.Error(), "51019") {
+			return &[]AppServiceV3InboundDependencies{}, nil
+		}
+
 		return nil, fmt.Errorf("reading paged results for Inbound Network Dependencies for %s: %+v", id, err)
 	}
 


### PR DESCRIPTION
#### Community Note

* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review

#### PR Checklist

- [x] Have you followed the guidelines in our Contributing Documentation?
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
- [x] Have you used a meaningful PR description to help maintainers and other users understand this change and help prevent duplicate work?
- [x] Do your changes close any open issues? If so please include appropriate closing keywords below.

#### Changes to existing Resource / Data Source

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your resource or datasource changes? Not added — the platform returns the `400`/`51019` response only for certain ASEv3 environments/regions/subscriptions (per reports in the linked issue), so it can't be reliably reproduced in a deterministic acceptance test.
- [ ] Have you successfully run tests with your changes locally? `go build`, `go vet`, and `make fmtcheck` all pass for the affected package. Acceptance tests were not run since reproducing the platform condition requires an ASEv3 environment that currently exhibits the deprecated-endpoint behavior; I don't have access to one that reproduces it.

#### Description

Azure no longer supports the legacy `inboundNetworkDependenciesEndpoints` API for some ASEv3 (`kind = ASEV3`) hosting environments, and now returns an HTTP `400` with `ExtendedCode` `51019` ("Operation not supported for resource type Microsoft.Web/hostingEnvironments with kind ASEV3"). The provider's `Read` for `azurerm_app_service_environment_v3` treated any error from this call as fatal, which aborts the entire `Read` (and therefore blocks `plan`/`apply`) for otherwise-healthy ASEv3 environments.

The addresses this resource exposes (`external_inbound_ip_addresses`, `internal_inbound_ip_addresses`, `linux_outbound_ip_addresses`, `windows_outbound_ip_addresses`) are already populated from the separate, still-supported `configurations/networking` endpoint. Only the `inbound_network_dependencies` block depends on the now-unsupported legacy endpoint.

This PR mirrors the existing `response.WasNotFound` guard pattern already used elsewhere in this same `Read` function: when the platform returns `400`/`51019` specifically for this call, `inbound_network_dependencies` is now treated as an empty list rather than failing the whole read.

The match is scoped tightly — HTTP status `400` **and** the error text containing `51019` — so it won't swallow unrelated `400` errors from this endpoint. (The SDK's OData error parser only recognizes a top-level `{"error": ...}` response shape; this ARM error body's shape doesn't match it, so the raw response body, including `51019`, is embedded verbatim into the returned error's message.)

#### Related Issue(s)

Fixes #32616

#### Change Log

* `azurerm_app_service_environment_v3` - prevent `Read` failure when the platform returns `400`/`51019` for `inboundNetworkDependenciesEndpoints` [GH-00000]

- [x] Bug Fix
- [ ] New Feature