### PR TITLE
fix: `azurerm_mssql_database` - do not force `min_capacity` to `0` for serverless databases

### DIFF
--- a/internal/services/mssql/mssql_database_resource.go
+++ b/internal/services/mssql/mssql_database_resource.go
@@ -340,7 +340,6 @@ func resourceMsSqlDatabaseCreate(d *pluginsdk.ResourceData, meta interface{}) er
 			Collation:                        pointer.To(d.Get("collation").(string)),
 			ElasticPoolId:                    pointer.To(elasticPoolId),
 			LicenseType:                      pointer.To(databases.DatabaseLicenseType(d.Get("license_type").(string))),
-			MinCapacity:                      pointer.To(d.Get("min_capacity").(float64)),
 			HighAvailabilityReplicaCount:     pointer.To(int64(d.Get("read_replica_count").(int))),
 			SampleName:                       pointer.To(databases.SampleName(d.Get("sample_name").(string))),
 			RequestedBackupStorageRedundancy: pointer.To(databases.BackupStorageRedundancy(d.Get("storage_account_type").(string))),
@@ -350,6 +349,13 @@ func resourceMsSqlDatabaseCreate(d *pluginsdk.ResourceData, meta interface{}) er
 		},
 
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
+	}
+
+	// NOTE: `min_capacity` is only supported by serverless SKUs and is `Optional`/`Computed`. Only send it when it has
+	// been explicitly configured, otherwise the provider forces `min_capacity: 0`, which the API rejects for SKUs that
+	// do not support a minimum capacity of `0` (e.g. `GP_S_Gen5_8`). When omitted, the service applies its own default.
+	if rawMinCapacity := d.GetRawConfig().AsValueMap()["min_capacity"]; rawMinCapacity.IsKnown() && !rawMinCapacity.IsNull() {
+		input.Properties.MinCapacity = pointer.To(d.Get("min_capacity").(float64))
 	}
 
 	// NOTE: The 'PreferredEnclaveType' field cannot be passed to the APIs Create if the 'sku_name' is a DW or DC-series SKU...
@@ -742,7 +748,11 @@ func resourceMsSqlDatabaseUpdate(d *pluginsdk.ResourceData, meta interface{}) er
 	}
 
 	if d.HasChange("min_capacity") {
-		props.MinCapacity = pointer.To(d.Get("min_capacity").(float64))
+		// Only send `min_capacity` when it is explicitly set in the config, otherwise the provider would force
+		// `min_capacity: 0`, which the API rejects for SKUs that do not support a minimum capacity of `0`. See #32873.
+		if rawMinCapacity := d.GetRawConfig().AsValueMap()["min_capacity"]; rawMinCapacity.IsKnown() && !rawMinCapacity.IsNull() {
+			props.MinCapacity = pointer.To(d.Get("min_capacity").(float64))
+		}
 	}
 
 	if d.HasChange("read_replica_count") {

--- a/internal/services/mssql/mssql_database_resource_test.go
+++ b/internal/services/mssql/mssql_database_resource_test.go
@@ -221,6 +221,26 @@ func TestAccMsSqlDatabase_gpServerless(t *testing.T) {
 	})
 }
 
+func TestAccMsSqlDatabase_gpServerlessWithoutMinCapacity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mssql_database", "test")
+	r := MssqlDatabaseResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			// `min_capacity` is optional for serverless databases. When it is omitted the provider must not force
+			// `min_capacity: 0`, which the API rejects for SKUs that do not support a minimum capacity of `0`
+			// (e.g. `GP_S_Gen5_8`). The service applies its own default instead. See #32873.
+			Config: r.gpServerlessWithoutMinCapacity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("sku_name").HasValue("GP_S_Gen5_8"),
+				check.That(data.ResourceName).Key("min_capacity").Exists(),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccMsSqlDatabase_updateLicenseType(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_database", "test")
 	r := MssqlDatabaseResource{}
@@ -1662,6 +1682,18 @@ resource "azurerm_mssql_database" "test" {
   auto_pause_delay_in_minutes = 90
   min_capacity                = 1.25
   sku_name                    = "GP_S_Gen5_2"
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r MssqlDatabaseResource) gpServerlessWithoutMinCapacity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_mssql_database" "test" {
+  name      = "acctest-db-%[2]d"
+  server_id = azurerm_mssql_server.test.id
+  sku_name  = "GP_S_Gen5_8"
 }
 `, r.template(data), data.RandomInteger)
 }


### PR DESCRIPTION
### Community Note

<!-- Please leave the community note as it is. -->

* Please vote on this PR by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave "+1" or "me too" comments, they generate extra noise for PR followers and do not help prioritize for review

---

Fixes #32873

### Description

`min_capacity` is documented as **Optional** for serverless databases and is defined as `Optional`/`Computed` in the schema. However, `Create` unconditionally sent `min_capacity` to the API:

```go
MinCapacity: pointer.To(d.Get("min_capacity").(float64)),
```

Because `d.Get("min_capacity")` returns `0` when the property is not configured, the provider always sent `min_capacity: 0`. The API rejects a minimum capacity of `0` for SKUs that do not support it (e.g. `GP_S_Gen5_8`):

```
The service level objective 'GP_S_Gen5_8' does not support the min capacity '0'
```

As a result, omitting a documented-optional field broke database creation for those SKUs.

This change only sends `min_capacity` when it has been explicitly set in the configuration (checked via `GetRawConfig()`, matching the pattern already used by this resource's `CustomizeDiff`). When omitted, the service applies its own default. The same guard is applied on `Update`.

### PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/hashicorp/terraform-provider-azurerm/pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://help.github.com/articles/closing-issues-using-keywords/) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.

### Changes to existing Resource / Data Source

- `azurerm_mssql_database` - `min_capacity` is no longer forced to `0` when omitted, so serverless databases can be created on SKUs that do not support a minimum capacity of `0`.

### Testing

New acceptance test covering a serverless database created without `min_capacity`:

```
make acctests SERVICE='mssql' TESTARGS='-run=TestAccMsSqlDatabase_gpServerlessWithoutMinCapacity'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
