### PR TITLE
monitor: support named severity values for alerts

### DIFF
--- a/internal/services/monitor/monitor_metric_alert_resource.go
+++ b/internal/services/monitor/monitor_metric_alert_resource.go
@@ -364,10 +364,12 @@ func resourceMonitorMetricAlert() *pluginsdk.Resource {
 			},
 
 			"severity": {
-				Type:         pluginsdk.TypeInt,
-				Optional:     true,
-				Default:      3,
-				ValidateFunc: validation.IntBetween(0, 4),
+				Type:             pluginsdk.TypeString,
+				Optional:         true,
+				Default:          "3",
+				ValidateFunc:     validateMonitorSeverity,
+				StateFunc:        normalizeMonitorSeverityState,
+				DiffSuppressFunc: suppressMonitorSeverityDiff,
 			},
 
 			"window_size": {
@@ -418,7 +420,11 @@ func resourceMonitorMetricAlertCreateUpdate(d *pluginsdk.ResourceData, meta inte
 	autoMitigate := d.Get("auto_mitigate").(bool)
 	description := d.Get("description").(string)
 	scopesRaw := d.Get("scopes").(*pluginsdk.Set).List()
-	severity := d.Get("severity").(int)
+	severityRaw := d.Get("severity").(string)
+	severity, err := normalizeMonitorSeverity(severityRaw)
+	if err != nil {
+		return fmt.Errorf("invalid severity %q: %s", severityRaw, err)
+	}
 	frequency := d.Get("frequency").(string)
 	windowSize := d.Get("window_size").(string)
 	actionRaw := d.Get("action").(*pluginsdk.Set).List()
@@ -535,7 +541,7 @@ func resourceMonitorMetricAlertFlatten(d *pluginsdk.ResourceData, id *metricaler
 		d.Set("enabled", props.Enabled)
 		d.Set("auto_mitigate", props.AutoMitigate)
 		d.Set("description", props.Description)
-		d.Set("severity", props.Severity)
+		d.Set("severity", strconv.FormatInt(props.Severity, 10))
 		d.Set("frequency", props.EvaluationFrequency)
 		d.Set("window_size", props.WindowSize)
 		if err := d.Set("scopes", props.Scopes); err != nil {

--- a/internal/services/monitor/monitor_scheduled_query_rules_alert_resource.go
+++ b/internal/services/monitor/monitor_scheduled_query_rules_alert_resource.go
@@ -144,9 +144,11 @@ func resourceMonitorScheduledQueryRulesAlert() *pluginsdk.Resource {
 				}, false),
 			},
 			"severity": {
-				Type:         pluginsdk.TypeInt,
-				Optional:     true,
-				ValidateFunc: validation.IntBetween(0, 4),
+				Type:             pluginsdk.TypeString,
+				Optional:         true,
+				ValidateFunc:     validateMonitorSeverity,
+				StateFunc:        normalizeMonitorSeverityState,
+				DiffSuppressFunc: suppressMonitorSeverityDiff,
 			},
 			"throttling": {
 				Type:          pluginsdk.TypeInt,
@@ -353,11 +355,11 @@ func resourceMonitorScheduledQueryRulesAlertFlatten(d *pluginsdk.ResourceData, i
 		if err := d.Set("action", flattenAzureRmScheduledQueryRulesAlertAction(action.AznsAction)); err != nil {
 			return fmt.Errorf("setting `action`: %+v", err)
 		}
-		severity, err := strconv.Atoi(string(action.Severity))
+		severity, err := normalizeMonitorSeverity(string(action.Severity))
 		if err != nil {
 			return fmt.Errorf("converting action.Severity %q to int in %s: %+v", action.Severity, *id, err)
 		}
-		d.Set("severity", severity)
+		d.Set("severity", strconv.Itoa(severity))
 		d.Set("throttling", action.ThrottlingInMin)
 		if err = d.Set("trigger", flattenAzureRmScheduledQueryRulesAlertTrigger(action.Trigger)); err != nil {
 			return fmt.Errorf("setting `trigger`: %+v", err)
@@ -403,8 +405,13 @@ func resourceMonitorScheduledQueryRulesAlertDelete(d *pluginsdk.ResourceData, me
 func expandMonitorScheduledQueryRulesAlertingAction(d *pluginsdk.ResourceData) *scheduledqueryrules.AlertingAction {
 	alertActionRaw := d.Get("action").([]interface{})
 	alertAction := expandMonitorScheduledQueryRulesAlertAction(alertActionRaw)
-	severityRaw := d.Get("severity").(int)
-	severity := strconv.Itoa(severityRaw)
+	severityRaw := d.Get("severity").(string)
+	severityValue, err := normalizeMonitorSeverity(severityRaw)
+	if err != nil {
+		// This should be prevented by schema validation, but we keep a safe fallback.
+		severityValue = 0
+	}
+	severity := strconv.Itoa(severityValue)
 
 	triggerRaw := d.Get("trigger").([]interface{})
 	trigger := expandMonitorScheduledQueryRulesAlertTrigger(triggerRaw)

--- a/internal/services/monitor/monitor_scheduled_query_rules_alert_v2_resource.go
+++ b/internal/services/monitor/monitor_scheduled_query_rules_alert_v2_resource.go
@@ -36,7 +36,7 @@ type ScheduledQueryRulesAlertV2Model struct {
 	MuteActionsDuration                   string                                     `tfschema:"mute_actions_after_alert_duration"`
 	OverrideQueryTimeRange                string                                     `tfschema:"query_time_range_override"`
 	Scopes                                []string                                   `tfschema:"scopes"`
-	Severity                              scheduledqueryrules.AlertSeverity          `tfschema:"severity"`
+	Severity                              string                                     `tfschema:"severity"`
 	SkipQueryValidation                   bool                                       `tfschema:"skip_query_validation"`
 	Tags                                  map[string]string                          `tfschema:"tags"`
 	TargetResourceTypes                   []string                                   `tfschema:"target_resource_types"`
@@ -258,9 +258,11 @@ func (r ScheduledQueryRulesAlertV2Resource) Arguments() map[string]*pluginsdk.Sc
 		},
 
 		"severity": {
-			Type:         pluginsdk.TypeInt,
-			Required:     true,
-			ValidateFunc: validation.IntBetween(0, 4),
+			Type:             pluginsdk.TypeString,
+			Required:         true,
+			ValidateFunc:     validateMonitorSeverity,
+			StateFunc:        normalizeMonitorSeverityState,
+			DiffSuppressFunc: suppressMonitorSeverityDiff,
 		},
 
 		"window_duration": {
@@ -433,6 +435,12 @@ func (r ScheduledQueryRulesAlertV2Resource) Create() sdk.ResourceFunc {
 				return fmt.Errorf("decoding: %+v", err)
 			}
 
+			severityLevel, err := normalizeMonitorSeverity(model.Severity)
+			if err != nil {
+				return fmt.Errorf("invalid severity %q: %s", model.Severity, err)
+			}
+			severity := scheduledqueryrules.AlertSeverity(severityLevel)
+
 			client := metadata.Client.Monitor.ScheduledQueryRulesV2Client
 			subscriptionId := metadata.Client.Account.SubscriptionId
 			id := scheduledqueryrules.NewScheduledQueryRuleID(subscriptionId, model.ResourceGroupName, model.Name)
@@ -457,7 +465,7 @@ func (r ScheduledQueryRulesAlertV2Resource) Create() sdk.ResourceFunc {
 					CheckWorkspaceAlertsStorageConfigured: &model.CheckWorkspaceAlertsStorageConfigured,
 					Enabled:                               &model.Enabled,
 					Scopes:                                &model.Scopes,
-					Severity:                              &model.Severity,
+					Severity:                              &severity,
 					SkipQueryValidation:                   &model.SkipQueryValidation,
 					TargetResourceTypes:                   &model.TargetResourceTypes,
 				},
@@ -596,7 +604,12 @@ func (r ScheduledQueryRulesAlertV2Resource) Update() sdk.ResourceFunc {
 			}
 
 			if metadata.ResourceData.HasChange("severity") {
-				model.Properties.Severity = &resourceModel.Severity
+				severityLevel, err := normalizeMonitorSeverity(resourceModel.Severity)
+				if err != nil {
+					return fmt.Errorf("invalid severity %q: %s", resourceModel.Severity, err)
+				}
+				severity := scheduledqueryrules.AlertSeverity(severityLevel)
+				model.Properties.Severity = &severity
 			}
 
 			if metadata.ResourceData.HasChange("skip_query_validation") {
@@ -698,7 +711,7 @@ func (r ScheduledQueryRulesAlertV2Resource) flatten(metadata sdk.ResourceMetaDat
 		state.MuteActionsDuration = pointer.From(properties.MuteActionsDuration)
 		state.OverrideQueryTimeRange = pointer.From(properties.OverrideQueryTimeRange)
 		state.Scopes = pointer.From(properties.Scopes)
-		state.Severity = pointer.From(properties.Severity)
+		state.Severity = fmt.Sprintf("%d", pointer.From(properties.Severity))
 		state.SkipQueryValidation = pointer.From(properties.SkipQueryValidation)
 		state.TargetResourceTypes = pointer.From(properties.TargetResourceTypes)
 		state.WindowSize = pointer.From(properties.WindowSize)

--- a/internal/services/monitor/severity.go
+++ b/internal/services/monitor/severity.go
@@ -1,0 +1,77 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package monitor
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+var monitorSeverityNameToLevel = map[string]int{
+	"critical":      0,
+	"error":         1,
+	"warning":       2,
+	"informational": 3,
+	"verbose":       4,
+}
+
+func normalizeMonitorSeverity(input string) (int, error) {
+	value := strings.TrimSpace(strings.ToLower(input))
+
+	if level, ok := monitorSeverityNameToLevel[value]; ok {
+		return level, nil
+	}
+
+	switch value {
+	case "0":
+		return 0, nil
+	case "1":
+		return 1, nil
+	case "2":
+		return 2, nil
+	case "3":
+		return 3, nil
+	case "4":
+		return 4, nil
+	default:
+		return 0, fmt.Errorf("expected one of 0, 1, 2, 3, 4, critical, error, warning, informational, verbose")
+	}
+}
+
+func normalizeMonitorSeverityState(input interface{}) string {
+	value := fmt.Sprintf("%v", input)
+	level, err := normalizeMonitorSeverity(value)
+	if err != nil {
+		return strings.TrimSpace(strings.ToLower(value))
+	}
+
+	return fmt.Sprintf("%d", level)
+}
+
+func validateMonitorSeverity(input interface{}, key string) (warnings []string, errors []error) {
+	value, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %s to be string", key))
+		return warnings, errors
+	}
+
+	if _, err := normalizeMonitorSeverity(value); err != nil {
+		errors = append(errors, fmt.Errorf("invalid %s %q: %s", key, value, err))
+	}
+
+	return warnings, errors
+}
+
+func suppressMonitorSeverityDiff(_, old, new string, _ *pluginsdk.ResourceData) bool {
+	oldLevel, oldErr := normalizeMonitorSeverity(old)
+	newLevel, newErr := normalizeMonitorSeverity(new)
+
+	if oldErr != nil || newErr != nil {
+		return false
+	}
+
+	return oldLevel == newLevel
+}

--- a/internal/services/monitor/severity_test.go
+++ b/internal/services/monitor/severity_test.go
@@ -1,0 +1,65 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package monitor
+
+import "testing"
+
+func TestNormalizeMonitorSeverity(t *testing.T) {
+	cases := []struct {
+		input       string
+		expected    int
+		expectError bool
+	}{
+		{input: "0", expected: 0},
+		{input: "1", expected: 1},
+		{input: "2", expected: 2},
+		{input: "3", expected: 3},
+		{input: "4", expected: 4},
+		{input: "critical", expected: 0},
+		{input: "error", expected: 1},
+		{input: "warning", expected: 2},
+		{input: "informational", expected: 3},
+		{input: "verbose", expected: 4},
+		{input: " Warning ", expected: 2},
+		{input: "invalid", expectError: true},
+	}
+
+	for _, tc := range cases {
+		actual, err := normalizeMonitorSeverity(tc.input)
+		if tc.expectError {
+			if err == nil {
+				t.Fatalf("expected error for %q", tc.input)
+			}
+			continue
+		}
+
+		if err != nil {
+			t.Fatalf("unexpected error for %q: %s", tc.input, err)
+		}
+
+		if actual != tc.expected {
+			t.Fatalf("expected %d, got %d for %q", tc.expected, actual, tc.input)
+		}
+	}
+}
+
+func TestNormalizeMonitorSeverityState(t *testing.T) {
+	if actual := normalizeMonitorSeverityState("warning"); actual != "2" {
+		t.Fatalf("expected warning to normalize to 2, got %q", actual)
+	}
+
+	if actual := normalizeMonitorSeverityState(" 3 "); actual != "3" {
+		t.Fatalf("expected 3 to normalize to 3, got %q", actual)
+	}
+}
+
+func TestSuppressMonitorSeverityDiff(t *testing.T) {
+	if !suppressMonitorSeverityDiff("severity", "2", "warning", nil) {
+		t.Fatal("expected 2 and warning to suppress diff")
+	}
+
+	if suppressMonitorSeverityDiff("severity", "1", "warning", nil) {
+		t.Fatal("did not expect 1 and warning to suppress diff")
+	}
+}

--- a/website/docs/r/monitor_metric_alert.html.markdown
+++ b/website/docs/r/monitor_metric_alert.html.markdown
@@ -87,7 +87,7 @@ The following arguments are supported:
 * `auto_mitigate` - (Optional) Should the alerts in this Metric Alert be auto resolved? Defaults to `true`.
 * `description` - (Optional) The description of this Metric Alert.
 * `frequency` - (Optional) The evaluation frequency of this Metric Alert, represented in ISO 8601 duration format. Possible values are `PT1M`, `PT5M`, `PT15M`, `PT30M` and `PT1H`. Defaults to `PT1M`.
-* `severity` - (Optional) The severity of this Metric Alert. Possible values are `0`, `1`, `2`, `3` and `4`. Defaults to `3`.
+* `severity` - (Optional) The severity of this Metric Alert. Possible numeric values are `0`, `1`, `2`, `3` and `4`. Possible string values are `critical`, `error`, `warning`, `informational`, and `verbose`. Defaults to `3`.
 * `target_resource_type` - (Optional) The resource type (e.g. `Microsoft.Compute/virtualMachines`) of the target resource.
 
 -> **Note:** This is Required when using a Subscription as scope, a Resource Group as scope or Multiple Scopes.

--- a/website/docs/r/monitor_scheduled_query_rules_alert.html.markdown
+++ b/website/docs/r/monitor_scheduled_query_rules_alert.html.markdown
@@ -122,7 +122,7 @@ The following arguments are supported:
 * `description` - (Optional) The description of the scheduled query rule.
 * `enabled` - (Optional) Whether this scheduled query rule is enabled. Default is `true`.
 * `query_type` - (Optional) The type of query results. Possible values are `ResultCount` and `Number`. Default is `ResultCount`. If set to `ResultCount`, `query` must include an `AggregatedValue` column of a numeric type, for example, `Heartbeat | summarize AggregatedValue = count() by bin(TimeGenerated, 5m)`.
-* `severity` - (Optional) Severity of the alert. Possible values include: 0, 1, 2, 3, or 4.
+* `severity` - (Optional) Severity of the alert. Possible numeric values include `0`, `1`, `2`, `3`, and `4`. Possible string values are `critical`, `error`, `warning`, `informational`, and `verbose`.
 * `throttling` - (Optional) Time (in minutes) for which Alerts should be throttled or suppressed. Values must be between 0 and 10000 (inclusive).
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 

--- a/website/docs/r/monitor_scheduled_query_rules_alert_v2.html.markdown
+++ b/website/docs/r/monitor_scheduled_query_rules_alert_v2.html.markdown
@@ -125,7 +125,7 @@ The following arguments are supported:
 
 * `scopes` - (Required) Specifies the list of resource IDs that this scheduled query rule is scoped to. Changing this forces a new resource to be created. Currently, the API supports exactly 1 resource ID in the scopes list.
 
-* `severity` - (Required) Severity of the alert. Should be an integer between 0 and 4. Value of 0 is severest.
+* `severity` - (Required) Severity of the alert. Possible numeric values are `0`, `1`, `2`, `3` and `4`. Possible string values are `critical`, `error`, `warning`, `informational`, and `verbose`. Value `0`/`critical` is severest.
 
 * `window_duration` - (Required) Specifies the period of time in ISO 8601 duration format on which the Scheduled Query Rule will be executed (bin size). If `evaluation_frequency` is `PT1M`, possible values are `PT1M`, `PT5M`, `PT10M`, `PT15M`, `PT30M`, `PT45M`, `PT1H`, `PT2H`, `PT3H`, `PT4H`, `PT5H`, and `PT6H`. Otherwise, possible values are `PT5M`, `PT10M`, `PT15M`, `PT30M`, `PT45M`, `PT1H`, `PT2H`, `PT3H`, `PT4H`, `PT5H`, `PT6H`, `P1D`, and `P2D`.
 


### PR DESCRIPTION
## Description

Fixes #32709

### Summary

This enhancement adds support for specifying Azure Monitor alert severity using descriptive string values in addition to numeric severity levels.

Currently, users must specify severity using numeric values (`0`-`4`), which requires referring to Azure documentation or maintaining custom lookup maps. This change allows more readable configuration while preserving Azure's numeric severity values internally.

Example:

Current:

```hcl
severity = "2"
```

New:

```hcl
severity = "warning"
```

The following severity names are supported:

| Severity | Numeric Value |
|----------|---------------|
| critical | 0 |
| error | 1 |
| warning | 2 |
| informational | 3 |
| verbose | 4 |

### Changes Included

- Added shared monitor severity normalization helpers.
- Added validation for supported severity values.
- Added state normalization to maintain a consistent Terraform state.
- Added diff suppression for equivalent severity representations.
- Updated the following resources:
  - `azurerm_monitor_metric_alert`
  - `azurerm_monitor_scheduled_query_rules_alert`
  - `azurerm_monitor_scheduled_query_rules_alert_v2`
- Added unit tests covering normalization, validation, and diff suppression.
- Updated the documentation for all affected resources.
