### PR TITLE
AppConfiguration: omit empty time window filter parameters

### DIFF
--- a/internal/services/appconfiguration/feature_structs.go
+++ b/internal/services/appconfiguration/feature_structs.go
@@ -145,8 +145,8 @@ type TargetingFeatureFilter struct {
 }
 
 type TimewindowFilterParameters struct {
-	Start string `json:"Start" tfschema:"start"`
-	End   string `json:"End"   tfschema:"end"`
+	Start string `json:"Start,omitempty" tfschema:"start"`
+	End   string `json:"End,omitempty"   tfschema:"end"`
 }
 
 type TimewindowFeatureFilter struct {


### PR DESCRIPTION
## Community Note

<!-- Please leave the community note as is. -->

* Please vote on this PR by adding a :thumbsup: [[reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/)](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

The `start` and `end` properties of the App Configuration feature time window filter are optional in the Terraform schema and can be configured independently.

However, because omitted fields are represented as empty strings in the Go model, the provider serializes the missing property into the feature flag JSON payload. For example, configuring only `start` currently results in:

```json
{
  "Start": "2026-08-04T10:00:00Z",
  "End": ""
}
```

Instead of omitting the unset property. This differs from the behavior in the Azure Portal, where only the configured property is persisted.

This change adds `omitempty` to the JSON tags for the time window filter parameters so that unset optional values are omitted from the payload while preserving the existing behavior for configured values.


This change adds `omitempty` to the JSON tags for the time window filter parameters so that unset optional values are omitted from the payload.

Configured `start` and `end` values continue to be serialized as before. This is not a breaking change.

## PR Checklist

* [x] I have followed the guidelines in our [[Contributing Documentation](https://github.com/hashicorp/terraform-provider-azurerm/compare/blob/main/contributing/README.md)](../blob/main/contributing/README.md).
* [x] I have checked to ensure there aren't other open [[Pull Requests](https://github.com/hashicorp/terraform-provider-azurerm/compare/pulls)](../pulls) for the same update/change.
* [ ] I have checked if my changes close any open issues. If so please include appropriate [[closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-keywords-in-issues-and-pull-requests)](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-keywords-in-issues-and-pull-requests) below.
* [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
* [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.

## Changes to existing Resource / Data Source

* [x] I have added an explanation of what my changes do and why I'd like you to include them.
* [ ] I have written new tests for my resource or datasource changes & updated any relevant documentation.
* [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
* [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.

## Testing

No automated tests were added for this change.

The change only updates the JSON serialization tags for the existing optional `start` and `end` fields.

Add the exact commands you ran here, for example:

```text
go test ./internal/services/appconfiguration/...
```

If you did not run tests locally, replace the section above with:

```text
Tests were not run locally. The change is limited to adding `omitempty` to the JSON tags of two existing optional string fields.
```

## Change Log

* `azurerm_app_configuration_feature` - omit unset `start` and `end` values from time window filter JSON payloads

This is a:

* [x] Bug Fix
* [ ] New Feature
* [ ] Enhancement
* [ ] Breaking Change

## Related Issue(s)

No related issue.

## AI Assistance Disclosure

* [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

AI assistance was used to review the serialization behavior and help prepare the pull request description. The code change was manually reviewed and applied.

## Rollback Plan

If this change needs to be reverted, the JSON tags can be restored by removing `omitempty` from the time window filter parameters.

## Changes to Security Controls

There are no changes to security controls, access controls, encryption, or logging in this pull request.