### PR TITLE
`azurerm_storage_account` - retry File service readiness during creation

### DIFF
--- a/internal/services/storage/custompollers/data_plane_file_share_availability_poller.go
+++ b/internal/services/storage/custompollers/data_plane_file_share_availability_poller.go
@@ -17,8 +17,14 @@ import (
 
 var _ pollers.PollerType = &DataPlaneFileShareAvailabilityPoller{}
 
+const fileServiceResourceNotFoundErrorCode = "ResourceNotFound"
+
+type fileServicesClient interface {
+	GetServiceProperties(ctx context.Context, id commonids.StorageAccountId) (fileservices.GetServicePropertiesOperationResponse, error)
+}
+
 type DataPlaneFileShareAvailabilityPoller struct {
-	client           *fileservices.FileServicesClient
+	client           fileServicesClient
 	storageAccountId commonids.StorageAccountId
 }
 
@@ -31,8 +37,14 @@ func NewDataPlaneFileShareAvailabilityPoller(client *storageClients.Client, acco
 
 func (d *DataPlaneFileShareAvailabilityPoller) Poll(ctx context.Context) (*pollers.PollResult, error) {
 	resp, err := d.client.GetServiceProperties(ctx, d.storageAccountId)
+	serviceIsBeingProvisioned := response.WasNotFound(resp.HttpResponse) &&
+		resp.OData != nil &&
+		resp.OData.Error != nil &&
+		resp.OData.Error.Code != nil &&
+		*resp.OData.Error.Code == fileServiceResourceNotFoundErrorCode
+
 	if err != nil {
-		if !response.WasNotFound(resp.HttpResponse) {
+		if !serviceIsBeingProvisioned {
 			return nil, pollers.PollingFailedError{
 				Message: err.Error(),
 				HttpResponse: &client.Response{
@@ -41,7 +53,7 @@ func (d *DataPlaneFileShareAvailabilityPoller) Poll(ctx context.Context) (*polle
 			}
 		}
 	}
-	if response.WasNotFound(resp.HttpResponse) {
+	if serviceIsBeingProvisioned {
 		return &pollers.PollResult{
 			HttpResponse: &client.Response{
 				Response: resp.HttpResponse,

--- a/internal/services/storage/custompollers/data_plane_file_share_availability_poller_test.go
+++ b/internal/services/storage/custompollers/data_plane_file_share_availability_poller_test.go
@@ -1,0 +1,112 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package custompollers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2025-08-01/fileservices"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+func TestDataPlaneFileShareAvailabilityPoller(t *testing.T) {
+	accountId := commonids.NewStorageAccountID("12345678-1234-1234-1234-123456789012", "resource-group", "storageaccount")
+
+	testCases := []struct {
+		name           string
+		statusCode     int
+		errorCode      string
+		responseError  error
+		expectedStatus pollers.PollingStatus
+		expectError    bool
+	}{
+		{
+			name:           "available",
+			statusCode:     http.StatusOK,
+			expectedStatus: pollers.PollingStatusSucceeded,
+		},
+		{
+			name:           "not yet available",
+			statusCode:     http.StatusNotFound,
+			errorCode:      fileServiceResourceNotFoundErrorCode,
+			responseError:  errors.New(fileServiceResourceNotFoundErrorCode),
+			expectedStatus: pollers.PollingStatusInProgress,
+		},
+		{
+			name:          "different not found error",
+			statusCode:    http.StatusNotFound,
+			errorCode:     "ParentResourceNotFound",
+			responseError: errors.New("ParentResourceNotFound"),
+			expectError:   true,
+		},
+		{
+			name:          "permanent error",
+			statusCode:    http.StatusForbidden,
+			errorCode:     "AuthorizationFailed",
+			responseError: errors.New("AuthorizationFailed"),
+			expectError:   true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var responseOData *odata.OData
+			if testCase.errorCode != "" {
+				responseOData = &odata.OData{
+					Error: &odata.Error{Code: &testCase.errorCode},
+				}
+			}
+
+			poller := DataPlaneFileShareAvailabilityPoller{
+				client: &mockFileServicesClient{
+					response: fileservices.GetServicePropertiesOperationResponse{
+						HttpResponse: &http.Response{StatusCode: testCase.statusCode},
+						OData:        responseOData,
+					},
+					err: testCase.responseError,
+				},
+				storageAccountId: accountId,
+			}
+
+			result, err := poller.Poll(context.Background())
+			if testCase.expectError {
+				if err == nil {
+					t.Fatal("expected a permanent error, got nil")
+				}
+				var pollingFailedError pollers.PollingFailedError
+				if !errors.As(err, &pollingFailedError) {
+					t.Fatalf("expected a polling failure, got %T: %v", err, err)
+				}
+				if result != nil {
+					t.Fatalf("expected no poll result, got %#v", result)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if result == nil {
+				t.Fatal("expected a poll result, got nil")
+			}
+			if result.Status != testCase.expectedStatus {
+				t.Fatalf("expected status %q, got %q", testCase.expectedStatus, result.Status)
+			}
+		})
+	}
+}
+
+type mockFileServicesClient struct {
+	response fileservices.GetServicePropertiesOperationResponse
+	err      error
+}
+
+func (m mockFileServicesClient) GetServiceProperties(context.Context, commonids.StorageAccountId) (fileservices.GetServicePropertiesOperationResponse, error) {
+	return m.response, m.err
+}

--- a/internal/services/storage/storage_account_data_plane_helpers.go
+++ b/internal/services/storage/storage_account_data_plane_helpers.go
@@ -64,6 +64,23 @@ func availableFunctionalityForAccount(kind storageaccounts.Kind, tier storageacc
 	}
 }
 
+func waitForFileServiceToBecomeAvailableForAccount(ctx context.Context, client *client.Client, account *client.AccountDetails) error {
+	const initialDelayDuration = 10 * time.Second
+
+	log.Printf("[DEBUG] waiting for the File Service to become available")
+	pollerType, err := custompollers.NewDataPlaneFileShareAvailabilityPoller(client, account)
+	if err != nil {
+		return fmt.Errorf("building File Service Poller: %+v", err)
+	}
+
+	poller := pollers.NewPoller(pollerType, initialDelayDuration, pollers.DefaultNumberOfDroppedConnectionsToAllow)
+	if err = poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("waiting for the File Service to become available: %+v", err)
+	}
+
+	return nil
+}
+
 func waitForDataPlaneToBecomeAvailableForAccount(ctx context.Context, client *client.Client, account *client.AccountDetails, supportLevel storageAccountServiceSupportLevel) error {
 	initialDelayDuration := 10 * time.Second
 
@@ -91,20 +108,6 @@ func waitForDataPlaneToBecomeAvailableForAccount(ctx context.Context, client *cl
 		if err = poller.PollUntilDone(ctx); err != nil {
 			if !connectionError(err) {
 				return fmt.Errorf("waiting for the Queues Service to become available: %+v", err)
-			}
-		}
-	}
-
-	if supportLevel.supportShare {
-		log.Printf("[DEBUG] waiting for the File Service to become available")
-		pollerType, err := custompollers.NewDataPlaneFileShareAvailabilityPoller(client, account)
-		if err != nil {
-			return fmt.Errorf("building File Share Poller: %+v", err)
-		}
-		poller := pollers.NewPoller(pollerType, initialDelayDuration, pollers.DefaultNumberOfDroppedConnectionsToAllow)
-		if err = poller.PollUntilDone(ctx); err != nil {
-			if !connectionError(err) {
-				return fmt.Errorf("waiting for the File Service to become available: %+v", err)
 			}
 		}
 	}

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -1573,6 +1573,22 @@ func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 	}
 
 	supportLevel := availableFunctionalityForAccount(accountKind, accountTier, replicationType)
+	if supportLevel.supportShare {
+		// The storage account LRO can complete before the ARM File Service child resource is available.
+		// Wait during creation so the immediate state refresh can read its service properties reliably.
+		fileServiceAccount, err := storageUtils.GetAccount(ctx, id)
+		if err != nil {
+			return fmt.Errorf("retrieving %s: %+v", id, err)
+		}
+		if fileServiceAccount == nil {
+			return fmt.Errorf("unable to locate %q", id)
+		}
+
+		if err := waitForFileServiceToBecomeAvailableForAccount(ctx, storageUtils, fileServiceAccount); err != nil {
+			return fmt.Errorf("waiting for the File Service for %s to become available: %+v", id, err)
+		}
+	}
+
 	// Start of Data Plane access - this entire block can be removed for 5.0, as the data_plane_available flag becomes redundant at that time.
 	if !features.FivePointOh() && dataPlaneAvailable {
 		dataPlaneClient := meta.(*clients.Client).Storage


### PR DESCRIPTION
## Community Note

* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

Azure can report a Storage Account create operation as complete before the ARM File Service child resource at `fileServices/default` is available. `azurerm_storage_account` immediately refreshes state after creation and reads File service properties for account kinds that support Azure Files, even when no `share_properties` block is configured. A transient `404 ResourceNotFound` from that request therefore fails the create after the Storage Account already exists, which can leave the Terraform resource tainted and cause repeated replacement attempts.

AzureRM v3.113.0 added service-readiness polling in #26218, including an existing File Service poller. In v5, that poller became unreachable because it remained inside the legacy data-plane block gated by `!features.FivePointOh()`, while File service properties continue to be read through the Resource Manager client.

This change invokes the existing File Service availability poller from the current Storage Account create path whenever the account supports Azure Files. The poller:

* retries only the observed `404` response with the structured Azure error code `ResourceNotFound`;
* fails immediately for other 404 error codes and non-transient errors;
* uses the Storage Account create context, so retries remain bounded by the existing create timeout and preserve cancellation; and
* remains creation-scoped, leaving ordinary refresh behavior unchanged.

Using `account_kind = "BlobStorage"` avoids the File and Queue service-property reads and was a viable workload-specific workaround, but it does not address the general `StorageV2` creation race. This PR does not change Queue service authentication or error handling; Queue authorization failures are separate from the File Service readiness issue.

## PR Checklist

- [x] I have followed the guidelines in the [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there are no other open Pull Requests for the same update/change.
- [x] I have checked whether these changes close any open issues.
- [x] Documentation changes are not required because this corrects provider lifecycle behavior without changing configuration.
- [x] I have used a meaningful PR title.

## Changes to existing Resource / Data Source

- [x] The behavior and reason for the change are explained above.
- [x] Focused deterministic unit coverage was added for successful readiness, transient `404 ResourceNotFound`, a different 404 error code, and a permanent authorization failure.
- [x] Relevant local tests and static checks pass.

## Testing

```text
go test ./internal/services/storage/custompollers -run '^TestDataPlaneFileShareAvailabilityPoller$' -count=1
ok  github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/custompollers

go test ./internal/services/storage/custompollers -count=1
ok  github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/custompollers

go test ./internal/services/storage -run '^$' -count=1
ok  github.com/hashicorp/terraform-provider-azurerm/internal/services/storage [no tests to run]

go vet ./internal/services/storage/custompollers ./internal/services/storage
```

Also run successfully:

* `gofmt` on all changed Go files
* `git diff --check`
* `scripts/checks/test-package-check.sh`
* `scripts/checks/timeouts-check.sh`

Acceptance tests were not run because they create paid Azure resources and no authorized acceptance-test credentials were available. The existing `TestAccStorageAccount_recreation` acceptance test covers the create/recreate lifecycle that originally motivated service-readiness polling.

## Change Log

* `azurerm_storage_account` - correctly wait for File service properties to become available during creation [GH-32973]

This is a:

- [x] Bug Fix
- [ ] New Feature
- [ ] Enhancement
- [ ] Breaking Change

## Related Issue(s)

Related historical fix: #26218

## AI Assistance Disclosure

- [x] AI Assisted - AI was used to investigate the current and historical code paths, implement the focused change and unit tests, run validation, and draft this pull request description.

## Rollback Plan

Revert this change and publish an updated provider version.

## Changes to Security Controls

None. The change does not alter authentication, authorization, encryption, or logging behavior.
