### PR TITLE
New Data Sources: Palo Alto next generation firewalls

### DIFF
--- a/internal/services/paloalto/palo_alto_next_generation_firewall_data_source.go
+++ b/internal/services/paloalto/palo_alto_next_generation_firewall_data_source.go
@@ -1,0 +1,443 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package paloalto
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
+	firewalls "github.com/hashicorp/go-azure-sdk/resource-manager/paloaltonetworks/2025-10-08/firewallresources"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/paloalto/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/paloalto/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+func (NextGenerationFirewallVHubLocalRulestackDataSource) ResourceType() string {
+	return "azurerm_palo_alto_next_generation_firewall_virtual_hub_local_rulestack"
+}
+
+func (NextGenerationFirewallVHubLocalRulestackDataSource) ModelObject() interface{} {
+	return &NextGenerationFirewallVHubLocalRuleStackModel{}
+}
+
+func (NextGenerationFirewallVHubLocalRulestackDataSource) Arguments() map[string]*pluginsdk.Schema {
+	return nextGenerationFirewallDataSourceArguments()
+}
+
+func (NextGenerationFirewallVHubLocalRulestackDataSource) Attributes() map[string]*pluginsdk.Schema {
+	attributes := nextGenerationFirewallDataSourceAttributes(schema.VHubNetworkProfileDataSourceSchema())
+	attributes["rulestack_id"] = computedStringSchema()
+	return attributes
+}
+
+func (NextGenerationFirewallVHubLocalRulestackDataSource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			var state NextGenerationFirewallVHubLocalRuleStackModel
+			if err := metadata.Decode(&state); err != nil {
+				return err
+			}
+
+			id, model, err := retrieveNextGenerationFirewall(ctx, metadata, state.ResourceGroupName, state.Name)
+			if err != nil {
+				return err
+			}
+
+			if model != nil {
+				props := model.Properties
+				state.DNSSettings = schema.FlattenDNSSettings(props.DnsSettings)
+				state.FrontEnd = schema.FlattenDestinationNAT(props.FrontEndSettings)
+				state.MarketplaceOfferId = props.MarketplaceDetails.OfferId
+				state.PlanId = props.PlanData.PlanId
+				state.Tags = tags.Flatten(model.Tags)
+				if props.AssociatedRulestack != nil {
+					state.RuleStackId = pointer.From(props.AssociatedRulestack.ResourceId)
+				}
+
+				networkProfile, err := schema.FlattenNetworkProfileVHub(props.NetworkProfile)
+				if err != nil {
+					return fmt.Errorf("flattening Network Profile for %s: %+v", id, err)
+				}
+				state.NetworkProfile = []schema.NetworkProfileVHub{*networkProfile}
+			}
+
+			return metadata.Encode(&state)
+		},
+	}
+}
+
+func (NextGenerationFirewallVNetLocalRulestackDataSource) ResourceType() string {
+	return "azurerm_palo_alto_next_generation_firewall_virtual_network_local_rulestack"
+}
+
+func (NextGenerationFirewallVNetLocalRulestackDataSource) ModelObject() interface{} {
+	return &NextGenerationFirewallVnetLocalRulestackModel{}
+}
+
+func (NextGenerationFirewallVNetLocalRulestackDataSource) Arguments() map[string]*pluginsdk.Schema {
+	return nextGenerationFirewallDataSourceArguments()
+}
+
+func (NextGenerationFirewallVNetLocalRulestackDataSource) Attributes() map[string]*pluginsdk.Schema {
+	attributes := nextGenerationFirewallDataSourceAttributes(schema.VnetNetworkProfileDataSourceSchema())
+	attributes["rulestack_id"] = computedStringSchema()
+	return attributes
+}
+
+func (NextGenerationFirewallVNetLocalRulestackDataSource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			var state NextGenerationFirewallVnetLocalRulestackModel
+			if err := metadata.Decode(&state); err != nil {
+				return err
+			}
+
+			_, model, err := retrieveNextGenerationFirewall(ctx, metadata, state.ResourceGroupName, state.Name)
+			if err != nil {
+				return err
+			}
+
+			if model != nil {
+				props := model.Properties
+				state.DNSSettings = schema.FlattenDNSSettings(props.DnsSettings)
+				state.FrontEnd = schema.FlattenDestinationNAT(props.FrontEndSettings)
+				state.MarketplaceOfferId = props.MarketplaceDetails.OfferId
+				state.NetworkProfile = schema.FlattenNetworkProfileVnet(props.NetworkProfile)
+				state.PlanId = props.PlanData.PlanId
+				state.Tags = tags.Flatten(model.Tags)
+				if props.AssociatedRulestack != nil {
+					state.RuleStackId = pointer.From(props.AssociatedRulestack.ResourceId)
+				}
+			}
+
+			return metadata.Encode(&state)
+		},
+	}
+}
+
+func (NextGenerationFirewallVHubPanoramaDataSource) ResourceType() string {
+	return "azurerm_palo_alto_next_generation_firewall_virtual_hub_panorama"
+}
+
+func (NextGenerationFirewallVHubPanoramaDataSource) ModelObject() interface{} {
+	return &NextGenerationFirewallVHubPanoramaResourceModel{}
+}
+
+func (NextGenerationFirewallVHubPanoramaDataSource) Arguments() map[string]*pluginsdk.Schema {
+	return nextGenerationFirewallDataSourceArguments()
+}
+
+func (NextGenerationFirewallVHubPanoramaDataSource) Attributes() map[string]*pluginsdk.Schema {
+	attributes := nextGenerationFirewallDataSourceAttributes(schema.VHubNetworkProfileDataSourceSchema())
+	attributes["location"] = commonschema.LocationComputed()
+	attributes["panorama"] = schema.PanoramaSchema()
+	attributes["panorama_base64_config"] = computedStringSchema()
+	return attributes
+}
+
+func (NextGenerationFirewallVHubPanoramaDataSource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			var state NextGenerationFirewallVHubPanoramaResourceModel
+			if err := metadata.Decode(&state); err != nil {
+				return err
+			}
+
+			id, model, err := retrieveNextGenerationFirewall(ctx, metadata, state.ResourceGroupName, state.Name)
+			if err != nil {
+				return err
+			}
+
+			if model != nil {
+				props := model.Properties
+				state.Location = location.Normalize(model.Location)
+				state.DNSSettings = schema.FlattenDNSSettings(props.DnsSettings)
+				state.FrontEnd = schema.FlattenDestinationNAT(props.FrontEndSettings)
+				state.MarketplaceOfferId = props.MarketplaceDetails.OfferId
+				state.PlanId = props.PlanData.PlanId
+				state.Tags = tags.Flatten(model.Tags)
+
+				networkProfile, err := schema.FlattenNetworkProfileVHub(props.NetworkProfile)
+				if err != nil {
+					return fmt.Errorf("flattening Network Profile for %s: %+v", id, err)
+				}
+				state.NetworkProfile = []schema.NetworkProfileVHub{*networkProfile}
+
+				flattenPanoramaConfig(props.PanoramaConfig, &state.PanoramaBase64Config, &state.PanoramaConfig)
+			}
+
+			return metadata.Encode(&state)
+		},
+	}
+}
+
+func (NextGenerationFirewallVNetPanoramaDataSource) ResourceType() string {
+	return "azurerm_palo_alto_next_generation_firewall_virtual_network_panorama"
+}
+
+func (NextGenerationFirewallVNetPanoramaDataSource) ModelObject() interface{} {
+	return &NextGenerationFirewallVnetPanoramaModel{}
+}
+
+func (NextGenerationFirewallVNetPanoramaDataSource) Arguments() map[string]*pluginsdk.Schema {
+	return nextGenerationFirewallDataSourceArguments()
+}
+
+func (NextGenerationFirewallVNetPanoramaDataSource) Attributes() map[string]*pluginsdk.Schema {
+	attributes := nextGenerationFirewallDataSourceAttributes(schema.VnetNetworkProfileDataSourceSchema())
+	attributes["location"] = commonschema.LocationComputed()
+	attributes["panorama"] = schema.PanoramaSchema()
+	attributes["panorama_base64_config"] = computedStringSchema()
+	return attributes
+}
+
+func (NextGenerationFirewallVNetPanoramaDataSource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			var state NextGenerationFirewallVnetPanoramaModel
+			if err := metadata.Decode(&state); err != nil {
+				return err
+			}
+
+			_, model, err := retrieveNextGenerationFirewall(ctx, metadata, state.ResourceGroupName, state.Name)
+			if err != nil {
+				return err
+			}
+
+			if model != nil {
+				props := model.Properties
+				state.Location = location.Normalize(model.Location)
+				state.DNSSettings = schema.FlattenDNSSettings(props.DnsSettings)
+				state.FrontEnd = schema.FlattenDestinationNAT(props.FrontEndSettings)
+				state.MarketplaceOfferId = props.MarketplaceDetails.OfferId
+				state.NetworkProfile = schema.FlattenNetworkProfileVnet(props.NetworkProfile)
+				state.PlanId = props.PlanData.PlanId
+				state.Tags = tags.Flatten(model.Tags)
+				flattenPanoramaConfig(props.PanoramaConfig, &state.PanoramaBase64Config, &state.PanoramaConfig)
+			}
+
+			return metadata.Encode(&state)
+		},
+	}
+}
+
+func (NextGenerationFirewallVHubStrataCloudManagerDataSource) ResourceType() string {
+	return "azurerm_palo_alto_next_generation_firewall_virtual_hub_strata_cloud_manager"
+}
+
+func (NextGenerationFirewallVHubStrataCloudManagerDataSource) ModelObject() interface{} {
+	return &NextGenerationFirewallVHubStrataCloudManagerModel{}
+}
+
+func (NextGenerationFirewallVHubStrataCloudManagerDataSource) Arguments() map[string]*pluginsdk.Schema {
+	return nextGenerationFirewallDataSourceArguments()
+}
+
+func (NextGenerationFirewallVHubStrataCloudManagerDataSource) Attributes() map[string]*pluginsdk.Schema {
+	attributes := nextGenerationFirewallDataSourceAttributes(schema.VHubNetworkProfileDataSourceSchema())
+	attributes["identity"] = userAssignedIdentityDataSourceSchema()
+	attributes["location"] = commonschema.LocationComputed()
+	attributes["strata_cloud_manager_tenant_name"] = computedStringSchema()
+	return attributes
+}
+
+func (NextGenerationFirewallVHubStrataCloudManagerDataSource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			var state NextGenerationFirewallVHubStrataCloudManagerModel
+			if err := metadata.Decode(&state); err != nil {
+				return err
+			}
+
+			id, model, err := retrieveNextGenerationFirewall(ctx, metadata, state.ResourceGroupName, state.Name)
+			if err != nil {
+				return err
+			}
+
+			if model != nil {
+				props := model.Properties
+				state.Location = location.Normalize(model.Location)
+				state.DNSSettings = schema.FlattenDNSSettings(props.DnsSettings)
+				state.FrontEnd = schema.FlattenDestinationNAT(props.FrontEndSettings)
+				state.MarketplaceOfferId = props.MarketplaceDetails.OfferId
+				state.PlanId = props.PlanData.PlanId
+				state.Tags = tags.Flatten(model.Tags)
+
+				networkProfile, err := schema.FlattenNetworkProfileVHub(props.NetworkProfile)
+				if err != nil {
+					return fmt.Errorf("flattening Network Profile for %s: %+v", id, err)
+				}
+				state.NetworkProfile = []schema.NetworkProfileVHub{*networkProfile}
+
+				if err := flattenStrataCloudManagerConfig(model, &state.StrataCloudManagerTenantName, &state.Identity); err != nil {
+					return err
+				}
+			}
+
+			return metadata.Encode(&state)
+		},
+	}
+}
+
+func (NextGenerationFirewallVNetStrataCloudManagerDataSource) ResourceType() string {
+	return "azurerm_palo_alto_next_generation_firewall_virtual_network_strata_cloud_manager"
+}
+
+func (NextGenerationFirewallVNetStrataCloudManagerDataSource) ModelObject() interface{} {
+	return &NextGenerationFirewallVNetStrataCloudManagerModel{}
+}
+
+func (NextGenerationFirewallVNetStrataCloudManagerDataSource) Arguments() map[string]*pluginsdk.Schema {
+	return nextGenerationFirewallDataSourceArguments()
+}
+
+func (NextGenerationFirewallVNetStrataCloudManagerDataSource) Attributes() map[string]*pluginsdk.Schema {
+	attributes := nextGenerationFirewallDataSourceAttributes(schema.VnetNetworkProfileDataSourceSchema())
+	attributes["identity"] = userAssignedIdentityDataSourceSchema()
+	attributes["location"] = commonschema.LocationComputed()
+	attributes["strata_cloud_manager_tenant_name"] = computedStringSchema()
+	return attributes
+}
+
+func (NextGenerationFirewallVNetStrataCloudManagerDataSource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			var state NextGenerationFirewallVNetStrataCloudManagerModel
+			if err := metadata.Decode(&state); err != nil {
+				return err
+			}
+
+			_, model, err := retrieveNextGenerationFirewall(ctx, metadata, state.ResourceGroupName, state.Name)
+			if err != nil {
+				return err
+			}
+
+			if model != nil {
+				props := model.Properties
+				state.Location = location.Normalize(model.Location)
+				state.DNSSettings = schema.FlattenDNSSettings(props.DnsSettings)
+				state.FrontEnd = schema.FlattenDestinationNAT(props.FrontEndSettings)
+				state.MarketplaceOfferId = props.MarketplaceDetails.OfferId
+				state.NetworkProfile = schema.FlattenNetworkProfileVnet(props.NetworkProfile)
+				state.PlanId = props.PlanData.PlanId
+				state.Tags = tags.Flatten(model.Tags)
+
+				if err := flattenStrataCloudManagerConfig(model, &state.StrataCloudManagerTenantName, &state.Identity); err != nil {
+					return err
+				}
+			}
+
+			return metadata.Encode(&state)
+		},
+	}
+}
+
+func nextGenerationFirewallDataSourceArguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validate.NextGenerationFirewallName,
+		},
+
+		"resource_group_name": commonschema.ResourceGroupNameForDataSource(),
+	}
+}
+
+func nextGenerationFirewallDataSourceAttributes(networkProfile *pluginsdk.Schema) map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"destination_nat":      schema.DestinationNATDataSourceSchema(),
+		"dns_settings":         schema.DNSSettingsDataSourceSchema(),
+		"marketplace_offer_id": computedStringSchema(),
+		"network_profile":      networkProfile,
+		"plan_id":              computedStringSchema(),
+		"tags":                 commonschema.TagsDataSource(),
+	}
+}
+
+func computedStringSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeString,
+		Computed: true,
+	}
+}
+
+func userAssignedIdentityDataSourceSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Computed: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"identity_ids": {
+					Type:     pluginsdk.TypeSet,
+					Computed: true,
+					Elem: &pluginsdk.Schema{
+						Type: pluginsdk.TypeString,
+					},
+				},
+				"type": computedStringSchema(),
+			},
+		},
+	}
+}
+
+func retrieveNextGenerationFirewall(ctx context.Context, metadata sdk.ResourceMetaData, resourceGroupName, name string) (firewalls.FirewallId, *firewalls.FirewallResource, error) {
+	client := metadata.Client.PaloAlto.FirewallResources
+	id := firewalls.NewFirewallID(metadata.Client.Account.SubscriptionId, resourceGroupName, name)
+
+	result, err := client.FirewallsGet(ctx, id)
+	if err != nil {
+		if response.WasNotFound(result.HttpResponse) {
+			return id, nil, fmt.Errorf("%s was not found", id)
+		}
+		return id, nil, fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	metadata.SetID(id)
+	return id, result.Model, nil
+}
+
+func flattenPanoramaConfig(input *firewalls.PanoramaConfig, base64Config *string, panoramaConfig *[]schema.Panorama) {
+	if input == nil {
+		return
+	}
+
+	*base64Config = input.ConfigString
+	*panoramaConfig = []schema.Panorama{{
+		Name:            pointer.From(input.CgName),
+		DeviceGroupName: pointer.From(input.DgName),
+		HostName:        pointer.From(input.HostName),
+		PanoramaServer:  pointer.From(input.PanoramaServer),
+		PanoramaServer2: pointer.From(input.PanoramaServer2),
+		TplName:         pointer.From(input.TplName),
+		VMAuthKey:       pointer.From(input.VMAuthKey),
+	}}
+}
+
+func flattenStrataCloudManagerConfig(input *firewalls.FirewallResource, tenantName *string, outputIdentity *[]identity.ModelUserAssigned) error {
+	if config := input.Properties.StrataCloudManagerConfig; config != nil {
+		*tenantName = config.CloudManagerName
+	}
+
+	flattenedIdentity, err := identity.FlattenUserAssignedMapToModel(input.Identity)
+	if err != nil {
+		return fmt.Errorf("flattening `identity`: %+v", err)
+	}
+	*outputIdentity = pointer.From(flattenedIdentity)
+	return nil
+}

--- a/internal/services/paloalto/palo_alto_next_generation_firewall_data_source_test.go
+++ b/internal/services/paloalto/palo_alto_next_generation_firewall_data_source_test.go
@@ -1,0 +1,209 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package paloalto_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/paloalto"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+func TestAccPaloAltoNextGenerationFirewallVHubLocalRulestackDataSource_basic(t *testing.T) {
+	resourceType := "azurerm_palo_alto_next_generation_firewall_virtual_hub_local_rulestack"
+	data := acceptance.BuildTestData(t, "data."+resourceType, "test")
+
+	data.DataSourceTest(t, []acceptance.TestStep{{
+		Config: nextGenerationFirewallDataSourceConfig(NextGenerationFirewallVWanResource{}.complete(data), resourceType),
+		Check: acceptance.ComposeTestCheckFunc(
+			check.That(data.ResourceName).Key("destination_nat.0.name").HasValue("testDNAT-1"),
+			check.That(data.ResourceName).Key("marketplace_offer_id").HasValue("pan_swfw_cloud_ngfw"),
+			check.That(data.ResourceName).Key("network_profile.0.virtual_hub_id").Exists(),
+			check.That(data.ResourceName).Key("plan_id").HasValue("panw-cngfw-payg"),
+			check.That(data.ResourceName).Key("rulestack_id").Exists(),
+		),
+	}})
+}
+
+func TestAccPaloAltoNextGenerationFirewallVNetLocalRulestackDataSource_basic(t *testing.T) {
+	resourceType := "azurerm_palo_alto_next_generation_firewall_virtual_network_local_rulestack"
+	data := acceptance.BuildTestData(t, "data."+resourceType, "test")
+
+	data.DataSourceTest(t, []acceptance.TestStep{{
+		Config: nextGenerationFirewallDataSourceConfig(NextGenerationFirewallVnetResource{}.complete(data), resourceType),
+		Check: acceptance.ComposeTestCheckFunc(
+			check.That(data.ResourceName).Key("destination_nat.0.name").HasValue("testDNAT-1"),
+			check.That(data.ResourceName).Key("marketplace_offer_id").HasValue("pan_swfw_cloud_ngfw"),
+			check.That(data.ResourceName).Key("network_profile.0.vnet_configuration.0.virtual_network_id").Exists(),
+			check.That(data.ResourceName).Key("plan_id").HasValue("panw-cngfw-payg"),
+			check.That(data.ResourceName).Key("rulestack_id").Exists(),
+		),
+	}})
+}
+
+func TestAccPaloAltoNextGenerationFirewallVHubPanoramaDataSource_basic(t *testing.T) {
+	if os.Getenv("ARM_PALO_ALTO_PANORAMA_CONFIG") == "" {
+		t.Skip("skipping as Palo Alto Panorama config not set in `ARM_PALO_ALTO_PANORAMA_CONFIG`")
+	}
+
+	resourceType := "azurerm_palo_alto_next_generation_firewall_virtual_hub_panorama"
+	data := acceptance.BuildTestData(t, "data."+resourceType, "test")
+
+	data.DataSourceTest(t, []acceptance.TestStep{{
+		Config: nextGenerationFirewallDataSourceConfig(NextGenerationFirewallVHubPanoramaResource{}.complete(data), resourceType),
+		Check: acceptance.ComposeTestCheckFunc(
+			check.That(data.ResourceName).Key("location").Exists(),
+			check.That(data.ResourceName).Key("marketplace_offer_id").HasValue("pan_swfw_cloud_ngfw"),
+			check.That(data.ResourceName).Key("network_profile.0.virtual_hub_id").Exists(),
+			check.That(data.ResourceName).Key("panorama_base64_config").Exists(),
+			check.That(data.ResourceName).Key("plan_id").HasValue("panw-cngfw-payg"),
+		),
+	}})
+}
+
+func TestAccPaloAltoNextGenerationFirewallVNetPanoramaDataSource_basic(t *testing.T) {
+	if os.Getenv("ARM_PALO_ALTO_PANORAMA_CONFIG") == "" {
+		t.Skip("skipping as Palo Alto Panorama config not set in `ARM_PALO_ALTO_PANORAMA_CONFIG`")
+	}
+
+	resourceType := "azurerm_palo_alto_next_generation_firewall_virtual_network_panorama"
+	data := acceptance.BuildTestData(t, "data."+resourceType, "test")
+
+	data.DataSourceTest(t, []acceptance.TestStep{{
+		Config: nextGenerationFirewallDataSourceConfig(NextGenerationFirewallVNetPanoramaResource{}.complete(data), resourceType),
+		Check: acceptance.ComposeTestCheckFunc(
+			check.That(data.ResourceName).Key("location").Exists(),
+			check.That(data.ResourceName).Key("marketplace_offer_id").HasValue("pan_swfw_cloud_ngfw"),
+			check.That(data.ResourceName).Key("network_profile.0.vnet_configuration.0.virtual_network_id").Exists(),
+			check.That(data.ResourceName).Key("panorama_base64_config").Exists(),
+			check.That(data.ResourceName).Key("plan_id").HasValue("panw-cngfw-payg"),
+		),
+	}})
+}
+
+func TestAccPaloAltoNextGenerationFirewallVHubStrataCloudManagerDataSource_basic(t *testing.T) {
+	if os.Getenv("ARM_PALO_ALTO_SCM_TENANT_NAME") == "" {
+		t.Skip("skipping as Palo Alto Strata Cloud Manager tenant name not set in `ARM_PALO_ALTO_SCM_TENANT_NAME`")
+	}
+
+	resourceType := "azurerm_palo_alto_next_generation_firewall_virtual_hub_strata_cloud_manager"
+	data := acceptance.BuildTestData(t, "data."+resourceType, "test")
+
+	data.DataSourceTest(t, []acceptance.TestStep{{
+		Config: nextGenerationFirewallDataSourceConfig(NextGenerationFirewallVHubStrataCloudManagerResource{}.complete(data), resourceType),
+		Check: acceptance.ComposeTestCheckFunc(
+			check.That(data.ResourceName).Key("identity.0.identity_ids.#").HasValue("1"),
+			check.That(data.ResourceName).Key("location").Exists(),
+			check.That(data.ResourceName).Key("network_profile.0.virtual_hub_id").Exists(),
+			check.That(data.ResourceName).Key("plan_id").HasValue("panw-cngfw-payg"),
+			check.That(data.ResourceName).Key("strata_cloud_manager_tenant_name").HasValue(os.Getenv("ARM_PALO_ALTO_SCM_TENANT_NAME")),
+		),
+	}})
+}
+
+func TestAccPaloAltoNextGenerationFirewallVNetStrataCloudManagerDataSource_basic(t *testing.T) {
+	if os.Getenv("ARM_PALO_ALTO_SCM_TENANT_NAME") == "" {
+		t.Skip("skipping as Palo Alto Strata Cloud Manager tenant name not set in `ARM_PALO_ALTO_SCM_TENANT_NAME`")
+	}
+
+	resourceType := "azurerm_palo_alto_next_generation_firewall_virtual_network_strata_cloud_manager"
+	data := acceptance.BuildTestData(t, "data."+resourceType, "test")
+
+	data.DataSourceTest(t, []acceptance.TestStep{{
+		Config: nextGenerationFirewallDataSourceConfig(NextGenerationFirewallVNetStrataCloudManagerResource{}.complete(data), resourceType),
+		Check: acceptance.ComposeTestCheckFunc(
+			check.That(data.ResourceName).Key("identity.0.identity_ids.#").HasValue("1"),
+			check.That(data.ResourceName).Key("location").Exists(),
+			check.That(data.ResourceName).Key("network_profile.0.vnet_configuration.0.virtual_network_id").Exists(),
+			check.That(data.ResourceName).Key("plan_id").HasValue("panw-cngfw-payg"),
+			check.That(data.ResourceName).Key("strata_cloud_manager_tenant_name").HasValue(os.Getenv("ARM_PALO_ALTO_SCM_TENANT_NAME")),
+		),
+	}})
+}
+
+func TestPaloAltoNextGenerationFirewallDataSourceSchemasMatchResources(t *testing.T) {
+	tests := []struct {
+		name       string
+		resource   sdk.Resource
+		dataSource sdk.DataSource
+	}{
+		{"virtual hub local rulestack", paloalto.NextGenerationFirewallVHubLocalRuleStackResource{}, paloalto.NextGenerationFirewallVHubLocalRulestackDataSource{}},
+		{"virtual hub panorama", paloalto.NextGenerationFirewallVHubPanoramaResource{}, paloalto.NextGenerationFirewallVHubPanoramaDataSource{}},
+		{"virtual hub strata cloud manager", paloalto.NextGenerationFirewallVHubStrataCloudManagerResource{}, paloalto.NextGenerationFirewallVHubStrataCloudManagerDataSource{}},
+		{"virtual network local rulestack", paloalto.NextGenerationFirewallVNetLocalRulestackResource{}, paloalto.NextGenerationFirewallVNetLocalRulestackDataSource{}},
+		{"virtual network panorama", paloalto.NextGenerationFirewallVNetPanoramaResource{}, paloalto.NextGenerationFirewallVNetPanoramaDataSource{}},
+		{"virtual network strata cloud manager", paloalto.NextGenerationFirewallVNetStrataCloudManagerResource{}, paloalto.NextGenerationFirewallVNetStrataCloudManagerDataSource{}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.resource.ResourceType() != test.dataSource.ResourceType() {
+				t.Fatalf("resource type mismatch: resource %q, data source %q", test.resource.ResourceType(), test.dataSource.ResourceType())
+			}
+
+			resourceSchema := mergeSchemas(test.resource.Arguments(), test.resource.Attributes())
+			dataSourceSchema := mergeSchemas(test.dataSource.Arguments(), test.dataSource.Attributes())
+			assertSchemaShapeMatches(t, test.resource.ResourceType(), resourceSchema, dataSourceSchema)
+		})
+	}
+}
+
+func nextGenerationFirewallDataSourceConfig(resourceConfig, resourceType string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data %[2]q "test" {
+  name                = %[2]s.test.name
+  resource_group_name = %[2]s.test.resource_group_name
+}
+`, resourceConfig, resourceType)
+}
+
+func mergeSchemas(first, second map[string]*pluginsdk.Schema) map[string]*pluginsdk.Schema {
+	result := make(map[string]*pluginsdk.Schema, len(first)+len(second))
+	for key, value := range first {
+		result[key] = value
+	}
+	for key, value := range second {
+		result[key] = value
+	}
+	return result
+}
+
+func assertSchemaShapeMatches(t *testing.T, path string, resourceSchema, dataSourceSchema map[string]*pluginsdk.Schema) {
+	t.Helper()
+
+	for name, resourceField := range resourceSchema {
+		dataSourceField, ok := dataSourceSchema[name]
+		if !ok {
+			t.Errorf("%s: data source does not expose resource field %q", path, name)
+			continue
+		}
+
+		if resourceField.Type != dataSourceField.Type {
+			t.Errorf("%s.%s: schema type mismatch: resource %v, data source %v", path, name, resourceField.Type, dataSourceField.Type)
+		}
+
+		resourceNested, resourceHasNested := resourceField.Elem.(*pluginsdk.Resource)
+		dataSourceNested, dataSourceHasNested := dataSourceField.Elem.(*pluginsdk.Resource)
+		if resourceHasNested != dataSourceHasNested {
+			t.Errorf("%s.%s: nested resource shape mismatch", path, name)
+			continue
+		}
+		if resourceHasNested {
+			assertSchemaShapeMatches(t, path+"."+name, resourceNested.Schema, dataSourceNested.Schema)
+		}
+	}
+
+	for name := range dataSourceSchema {
+		if _, ok := resourceSchema[name]; !ok {
+			t.Errorf("%s: data source exposes field %q which is not exposed by the resource", path, name)
+		}
+	}
+}

--- a/internal/services/paloalto/palo_alto_next_generation_firewall_virtual_hub_local_rulestack_data_source.go
+++ b/internal/services/paloalto/palo_alto_next_generation_firewall_virtual_hub_local_rulestack_data_source.go
@@ -1,0 +1,10 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package paloalto
+
+import "github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+
+type NextGenerationFirewallVHubLocalRulestackDataSource struct{}
+
+var _ sdk.DataSource = NextGenerationFirewallVHubLocalRulestackDataSource{}

--- a/internal/services/paloalto/palo_alto_next_generation_firewall_virtual_hub_panorama_data_source.go
+++ b/internal/services/paloalto/palo_alto_next_generation_firewall_virtual_hub_panorama_data_source.go
@@ -1,0 +1,10 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package paloalto
+
+import "github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+
+type NextGenerationFirewallVHubPanoramaDataSource struct{}
+
+var _ sdk.DataSource = NextGenerationFirewallVHubPanoramaDataSource{}

--- a/internal/services/paloalto/palo_alto_next_generation_firewall_virtual_hub_strata_cloud_manager_data_source.go
+++ b/internal/services/paloalto/palo_alto_next_generation_firewall_virtual_hub_strata_cloud_manager_data_source.go
@@ -1,0 +1,10 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package paloalto
+
+import "github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+
+type NextGenerationFirewallVHubStrataCloudManagerDataSource struct{}
+
+var _ sdk.DataSource = NextGenerationFirewallVHubStrataCloudManagerDataSource{}

--- a/internal/services/paloalto/palo_alto_next_generation_firewall_virtual_network_local_rulestack_data_source.go
+++ b/internal/services/paloalto/palo_alto_next_generation_firewall_virtual_network_local_rulestack_data_source.go
@@ -1,0 +1,10 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package paloalto
+
+import "github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+
+type NextGenerationFirewallVNetLocalRulestackDataSource struct{}
+
+var _ sdk.DataSource = NextGenerationFirewallVNetLocalRulestackDataSource{}

--- a/internal/services/paloalto/palo_alto_next_generation_firewall_virtual_network_panorama_data_source.go
+++ b/internal/services/paloalto/palo_alto_next_generation_firewall_virtual_network_panorama_data_source.go
@@ -1,0 +1,10 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package paloalto
+
+import "github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+
+type NextGenerationFirewallVNetPanoramaDataSource struct{}
+
+var _ sdk.DataSource = NextGenerationFirewallVNetPanoramaDataSource{}

--- a/internal/services/paloalto/palo_alto_next_generation_firewall_virtual_network_strata_cloud_manager_data_source.go
+++ b/internal/services/paloalto/palo_alto_next_generation_firewall_virtual_network_strata_cloud_manager_data_source.go
@@ -1,0 +1,10 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package paloalto
+
+import "github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+
+type NextGenerationFirewallVNetStrataCloudManagerDataSource struct{}
+
+var _ sdk.DataSource = NextGenerationFirewallVNetStrataCloudManagerDataSource{}

--- a/internal/services/paloalto/registration.go
+++ b/internal/services/paloalto/registration.go
@@ -28,6 +28,12 @@ func (r Registration) Name() string {
 func (r Registration) DataSources() []sdk.DataSource {
 	return []sdk.DataSource{
 		LocalRulestackDataSource{},
+		NextGenerationFirewallVHubLocalRulestackDataSource{},
+		NextGenerationFirewallVHubPanoramaDataSource{},
+		NextGenerationFirewallVHubStrataCloudManagerDataSource{},
+		NextGenerationFirewallVNetLocalRulestackDataSource{},
+		NextGenerationFirewallVNetPanoramaDataSource{},
+		NextGenerationFirewallVNetStrataCloudManagerDataSource{},
 	}
 }
 

--- a/internal/services/paloalto/schema/data_source.go
+++ b/internal/services/paloalto/schema/data_source.go
@@ -1,0 +1,154 @@
+// Copyright IBM Corp. 2014, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+import "github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+
+func DNSSettingsDataSourceSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Computed: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"azure_dns_servers": computedStringListSchema(),
+				"dns_servers":       computedStringListSchema(),
+				"use_azure_dns": {
+					Type:     pluginsdk.TypeBool,
+					Computed: true,
+				},
+			},
+		},
+	}
+}
+
+func DestinationNATDataSourceSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Computed: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"backend_config":  endpointConfigurationDataSourceSchema(false),
+				"frontend_config": endpointConfigurationDataSourceSchema(true),
+				"name": {
+					Type:     pluginsdk.TypeString,
+					Computed: true,
+				},
+				"protocol": {
+					Type:     pluginsdk.TypeString,
+					Computed: true,
+				},
+			},
+		},
+	}
+}
+
+func VHubNetworkProfileDataSourceSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Computed: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"egress_nat_ip_address_ids": computedStringListSchema(),
+				"egress_nat_ip_addresses":   computedStringListSchema(),
+				"ip_of_trust_for_user_defined_routes": {
+					Type:     pluginsdk.TypeString,
+					Computed: true,
+				},
+				"network_virtual_appliance_id": {
+					Type:     pluginsdk.TypeString,
+					Computed: true,
+				},
+				"public_ip_address_ids":  computedStringListSchema(),
+				"public_ip_addresses":    computedStringListSchema(),
+				"trusted_address_ranges": computedStringListSchema(),
+				"trusted_subnet_id": {
+					Type:     pluginsdk.TypeString,
+					Computed: true,
+				},
+				"untrusted_subnet_id": {
+					Type:     pluginsdk.TypeString,
+					Computed: true,
+				},
+				"virtual_hub_id": {
+					Type:     pluginsdk.TypeString,
+					Computed: true,
+				},
+			},
+		},
+	}
+}
+
+func VnetNetworkProfileDataSourceSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Computed: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"egress_nat_ip_address_ids": computedStringListSchema(),
+				"egress_nat_ip_addresses":   computedStringListSchema(),
+				"public_ip_address_ids":     computedStringListSchema(),
+				"public_ip_addresses":       computedStringListSchema(),
+				"trusted_address_ranges":    computedStringListSchema(),
+				"vnet_configuration": {
+					Type:     pluginsdk.TypeList,
+					Computed: true,
+					Elem: &pluginsdk.Resource{
+						Schema: map[string]*pluginsdk.Schema{
+							"ip_of_trust_for_user_defined_routes": {
+								Type:     pluginsdk.TypeString,
+								Computed: true,
+							},
+							"trusted_subnet_id": {
+								Type:     pluginsdk.TypeString,
+								Computed: true,
+							},
+							"untrusted_subnet_id": {
+								Type:     pluginsdk.TypeString,
+								Computed: true,
+							},
+							"virtual_network_id": {
+								Type:     pluginsdk.TypeString,
+								Computed: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func computedStringListSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Computed: true,
+		Elem: &pluginsdk.Schema{
+			Type: pluginsdk.TypeString,
+		},
+	}
+}
+
+func endpointConfigurationDataSourceSchema(frontend bool) *pluginsdk.Schema {
+	addressField := "public_ip_address"
+	if frontend {
+		addressField = "public_ip_address_id"
+	}
+
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Computed: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				addressField: {
+					Type:     pluginsdk.TypeString,
+					Computed: true,
+				},
+				"port": {
+					Type:     pluginsdk.TypeInt,
+					Computed: true,
+				},
+			},
+		},
+	}
+}

--- a/website/docs/d/palo_alto_next_generation_firewall_virtual_hub_local_rulestack.html.markdown
+++ b/website/docs/d/palo_alto_next_generation_firewall_virtual_hub_local_rulestack.html.markdown
@@ -1,0 +1,116 @@
+---
+subcategory: "Palo Alto"
+layout: "azurerm"
+page_title: "Azure Resource Manager: Data Source: azurerm_palo_alto_next_generation_firewall_virtual_hub_local_rulestack"
+description: |-
+  Gets information about an existing Palo Alto Next Generation Firewall Virtual Hub Local Rulestack.
+---
+
+# Data Source: azurerm_palo_alto_next_generation_firewall_virtual_hub_local_rulestack
+
+Use this data source to access information about an existing Palo Alto Next Generation Firewall Virtual Hub Local Rulestack.
+
+## Example Usage
+
+```hcl
+data "azurerm_palo_alto_next_generation_firewall_virtual_hub_local_rulestack" "example" {
+  name                = "existing-firewall"
+  resource_group_name = "existing-resource-group"
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the Palo Alto Next Generation Firewall Virtual Hub Local Rulestack.
+
+* `resource_group_name` - (Required) The name of the Resource Group where the Palo Alto Next Generation Firewall Virtual Hub Local Rulestack exists.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Palo Alto Next Generation Firewall Virtual Hub Local Rulestack.
+
+* `destination_nat` - One or more `destination_nat` blocks as defined below.
+
+* `dns_settings` - A `dns_settings` block as defined below.
+
+* `marketplace_offer_id` - The marketplace offer ID.
+
+* `network_profile` - A `network_profile` block as defined below.
+
+* `plan_id` - The billing plan ID.
+
+* `rulestack_id` - The ID of the Local Rulestack used by this Firewall.
+
+* `tags` - A mapping of tags assigned to the Firewall.
+
+---
+
+A `backend_config` block exports the following:
+
+* `port` - The port number to which traffic is sent.
+
+* `public_ip_address` - The IP Address to which traffic is sent.
+
+---
+
+A `destination_nat` block exports the following:
+
+* `backend_config` - A `backend_config` block as defined above.
+
+* `frontend_config` - A `frontend_config` block as defined below.
+
+* `name` - The name of this Destination NAT configuration.
+
+* `protocol` - The protocol used by this Destination NAT configuration.
+
+---
+
+A `dns_settings` block exports the following:
+
+* `azure_dns_servers` - The Azure DNS Servers used by the Firewall.
+
+* `dns_servers` - The custom DNS Servers used by the Firewall.
+
+* `use_azure_dns` - Whether the Firewall uses Azure DNS Servers.
+
+---
+
+A `frontend_config` block exports the following:
+
+* `port` - The port on which traffic is received.
+
+* `public_ip_address_id` - The ID of the Public IP Address on which traffic is received.
+
+---
+
+A `network_profile` block exports the following:
+
+* `egress_nat_ip_address_ids` - The IDs of the Public IP Addresses used for Egress NAT.
+
+* `egress_nat_ip_addresses` - The Public IP Addresses used for Egress NAT.
+
+* `ip_of_trust_for_user_defined_routes` - The trusted IP Address used for user-defined routes.
+
+* `network_virtual_appliance_id` - The ID of the Palo Alto Network Virtual Appliance in the Virtual Hub.
+
+* `public_ip_address_ids` - The IDs of the Public IP Addresses used by the Firewall.
+
+* `public_ip_addresses` - The Public IP Addresses used by the Firewall.
+
+* `trusted_address_ranges` - The trusted address ranges used by the Firewall.
+
+* `trusted_subnet_id` - The ID of the trusted subnet.
+
+* `untrusted_subnet_id` - The ID of the untrusted subnet.
+
+* `virtual_hub_id` - The ID of the Virtual Hub in which the Firewall is deployed.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/configure#define-operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Palo Alto Next Generation Firewall Virtual Hub Local Rulestack.

--- a/website/docs/d/palo_alto_next_generation_firewall_virtual_hub_panorama.html.markdown
+++ b/website/docs/d/palo_alto_next_generation_firewall_virtual_hub_panorama.html.markdown
@@ -1,0 +1,138 @@
+---
+subcategory: "Palo Alto"
+layout: "azurerm"
+page_title: "Azure Resource Manager: Data Source: azurerm_palo_alto_next_generation_firewall_virtual_hub_panorama"
+description: |-
+  Gets information about an existing Palo Alto Next Generation Firewall Virtual Hub Panorama.
+---
+
+# Data Source: azurerm_palo_alto_next_generation_firewall_virtual_hub_panorama
+
+Use this data source to access information about an existing Palo Alto Next Generation Firewall Virtual Hub Panorama.
+
+## Example Usage
+
+```hcl
+data "azurerm_palo_alto_next_generation_firewall_virtual_hub_panorama" "example" {
+  name                = "existing-firewall"
+  resource_group_name = "existing-resource-group"
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the Palo Alto Next Generation Firewall Virtual Hub Panorama.
+
+* `resource_group_name` - (Required) The name of the Resource Group where the Palo Alto Next Generation Firewall Virtual Hub Panorama exists.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Palo Alto Next Generation Firewall Virtual Hub Panorama.
+
+* `destination_nat` - One or more `destination_nat` blocks as defined below.
+
+* `dns_settings` - A `dns_settings` block as defined below.
+
+* `location` - The Azure Region where the Firewall exists.
+
+* `marketplace_offer_id` - The marketplace offer ID.
+
+* `network_profile` - A `network_profile` block as defined below.
+
+* `panorama` - A `panorama` block as defined below.
+
+* `panorama_base64_config` - The Base64 encoded Panorama configuration registration string.
+
+* `plan_id` - The billing plan ID.
+
+* `tags` - A mapping of tags assigned to the Firewall.
+
+---
+
+A `backend_config` block exports the following:
+
+* `port` - The port number to which traffic is sent.
+
+* `public_ip_address` - The IP Address to which traffic is sent.
+
+---
+
+A `destination_nat` block exports the following:
+
+* `backend_config` - A `backend_config` block as defined above.
+
+* `frontend_config` - A `frontend_config` block as defined below.
+
+* `name` - The name of this Destination NAT configuration.
+
+* `protocol` - The protocol used by this Destination NAT configuration.
+
+---
+
+A `dns_settings` block exports the following:
+
+* `azure_dns_servers` - The Azure DNS Servers used by the Firewall.
+
+* `dns_servers` - The custom DNS Servers used by the Firewall.
+
+* `use_azure_dns` - Whether the Firewall uses Azure DNS Servers.
+
+---
+
+A `frontend_config` block exports the following:
+
+* `port` - The port on which traffic is received.
+
+* `public_ip_address_id` - The ID of the Public IP Address on which traffic is received.
+
+---
+
+A `network_profile` block exports the following:
+
+* `egress_nat_ip_address_ids` - The IDs of the Public IP Addresses used for Egress NAT.
+
+* `egress_nat_ip_addresses` - The Public IP Addresses used for Egress NAT.
+
+* `ip_of_trust_for_user_defined_routes` - The trusted IP Address used for user-defined routes.
+
+* `network_virtual_appliance_id` - The ID of the Palo Alto Network Virtual Appliance in the Virtual Hub.
+
+* `public_ip_address_ids` - The IDs of the Public IP Addresses used by the Firewall.
+
+* `public_ip_addresses` - The Public IP Addresses used by the Firewall.
+
+* `trusted_address_ranges` - The trusted address ranges used by the Firewall.
+
+* `trusted_subnet_id` - The ID of the trusted subnet.
+
+* `untrusted_subnet_id` - The ID of the untrusted subnet.
+
+* `virtual_hub_id` - The ID of the Virtual Hub in which the Firewall is deployed.
+
+---
+
+A `panorama` block exports the following:
+
+* `device_group_name` - The Device Group Name to which the Firewall is registered.
+
+* `host_name` - The Host Name of the Firewall.
+
+* `name` - The name of the Firewall.
+
+* `panorama_server_1` - The name of the first Panorama Server.
+
+* `panorama_server_2` - The name of the second Panorama Server.
+
+* `template_name` - The name of the Panorama Template applied to the Firewall.
+
+* `virtual_machine_ssh_key` - The SSH Key used to connect to the Firewall.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/configure#define-operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Palo Alto Next Generation Firewall Virtual Hub Panorama.

--- a/website/docs/d/palo_alto_next_generation_firewall_virtual_hub_strata_cloud_manager.html.markdown
+++ b/website/docs/d/palo_alto_next_generation_firewall_virtual_hub_strata_cloud_manager.html.markdown
@@ -1,0 +1,128 @@
+---
+subcategory: "Palo Alto"
+layout: "azurerm"
+page_title: "Azure Resource Manager: Data Source: azurerm_palo_alto_next_generation_firewall_virtual_hub_strata_cloud_manager"
+description: |-
+  Gets information about an existing Palo Alto Next Generation Firewall Virtual Hub Strata Cloud Manager.
+---
+
+# Data Source: azurerm_palo_alto_next_generation_firewall_virtual_hub_strata_cloud_manager
+
+Use this data source to access information about an existing Palo Alto Next Generation Firewall Virtual Hub managed by Strata Cloud Manager.
+
+## Example Usage
+
+```hcl
+data "azurerm_palo_alto_next_generation_firewall_virtual_hub_strata_cloud_manager" "example" {
+  name                = "existing-firewall"
+  resource_group_name = "existing-resource-group"
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the Palo Alto Next Generation Firewall Virtual Hub Strata Cloud Manager.
+
+* `resource_group_name` - (Required) The name of the Resource Group where the Palo Alto Next Generation Firewall Virtual Hub Strata Cloud Manager exists.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Palo Alto Next Generation Firewall Virtual Hub Strata Cloud Manager.
+
+* `destination_nat` - One or more `destination_nat` blocks as defined below.
+
+* `dns_settings` - A `dns_settings` block as defined below.
+
+* `identity` - An `identity` block as defined below.
+
+* `location` - The Azure Region where the Firewall exists.
+
+* `marketplace_offer_id` - The marketplace offer ID.
+
+* `network_profile` - A `network_profile` block as defined below.
+
+* `plan_id` - The billing plan ID.
+
+* `strata_cloud_manager_tenant_name` - The name of the Strata Cloud Manager tenant which manages the Firewall.
+
+* `tags` - A mapping of tags assigned to the Firewall.
+
+---
+
+A `backend_config` block exports the following:
+
+* `port` - The port number to which traffic is sent.
+
+* `public_ip_address` - The IP Address to which traffic is sent.
+
+---
+
+A `destination_nat` block exports the following:
+
+* `backend_config` - A `backend_config` block as defined above.
+
+* `frontend_config` - A `frontend_config` block as defined below.
+
+* `name` - The name of this Destination NAT configuration.
+
+* `protocol` - The protocol used by this Destination NAT configuration.
+
+---
+
+A `dns_settings` block exports the following:
+
+* `azure_dns_servers` - The Azure DNS Servers used by the Firewall.
+
+* `dns_servers` - The custom DNS Servers used by the Firewall.
+
+* `use_azure_dns` - Whether the Firewall uses Azure DNS Servers.
+
+---
+
+A `frontend_config` block exports the following:
+
+* `port` - The port on which traffic is received.
+
+* `public_ip_address_id` - The ID of the Public IP Address on which traffic is received.
+
+---
+
+An `identity` block exports the following:
+
+* `identity_ids` - The IDs of the User Assigned Managed Identities assigned to the Firewall.
+
+* `type` - The type of Managed Identity assigned to the Firewall.
+
+---
+
+A `network_profile` block exports the following:
+
+* `egress_nat_ip_address_ids` - The IDs of the Public IP Addresses used for Egress NAT.
+
+* `egress_nat_ip_addresses` - The Public IP Addresses used for Egress NAT.
+
+* `ip_of_trust_for_user_defined_routes` - The trusted IP Address used for user-defined routes.
+
+* `network_virtual_appliance_id` - The ID of the Palo Alto Network Virtual Appliance in the Virtual Hub.
+
+* `public_ip_address_ids` - The IDs of the Public IP Addresses used by the Firewall.
+
+* `public_ip_addresses` - The Public IP Addresses used by the Firewall.
+
+* `trusted_address_ranges` - The trusted address ranges used by the Firewall.
+
+* `trusted_subnet_id` - The ID of the trusted subnet.
+
+* `untrusted_subnet_id` - The ID of the untrusted subnet.
+
+* `virtual_hub_id` - The ID of the Virtual Hub in which the Firewall is deployed.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/configure#define-operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Palo Alto Next Generation Firewall Virtual Hub Strata Cloud Manager.

--- a/website/docs/d/palo_alto_next_generation_firewall_virtual_network_local_rulestack.html.markdown
+++ b/website/docs/d/palo_alto_next_generation_firewall_virtual_network_local_rulestack.html.markdown
@@ -1,0 +1,120 @@
+---
+subcategory: "Palo Alto"
+layout: "azurerm"
+page_title: "Azure Resource Manager: Data Source: azurerm_palo_alto_next_generation_firewall_virtual_network_local_rulestack"
+description: |-
+  Gets information about an existing Palo Alto Next Generation Firewall Virtual Network Local Rulestack.
+---
+
+# Data Source: azurerm_palo_alto_next_generation_firewall_virtual_network_local_rulestack
+
+Use this data source to access information about an existing Palo Alto Next Generation Firewall Virtual Network Local Rulestack.
+
+## Example Usage
+
+```hcl
+data "azurerm_palo_alto_next_generation_firewall_virtual_network_local_rulestack" "example" {
+  name                = "existing-firewall"
+  resource_group_name = "existing-resource-group"
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the Palo Alto Next Generation Firewall Virtual Network Local Rulestack.
+
+* `resource_group_name` - (Required) The name of the Resource Group where the Palo Alto Next Generation Firewall Virtual Network Local Rulestack exists.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Palo Alto Next Generation Firewall Virtual Network Local Rulestack.
+
+* `destination_nat` - One or more `destination_nat` blocks as defined below.
+
+* `dns_settings` - A `dns_settings` block as defined below.
+
+* `marketplace_offer_id` - The marketplace offer ID.
+
+* `network_profile` - A `network_profile` block as defined below.
+
+* `plan_id` - The billing plan ID.
+
+* `rulestack_id` - The ID of the Local Rulestack used by this Firewall.
+
+* `tags` - A mapping of tags assigned to the Firewall.
+
+---
+
+A `backend_config` block exports the following:
+
+* `port` - The port number to which traffic is sent.
+
+* `public_ip_address` - The IP Address to which traffic is sent.
+
+---
+
+A `destination_nat` block exports the following:
+
+* `backend_config` - A `backend_config` block as defined above.
+
+* `frontend_config` - A `frontend_config` block as defined below.
+
+* `name` - The name of this Destination NAT configuration.
+
+* `protocol` - The protocol used by this Destination NAT configuration.
+
+---
+
+A `dns_settings` block exports the following:
+
+* `azure_dns_servers` - The Azure DNS Servers used by the Firewall.
+
+* `dns_servers` - The custom DNS Servers used by the Firewall.
+
+* `use_azure_dns` - Whether the Firewall uses Azure DNS Servers.
+
+---
+
+A `frontend_config` block exports the following:
+
+* `port` - The port on which traffic is received.
+
+* `public_ip_address_id` - The ID of the Public IP Address on which traffic is received.
+
+---
+
+A `network_profile` block exports the following:
+
+* `egress_nat_ip_address_ids` - The IDs of the Public IP Addresses used for Egress NAT.
+
+* `egress_nat_ip_addresses` - The Public IP Addresses used for Egress NAT.
+
+* `public_ip_address_ids` - The IDs of the Public IP Addresses used by the Firewall.
+
+* `public_ip_addresses` - The Public IP Addresses used by the Firewall.
+
+* `trusted_address_ranges` - The trusted address ranges used by the Firewall.
+
+* `vnet_configuration` - A `vnet_configuration` block as defined below.
+
+---
+
+A `vnet_configuration` block exports the following:
+
+* `ip_of_trust_for_user_defined_routes` - The trusted IP Address used for user-defined routes.
+
+* `trusted_subnet_id` - The ID of the trusted subnet.
+
+* `untrusted_subnet_id` - The ID of the untrusted subnet.
+
+* `virtual_network_id` - The ID of the Virtual Network in which the Firewall is deployed.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/configure#define-operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Palo Alto Next Generation Firewall Virtual Network Local Rulestack.

--- a/website/docs/d/palo_alto_next_generation_firewall_virtual_network_panorama.html.markdown
+++ b/website/docs/d/palo_alto_next_generation_firewall_virtual_network_panorama.html.markdown
@@ -1,0 +1,142 @@
+---
+subcategory: "Palo Alto"
+layout: "azurerm"
+page_title: "Azure Resource Manager: Data Source: azurerm_palo_alto_next_generation_firewall_virtual_network_panorama"
+description: |-
+  Gets information about an existing Palo Alto Next Generation Firewall Virtual Network Panorama.
+---
+
+# Data Source: azurerm_palo_alto_next_generation_firewall_virtual_network_panorama
+
+Use this data source to access information about an existing Palo Alto Next Generation Firewall Virtual Network Panorama.
+
+## Example Usage
+
+```hcl
+data "azurerm_palo_alto_next_generation_firewall_virtual_network_panorama" "example" {
+  name                = "existing-firewall"
+  resource_group_name = "existing-resource-group"
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the Palo Alto Next Generation Firewall Virtual Network Panorama.
+
+* `resource_group_name` - (Required) The name of the Resource Group where the Palo Alto Next Generation Firewall Virtual Network Panorama exists.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Palo Alto Next Generation Firewall Virtual Network Panorama.
+
+* `destination_nat` - One or more `destination_nat` blocks as defined below.
+
+* `dns_settings` - A `dns_settings` block as defined below.
+
+* `location` - The Azure Region where the Firewall exists.
+
+* `marketplace_offer_id` - The marketplace offer ID.
+
+* `network_profile` - A `network_profile` block as defined below.
+
+* `panorama` - A `panorama` block as defined below.
+
+* `panorama_base64_config` - The Base64 encoded Panorama configuration registration string.
+
+* `plan_id` - The billing plan ID.
+
+* `tags` - A mapping of tags assigned to the Firewall.
+
+---
+
+A `backend_config` block exports the following:
+
+* `port` - The port number to which traffic is sent.
+
+* `public_ip_address` - The IP Address to which traffic is sent.
+
+---
+
+A `destination_nat` block exports the following:
+
+* `backend_config` - A `backend_config` block as defined above.
+
+* `frontend_config` - A `frontend_config` block as defined below.
+
+* `name` - The name of this Destination NAT configuration.
+
+* `protocol` - The protocol used by this Destination NAT configuration.
+
+---
+
+A `dns_settings` block exports the following:
+
+* `azure_dns_servers` - The Azure DNS Servers used by the Firewall.
+
+* `dns_servers` - The custom DNS Servers used by the Firewall.
+
+* `use_azure_dns` - Whether the Firewall uses Azure DNS Servers.
+
+---
+
+A `frontend_config` block exports the following:
+
+* `port` - The port on which traffic is received.
+
+* `public_ip_address_id` - The ID of the Public IP Address on which traffic is received.
+
+---
+
+A `network_profile` block exports the following:
+
+* `egress_nat_ip_address_ids` - The IDs of the Public IP Addresses used for Egress NAT.
+
+* `egress_nat_ip_addresses` - The Public IP Addresses used for Egress NAT.
+
+* `public_ip_address_ids` - The IDs of the Public IP Addresses used by the Firewall.
+
+* `public_ip_addresses` - The Public IP Addresses used by the Firewall.
+
+* `trusted_address_ranges` - The trusted address ranges used by the Firewall.
+
+* `vnet_configuration` - A `vnet_configuration` block as defined below.
+
+---
+
+A `panorama` block exports the following:
+
+* `device_group_name` - The Device Group Name to which the Firewall is registered.
+
+* `host_name` - The Host Name of the Firewall.
+
+* `name` - The name of the Firewall.
+
+* `panorama_server_1` - The name of the first Panorama Server.
+
+* `panorama_server_2` - The name of the second Panorama Server.
+
+* `template_name` - The name of the Panorama Template applied to the Firewall.
+
+* `virtual_machine_ssh_key` - The SSH Key used to connect to the Firewall.
+
+---
+
+A `vnet_configuration` block exports the following:
+
+* `ip_of_trust_for_user_defined_routes` - The trusted IP Address used for user-defined routes.
+
+* `trusted_subnet_id` - The ID of the trusted subnet.
+
+* `untrusted_subnet_id` - The ID of the untrusted subnet.
+
+* `virtual_network_id` - The ID of the Virtual Network in which the Firewall is deployed.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/configure#define-operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Palo Alto Next Generation Firewall Virtual Network Panorama.

--- a/website/docs/d/palo_alto_next_generation_firewall_virtual_network_strata_cloud_manager.html.markdown
+++ b/website/docs/d/palo_alto_next_generation_firewall_virtual_network_strata_cloud_manager.html.markdown
@@ -1,0 +1,132 @@
+---
+subcategory: "Palo Alto"
+layout: "azurerm"
+page_title: "Azure Resource Manager: Data Source: azurerm_palo_alto_next_generation_firewall_virtual_network_strata_cloud_manager"
+description: |-
+  Gets information about an existing Palo Alto Next Generation Firewall Virtual Network Strata Cloud Manager.
+---
+
+# Data Source: azurerm_palo_alto_next_generation_firewall_virtual_network_strata_cloud_manager
+
+Use this data source to access information about an existing Palo Alto Next Generation Firewall Virtual Network managed by Strata Cloud Manager.
+
+## Example Usage
+
+```hcl
+data "azurerm_palo_alto_next_generation_firewall_virtual_network_strata_cloud_manager" "example" {
+  name                = "existing-firewall"
+  resource_group_name = "existing-resource-group"
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the Palo Alto Next Generation Firewall Virtual Network Strata Cloud Manager.
+
+* `resource_group_name` - (Required) The name of the Resource Group where the Palo Alto Next Generation Firewall Virtual Network Strata Cloud Manager exists.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Palo Alto Next Generation Firewall Virtual Network Strata Cloud Manager.
+
+* `destination_nat` - One or more `destination_nat` blocks as defined below.
+
+* `dns_settings` - A `dns_settings` block as defined below.
+
+* `identity` - An `identity` block as defined below.
+
+* `location` - The Azure Region where the Firewall exists.
+
+* `marketplace_offer_id` - The marketplace offer ID.
+
+* `network_profile` - A `network_profile` block as defined below.
+
+* `plan_id` - The billing plan ID.
+
+* `strata_cloud_manager_tenant_name` - The name of the Strata Cloud Manager tenant which manages the Firewall.
+
+* `tags` - A mapping of tags assigned to the Firewall.
+
+---
+
+A `backend_config` block exports the following:
+
+* `port` - The port number to which traffic is sent.
+
+* `public_ip_address` - The IP Address to which traffic is sent.
+
+---
+
+A `destination_nat` block exports the following:
+
+* `backend_config` - A `backend_config` block as defined above.
+
+* `frontend_config` - A `frontend_config` block as defined below.
+
+* `name` - The name of this Destination NAT configuration.
+
+* `protocol` - The protocol used by this Destination NAT configuration.
+
+---
+
+A `dns_settings` block exports the following:
+
+* `azure_dns_servers` - The Azure DNS Servers used by the Firewall.
+
+* `dns_servers` - The custom DNS Servers used by the Firewall.
+
+* `use_azure_dns` - Whether the Firewall uses Azure DNS Servers.
+
+---
+
+A `frontend_config` block exports the following:
+
+* `port` - The port on which traffic is received.
+
+* `public_ip_address_id` - The ID of the Public IP Address on which traffic is received.
+
+---
+
+An `identity` block exports the following:
+
+* `identity_ids` - The IDs of the User Assigned Managed Identities assigned to the Firewall.
+
+* `type` - The type of Managed Identity assigned to the Firewall.
+
+---
+
+A `network_profile` block exports the following:
+
+* `egress_nat_ip_address_ids` - The IDs of the Public IP Addresses used for Egress NAT.
+
+* `egress_nat_ip_addresses` - The Public IP Addresses used for Egress NAT.
+
+* `public_ip_address_ids` - The IDs of the Public IP Addresses used by the Firewall.
+
+* `public_ip_addresses` - The Public IP Addresses used by the Firewall.
+
+* `trusted_address_ranges` - The trusted address ranges used by the Firewall.
+
+* `vnet_configuration` - A `vnet_configuration` block as defined below.
+
+---
+
+A `vnet_configuration` block exports the following:
+
+* `ip_of_trust_for_user_defined_routes` - The trusted IP Address used for user-defined routes.
+
+* `trusted_subnet_id` - The ID of the trusted subnet.
+
+* `untrusted_subnet_id` - The ID of the untrusted subnet.
+
+* `virtual_network_id` - The ID of the Virtual Network in which the Firewall is deployed.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/configure#define-operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Palo Alto Next Generation Firewall Virtual Network Strata Cloud Manager.


### PR DESCRIPTION
## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests/issues/1) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

This PR adds typed data sources for the six existing Palo Alto Networks Cloud NGFW resource variants:

* `azurerm_palo_alto_next_generation_firewall_virtual_hub_local_rulestack`
* `azurerm_palo_alto_next_generation_firewall_virtual_hub_panorama`
* `azurerm_palo_alto_next_generation_firewall_virtual_hub_strata_cloud_manager`
* `azurerm_palo_alto_next_generation_firewall_virtual_network_local_rulestack`
* `azurerm_palo_alto_next_generation_firewall_virtual_network_panorama`
* `azurerm_palo_alto_next_generation_firewall_virtual_network_strata_cloud_manager`

Each data source looks up an existing firewall using its `name` and `resource_group_name`.

The data sources expose the fields available from their corresponding resources, including:

* DNS settings
* Destination NAT configuration
* Marketplace offer and billing plan IDs
* Virtual Hub or Virtual Network profiles
* Public IP, Egress NAT, trusted range, subnet, and routing information
* Local Rulestack IDs
* Panorama registration and returned Panorama configuration
* Strata Cloud Manager tenant and managed identity information
* Tags and location where exposed by the corresponding resource

The implementation reuses the existing API client and resource flattening logic. It also includes a recursive schema-parity unit test that ensures every top-level and nested resource field remains exposed by the matching data source.

This is a non-breaking addition targeting the current v5 provider development branch. It is not being backported to v4, consistent with the repository policy of adding new features only to the current major version.


## PR Checklist

- [x] I have followed the guidelines in our [Contributing Documentation](../blob/main/contributing/README.md).
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change.
- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-a-pull-request/linking-a-pull-request-to-an-issue) below.
- [x] I have updated/added Documentation as required written in a helpful and kind way to assist users that may be unfamiliar with the resource / data source.
- [x] I have used a meaningful PR title to help maintainers and other users understand this change and help prevent duplicate work.


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them.
- [x] I have written new tests for my resource or datasource changes & updated any relevant documentation.
- [ ] I have successfully run tests with my changes locally. Live acceptance tests have not yet been executed because the required Azure and Palo Alto credentials were unavailable.


## Testing

- [x] My submission includes test coverage as described in the Contribution Guide.

> [!NOTE]
> Live acceptance tests were not executed because the required Azure test subscription, Panorama configuration, and Strata Cloud Manager tenant credentials were unavailable. Acceptance-test coverage is included for all six data sources. All unit, schema, lint, and documentation checks pass. Maintainer acceptance testing is requested.

The following local checks passed:

```text
go test ./internal/services/paloalto ./internal/provider -count=1
make quick-checks
./scripts/checks/tfproviderlint.sh
make website-lint
make document-validate
golangci-lint run ./internal/services/paloalto/...
```

The recursive schema-parity test passed:

```text
go test ./internal/services/paloalto \
  -run TestPaloAltoNextGenerationFirewallDataSourceSchemasMatchResources \
  -count=1
```

Acceptance tests are included for all six data sources. They can be executed with:

```text
make acctests \
  SERVICE='paloalto' \
  TESTARGS='-run=TestAccPaloAltoNextGenerationFirewall.*DataSource_basic' \
  TESTTIMEOUT='180m'
```

The Panorama tests require `ARM_PALO_ALTO_PANORAMA_CONFIG`. The Strata Cloud Manager tests require `ARM_PALO_ALTO_SCM_TENANT_NAME`.


## Change Log

* **New Data Source**: `azurerm_palo_alto_next_generation_firewall_virtual_hub_local_rulestack` [GH-32977]
* **New Data Source**: `azurerm_palo_alto_next_generation_firewall_virtual_hub_panorama` [GH-32977]
* **New Data Source**: `azurerm_palo_alto_next_generation_firewall_virtual_hub_strata_cloud_manager` [GH-32977]
* **New Data Source**: `azurerm_palo_alto_next_generation_firewall_virtual_network_local_rulestack` [GH-32977]
* **New Data Source**: `azurerm_palo_alto_next_generation_firewall_virtual_network_panorama` [GH-32977]
* **New Data Source**: `azurerm_palo_alto_next_generation_firewall_virtual_network_strata_cloud_manager` [GH-32977]


This is a:

- [ ] Bug Fix
- [x] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking Change


## Related Issue(s)

No related issue.

<!-- If this closes an existing issue, replace the line above with: Fixes #12345 -->


## AI Assistance Disclosure

- [x] AI Assisted - This contribution was made by, or with the assistance of, AI/LLMs

AI assistance was used to review the contribution requirements, implement the data sources and computed schemas, generate tests and documentation, run and interpret local validation checks, and prepare this pull request description. The resulting code, documentation, and test output were reviewed by the contributor.


## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.


## Changes to Security Controls

No security controls are changed by this pull request.


> [!NOTE]
> If this PR changes meaningfully during the course of review please update the title and description as required.